### PR TITLE
Fix: prevent buffer overflow in GHI fast path

### DIFF
--- a/src/lib/zxc_decompress.c
+++ b/src/lib/zxc_decompress.c
@@ -1384,6 +1384,9 @@ static int zxc_decode_block_ghi(zxc_cctx_t* ctx, const uint8_t* RESTRICT src, si
         if (UNLIKELY(m_bits == ZXC_SEQ_ML_MASK)) ml += zxc_read_vbyte(&extras_ptr, extras_end);
         uint32_t offset = (uint32_t)(seq & 0xFFFF);
 
+        // Validate literal length against available literals
+        if (UNLIKELY(l_ptr + ll > l_end)) return -1;
+
         // Check bounds before wild copies - if too close to end, fall back to Safe Path
         if (UNLIKELY(d_ptr + ll + ml + ZXC_PAD_SIZE > d_end)) {
             seq_ptr = seq_save;


### PR DESCRIPTION
The "Fast Path" loop in `zxc_decode_block_ghi` relied on a static safety margin 
(`d_end_safe`) which was insufficient for large sequences decoded via VBytes. 
This allowed the destination pointer (`d_ptr`) to exceed the buffer limit, 
causing a segmentation fault in `zxc_copy32`.

This commit introduces a dynamic bounds check inside the loop:
1. Saves the stream pointers (`seq_ptr`, `extras_ptr`) before reading variable-length data.
2. Checks if the decoded sequence fits within the destination buffer.
3. If the sequence is too large, restores the pointers (rewind) and breaks the loop 
   to fall back to the "Safe Path", ensuring correct boundary handling.

This approach fixes the crash while preserving SIMD performance for standard sequences.