### PR TITLE
Flushes stdout buffer before exiting

### DIFF
--- a/src/cli/main.c
+++ b/src/cli/main.c
@@ -514,7 +514,10 @@ int main(int argc, char** argv) {
     double dt = zxc_now() - t0;
 
     if (!use_stdin) fclose(f_in);
-    if (!use_stdout) fclose(f_out);
+    if (!use_stdout)
+        fclose(f_out);
+    else
+        fflush(f_out);
     free(b1);
     free(b2);
 


### PR DESCRIPTION
Ensures that the standard output buffer is flushed before the program exits when the `-c` flag is used, preventing potential data loss.
Fix issue https://github.com/hellobertrand/zxc/issues/20 from @xcfmc