### PR TITLE
Refactors multiarch CI to use Debian containers

### DIFF
--- a/.github/workflows/multiarch.yml
+++ b/.github/workflows/multiarch.yml
@@ -262,6 +262,11 @@ jobs:
             cross_prefix: mips64el-linux-gnuabi64
             cmake_processor: mips64
             qemu_binary: qemu-mips64el
+          - name: Linux loong64
+            cross_pkg: gcc-loongarch64-linux-gnu
+            cross_prefix: loongarch64-linux-gnu
+            cmake_processor: loongarch64
+            qemu_binary: qemu-loongarch64
 
     steps:
       - name: Checkout Repository


### PR DESCRIPTION
Simplifies the multi-architecture CI workflow by utilizing Debian containers for Tier 2 and Tier 3 builds.

This eliminates the need for `docker/setup-qemu-action` and streamlines the installation of cross-compilers and build tools.
