### PR TITLE
Refines decompression match length and varint

### DIFF
--- a/src/lib/zxc_decompress.c
+++ b/src/lib/zxc_decompress.c
@@ -494,9 +494,9 @@ static int zxc_decode_block_num(const uint8_t* RESTRICT src, const size_t src_si
  * a negative zxc_error_t code on failure (e.g., invalid header, buffer overflow, or corrupted
  * data).
  */
-static ZXC_HOT int zxc_decode_block_glo(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRICT src,
-                                        const size_t src_size, uint8_t* RESTRICT dst,
-                                        const size_t dst_capacity) {
+static int zxc_decode_block_glo(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRICT src,
+                                const size_t src_size, uint8_t* RESTRICT dst,
+                                const size_t dst_capacity) {
     zxc_gnr_header_t gh;
     zxc_section_desc_t desc[ZXC_GLO_SECTIONS];
 
@@ -1083,9 +1083,9 @@ static ZXC_HOT int zxc_decode_block_glo(zxc_cctx_t* RESTRICT ctx, const uint8_t*
  * @return int Returns the number of bytes written on success, or a negative zxc_error_t code on
  * failure.
  */
-static ZXC_HOT int zxc_decode_block_ghi(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRICT src,
-                                        const size_t src_size, uint8_t* RESTRICT dst,
-                                        const size_t dst_capacity) {
+static int zxc_decode_block_ghi(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRICT src,
+                                const size_t src_size, uint8_t* RESTRICT dst,
+                                const size_t dst_capacity) {
     (void)ctx;
     zxc_gnr_header_t gh;
     zxc_section_desc_t desc[ZXC_GHI_SECTIONS];

--- a/src/lib/zxc_decompress.c
+++ b/src/lib/zxc_decompress.c
@@ -1013,7 +1013,13 @@ static int zxc_decode_block_glo(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRIC
                 d_ptr += ml;
                 written += ml;
             } else {
-                for (size_t i = 0; i < ml; i++) d_ptr[i] = match_src[i];
+                for (uint32_t i = 0; i < offset; i++) d_ptr[i] = match_src[i];
+                uint32_t copied = offset;
+                while (copied < ml) {
+                    uint32_t n = copied < ml - copied ? copied : ml - copied;
+                    ZXC_MEMCPY(d_ptr + copied, d_ptr, n);
+                    copied += n;
+                }
                 d_ptr += ml;
                 written += ml;
             }
@@ -1047,7 +1053,13 @@ static int zxc_decode_block_glo(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRIC
         if (UNLIKELY(match_src < dst || d_ptr + ml > d_end)) return ZXC_ERROR_BAD_OFFSET;
 
         if (offset < ml) {
-            for (size_t i = 0; i < ml; i++) d_ptr[i] = match_src[i];
+            for (uint32_t i = 0; i < offset; i++) d_ptr[i] = match_src[i];
+            uint32_t copied = offset;
+            while (copied < ml) {
+                uint32_t n = copied < ml - copied ? copied : ml - copied;
+                ZXC_MEMCPY(d_ptr + copied, d_ptr, n);
+                copied += n;
+            }
         } else {
             ZXC_MEMCPY(d_ptr, match_src, ml);
         }
@@ -1327,7 +1339,13 @@ static int zxc_decode_block_ghi(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRIC
             const uint8_t* match_src = d_ptr - offset;
 
             if (offset < ml) {
-                for (size_t i = 0; i < ml; i++) d_ptr[i] = match_src[i];
+                for (uint32_t i = 0; i < offset; i++) d_ptr[i] = match_src[i];
+                uint32_t copied = offset;
+                while (copied < ml) {
+                    uint32_t n = copied < ml - copied ? copied : ml - copied;
+                    ZXC_MEMCPY(d_ptr + copied, d_ptr, n);
+                    copied += n;
+                }
             } else {
                 ZXC_MEMCPY(d_ptr, match_src, ml);
             }
@@ -1499,7 +1517,13 @@ static int zxc_decode_block_ghi(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRIC
                 d_ptr += ml;
                 written += ml;
             } else {
-                for (size_t i = 0; i < ml; i++) d_ptr[i] = match_src[i];
+                for (uint32_t i = 0; i < offset; i++) d_ptr[i] = match_src[i];
+                uint32_t copied = offset;
+                while (copied < ml) {
+                    uint32_t n = copied < ml - copied ? copied : ml - copied;
+                    ZXC_MEMCPY(d_ptr + copied, d_ptr, n);
+                    copied += n;
+                }
                 d_ptr += ml;
                 written += ml;
             }
@@ -1529,7 +1553,13 @@ static int zxc_decode_block_ghi(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRIC
         if (UNLIKELY(match_src < dst || d_ptr + ml > d_end)) return ZXC_ERROR_BAD_OFFSET;
 
         if (offset < ml) {
-            for (size_t i = 0; i < ml; i++) d_ptr[i] = match_src[i];
+            for (uint32_t i = 0; i < offset; i++) d_ptr[i] = match_src[i];
+            uint32_t copied = offset;
+            while (copied < ml) {
+                uint32_t n = copied < ml - copied ? copied : ml - copied;
+                ZXC_MEMCPY(d_ptr + copied, d_ptr, n);
+                copied += n;
+            }
         } else {
             ZXC_MEMCPY(d_ptr, match_src, ml);
         }

--- a/src/lib/zxc_decompress.c
+++ b/src/lib/zxc_decompress.c
@@ -45,7 +45,8 @@
  * depending on implementation).
  * @return The value of the consumed bits as a 32-bit unsigned integer.
  */
-static ZXC_ALWAYS_INLINE uint32_t zxc_br_consume_fast(zxc_bit_reader_t* RESTRICT br, const uint8_t n) {
+static ZXC_ALWAYS_INLINE uint32_t zxc_br_consume_fast(zxc_bit_reader_t* RESTRICT br,
+                                                      const uint8_t n) {
 #if !defined(ZXC_DISABLE_SIMD) && defined(__BMI2__) && (defined(__x86_64__) || defined(_M_X64))
     // BMI2 Optimization: _bzhi_u64(x, n) copies the lower n bits of x to dst and
     // clears the rest. It is equivalent to x & ((1ULL << n) - 1) but executes in

--- a/src/lib/zxc_decompress.c
+++ b/src/lib/zxc_decompress.c
@@ -84,13 +84,13 @@ static ZXC_ALWAYS_INLINE uint32_t zxc_read_varint(const uint8_t** ptr, const uin
 
     const uint32_t b0 = p[0];
 
-    // 1 Byte: 0xxxxxxx (7 bits) -> val < 128
+    // 1 Byte: 0xxxxxxx (7 bits) -> val < 128 (2^7)
     if (LIKELY(b0 < 0x80)) {
         *ptr = p + 1;
         return b0;
     }
 
-    // 2 Bytes: 10xxxxxx xxxxxxxx (14 bits)
+    // 2 Bytes: 10xxxxxx xxxxxxxx (14 bits) -> val < 16384 (2^14)
     if (LIKELY(b0 < 0xC0)) {
         if (UNLIKELY(p + 1 >= end)) {
             *ptr = end;
@@ -100,7 +100,7 @@ static ZXC_ALWAYS_INLINE uint32_t zxc_read_varint(const uint8_t** ptr, const uin
         return (b0 & 0x3F) | ((uint32_t)p[1] << 6);
     }
 
-    // 3 Bytes: 110xxxxx xxxxxxxx xxxxxxxx (21 bits)
+    // 3 Bytes: 110xxxxx xxxxxxxx xxxxxxxx (21 bits) -> val < 2097152 (2^21)
     if (LIKELY(b0 < 0xE0)) {
         if (UNLIKELY(p + 2 >= end)) {
             *ptr = end;
@@ -110,7 +110,7 @@ static ZXC_ALWAYS_INLINE uint32_t zxc_read_varint(const uint8_t** ptr, const uin
         return (b0 & 0x1F) | ((uint32_t)p[1] << 5) | ((uint32_t)p[2] << 13);
     }
 
-    // 4 Bytes: 1110xxxx ... (28 bits)
+    // 4 Bytes: 1110xxxx ... (28 bits) -> val < 268435456 (2^28)
     if (UNLIKELY(b0 < 0xF0)) {
         if (UNLIKELY(p + 3 >= end)) {
             *ptr = end;
@@ -121,7 +121,7 @@ static ZXC_ALWAYS_INLINE uint32_t zxc_read_varint(const uint8_t** ptr, const uin
                ((uint32_t)p[3] << 20);
     }
 
-    // 5 Bytes: 11110xxx ... (32 bits)
+    // 5 Bytes: 11110xxx ... (32 bits) -> val < 4294967296 (2^32)
     if (UNLIKELY(p + 4 >= end)) {
         *ptr = end;
         return 0;
@@ -494,7 +494,7 @@ static int zxc_decode_block_num(const uint8_t* RESTRICT src, const size_t src_si
  * a negative zxc_error_t code on failure (e.g., invalid header, buffer overflow, or corrupted
  * data).
  */
-static int zxc_decode_block_glo(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRICT src,
+static ZXC_HOT int zxc_decode_block_glo(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRICT src,
                                 const size_t src_size, uint8_t* RESTRICT dst,
                                 const size_t dst_capacity) {
     zxc_gnr_header_t gh;
@@ -1083,7 +1083,7 @@ static int zxc_decode_block_glo(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRIC
  * @return int Returns the number of bytes written on success, or a negative zxc_error_t code on
  * failure.
  */
-static int zxc_decode_block_ghi(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRICT src,
+static ZXC_HOT int zxc_decode_block_ghi(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRICT src,
                                 const size_t src_size, uint8_t* RESTRICT dst,
                                 const size_t dst_capacity) {
     (void)ctx;

--- a/src/lib/zxc_decompress.c
+++ b/src/lib/zxc_decompress.c
@@ -495,8 +495,8 @@ static int zxc_decode_block_num(const uint8_t* RESTRICT src, const size_t src_si
  * data).
  */
 static ZXC_HOT int zxc_decode_block_glo(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRICT src,
-                                const size_t src_size, uint8_t* RESTRICT dst,
-                                const size_t dst_capacity) {
+                                        const size_t src_size, uint8_t* RESTRICT dst,
+                                        const size_t dst_capacity) {
     zxc_gnr_header_t gh;
     zxc_section_desc_t desc[ZXC_GLO_SECTIONS];
 
@@ -1084,8 +1084,8 @@ static ZXC_HOT int zxc_decode_block_glo(zxc_cctx_t* RESTRICT ctx, const uint8_t*
  * failure.
  */
 static ZXC_HOT int zxc_decode_block_ghi(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRICT src,
-                                const size_t src_size, uint8_t* RESTRICT dst,
-                                const size_t dst_capacity) {
+                                        const size_t src_size, uint8_t* RESTRICT dst,
+                                        const size_t dst_capacity) {
     (void)ctx;
     zxc_gnr_header_t gh;
     zxc_section_desc_t desc[ZXC_GHI_SECTIONS];

--- a/src/lib/zxc_decompress.c
+++ b/src/lib/zxc_decompress.c
@@ -45,7 +45,7 @@
  * depending on implementation).
  * @return The value of the consumed bits as a 32-bit unsigned integer.
  */
-static ZXC_ALWAYS_INLINE uint32_t zxc_br_consume_fast(zxc_bit_reader_t* br, uint8_t n) {
+static ZXC_ALWAYS_INLINE uint32_t zxc_br_consume_fast(zxc_bit_reader_t* RESTRICT br, const uint8_t n) {
 #if !defined(ZXC_DISABLE_SIMD) && defined(__BMI2__) && (defined(__x86_64__) || defined(_M_X64))
     // BMI2 Optimization: _bzhi_u64(x, n) copies the lower n bits of x to dst and
     // clears the rest. It is equivalent to x & ((1ULL << n) - 1) but executes in
@@ -185,7 +185,7 @@ static const ZXC_ALIGN(16) uint8_t zxc_overlap_masks[16][16] = {
  *                 (i.e., source address is `dst - off`).
  */
 // codeql[cpp/unused-static-function] : False positive, used in DECODE_SEQ_SAFE/FAST macros
-static ZXC_ALWAYS_INLINE void zxc_copy_overlap16(uint8_t* dst, uint32_t off) {
+static ZXC_ALWAYS_INLINE void zxc_copy_overlap16(uint8_t* dst, const uint32_t off) {
     // off is always >= ZXC_LZ_OFFSET_BIAS by design (offset bias encoding: stored +
     // ZXC_LZ_OFFSET_BIAS)
 #if defined(ZXC_USE_NEON64)

--- a/src/lib/zxc_decompress.c
+++ b/src/lib/zxc_decompress.c
@@ -67,11 +67,11 @@ static ZXC_ALWAYS_INLINE uint32_t zxc_br_consume_fast(zxc_bit_reader_t* br, uint
  * the total length (1-5 bytes).
  *
  * Format:
- * - 1 byte (0xxxxxxx): 7 bits (val < 128)
- * - 2 bytes (10xxxxxx ...): 14 bits (val < 16384)
- * - 3 bytes (110xxxxx ...): 21 bits (val < 2M)
- * - 4 bytes (1110xxxx ...): 28 bits (val < 256M)
- * - 5 bytes (11110xxx ...): 32 bits (Full Range)
+ * - 1 byte  (0xxxxxxx):  7-bit payload (val < 2^7  = 128)
+ * - 2 bytes (10xxxxxx): 14-bit payload (val < 2^14 = 16384)
+ * - 3 bytes (110xxxxx): 21-bit payload (val < 2^21 = 2097152)
+ * - 4 bytes (1110xxxx): 28-bit payload (val < 2^28 = 268435456)
+ * - 5 bytes (11110xxx): 32-bit payload (full uint32_t range)
  *
  * @param[in,out] ptr Pointer to a pointer to the current position in the stream.
  * @param[in] end Pointer to the end of the readable stream (for bounds checking).
@@ -85,7 +85,7 @@ static ZXC_ALWAYS_INLINE uint32_t zxc_read_varint(const uint8_t** ptr, const uin
     const uint32_t b0 = p[0];
 
     // 1 Byte: 0xxxxxxx (7 bits) -> val < 128
-    if (LIKELY(b0 < 128)) {
+    if (LIKELY(b0 < 0x80)) {
         *ptr = p + 1;
         return b0;
     }

--- a/src/lib/zxc_decompress.c
+++ b/src/lib/zxc_decompress.c
@@ -776,11 +776,10 @@ static int zxc_decode_block_glo(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRIC
         }
         if (UNLIKELY(ml1 == ZXC_TOKEN_ML_MASK)) {
             ml1 += zxc_read_varint(&e_ptr, e_end);
-            ml1 += ZXC_LZ_MIN_MATCH_LEN;
-            if (UNLIKELY(d_ptr + ll1 + ml1 + ZXC_PAD_SIZE > d_end)) return ZXC_ERROR_OVERFLOW;
-        } else {
-            ml1 += ZXC_LZ_MIN_MATCH_LEN;
+            if (UNLIKELY(d_ptr + ll1 + ml1 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE > d_end))
+                return ZXC_ERROR_OVERFLOW;
         }
+        ml1 += ZXC_LZ_MIN_MATCH_LEN;
         DECODE_SEQ_SAFE(ll1, ml1, off1);
 
         uint32_t ll2 = (tokens & 0x0F000) >> 12;
@@ -792,11 +791,10 @@ static int zxc_decode_block_glo(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRIC
         }
         if (UNLIKELY(ml2 == ZXC_TOKEN_ML_MASK)) {
             ml2 += zxc_read_varint(&e_ptr, e_end);
-            ml2 += ZXC_LZ_MIN_MATCH_LEN;
-            if (UNLIKELY(d_ptr + ll2 + ml2 + ZXC_PAD_SIZE > d_end)) return ZXC_ERROR_OVERFLOW;
-        } else {
-            ml2 += ZXC_LZ_MIN_MATCH_LEN;
+            if (UNLIKELY(d_ptr + ll2 + ml2 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE > d_end))
+                return ZXC_ERROR_OVERFLOW;
         }
+        ml2 += ZXC_LZ_MIN_MATCH_LEN;
         DECODE_SEQ_SAFE(ll2, ml2, off2);
 
         uint32_t ll3 = (tokens & 0x0F00000) >> 20;
@@ -808,11 +806,10 @@ static int zxc_decode_block_glo(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRIC
         }
         if (UNLIKELY(ml3 == ZXC_TOKEN_ML_MASK)) {
             ml3 += zxc_read_varint(&e_ptr, e_end);
-            ml3 += ZXC_LZ_MIN_MATCH_LEN;
-            if (UNLIKELY(d_ptr + ll3 + ml3 + ZXC_PAD_SIZE > d_end)) return ZXC_ERROR_OVERFLOW;
-        } else {
-            ml3 += ZXC_LZ_MIN_MATCH_LEN;
+            if (UNLIKELY(d_ptr + ll3 + ml3 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE > d_end))
+                return ZXC_ERROR_OVERFLOW;
         }
+        ml3 += ZXC_LZ_MIN_MATCH_LEN;
         DECODE_SEQ_SAFE(ll3, ml3, off3);
 
         uint32_t ll4 = (tokens >> 28);
@@ -824,11 +821,10 @@ static int zxc_decode_block_glo(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRIC
         }
         if (UNLIKELY(ml4 == ZXC_TOKEN_ML_MASK)) {
             ml4 += zxc_read_varint(&e_ptr, e_end);
-            ml4 += ZXC_LZ_MIN_MATCH_LEN;
-            if (UNLIKELY(d_ptr + ll4 + ml4 + ZXC_PAD_SIZE > d_end)) return ZXC_ERROR_OVERFLOW;
-        } else {
-            ml4 += ZXC_LZ_MIN_MATCH_LEN;
+            if (UNLIKELY(d_ptr + ll4 + ml4 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE > d_end))
+                return ZXC_ERROR_OVERFLOW;
         }
+        ml4 += ZXC_LZ_MIN_MATCH_LEN;
         DECODE_SEQ_SAFE(ll4, ml4, off4);
 
         n_seq -= 4;
@@ -868,11 +864,10 @@ static int zxc_decode_block_glo(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRIC
         }
         if (UNLIKELY(ml1 == ZXC_TOKEN_ML_MASK)) {
             ml1 += zxc_read_varint(&e_ptr, e_end);
-            ml1 += ZXC_LZ_MIN_MATCH_LEN;
-            if (UNLIKELY(d_ptr + ll1 + ml1 + ZXC_PAD_SIZE > d_end)) return ZXC_ERROR_OVERFLOW;
-        } else {
-            ml1 += ZXC_LZ_MIN_MATCH_LEN;
+            if (UNLIKELY(d_ptr + ll1 + ml1 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE > d_end))
+                return ZXC_ERROR_OVERFLOW;
         }
+        ml1 += ZXC_LZ_MIN_MATCH_LEN;
         DECODE_SEQ_FAST(ll1, ml1, off1);
 
         uint32_t ll2 = (tokens & 0x0F000) >> 12;
@@ -884,11 +879,10 @@ static int zxc_decode_block_glo(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRIC
         }
         if (UNLIKELY(ml2 == ZXC_TOKEN_ML_MASK)) {
             ml2 += zxc_read_varint(&e_ptr, e_end);
-            ml2 += ZXC_LZ_MIN_MATCH_LEN;
-            if (UNLIKELY(d_ptr + ll2 + ml2 + ZXC_PAD_SIZE > d_end)) return ZXC_ERROR_OVERFLOW;
-        } else {
-            ml2 += ZXC_LZ_MIN_MATCH_LEN;
+            if (UNLIKELY(d_ptr + ll2 + ml2 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE > d_end))
+                return ZXC_ERROR_OVERFLOW;
         }
+        ml2 += ZXC_LZ_MIN_MATCH_LEN;
         DECODE_SEQ_FAST(ll2, ml2, off2);
 
         uint32_t ll3 = (tokens & 0x0F00000) >> 20;
@@ -900,11 +894,10 @@ static int zxc_decode_block_glo(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRIC
         }
         if (UNLIKELY(ml3 == ZXC_TOKEN_ML_MASK)) {
             ml3 += zxc_read_varint(&e_ptr, e_end);
-            ml3 += ZXC_LZ_MIN_MATCH_LEN;
-            if (UNLIKELY(d_ptr + ll3 + ml3 + ZXC_PAD_SIZE > d_end)) return ZXC_ERROR_OVERFLOW;
-        } else {
-            ml3 += ZXC_LZ_MIN_MATCH_LEN;
+            if (UNLIKELY(d_ptr + ll3 + ml3 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE > d_end))
+                return ZXC_ERROR_OVERFLOW;
         }
+        ml3 += ZXC_LZ_MIN_MATCH_LEN;
         DECODE_SEQ_FAST(ll3, ml3, off3);
 
         uint32_t ll4 = (tokens >> 28);
@@ -916,11 +909,10 @@ static int zxc_decode_block_glo(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRIC
         }
         if (UNLIKELY(ml4 == ZXC_TOKEN_ML_MASK)) {
             ml4 += zxc_read_varint(&e_ptr, e_end);
-            ml4 += ZXC_LZ_MIN_MATCH_LEN;
-            if (UNLIKELY(d_ptr + ll4 + ml4 + ZXC_PAD_SIZE > d_end)) return ZXC_ERROR_OVERFLOW;
-        } else {
-            ml4 += ZXC_LZ_MIN_MATCH_LEN;
+            if (UNLIKELY(d_ptr + ll4 + ml4 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE > d_end))
+                return ZXC_ERROR_OVERFLOW;
         }
+        ml4 += ZXC_LZ_MIN_MATCH_LEN;
         DECODE_SEQ_FAST(ll4, ml4, off4);
 
         n_seq -= 4;

--- a/src/lib/zxc_internal.h
+++ b/src/lib/zxc_internal.h
@@ -172,6 +172,10 @@ extern "C" {
  * @brief Forces a function to be inlined at all optimization levels.
  */
 #define ZXC_ALWAYS_INLINE inline __attribute__((always_inline))
+/** @def ZXC_HOT
+ * @brief Marks a function as a hot path for aggressive optimization and code layout.
+ */
+#define ZXC_HOT __attribute__((hot))
 
 #elif defined(_MSC_VER)
 #include <intrin.h>
@@ -200,6 +204,7 @@ extern "C" {
  * @brief Forces a function to be inlined at all optimization levels (MSVC).
  */
 #define ZXC_ALWAYS_INLINE __forceinline
+#define ZXC_HOT
 #pragma intrinsic(_BitScanReverse)
 #else
 #define LIKELY(x) (x)
@@ -214,6 +219,7 @@ extern "C" {
  * @brief Forces a function to be inlined (fallback for non-GCC/Clang/MSVC compilers).
  */
 #define ZXC_ALWAYS_INLINE inline
+#define ZXC_HOT
 
 #if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L
 #include <stdalign.h>

--- a/src/lib/zxc_internal.h
+++ b/src/lib/zxc_internal.h
@@ -172,10 +172,6 @@ extern "C" {
  * @brief Forces a function to be inlined at all optimization levels.
  */
 #define ZXC_ALWAYS_INLINE inline __attribute__((always_inline))
-/** @def ZXC_HOT
- * @brief Marks a function as a hot path for aggressive optimization and code layout.
- */
-#define ZXC_HOT __attribute__((hot))
 
 #elif defined(_MSC_VER)
 #include <intrin.h>
@@ -204,7 +200,6 @@ extern "C" {
  * @brief Forces a function to be inlined at all optimization levels (MSVC).
  */
 #define ZXC_ALWAYS_INLINE __forceinline
-#define ZXC_HOT
 #pragma intrinsic(_BitScanReverse)
 #else
 #define LIKELY(x) (x)
@@ -219,7 +214,6 @@ extern "C" {
  * @brief Forces a function to be inlined (fallback for non-GCC/Clang/MSVC compilers).
  */
 #define ZXC_ALWAYS_INLINE inline
-#define ZXC_HOT
 
 #if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L
 #include <stdalign.h>


### PR DESCRIPTION
Refines the decompression logic for improved correctness and clarity:

*   **Improves varint format documentation:** Updates the description of varint payload sizes and value ranges for better understanding. Also, uses a hexadecimal constant for a bitmask comparison for consistency.

*   **Simplifies match length calculation:** Moves the addition of `ZXC_LZ_MIN_MATCH_LEN` to match lengths (`mlX`) to execute unconditionally. This streamlines the logic by removing redundant additions within conditional blocks.

*   **Enhances overflow checks:** Adjusts buffer overflow checks to accurately account for `ZXC_LZ_MIN_MATCH_LEN` *before* it's added to the match length. This ensures a more precise and robust bounds check for the target buffer, preventing potential overflows during decompression.