### PR TITLE
Adds test for decompressed size function

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,8 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 80%
+
+ignore:
+  - "src/cli/**"


### PR DESCRIPTION
Adds a unit test for the `zxc_get_decompressed_size` function.

This test verifies that the function correctly reports the
decompressed size for valid compressed data and returns 0 for
invalid or too-small input buffers.
