### PR TITLE
Standardizes block unit and chunk size logic

### DIFF
--- a/docs/FORMAT.md
+++ b/docs/FORMAT.md
@@ -54,8 +54,8 @@ Offset  Size  Field
 - **Magic Word** (`u32`): `0x9CB02EF5`.
 - **Format Version** (`u8`): currently `5`.
 - **Chunk Size Code** (`u8`):
-  - `0` means default legacy value = 64 units.
-  - otherwise actual chunk size = `code * 4096` bytes.
+  - `0` is interpreted as `1` unit (minimum size).
+  - actual chunk size = `max(1, code) * 16384` bytes.
 - **Flags** (`u8`):
   - Bit 7 (`0x80`): `HAS_CHECKSUM`.
   - Bits 0..3: checksum algorithm id (`0` = RapidHash-based folding).
@@ -414,7 +414,7 @@ Generated archive size: **58 bytes**.
 ### 11.1 Full hexdump
 
 ```text
-00000000: F5 2E B0 9C 05 40 80 00 00 00 00 00 00 00 26 2E
+00000000: F5 2E B0 9C 05 10 80 00 00 00 00 00 00 00 D2 D5
 00000010: 00 00 00 0A 00 00 00 69 48 65 6C 6C 6F 20 5A 58
 00000020: 43 0A 90 BB A1 75 FF 00 00 00 00 00 00 02 0A 00
 00000030: 00 00 00 00 00 00 90 BB A1 75
@@ -425,15 +425,15 @@ Generated archive size: **58 bytes**.
 #### A) File Header (offset `0x00`, 16 bytes)
 
 ```text
-F5 2E B0 9C | 05 | 40 | 80 | 00 00 00 00 00 00 00 | 26 2E
+F5 2E B0 9C | 05 | 10 | 80 | 00 00 00 00 00 00 00 | D2 D5
 ```
 
 - `F5 2E B0 9C` → magic word (LE) = `0x9CB02EF5`.
 - `05` → format version 5.
-- `40` → chunk-size code 64 (`64 * 4096 = 262144` bytes, i.e. 256 KiB).
+- `10` → chunk-size code 16 (`16 * 16384 = 262144` bytes, i.e. 256 KB).
 - `80` → checksum enabled (`HAS_CHECKSUM=1`, algo id 0).
 - next 7 bytes are reserved zeros.
-- `26 2E` → header CRC16.
+- `D2 D5` → header CRC16.
 
 #### B) Data Block #0 (RAW)
 

--- a/docs/WHITEPAPER.md
+++ b/docs/WHITEPAPER.md
@@ -104,8 +104,8 @@ The file begins with a **16-byte** header that identifies the format and specifi
 * **Magic Word (4 bytes)**: `0x9 0xCB 0x02E 0xF5`.
 * **Version (1 byte)**: Current version is `5`.
 * **Chunk Size Code (1 byte)**: Defines the processing block size:
-  - `0` = Default mode (256 KB, for backward compatibility)
-  - `N` = Chunk size is `N × 4096` bytes (e.g., `62` = 248 KB)
+  - `0` is interpreted as `1` unit (minimum size 16 KB)
+  - `N` = Chunk size is `N × 16384` bytes (e.g., `16` = 256 KB)
 * **Flags (1 byte)**: Global configuration flags.
   - **Bit 7 (MSB)**: `HAS_CHECKSUM`. If `1`, checksums are enabled for the stream. Every block will carry a trailing 4-byte checksum, and the footer will contain a global checksum. If `0`, no checksums are present.
   - **Bits 4-6**: Reserved.

--- a/src/lib/zxc_common.c
+++ b/src/lib/zxc_common.c
@@ -221,7 +221,7 @@ int zxc_read_file_header(const uint8_t* RESTRICT src, const size_t src_size,
     if (UNLIKELY(zxc_le16(src + 14) != zxc_hash16(temp))) return ZXC_ERROR_BAD_HEADER;
 
     if (out_block_size) {
-        const size_t units = src[5] ? src[5] : 64;  // Default to 64 block units (256KB)
+        const size_t units = src[5] ? src[5] : 1;  // Minimum 1 block unit (16KB)
         *out_block_size = units * ZXC_BLOCK_UNIT;
     }
     if (out_has_checksum) *out_has_checksum = (src[6] & ZXC_FILE_FLAG_HAS_CHECKSUM) ? 1 : 0;

--- a/src/lib/zxc_internal.h
+++ b/src/lib/zxc_internal.h
@@ -280,10 +280,10 @@ extern "C" {
 #define ZXC_MAGIC_WORD 0x9CB02EF5U
 /** @brief Current on-disk file format version. */
 #define ZXC_FILE_FORMAT_VERSION 5
-/** @brief Block size unit (4 KB). */
-#define ZXC_BLOCK_UNIT (4 * 1024)
+/** @brief Block size unit (16 KB). */
+#define ZXC_BLOCK_UNIT (16 * 1024)
 /** @brief Default block size processed per thread (256 KB). */
-#define ZXC_BLOCK_SIZE (64 * ZXC_BLOCK_UNIT)
+#define ZXC_BLOCK_SIZE (16 * ZXC_BLOCK_UNIT)
 /** @brief Size of stdio I/O buffers (1 MB). */
 #define ZXC_IO_BUFFER_SIZE (1024 * 1024)
 /** @brief Safety padding appended to buffers to tolerate overruns. */


### PR DESCRIPTION
Increases the fundamental block unit from 4KB to 16KB, aligning with common memory page sizes.

Reworks the chunk size code interpretation to be more consistent:
- Code `0` now explicitly maps to the minimum `1` unit (16KB), eliminating the previous "legacy default" interpretation of 256KB. This provides a clear minimum chunk size.
- The chunk size is now calculated as `max(1, code) * 16384` bytes, directly using the new block unit.

The effective default processing block size remains 256KB, with internal constants and documentation updated to reflect the new 16KB block unit. This change enhances clarity and consistency in block size definitions.
