### PR TITLE
Adds CI support for alpha architecture

### DIFF
--- a/.github/workflows/multiarch.yml
+++ b/.github/workflows/multiarch.yml
@@ -287,6 +287,11 @@ jobs:
             cross_prefix: loongarch64-linux-gnu
             cmake_processor: loongarch64
             qemu_binary: qemu-loongarch64
+          - name: Linux alpha
+            cross_pkg: gcc-alpha-linux-gnu
+            cross_prefix: alpha-linux-gnu
+            cmake_processor: alpha
+            qemu_binary: qemu-alpha
 
     steps:
       - name: Checkout Repository


### PR DESCRIPTION
Expands the multi-architecture CI build matrix to include Linux Alpha. This provides the necessary cross-compilation package, prefix, CMake processor, and QEMU binary settings to enable Alpha architecture builds in the CI pipeline.
