### PR TITLE
Optimizes overlapping match copies in block decoding

### DIFF
--- a/src/lib/zxc_decompress.c
+++ b/src/lib/zxc_decompress.c
@@ -1014,7 +1014,13 @@ static int zxc_decode_block_glo(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRIC
                 d_ptr += ml;
                 written += ml;
             } else {
-                for (size_t i = 0; i < ml; i++) d_ptr[i] = match_src[i];
+                for (uint32_t i = 0; i < offset; i++) d_ptr[i] = match_src[i];
+                uint32_t copied = offset;
+                while (copied < ml) {
+                    uint32_t n = copied < ml - copied ? copied : ml - copied;
+                    ZXC_MEMCPY(d_ptr + copied, d_ptr, n);
+                    copied += n;
+                }
                 d_ptr += ml;
                 written += ml;
             }
@@ -1048,7 +1054,13 @@ static int zxc_decode_block_glo(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRIC
         if (UNLIKELY(match_src < dst || d_ptr + ml > d_end)) return ZXC_ERROR_BAD_OFFSET;
 
         if (offset < ml) {
-            for (size_t i = 0; i < ml; i++) d_ptr[i] = match_src[i];
+            for (uint32_t i = 0; i < offset; i++) d_ptr[i] = match_src[i];
+            uint32_t copied = offset;
+            while (copied < ml) {
+                uint32_t n = copied < ml - copied ? copied : ml - copied;
+                ZXC_MEMCPY(d_ptr + copied, d_ptr, n);
+                copied += n;
+            }
         } else {
             ZXC_MEMCPY(d_ptr, match_src, ml);
         }
@@ -1328,7 +1340,13 @@ static int zxc_decode_block_ghi(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRIC
             const uint8_t* match_src = d_ptr - offset;
 
             if (offset < ml) {
-                for (size_t i = 0; i < ml; i++) d_ptr[i] = match_src[i];
+                for (uint32_t i = 0; i < offset; i++) d_ptr[i] = match_src[i];
+                uint32_t copied = offset;
+                while (copied < ml) {
+                    uint32_t n = copied < ml - copied ? copied : ml - copied;
+                    ZXC_MEMCPY(d_ptr + copied, d_ptr, n);
+                    copied += n;
+                }
             } else {
                 ZXC_MEMCPY(d_ptr, match_src, ml);
             }
@@ -1500,7 +1518,13 @@ static int zxc_decode_block_ghi(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRIC
                 d_ptr += ml;
                 written += ml;
             } else {
-                for (size_t i = 0; i < ml; i++) d_ptr[i] = match_src[i];
+                for (uint32_t i = 0; i < offset; i++) d_ptr[i] = match_src[i];
+                uint32_t copied = offset;
+                while (copied < ml) {
+                    uint32_t n = copied < ml - copied ? copied : ml - copied;
+                    ZXC_MEMCPY(d_ptr + copied, d_ptr, n);
+                    copied += n;
+                }
                 d_ptr += ml;
                 written += ml;
             }
@@ -1530,7 +1554,13 @@ static int zxc_decode_block_ghi(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRIC
         if (UNLIKELY(match_src < dst || d_ptr + ml > d_end)) return ZXC_ERROR_BAD_OFFSET;
 
         if (offset < ml) {
-            for (size_t i = 0; i < ml; i++) d_ptr[i] = match_src[i];
+            for (uint32_t i = 0; i < offset; i++) d_ptr[i] = match_src[i];
+            uint32_t copied = offset;
+            while (copied < ml) {
+                uint32_t n = copied < ml - copied ? copied : ml - copied;
+                ZXC_MEMCPY(d_ptr + copied, d_ptr, n);
+                copied += n;
+            }
         } else {
             ZXC_MEMCPY(d_ptr, match_src, ml);
         }


### PR DESCRIPTION
Replaces byte-by-byte loops with a doubling algorithm that utilizes `ZXC_MEMCPY` when the match length exceeds the offset. This allows for more efficient data replication by using block transfers once the initial pattern is established.
