### PR TITLE
Resource management and enforces thread limits

### DIFF
--- a/src/cli/main.c
+++ b/src/cli/main.c
@@ -907,10 +907,10 @@ static int process_single_file(const char* in_path, const char* out_path_overrid
     else
         setvbuf(stdin, NULL, _IONBF, 0);
 
-    if (!use_stdout) {
-        if (f_out) fclose(f_out);
-    } else {
-        fflush(f_out);
+    if (created_out_file && f_out) {
+        fclose(f_out);
+    } else if (use_stdout) {
+        fflush(stdout);
         setvbuf(stdout, NULL, _IONBF, 0);
     }
 
@@ -1052,8 +1052,9 @@ int main(int argc, char** argv) {
                 break;
             case 'T':
                 num_threads = atoi(optarg);
-                if (num_threads < 0 || num_threads > 1024) {
-                    fprintf(stderr, "Error: num_threads must be between 0 and 1024\n");
+                if (num_threads < 0 || num_threads > ZXC_MAX_THREADS) {
+                    fprintf(stderr, "Error: num_threads must be between 0 and %d\n",
+                            ZXC_MAX_THREADS);
                     return 1;
                 }
                 break;
@@ -1143,8 +1144,8 @@ int main(int argc, char** argv) {
             }
         }
 
-        if (num_threads < 0 || num_threads > 1024) {
-            zxc_log("Error: num_threads must be between 0 and 1024\n");
+        if (num_threads < 0 || num_threads > ZXC_MAX_THREADS) {
+            zxc_log("Error: num_threads must be between 0 and %d\n", ZXC_MAX_THREADS);
             return 1;
         }
 

--- a/src/lib/zxc_driver.c
+++ b/src/lib/zxc_driver.c
@@ -532,7 +532,8 @@ static int64_t zxc_stream_engine_run(FILE* f_in, FILE* f_out, const int n_thread
             return ZXC_ERROR_BAD_HEADER;
     }
 
-    const int num_threads = (n_threads > 0) ? n_threads : (int)sysconf(_SC_NPROCESSORS_ONLN);
+    int num_threads = (n_threads > 0) ? n_threads : (int)sysconf(_SC_NPROCESSORS_ONLN);
+    if (num_threads > ZXC_MAX_THREADS) num_threads = ZXC_MAX_THREADS;
     // Reserve 1 thread for Writer/Reader overhead if possible
     const int num_workers = (num_threads > 1) ? num_threads - 1 : 1;
 

--- a/src/lib/zxc_internal.h
+++ b/src/lib/zxc_internal.h
@@ -286,6 +286,8 @@ extern "C" {
 #define ZXC_BLOCK_SIZE (64 * ZXC_BLOCK_UNIT)
 /** @brief Size of stdio I/O buffers (1 MB). */
 #define ZXC_IO_BUFFER_SIZE (1024 * 1024)
+/** @brief Maximum number of threads allowed for streaming operations. */
+#define ZXC_MAX_THREADS 1024
 /** @brief Safety padding appended to buffers to tolerate overruns. */
 #define ZXC_PAD_SIZE 32
 /** @brief Number of bits per byte (constant 8). */


### PR DESCRIPTION
Addresses findings from static analysis (Snyk) to improve resource safety:

- Refines CLI file handling to ensure `stdout` is flushed rather than closed and that only explicitly created files are closed.
- Introduces `ZXC_MAX_THREADS` to provide a consistent upper bound for thread allocation, preventing potential resource exhaustion.
- Updates the CLI and driver to clamp thread counts to this safe limit.
