### PR TITLE
Fix potential out-of-bounds read (static analysis)

### DIFF
--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -4,7 +4,7 @@
 #  This source code is licensed under the BSD-style license found in the
 #  LICENSE file in the root directory of this source tree.
 
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM gcr.io/oss-fuzz-base/base-builder:v1
 
 RUN apt-get update && apt-get install -y make cmake
 

--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -45,6 +45,21 @@ jobs:
       run: |
         sed -i '2i export FUZZER_TARGET="${{ matrix.fuzzer }}"' .clusterfuzzlite/build.sh
 
+    # TODO: Remove this step once ClusterFuzzLite updates to support Docker 29+
+    - name: Downgrade Docker (Temporary Workaround)
+      run: |
+        # ClusterFuzzLite v1 uses Docker API 1.41 which is incompatible with Docker 29.0+
+        # Downgrade to Docker 28 until the action is updated
+        sudo apt-get update
+        sudo apt-get install -y apt-transport-https ca-certificates curl
+        curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
+        echo "deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+        sudo apt-get update
+        # Install Docker 28.0.4 specifically
+        sudo apt-get install -y --allow-downgrades docker-ce=5:28.0.4-1~ubuntu.$(lsb_release -rs)~$(lsb_release -cs) docker-ce-cli=5:28.0.4-1~ubuntu.$(lsb_release -rs)~$(lsb_release -cs) containerd.io
+        sudo systemctl restart docker
+        docker version
+
     - name: Build Fuzzers (${{ matrix.fuzzer }} - ${{ matrix.sanitizer }})
       id: build
       uses: google/clusterfuzzlite/actions/build_fuzzers@v1


### PR DESCRIPTION
Add defensive bounds check in `zxc_le_partial`.

Also, downgrades Docker in the fuzzing workflow to resolve incompatibility issues with ClusterFuzzLite.