### PR TITLE
Removes static branch prediction hints from varint routines

### DIFF
--- a/src/lib/zxc_compress.c
+++ b/src/lib/zxc_compress.c
@@ -99,14 +99,14 @@ static ZXC_ALWAYS_INLINE size_t zxc_write_varint(uint8_t* RESTRICT dst, uint32_t
     }
 
     // 2 bytes: 10xxxxxx xxxxxxxx (14 bits) -> val < 16384 (2^14)
-    if (LIKELY(val < 16384)) {
+    if (val < 16384) {
         dst[0] = (uint8_t)(0x80 | (val & 0x3F));
         dst[1] = (uint8_t)(val >> 6);
         return 2;
     }
 
     // 3 bytes: 110xxxxx xxxxxxxx xxxxxxxx (21 bits) -> val < 2097152 (2^21)
-    if (LIKELY(val < 2097152)) {
+    if (val < 2097152) {
         dst[0] = (uint8_t)(0xC0 | (val & 0x1F));
         dst[1] = (uint8_t)(val >> 5);
         dst[2] = (uint8_t)(val >> 13);
@@ -114,7 +114,7 @@ static ZXC_ALWAYS_INLINE size_t zxc_write_varint(uint8_t* RESTRICT dst, uint32_t
     }
 
     // 4 bytes: 1110xxxx xxxxxxxx xxxxxxxx xxxxxxxx (28 bits) -> val < 268435456 (2^28)
-    if (LIKELY(val < 268435456)) {
+    if (val < 268435456) {
         dst[0] = (uint8_t)(0xE0 | (val & 0x0F));
         dst[1] = (uint8_t)(val >> 4);
         dst[2] = (uint8_t)(val >> 12);

--- a/src/lib/zxc_compress.c
+++ b/src/lib/zxc_compress.c
@@ -195,8 +195,7 @@ static ZXC_ALWAYS_INLINE zxc_match_t zxc_lz77_find_best_match(
 
     // If the epoch in raw_head matches the current epoch_mark, extract the
     // stored position; otherwise treat this bucket as empty (index 0).
-    const uint32_t epoch_mask = -((int32_t)((raw_head & ~offset_mask) == epoch_mark));
-    uint32_t match_idx = (raw_head & offset_mask) & epoch_mask;
+    uint32_t match_idx = ((raw_head & ~offset_mask) == epoch_mark) ? (raw_head & offset_mask) : 0;
 
     // Decide whether to skip the head entry of the hash chain.
     const int skip_head = (match_idx != 0) & (stored_tag != cur_tag);
@@ -373,8 +372,8 @@ static ZXC_ALWAYS_INLINE zxc_match_t zxc_lz77_find_best_match(
         const uint32_t h2 = zxc_hash_func(next_val8, use_hash5);
         const uint8_t next_stored_tag = hash_tags[h2];
         const uint32_t next_head = hash_table[h2];
-        const uint32_t epoch_mask2 = -((int32_t)((next_head & ~offset_mask) == epoch_mark));
-        uint32_t next_idx = (next_head & offset_mask) & epoch_mask2;
+        uint32_t next_idx =
+            (next_head & ~offset_mask) == epoch_mark ? (next_head & offset_mask) : 0;
         const uint8_t next_tag = (uint8_t)(next_val ^ (next_val >> 16));
         const int skip_lazy_head = (next_idx > 0 && next_stored_tag != next_tag);
         uint32_t max_lazy = 0;
@@ -417,8 +416,7 @@ static ZXC_ALWAYS_INLINE zxc_match_t zxc_lz77_find_best_match(
             const uint32_t h3 = zxc_hash_func(val3_8, use_hash5);
             const uint8_t tag3 = hash_tags[h3];
             const uint32_t head3 = hash_table[h3];
-            const uint32_t epoch_mask3 = -((int32_t)((head3 & ~offset_mask) == epoch_mark));
-            uint32_t idx3 = (head3 & offset_mask) & epoch_mask3;
+            uint32_t idx3 = (head3 & ~offset_mask) == epoch_mark ? (head3 & offset_mask) : 0;
             const uint8_t cur_tag3 = (uint8_t)(val3 ^ (val3 >> 16));
             const int skip_head3 = (idx3 > 0 && tag3 != cur_tag3);
 

--- a/src/lib/zxc_compress.c
+++ b/src/lib/zxc_compress.c
@@ -105,7 +105,7 @@ static ZXC_ALWAYS_INLINE size_t zxc_write_varint(uint8_t* RESTRICT dst, uint32_t
     }
 
     // 3 bytes: 110xxxxx xxxxxxxx xxxxxxxx (21 bits) = 2^21 = 2097152
-    if (val < (1 << 21)) {
+    if (LIKELY(val < (1 << 21))) {
         dst[0] = (uint8_t)(0xC0 | (val & 0x1F));
         dst[1] = (uint8_t)(val >> 5);
         dst[2] = (uint8_t)(val >> 13);
@@ -113,7 +113,7 @@ static ZXC_ALWAYS_INLINE size_t zxc_write_varint(uint8_t* RESTRICT dst, uint32_t
     }
 
     // 4 bytes: 1110xxxx xxxxxxxx xxxxxxxx xxxxxxxx (28 bits) = 2^28 = 268435456
-    if (val < (1 << 28)) {
+    if (LIKELY(val < (1 << 28))) {
         dst[0] = (uint8_t)(0xE0 | (val & 0x0F));
         dst[1] = (uint8_t)(val >> 4);
         dst[2] = (uint8_t)(val >> 12);

--- a/src/lib/zxc_compress.c
+++ b/src/lib/zxc_compress.c
@@ -91,30 +91,29 @@ static ZXC_ALWAYS_INLINE uint32_t zxc_mm256_reduce_max_epu32(__m256i v) {
  * @return The number of bytes written to the destination buffer.
  */
 static ZXC_ALWAYS_INLINE size_t zxc_write_varint(uint8_t* RESTRICT dst, uint32_t val) {
-    // Prefix Varint Encoding
-    // 1 byte: 0xxxxxxx (7 bits) -> val < 128
-    if (LIKELY(val < 128)) {
+    // 1 byte: 0xxxxxxx (7 bits) = 2^7 = 128
+    if (LIKELY(val < (1 << 7))) {
         dst[0] = (uint8_t)val;
         return 1;
     }
 
-    // 2 bytes: 10xxxxxx xxxxxxxx (14 bits) -> val < 16384 (2^14)
-    if (val < 16384) {
+    // 2 bytes: 10xxxxxx xxxxxxxx (14 bits) = 2^14 = 16384
+    if (LIKELY(val < (1 << 14))) {
         dst[0] = (uint8_t)(0x80 | (val & 0x3F));
         dst[1] = (uint8_t)(val >> 6);
         return 2;
     }
 
-    // 3 bytes: 110xxxxx xxxxxxxx xxxxxxxx (21 bits) -> val < 2097152 (2^21)
-    if (val < 2097152) {
+    // 3 bytes: 110xxxxx xxxxxxxx xxxxxxxx (21 bits) = 2^21 = 2097152
+    if (val < (1 << 21)) {
         dst[0] = (uint8_t)(0xC0 | (val & 0x1F));
         dst[1] = (uint8_t)(val >> 5);
         dst[2] = (uint8_t)(val >> 13);
         return 3;
     }
 
-    // 4 bytes: 1110xxxx xxxxxxxx xxxxxxxx xxxxxxxx (28 bits) -> val < 268435456 (2^28)
-    if (val < 268435456) {
+    // 4 bytes: 1110xxxx xxxxxxxx xxxxxxxx xxxxxxxx (28 bits) = 2^28 = 268435456
+    if (val < (1 << 28)) {
         dst[0] = (uint8_t)(0xE0 | (val & 0x0F));
         dst[1] = (uint8_t)(val >> 4);
         dst[2] = (uint8_t)(val >> 12);
@@ -122,7 +121,7 @@ static ZXC_ALWAYS_INLINE size_t zxc_write_varint(uint8_t* RESTRICT dst, uint32_t
         return 4;
     }
 
-    // 5 bytes: 11110xxx ... (35 bits) -> Full 32-bit range
+    // 5 bytes: 11110xxx ... (35 bits) -> Full 32-bit range = 2^32
     dst[0] = (uint8_t)(0xF0 | (val & 0x07));
     dst[1] = (uint8_t)(val >> 3);
     dst[2] = (uint8_t)(val >> 11);

--- a/src/lib/zxc_compress.c
+++ b/src/lib/zxc_compress.c
@@ -373,8 +373,8 @@ static ZXC_ALWAYS_INLINE zxc_match_t zxc_lz77_find_best_match(
         const uint32_t h2 = zxc_hash_func(next_val8, use_hash5);
         const uint8_t next_stored_tag = hash_tags[h2];
         const uint32_t next_head = hash_table[h2];
-        uint32_t next_idx =
-            (next_head & ~offset_mask) == epoch_mark ? (next_head & offset_mask) : 0;
+        const uint32_t epoch_mask2 = -((int32_t)((next_head & ~offset_mask) == epoch_mark));
+        uint32_t next_idx = (next_head & offset_mask) & epoch_mask2;
         const uint8_t next_tag = (uint8_t)(next_val ^ (next_val >> 16));
         const int skip_lazy_head = (next_idx > 0 && next_stored_tag != next_tag);
         uint32_t max_lazy = 0;
@@ -400,7 +400,7 @@ static ZXC_ALWAYS_INLINE zxc_match_t zxc_lz77_find_best_match(
                 }
                 while (ip + 1 + l2 < iend && ref2[l2] == ip[1 + l2]) l2++;
             lazy1_done:
-                if (l2 > max_lazy) max_lazy = l2;
+                max_lazy = l2 > max_lazy ? l2 : max_lazy;
             }
 
             const uint16_t delta = chain_table[next_idx];
@@ -417,7 +417,8 @@ static ZXC_ALWAYS_INLINE zxc_match_t zxc_lz77_find_best_match(
             const uint32_t h3 = zxc_hash_func(val3_8, use_hash5);
             const uint8_t tag3 = hash_tags[h3];
             const uint32_t head3 = hash_table[h3];
-            uint32_t idx3 = (head3 & ~offset_mask) == epoch_mark ? (head3 & offset_mask) : 0;
+            const uint32_t epoch_mask3 = -((int32_t)((head3 & ~offset_mask) == epoch_mark));
+            uint32_t idx3 = (head3 & offset_mask) & epoch_mask3;
             const uint8_t cur_tag3 = (uint8_t)(val3 ^ (val3 >> 16));
             const int skip_head3 = (idx3 > 0 && tag3 != cur_tag3);
 
@@ -442,7 +443,7 @@ static ZXC_ALWAYS_INLINE zxc_match_t zxc_lz77_find_best_match(
                     }
                     while (ip + 2 + l3 < iend && ref3[l3] == ip[2 + l3]) l3++;
                 lazy2_done:
-                    if (l3 > max_lazy3) max_lazy3 = l3;
+                    max_lazy3 = l3 > max_lazy3 ? l3 : max_lazy3;
                 }
 
                 const uint16_t delta = chain_table[idx3];

--- a/src/lib/zxc_decompress.c
+++ b/src/lib/zxc_decompress.c
@@ -692,7 +692,7 @@ static int zxc_decode_block_glo(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRIC
                 zxc_copy32(out, ref);                                \
             }                                                        \
             d_ptr += ml;                                             \
-        } else if (off >= (ZXC_PAD_SIZE / 2)) {                      \
+        } else if (LIKELY(off >= (ZXC_PAD_SIZE / 2))) {                \
             zxc_copy16(d_ptr, match_src);                            \
             if (UNLIKELY(ml > (ZXC_PAD_SIZE / 2))) {                 \
                 uint8_t* out = d_ptr + (ZXC_PAD_SIZE / 2);           \
@@ -1187,7 +1187,7 @@ static int zxc_decode_block_ghi(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRIC
                 zxc_copy32(out, ref);                                \
             }                                                        \
             d_ptr += ml;                                             \
-        } else if (off >= (ZXC_PAD_SIZE / 2)) {                      \
+        } else if (LIKELY(off >= (ZXC_PAD_SIZE / 2))) {                \
             zxc_copy16(d_ptr, match_src);                            \
             if (UNLIKELY(ml > (ZXC_PAD_SIZE / 2))) {                 \
                 uint8_t* out = d_ptr + (ZXC_PAD_SIZE / 2);           \

--- a/src/lib/zxc_decompress.c
+++ b/src/lib/zxc_decompress.c
@@ -707,9 +707,6 @@ static int zxc_decode_block_glo(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRIC
                 zxc_copy16(out, ref);                                \
             }                                                        \
             d_ptr += ml;                                             \
-        } else if (off == 1) {                                       \
-            ZXC_MEMSET(d_ptr, match_src[0], ml);                     \
-            d_ptr += ml;                                             \
         } else {                                                     \
             size_t copied = 0;                                       \
             while (copied < ml) {                                    \
@@ -1201,9 +1198,6 @@ static int zxc_decode_block_ghi(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRIC
                 }                                                    \
                 zxc_copy16(out, ref);                                \
             }                                                        \
-            d_ptr += ml;                                             \
-        } else if (off == 1) {                                       \
-            ZXC_MEMSET(d_ptr, match_src[0], ml);                     \
             d_ptr += ml;                                             \
         } else {                                                     \
             size_t copied = 0;                                       \

--- a/src/lib/zxc_decompress.c
+++ b/src/lib/zxc_decompress.c
@@ -101,7 +101,7 @@ static ZXC_ALWAYS_INLINE uint32_t zxc_read_varint(const uint8_t** ptr, const uin
     }
 
     // 3 Bytes: 110xxxxx xxxxxxxx xxxxxxxx (21 bits)
-    if (b0 < 0xE0) {
+    if (LIKELY(b0 < 0xE0)) {
         if (UNLIKELY(p + 2 >= end)) {
             *ptr = end;
             return 0;

--- a/src/lib/zxc_decompress.c
+++ b/src/lib/zxc_decompress.c
@@ -91,7 +91,7 @@ static ZXC_ALWAYS_INLINE uint32_t zxc_read_varint(const uint8_t** ptr, const uin
     }
 
     // 2 Bytes: 10xxxxxx xxxxxxxx (14 bits)
-    if (LIKELY(b0 < 0xC0)) {
+    if (b0 < 0xC0) {
         if (UNLIKELY(p + 1 >= end)) {
             *ptr = end;
             return 0;
@@ -101,7 +101,7 @@ static ZXC_ALWAYS_INLINE uint32_t zxc_read_varint(const uint8_t** ptr, const uin
     }
 
     // 3 Bytes: 110xxxxx xxxxxxxx xxxxxxxx (21 bits)
-    if (LIKELY(b0 < 0xE0)) {
+    if (b0 < 0xE0) {
         if (UNLIKELY(p + 2 >= end)) {
             *ptr = end;
             return 0;

--- a/src/lib/zxc_decompress.c
+++ b/src/lib/zxc_decompress.c
@@ -692,7 +692,7 @@ static int zxc_decode_block_glo(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRIC
                 zxc_copy32(out, ref);                                \
             }                                                        \
             d_ptr += ml;                                             \
-        } else if (LIKELY(off >= (ZXC_PAD_SIZE / 2))) {                \
+        } else if (LIKELY(off >= (ZXC_PAD_SIZE / 2))) {              \
             zxc_copy16(d_ptr, match_src);                            \
             if (UNLIKELY(ml > (ZXC_PAD_SIZE / 2))) {                 \
                 uint8_t* out = d_ptr + (ZXC_PAD_SIZE / 2);           \
@@ -1187,7 +1187,7 @@ static int zxc_decode_block_ghi(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRIC
                 zxc_copy32(out, ref);                                \
             }                                                        \
             d_ptr += ml;                                             \
-        } else if (LIKELY(off >= (ZXC_PAD_SIZE / 2))) {                \
+        } else if (LIKELY(off >= (ZXC_PAD_SIZE / 2))) {              \
             zxc_copy16(d_ptr, match_src);                            \
             if (UNLIKELY(ml > (ZXC_PAD_SIZE / 2))) {                 \
                 uint8_t* out = d_ptr + (ZXC_PAD_SIZE / 2);           \

--- a/src/lib/zxc_decompress.c
+++ b/src/lib/zxc_decompress.c
@@ -67,11 +67,11 @@ static ZXC_ALWAYS_INLINE uint32_t zxc_br_consume_fast(zxc_bit_reader_t* br, uint
  * the total length (1-5 bytes).
  *
  * Format:
- * - 1 byte (0xxxxxxx): 7 bits (val < 128)
- * - 2 bytes (10xxxxxx ...): 14 bits (val < 16384)
- * - 3 bytes (110xxxxx ...): 21 bits (val < 2M)
- * - 4 bytes (1110xxxx ...): 28 bits (val < 256M)
- * - 5 bytes (11110xxx ...): 32 bits (Full Range)
+ * - 1 byte  (0xxxxxxx):  7-bit payload (val < 2^7  = 128)
+ * - 2 bytes (10xxxxxx): 14-bit payload (val < 2^14 = 16 384)
+ * - 3 bytes (110xxxxx): 21-bit payload (val < 2^21 = 2 097 152)
+ * - 4 bytes (1110xxxx): 28-bit payload (val < 2^28 = 268 435 456)
+ * - 5 bytes (11110xxx): 32-bit payload (full uint32_t range)
  *
  * @param[in,out] ptr Pointer to a pointer to the current position in the stream.
  * @param[in] end Pointer to the end of the readable stream (for bounds checking).
@@ -84,14 +84,14 @@ static ZXC_ALWAYS_INLINE uint32_t zxc_read_varint(const uint8_t** ptr, const uin
 
     const uint32_t b0 = p[0];
 
-    // 1 Byte: 0xxxxxxx (7 bits) -> val < 128
-    if (LIKELY(b0 < 128)) {
+    // 1 Byte: 0xxxxxxx (7 bits)
+    if (LIKELY(b0 < 0x80)) {
         *ptr = p + 1;
         return b0;
     }
 
     // 2 Bytes: 10xxxxxx xxxxxxxx (14 bits)
-    if (b0 < 0xC0) {
+    if (LIKELY(b0 < 0xC0)) {
         if (UNLIKELY(p + 1 >= end)) {
             *ptr = end;
             return 0;

--- a/src/lib/zxc_decompress.c
+++ b/src/lib/zxc_decompress.c
@@ -692,7 +692,7 @@ static int zxc_decode_block_glo(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRIC
                 zxc_copy32(out, ref);                                \
             }                                                        \
             d_ptr += ml;                                             \
-        } else if (LIKELY(off >= (ZXC_PAD_SIZE / 2))) {              \
+        } else if (off >= (ZXC_PAD_SIZE / 2)) {                      \
             zxc_copy16(d_ptr, match_src);                            \
             if (UNLIKELY(ml > (ZXC_PAD_SIZE / 2))) {                 \
                 uint8_t* out = d_ptr + (ZXC_PAD_SIZE / 2);           \
@@ -706,6 +706,9 @@ static int zxc_decode_block_glo(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRIC
                 }                                                    \
                 zxc_copy16(out, ref);                                \
             }                                                        \
+            d_ptr += ml;                                             \
+        } else if (off == 1) {                                       \
+            ZXC_MEMSET(d_ptr, match_src[0], ml);                     \
             d_ptr += ml;                                             \
         } else {                                                     \
             size_t copied = 0;                                       \
@@ -1184,7 +1187,7 @@ static int zxc_decode_block_ghi(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRIC
                 zxc_copy32(out, ref);                                \
             }                                                        \
             d_ptr += ml;                                             \
-        } else if (LIKELY(off >= (ZXC_PAD_SIZE / 2))) {              \
+        } else if (off >= (ZXC_PAD_SIZE / 2)) {                      \
             zxc_copy16(d_ptr, match_src);                            \
             if (UNLIKELY(ml > (ZXC_PAD_SIZE / 2))) {                 \
                 uint8_t* out = d_ptr + (ZXC_PAD_SIZE / 2);           \
@@ -1198,6 +1201,9 @@ static int zxc_decode_block_ghi(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRIC
                 }                                                    \
                 zxc_copy16(out, ref);                                \
             }                                                        \
+            d_ptr += ml;                                             \
+        } else if (off == 1) {                                       \
+            ZXC_MEMSET(d_ptr, match_src[0], ml);                     \
             d_ptr += ml;                                             \
         } else {                                                     \
             size_t copied = 0;                                       \

--- a/src/lib/zxc_decompress.c
+++ b/src/lib/zxc_decompress.c
@@ -776,11 +776,10 @@ static int zxc_decode_block_glo(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRIC
         }
         if (UNLIKELY(ml1 == ZXC_TOKEN_ML_MASK)) {
             ml1 += zxc_read_varint(&e_ptr, e_end);
-            ml1 += ZXC_LZ_MIN_MATCH_LEN;
-            if (UNLIKELY(d_ptr + ll1 + ml1 + ZXC_PAD_SIZE > d_end)) return ZXC_ERROR_OVERFLOW;
-        } else {
-            ml1 += ZXC_LZ_MIN_MATCH_LEN;
+            if (UNLIKELY(d_ptr + ll1 + ml1 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE > d_end))
+                return ZXC_ERROR_OVERFLOW;
         }
+        ml1 += ZXC_LZ_MIN_MATCH_LEN;
         DECODE_SEQ_SAFE(ll1, ml1, off1);
 
         uint32_t ll2 = (tokens & 0x0F000) >> 12;
@@ -792,11 +791,10 @@ static int zxc_decode_block_glo(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRIC
         }
         if (UNLIKELY(ml2 == ZXC_TOKEN_ML_MASK)) {
             ml2 += zxc_read_varint(&e_ptr, e_end);
-            ml2 += ZXC_LZ_MIN_MATCH_LEN;
-            if (UNLIKELY(d_ptr + ll2 + ml2 + ZXC_PAD_SIZE > d_end)) return ZXC_ERROR_OVERFLOW;
-        } else {
-            ml2 += ZXC_LZ_MIN_MATCH_LEN;
+            if (UNLIKELY(d_ptr + ll2 + ml2 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE > d_end))
+                return ZXC_ERROR_OVERFLOW;
         }
+        ml2 += ZXC_LZ_MIN_MATCH_LEN;
         DECODE_SEQ_SAFE(ll2, ml2, off2);
 
         uint32_t ll3 = (tokens & 0x0F00000) >> 20;
@@ -808,11 +806,10 @@ static int zxc_decode_block_glo(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRIC
         }
         if (UNLIKELY(ml3 == ZXC_TOKEN_ML_MASK)) {
             ml3 += zxc_read_varint(&e_ptr, e_end);
-            ml3 += ZXC_LZ_MIN_MATCH_LEN;
-            if (UNLIKELY(d_ptr + ll3 + ml3 + ZXC_PAD_SIZE > d_end)) return ZXC_ERROR_OVERFLOW;
-        } else {
-            ml3 += ZXC_LZ_MIN_MATCH_LEN;
+            if (UNLIKELY(d_ptr + ll3 + ml3 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE > d_end))
+                return ZXC_ERROR_OVERFLOW;
         }
+        ml3 += ZXC_LZ_MIN_MATCH_LEN;
         DECODE_SEQ_SAFE(ll3, ml3, off3);
 
         uint32_t ll4 = (tokens >> 28);
@@ -824,11 +821,10 @@ static int zxc_decode_block_glo(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRIC
         }
         if (UNLIKELY(ml4 == ZXC_TOKEN_ML_MASK)) {
             ml4 += zxc_read_varint(&e_ptr, e_end);
-            ml4 += ZXC_LZ_MIN_MATCH_LEN;
-            if (UNLIKELY(d_ptr + ll4 + ml4 + ZXC_PAD_SIZE > d_end)) return ZXC_ERROR_OVERFLOW;
-        } else {
-            ml4 += ZXC_LZ_MIN_MATCH_LEN;
+            if (UNLIKELY(d_ptr + ll4 + ml4 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE > d_end))
+                return ZXC_ERROR_OVERFLOW;
         }
+        ml4 += ZXC_LZ_MIN_MATCH_LEN;
         DECODE_SEQ_SAFE(ll4, ml4, off4);
 
         n_seq -= 4;
@@ -868,11 +864,10 @@ static int zxc_decode_block_glo(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRIC
         }
         if (UNLIKELY(ml1 == ZXC_TOKEN_ML_MASK)) {
             ml1 += zxc_read_varint(&e_ptr, e_end);
-            ml1 += ZXC_LZ_MIN_MATCH_LEN;
-            if (UNLIKELY(d_ptr + ll1 + ml1 + ZXC_PAD_SIZE > d_end)) return ZXC_ERROR_OVERFLOW;
-        } else {
-            ml1 += ZXC_LZ_MIN_MATCH_LEN;
+            if (UNLIKELY(d_ptr + ll1 + ml1 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE > d_end))
+                return ZXC_ERROR_OVERFLOW;
         }
+        ml1 += ZXC_LZ_MIN_MATCH_LEN;
         DECODE_SEQ_FAST(ll1, ml1, off1);
 
         uint32_t ll2 = (tokens & 0x0F000) >> 12;
@@ -884,11 +879,10 @@ static int zxc_decode_block_glo(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRIC
         }
         if (UNLIKELY(ml2 == ZXC_TOKEN_ML_MASK)) {
             ml2 += zxc_read_varint(&e_ptr, e_end);
-            ml2 += ZXC_LZ_MIN_MATCH_LEN;
-            if (UNLIKELY(d_ptr + ll2 + ml2 + ZXC_PAD_SIZE > d_end)) return ZXC_ERROR_OVERFLOW;
-        } else {
-            ml2 += ZXC_LZ_MIN_MATCH_LEN;
+            if (UNLIKELY(d_ptr + ll2 + ml2 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE > d_end))
+                return ZXC_ERROR_OVERFLOW;
         }
+        ml2 += ZXC_LZ_MIN_MATCH_LEN;
         DECODE_SEQ_FAST(ll2, ml2, off2);
 
         uint32_t ll3 = (tokens & 0x0F00000) >> 20;
@@ -900,11 +894,10 @@ static int zxc_decode_block_glo(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRIC
         }
         if (UNLIKELY(ml3 == ZXC_TOKEN_ML_MASK)) {
             ml3 += zxc_read_varint(&e_ptr, e_end);
-            ml3 += ZXC_LZ_MIN_MATCH_LEN;
-            if (UNLIKELY(d_ptr + ll3 + ml3 + ZXC_PAD_SIZE > d_end)) return ZXC_ERROR_OVERFLOW;
-        } else {
-            ml3 += ZXC_LZ_MIN_MATCH_LEN;
+            if (UNLIKELY(d_ptr + ll3 + ml3 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE > d_end))
+                return ZXC_ERROR_OVERFLOW;
         }
+        ml3 += ZXC_LZ_MIN_MATCH_LEN;
         DECODE_SEQ_FAST(ll3, ml3, off3);
 
         uint32_t ll4 = (tokens >> 28);
@@ -916,11 +909,10 @@ static int zxc_decode_block_glo(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRIC
         }
         if (UNLIKELY(ml4 == ZXC_TOKEN_ML_MASK)) {
             ml4 += zxc_read_varint(&e_ptr, e_end);
-            ml4 += ZXC_LZ_MIN_MATCH_LEN;
-            if (UNLIKELY(d_ptr + ll4 + ml4 + ZXC_PAD_SIZE > d_end)) return ZXC_ERROR_OVERFLOW;
-        } else {
-            ml4 += ZXC_LZ_MIN_MATCH_LEN;
+            if (UNLIKELY(d_ptr + ll4 + ml4 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE > d_end))
+                return ZXC_ERROR_OVERFLOW;
         }
+        ml4 += ZXC_LZ_MIN_MATCH_LEN;
         DECODE_SEQ_FAST(ll4, ml4, off4);
 
         n_seq -= 4;

--- a/src/lib/zxc_internal.h
+++ b/src/lib/zxc_internal.h
@@ -789,13 +789,13 @@ static ZXC_ALWAYS_INLINE uint8_t zxc_hash8(const uint8_t* p) {
  * @return uint16_t The computed hash value.
  */
 static ZXC_ALWAYS_INLINE uint16_t zxc_hash16(const uint8_t* p) {
-    const uint64_t h1 = zxc_le64(p);
-    const uint64_t h2 = zxc_le64(p + 8);
-    uint64_t h = h1 ^ h2 ^ ZXC_HASH_PRIME2;
+    const uint64_t v1 = zxc_le64(p);
+    const uint64_t v2 = zxc_le64(p + 8);
+    uint64_t h = v1 ^ v2 ^ ZXC_HASH_PRIME2;
     h ^= h << 13;
     h ^= h >> 7;
     h ^= h << 17;
-    uint32_t res = (uint32_t)((h >> 32) ^ h);
+    const uint32_t res = (uint32_t)((h >> 32) ^ h);
     return (uint16_t)((res >> 16) ^ res);
 }
 


### PR DESCRIPTION
Eliminates LIKELY() macros from varint read and write functions. These hints are often inaccurate as they depend on input data distributions, and removing them allows the hardware branch predictor to adapt more effectively to the actual stream characteristics.
