### PR TITLE
Optimizes literal copying with a unified 32-byte fast path

### DIFF
--- a/src/lib/zxc_compress.c
+++ b/src/lib/zxc_compress.c
@@ -752,12 +752,15 @@ static int zxc_encode_block_glo(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRIC
             const uint32_t off = (uint32_t)(ip - m.ref);
 
             if (ll > 0) {
-                if (ll <= 16 && anchor + 16 <= iend)
-                    zxc_copy16(literals + lit_c, anchor);
-                else if (ll <= 32 && anchor + 32 <= iend)
+                if (LIKELY(anchor + ZXC_PAD_SIZE <= iend)) {
                     zxc_copy32(literals + lit_c, anchor);
-                else
+                    if (UNLIKELY(ll > ZXC_PAD_SIZE)) {
+                        ZXC_MEMCPY(literals + lit_c + ZXC_PAD_SIZE, anchor + ZXC_PAD_SIZE,
+                                   ll - ZXC_PAD_SIZE);
+                    }
+                } else {
                     ZXC_MEMCPY(literals + lit_c, anchor, ll);
+                }
                 lit_c += ll;
             }
 
@@ -1251,12 +1254,15 @@ static int zxc_encode_block_ghi(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRIC
             const uint32_t off = (uint32_t)(ip - m.ref);
 
             if (ll > 0) {
-                if (ll <= 16 && anchor + 16 <= iend)
-                    zxc_copy16(literals + lit_c, anchor);
-                else if (ll <= 32 && anchor + 32 <= iend)
+                if (LIKELY(anchor + ZXC_PAD_SIZE <= iend)) {
                     zxc_copy32(literals + lit_c, anchor);
-                else
+                    if (UNLIKELY(ll > ZXC_PAD_SIZE)) {
+                        ZXC_MEMCPY(literals + lit_c + ZXC_PAD_SIZE, anchor + ZXC_PAD_SIZE,
+                                   ll - ZXC_PAD_SIZE);
+                    }
+                } else {
                     ZXC_MEMCPY(literals + lit_c, anchor, ll);
+                }
                 lit_c += ll;
             }
 


### PR DESCRIPTION
Replaces conditional 16-byte and 32-byte literal copies with a single 32-byte copy when buffer padding allows. This reduces branching in the compression hot path and uses compiler hints to prioritize the fast path for typical literal lengths.
