### PR TITLE
Finds rapidhash via system or vendored fallback

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,17 @@ elseif(ZXC_ENABLE_COVERAGE)
 endif()
 
 # =============================================================================
+# Rapidhash: system-installed (e.g. vcpkg) or vendored fallback
+# =============================================================================
+find_path(RAPIDHASH_INCLUDE_DIR rapidhash.h)
+if(NOT RAPIDHASH_INCLUDE_DIR)
+    set(RAPIDHASH_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/src/lib/vendors")
+    message(STATUS "Using vendored rapidhash from ${RAPIDHASH_INCLUDE_DIR}")
+else()
+    message(STATUS "Found system rapidhash in ${RAPIDHASH_INCLUDE_DIR}")
+endif()
+
+# =============================================================================
 # Core Library & Runtime Dispatch
 # =============================================================================
 
@@ -80,7 +91,7 @@ macro(zxc_add_variant suffix flags)
         endif()
     endif()
     # Inherit include directories
-    target_include_directories(zxc_compress${suffix} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src/lib ${CMAKE_CURRENT_SOURCE_DIR}/src/lib/vendors PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>)
+    target_include_directories(zxc_compress${suffix} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src/lib ${RAPIDHASH_INCLUDE_DIR} PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>)
 
     add_library(zxc_decompress${suffix} OBJECT src/lib/zxc_decompress.c)
     target_compile_options(zxc_decompress${suffix} PRIVATE ${flags})
@@ -97,7 +108,7 @@ macro(zxc_add_variant suffix flags)
             target_compile_options(zxc_decompress${suffix} PRIVATE -fvisibility=hidden)
         endif()
     endif()
-    target_include_directories(zxc_decompress${suffix} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src/lib ${CMAKE_CURRENT_SOURCE_DIR}/src/lib/vendors PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>)
+    target_include_directories(zxc_decompress${suffix} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src/lib ${RAPIDHASH_INCLUDE_DIR} PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>)
     
     list(APPEND ZXC_VARIANT_OBJECTS $<TARGET_OBJECTS:zxc_compress${suffix}> $<TARGET_OBJECTS:zxc_decompress${suffix}>)
 endmacro()
@@ -158,7 +169,7 @@ target_include_directories(zxc_lib
         $<INSTALL_INTERFACE:include>
     PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/src/lib
-        ${CMAKE_CURRENT_SOURCE_DIR}/src/lib/vendors
+        ${RAPIDHASH_INCLUDE_DIR}
 )
 
 # Symbol visibility for shared libraries
@@ -248,7 +259,7 @@ target_link_libraries(zxc_lib PRIVATE Threads::Threads)
 if(ZXC_BUILD_CLI)
     add_executable(zxc src/cli/main.c)
     target_link_libraries(zxc PRIVATE zxc_lib)
-    target_include_directories(zxc PRIVATE src/lib/vendors)
+    target_include_directories(zxc PRIVATE ${RAPIDHASH_INCLUDE_DIR})
     
     # Math library on Unix
     if(UNIX)
@@ -341,7 +352,7 @@ if(ZXC_BUILD_TESTS)
                 $<INSTALL_INTERFACE:include>
             PRIVATE
                 ${CMAKE_CURRENT_SOURCE_DIR}/src/lib
-                ${CMAKE_CURRENT_SOURCE_DIR}/src/lib/vendors
+                ${RAPIDHASH_INCLUDE_DIR}
         )
         
         # Apply same compiler settings as main library
@@ -382,7 +393,7 @@ if(ZXC_BUILD_TESTS)
         endif()
     endif()
     
-    target_include_directories(zxc_test PRIVATE src/lib src/lib/vendors)
+    target_include_directories(zxc_test PRIVATE src/lib ${RAPIDHASH_INCLUDE_DIR})
     add_test(NAME UnitTests COMMAND zxc_test)
 endif()
 


### PR DESCRIPTION
Ensures rapidhash is located either as a system-installed
dependency or through a vendored copy.

This allows the project to function correctly regardless of
whether rapidhash is pre-installed on the system.
