### PR TITLE
Adds seekable archives for random access

### DIFF
--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -8,7 +8,7 @@
 
 AVAILABLE_FUZZERS="decompress roundtrip"
 
-LIB_SOURCES="src/lib/zxc_common.c src/lib/zxc_compress.c src/lib/zxc_decompress.c src/lib/zxc_driver.c src/lib/zxc_dispatch.c"
+LIB_SOURCES="src/lib/zxc_common.c src/lib/zxc_compress.c src/lib/zxc_decompress.c src/lib/zxc_driver.c src/lib/zxc_dispatch.c src/lib/zxc_seekable.c"
 
 for fuzzer in $AVAILABLE_FUZZERS; do
     if [ -z "${FUZZER_TARGET:-}" ] || [ "${FUZZER_TARGET}" == "$fuzzer" ]; then

--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -123,7 +123,7 @@ jobs:
           CFLAGS="-g -O1 -fprofile-instr-generate -fcoverage-mapping"
           DEFS="-DZXC_FUNCTION_SUFFIX=_default -DZXC_ONLY_DEFAULT"
           INCLUDES="-I include -I src/lib/vendors"
-          SOURCES="src/lib/zxc_common.c src/lib/zxc_compress.c src/lib/zxc_decompress.c src/lib/zxc_driver.c src/lib/zxc_dispatch.c"
+          SOURCES="src/lib/zxc_common.c src/lib/zxc_compress.c src/lib/zxc_decompress.c src/lib/zxc_driver.c src/lib/zxc_dispatch.c src/lib/zxc_seekable.c"
 
           clang $CFLAGS $INCLUDES $DEFS $SOURCES tests/fuzz_roundtrip.c \
             -fsanitize=fuzzer -lm -lpthread -o build-cov/fuzz_roundtrip

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -240,7 +240,7 @@ add_library(zxc_lib
 # ABI Versioning (Debian/Linux shared libraries)
 # =============================================================================
 # Increment this number ONLY when breaking the ABI. 
-set(ZXC_SOVERSION 2)
+set(ZXC_SOVERSION 3)
 
 # Set library output name and version
 set_target_properties(zxc_lib PROPERTIES

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,7 +61,10 @@ set(CMAKE_C_STANDARD_REQUIRED ON)
 set(CMAKE_C_EXTENSIONS OFF)
 
 # Enable _GNU_SOURCE for ftello/fseeko on Linux
-if(UNIX)
+# Enable 64-bit off_t on 32-bit Linux to prevent fseeko/ftello/pread truncation
+if(UNIX AND NOT APPLE)
+    add_compile_definitions(_GNU_SOURCE _FILE_OFFSET_BITS=64 _LARGEFILE_SOURCE)
+elseif(APPLE)
     add_compile_definitions(_GNU_SOURCE)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -419,6 +419,7 @@ if(ZXC_BUILD_TESTS)
             src/lib/zxc_common.c
             src/lib/zxc_driver.c
             src/lib/zxc_dispatch.c
+            src/lib/zxc_seekable.c
             ${ZXC_VARIANT_OBJECTS}
         )
         

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -560,7 +560,7 @@ if(CLANG_FORMAT)
         VERBATIM
     )
 else()
-    message(STATUS "clang-format not found — format/format-check targets disabled")
+    message(STATUS "clang-format not found - format/format-check targets disabled")
 endif()
 
 # =============================================================================

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -225,12 +225,14 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
     set(ZXC_CORE_SOURCES
         src/lib/zxc_common.c
         src/lib/zxc_dispatch.c
+        src/lib/zxc_seekable.c
     )
 else()
     set(ZXC_CORE_SOURCES
         src/lib/zxc_common.c
         src/lib/zxc_driver.c
         src/lib/zxc_dispatch.c
+        src/lib/zxc_seekable.c
     )
 endif()
 

--- a/README.md
+++ b/README.md
@@ -397,7 +397,7 @@ uint64_t bound = zxc_compress_bound(src_size);
 zxc_compress_opts_t c_opts = {
     .level            = ZXC_LEVEL_DEFAULT,
     .checksum_enabled = 1,
-    /* .block_size = 0 → 256 KB default */
+    /* .block_size = 0 -> 256 KB default */
 };
 int64_t compressed_size = zxc_compress(src, src_size, dst, bound, &c_opts);
 
@@ -415,7 +415,7 @@ zxc_compress_opts_t c_opts = {
     .n_threads        = 0,               // 0 = auto
     .level            = ZXC_LEVEL_DEFAULT,
     .checksum_enabled = 1,
-    /* .block_size = 0 → 256 KB default */
+    /* .block_size = 0 -> 256 KB default */
 };
 int64_t bytes_written = zxc_stream_compress(f_in, f_out, &c_opts);
 
@@ -453,7 +453,7 @@ zxc_free_dctx(dctx);
 - Optional checksum validation
 - Reusable contexts for high-frequency call sites
 
-**[See complete examples and advanced usage →](docs/EXAMPLES.md)**
+**[See complete examples and advanced usage ->](docs/EXAMPLES.md)**
 
 ## Language Bindings
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ It is designed to be **"Write Once, Read Many"** *(WORM)*. Unlike codecs like LZ
 - **What:** A C library for lossless compression, optimized for **maximum decompression speed**.
 - **Key Result:** Up to **>40% faster** decompression than LZ4 on Apple Silicon, **>25% faster** on Google Axion (ARM64), **>5% faster** on x86_64, **all with better compression ratios**.
 - **Use Cases:** Game assets, firmware, app bundles, anything *compressed once, decompressed millions of times*.
+- **Seekable:** Built-in seek table for **O(1) random-access** decompression, load any block without scanning the entire file.
 - **Install:** `conan install --requires="zxc/[*]"` · `vcpkg install zxc` · `brew install zxc` · `pip install zxc-compress` · `cargo add zxc-compress` · `npm i zxc-compress`
 - **Quality:** Fuzzed, sanitized, formally tested, thread-safe API. BSD-3-Clause.
 
@@ -353,6 +354,9 @@ zxc -z input_file output_file
 # High Compression (Level 5)
 zxc -z -5 input_file output_file
 
+# Seekable Archive (enables O(1) random-access decompression)
+zxc -z -S input_file output_file
+
 # -z for compression can be omitted
 zxc input_file output_file
 
@@ -452,6 +456,7 @@ zxc_free_dctx(dctx);
 - Multi-threaded streaming (auto-detects CPU cores)
 - Optional checksum validation
 - Reusable contexts for high-frequency call sites
+- Seekable archives: optional seek table for O(1) random-access decompression (`.seekable = 1`)
 
 **[See complete examples and advanced usage ->](docs/EXAMPLES.md)**
 

--- a/README.md
+++ b/README.md
@@ -298,13 +298,13 @@ cmake -B build -DZXC_DISABLE_SIMD=ON
 
 PGO uses runtime profiling data to optimize branch layout, inlining decisions, and code placement.
 
-**Step 1 — Build with instrumentation:**
+**Step 1 - Build with instrumentation:**
 ```bash
 cmake -B build -DCMAKE_BUILD_TYPE=Release -DZXC_PGO_MODE=GENERATE
 cmake --build build --parallel
 ```
 
-**Step 2 — Run a representative workload to collect profile data:**
+**Step 2 - Run a representative workload to collect profile data:**
 ```bash
 # Run the test suite (exercises all block types and compression levels)
 ./build/zxc_test
@@ -313,14 +313,14 @@ cmake --build build --parallel
 ./build/zxc -b your_data_file
 ```
 
-**Step 3 — (Clang only) Merge raw profiles:**
+**Step 3 - (Clang only) Merge raw profiles:**
 ```bash
 # Clang generates .profraw files that must be merged before use
 llvm-profdata merge -output=build/pgo/default.profdata build/pgo/*.profraw
 ```
 > GCC uses a directory-based format and does not require this step.
 
-**Step 4 — Rebuild with profile data:**
+**Step 4 - Rebuild with profile data:**
 ```bash
 cmake -B build -DCMAKE_BUILD_TYPE=Release -DZXC_PGO_MODE=USE
 cmake --build build --parallel
@@ -428,7 +428,7 @@ int64_t bytes_out = zxc_stream_decompress(f_in, f_out, &d_opts);
 
 For tight loops (e.g. filesystem plug-ins) where per-call `malloc`/`free`
 overhead matters, use opaque reusable contexts.
-Options are **sticky** — settings from `zxc_create_cctx()` are reused when
+Options are **sticky** - settings from `zxc_create_cctx()` are reused when
 passing `NULL`:
 ```c
 #include "zxc.h"
@@ -437,7 +437,7 @@ zxc_compress_opts_t opts = { .level = 3, .checksum_enabled = 0 };
 zxc_cctx* cctx = zxc_create_cctx(&opts);   // allocate once, settings remembered
 zxc_dctx* dctx = zxc_create_dctx();        // allocate once
 
-// reuse across many blocks — NULL reuses sticky settings:
+// reuse across many blocks - NULL reuses sticky settings:
 int64_t csz = zxc_compress_cctx(cctx, src, src_sz, dst, dst_cap, NULL);
 int64_t dsz = zxc_decompress_dctx(dctx, dst, csz, out, src_sz, NULL);
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -458,7 +458,7 @@ Reads the original size from the file footer. File position is restored.
 
 ## 10. Sans-IO API
 
-Declared in `zxc_sans_io.h` (not included by `zxc.h` — opt-in).
+Declared in `zxc_sans_io.h` (not included by `zxc.h` - opt-in).
 Low-level primitives for building custom compression drivers.
 
 ### `zxc_cctx_init`
@@ -589,7 +589,7 @@ if (result < 0) {
 | **Buffer API** | Yes (stateless) | Each call is self-contained.  Multiple threads can compress/decompress simultaneously with independent buffers. |
 | **Context API** | Per-context | A single `zxc_cctx` / `zxc_dctx` must not be shared between threads.  Create one context per thread. |
 | **Streaming API** | Per-call | Each `zxc_stream_*` call manages its own thread pool internally.  Do not call from multiple threads on the same `FILE*`. |
-| **Sans-IO API** | Per-context | Same rule as context API — one `zxc_cctx_t` per thread. |
+| **Sans-IO API** | Per-context | Same rule as context API - one `zxc_cctx_t` per thread. |
 | `zxc_error_name` | Yes | Returns a pointer to a static string. |
 
 ---

--- a/docs/API.md
+++ b/docs/API.md
@@ -93,8 +93,8 @@ any libzxc with the same SOVERSION, regardless of the `VERSION` triple.
 
 | Platform | Files |
 |----------|-------|
-| Linux | `libzxc.so` → `libzxc.so.2` → `libzxc.so.0.9.1` |
-| macOS | `libzxc.dylib` → `libzxc.2.dylib` → `libzxc.0.9.1.dylib` |
+| Linux | `libzxc.so` -> `libzxc.so.2` -> `libzxc.so.0.9.1` |
+| macOS | `libzxc.dylib` -> `libzxc.2.dylib` -> `libzxc.0.9.1.dylib` |
 | Windows | `zxc.dll` + `zxc.lib` (import) |
 
 ---
@@ -413,7 +413,7 @@ Same as `zxc_decompress()` but reuses buffers from `dctx`.
 ## 9. Streaming API
 
 Declared in `zxc_stream.h`. Multi-threaded, `FILE*`-based pipeline
-(reader → workers → writer).
+(reader -> workers -> writer).
 
 ### `zxc_stream_compress`
 
@@ -425,7 +425,7 @@ ZXC_EXPORT int64_t zxc_stream_compress(
 );
 ```
 
-Compresses `f_in` → `f_out` using a parallel pipeline.
+Compresses `f_in` -> `f_out` using a parallel pipeline.
 All fields of `opts` are used, including `n_threads` and `progress_cb`.
 
 **Returns**: total compressed bytes written, or negative `zxc_error_t`.
@@ -440,7 +440,7 @@ ZXC_EXPORT int64_t zxc_stream_decompress(
 );
 ```
 
-Decompresses `f_in` → `f_out` using a parallel pipeline.
+Decompresses `f_in` -> `f_out` using a parallel pipeline.
 
 **Returns**: total decompressed bytes written, or negative `zxc_error_t`.
 

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -215,7 +215,7 @@ gcc -o stream_example stream_example.c -I include -L build -lzxc_lib -lpthread -
 
 ## Reusable Context API
 
-For tight loops — such as filesystem plug-ins (squashfs, dwarfs, erofs) —
+For tight loops - such as filesystem plug-ins (squashfs, dwarfs, erofs) -
 where allocating and freeing internal buffers on every call would add latency,
 ZXC provides opaque reusable contexts.
 
@@ -232,7 +232,7 @@ Options are **sticky**: settings passed via `opts` to `zxc_create_cctx()` or
 #include <stdlib.h>
 #include <string.h>
 
-#define BLOCK_SIZE   (64 * 1024)   // 64 KB — typical squashfs block size
+#define BLOCK_SIZE   (64 * 1024)   // 64 KB - typical squashfs block size
 #define NUM_BLOCKS   32
 
 int main(void) {
@@ -262,12 +262,12 @@ int main(void) {
         // Fill block with pseudo-random data
         for (size_t j = 0; j < BLOCK_SIZE; j++) src[j] = (uint8_t)(i ^ j);
 
-        // Compress — pass NULL to reuse sticky settings from create_opts.
+        // Compress - pass NULL to reuse sticky settings from create_opts.
         // No malloc/free inside, no need to pass opts again.
         int64_t csz = zxc_compress_cctx(cctx, src, BLOCK_SIZE, comp, comp_cap, NULL);
         if (csz <= 0) { fprintf(stderr, "Block %d: compress error %lld\n", i, (long long)csz); break; }
 
-        // Decompress — no malloc/free inside
+        // Decompress - no malloc/free inside
         int64_t dsz = zxc_decompress_dctx(dctx, comp, (size_t)csz, dec, BLOCK_SIZE, NULL);
         if (dsz != BLOCK_SIZE || memcmp(src, dec, BLOCK_SIZE) != 0) {
             fprintf(stderr, "Block %d: roundtrip mismatch\n", i);
@@ -281,7 +281,7 @@ int main(void) {
     int64_t csz = zxc_compress_cctx(cctx, src, BLOCK_SIZE, comp, comp_cap, &high_opts);
     printf("Level-5 compressed: %lld bytes\n", (long long)csz);
 
-    printf("Processed %d blocks of %d KB — no per-block allocation.\n",
+    printf("Processed %d blocks of %d KB - no per-block allocation.\n",
            NUM_BLOCKS, BLOCK_SIZE / 1024);
 
     zxc_free_cctx(cctx);

--- a/docs/FORMAT.md
+++ b/docs/FORMAT.md
@@ -31,6 +31,8 @@ It formalizes the current reference implementation of format version **5**.
 +----------------------+
 | EOF Block            | 8 bytes (type=255, comp_size=0)
 +----------------------+
+| SEK Block (Optional) | table of contents for random access
++----------------------+
 | File Footer          | 12 bytes
 +----------------------+
 ```
@@ -88,6 +90,7 @@ Offset  Size  Field
   - `1` = GLO
   - `2` = NUM
   - `3` = GHI
+  - `254` = SEK
   - `255` = EOF
 - **Block Flags**: currently not used by implementation (written as `0`).
 - **Reserved**: must be 0.
@@ -304,7 +307,32 @@ Constraints:
 - no payload
 - no per-block trailing checksum
 
-Immediately after EOF block header comes the 12-byte file footer.
+Immediately after EOF block header comes the Optional SEK block, followed by the 12-byte file footer.
+
+---
+
+## 5.6 SEK block (`type=254`)
+
+The **Seek Table** block is an optional block appended between the EOF block and the File Footer. It provides `O(log N)` random-access capabilities by recording the compressed and decompressed sizes of every block in the archive.
+
+**Layout of a SEK Block**:
+```text
+  Offset             Size    Field
+  0x00               8       Block Header (type=254, comp_size=N*8+4)
+  0x08               4       Block 0 Compressed Size (u32 LE)
+  0x0C               4       Block 0 Decompressed Size (u32 LE)
+  ...                ...     ...
+  8 + (N-1)*8        4       Block N-1 Compressed Size (u32 LE)
+  12 + (N-1)*8       4       Block N-1 Decompressed Size (u32 LE)
+  8 + N*8            4       Number of Blocks (u32 LE / Tail)
+```
+
+**Backward Detection Strategy**:
+1. Read the File Footer (last 12 bytes of file).
+2. Read 4 bytes **immediately before** the footer. This is the `Number of Blocks`.
+3. If `Number of Blocks > 0`, calculating `seek_block_size = 8 + (N * 8) + 4` gives the length of the seek block.
+4. Seek backward by `seek_block_size` bytes from the start of the footer to read the Block Header.
+5. Validate `block_type == 254 (SEK)`.
 
 ---
 

--- a/docs/FORMAT.md
+++ b/docs/FORMAT.md
@@ -443,10 +443,10 @@ A conforming decoder **MUST** reject any file whose version it does not support.
 
 A minimal conforming decoder for version 5 **MUST** support:
 - File header parsing and CRC16 validation.
-- **RAW** blocks (type 0) — passthrough copy.
-- **GLO** blocks (type 1) — full LZ decode with extras varint.
-- **GHI** blocks (type 3) — full LZ decode with extras varint.
-- **EOF** block (type 255) — stream termination.
+- **RAW** blocks (type 0) - passthrough copy.
+- **GLO** blocks (type 1) - full LZ decode with extras varint.
+- **GHI** blocks (type 3) - full LZ decode with extras varint.
+- **EOF** block (type 255) - stream termination.
 - File footer validation (source size check).
 
 Support for **NUM** (type 2) and checksum verification is **RECOMMENDED** but not strictly required for a minimal implementation.
@@ -497,7 +497,7 @@ For decoders processing untrusted input (e.g. network data, user uploads):
 - Validate **all** header checksums before processing payloads.
 - Enforce maximum allocation limits based on `comp_size` and chunk size code.
 - Reject files where `comp_size` exceeds `zxc_compress_bound(chunk_size)`.
-- Use bounded memory copies — never trust decoded lengths without cross-checking against output buffer capacity.
+- Use bounded memory copies - never trust decoded lengths without cross-checking against output buffer capacity.
 
 ---
 

--- a/docs/FORMAT.md
+++ b/docs/FORMAT.md
@@ -313,26 +313,25 @@ Immediately after EOF block header comes the Optional SEK block, followed by the
 
 ## 5.6 SEK block (`type=254`)
 
-The **Seek Table** block is an optional block appended between the EOF block and the File Footer. It provides `O(log N)` random-access capabilities by recording the compressed and decompressed sizes of every block in the archive.
+The **Seek Table** block is an optional block appended between the EOF block and the File Footer. It provides `O(1)` random-access capabilities by recording the compressed size of every block in the archive. Decompressed sizes and block indices are derived from the file header's `block_size` (all blocks are `block_size` except the last, which may be smaller).
 
 **Layout of a SEK Block**:
 ```text
   Offset             Size    Field
-  0x00               8       Block Header (type=254, comp_size=N*8+4)
+  0x00               8       Block Header (type=254, comp_size=N*4)
   0x08               4       Block 0 Compressed Size (u32 LE)
-  0x0C               4       Block 0 Decompressed Size (u32 LE)
+  0x0C               4       Block 1 Compressed Size (u32 LE)
   ...                ...     ...
-  8 + (N-1)*8        4       Block N-1 Compressed Size (u32 LE)
-  12 + (N-1)*8       4       Block N-1 Decompressed Size (u32 LE)
-  8 + N*8            4       Number of Blocks (u32 LE / Tail)
+  8 + (N-1)*4        4       Block N-1 Compressed Size (u32 LE)
 ```
 
 **Backward Detection Strategy**:
-1. Read the File Footer (last 12 bytes of file).
-2. Read 4 bytes **immediately before** the footer. This is the `Number of Blocks`.
-3. If `Number of Blocks > 0`, calculating `seek_block_size = 8 + (N * 8) + 4` gives the length of the seek block.
-4. Seek backward by `seek_block_size` bytes from the start of the footer to read the Block Header.
-5. Validate `block_type == 254 (SEK)`.
+1. Read the **File Header** (first 16 bytes) → extract `block_size`.
+2. Read the **File Footer** (last 12 bytes) → extract `total_decompressed_size`.
+3. Derive `num_blocks = ceil(total_decompressed_size / block_size)`.
+4. Calculate `seek_block_size = 8 + (N × 4)`.
+5. Seek backward by `seek_block_size` bytes from the start of the footer to read the Block Header.
+6. Validate `block_type == 254 (SEK)` and `comp_size == N × 4`.
 
 ---
 

--- a/docs/FORMAT.md
+++ b/docs/FORMAT.md
@@ -615,3 +615,77 @@ global1 = rotl1(global0) XOR block_crc = block_crc
 0x26..0x2D  EOF Block Header (8)
 0x2E..0x39  File Footer (12)
 ```
+
+### 13.4 Seekable Variant (with Seek Table)
+
+Same 10-byte input (`Hello ZXC\n`), compressed with seekable mode enabled:
+
+```bash
+zxc -z -C -1 -S sample.txt
+```
+
+Generated archive size: **70 bytes** (12 bytes larger than the non-seekable variant).
+
+#### Full hexdump
+
+```text
+00000000: F5 2E B0 9C 05 12 80 00 00 00 00 00 00 00 9E 53
+00000010: 00 00 00 0A 00 00 00 69 48 65 6C 6C 6F 20 5A 58
+00000020: 43 0A 90 BB A1 75 FF 00 00 00 00 00 00 02 FE 00
+00000030: 00 04 00 00 00 D2 16 00 00 00 0A 00 00 00 00 00
+00000040: 00 00 90 BB A1 75
+```
+
+#### Byte-level decoding
+
+**A) File Header** (offset `0x00`, 16 bytes) - identical to non-seekable.
+
+**B) Data Block #0 (RAW)** (offset `0x10`, 22 bytes) - identical to non-seekable.
+
+**C) EOF Block** (offset `0x26`, 8 bytes) - identical to non-seekable.
+
+**D) SEK Block** (offset `0x2E`, 12 bytes)
+
+Block header at `0x2E`:
+
+```text
+FE | 00 | 00 | 04 00 00 00 | D2
+```
+
+- `FE` -> type 254 = SEK (Seek Table).
+- flags `00`, reserved `00`.
+- `comp_size = 0x00000004 = 4` bytes (one entry x 4 bytes/entry).
+- header CRC8 = `0xD2`.
+
+Seek table entry at `0x36`:
+
+```text
+16 00 00 00
+```
+
+- Entry #0: compressed block size = `0x00000016 = 22` bytes.
+  This is the total size of data block #0 including its header (8) + payload (10) + checksum (4) = 22. ✓
+
+**E) File Footer** (offset `0x3A`, 12 bytes)
+
+```text
+0A 00 00 00 00 00 00 00 | 90 BB A1 75
+```
+
+- original source size = `10` bytes.
+- global hash = `0x75A1BB90`.
+
+#### Structural view with absolute offsets
+
+```text
+0x00..0x0F  File Header (16)
+0x10..0x17  RAW Block Header (8)
+0x18..0x21  RAW Payload (10)
+0x22..0x25  RAW Block Checksum (4)
+0x26..0x2D  EOF Block Header (8)
+0x2E..0x35  SEK Block Header (8)    <- seek table
+0x36..0x39  SEK Entry #0 (4)        <- comp_size of block #0
+0x3A..0x45  File Footer (12)
+```
+
+> **Key difference**: The SEK block is inserted between the EOF block and the file footer. A decoder that does not support seekable archives simply ignores the SEK block since it encounters the EOF block first and stops. The footer remains the last 12 bytes of the file regardless of whether a seek table is present.

--- a/docs/FORMAT.md
+++ b/docs/FORMAT.md
@@ -688,4 +688,4 @@ Seek table entry at `0x36`:
 0x3A..0x45  File Footer (12)
 ```
 
-> **Key difference**: The SEK block is inserted between the EOF block and the file footer. A decoder that does not support seekable archives simply ignores the SEK block since it encounters the EOF block first and stops. The footer remains the last 12 bytes of the file regardless of whether a seek table is present.
+> **Compatibility note**: The SEK block is inserted between the EOF block and the file footer. The footer always remains the **last 12 bytes of the file**, so decoders that locate the footer from the end of the file (e.g. `src + src_size - 12` for buffer APIs, or `fseek(END - 12)` for file APIs) work unchanged with seekable archives. However, **streaming decoders** that read the footer sequentially immediately after the EOF block must be updated to detect and skip the SEK block. In practice, all ZXC decoders since v0.9.0 handle both seekable and non-seekable archives transparently.

--- a/docs/FORMAT.md
+++ b/docs/FORMAT.md
@@ -326,8 +326,8 @@ The **Seek Table** block is an optional block appended between the EOF block and
 ```
 
 **Backward Detection Strategy**:
-1. Read the **File Header** (first 16 bytes) → extract `block_size`.
-2. Read the **File Footer** (last 12 bytes) → extract `total_decompressed_size`.
+1. Read the **File Header** (first 16 bytes) -> extract `block_size`.
+2. Read the **File Footer** (last 12 bytes) -> extract `total_decompressed_size`.
 3. Derive `num_blocks = ceil(total_decompressed_size / block_size)`.
 4. Calculate `seek_block_size = 8 + (N × 4)`.
 5. Seek backward by `seek_block_size` bytes from the start of the footer to read the Block Header.
@@ -341,11 +341,11 @@ ZXC extras use a prefix-length varint.
 
 Length is encoded in unary form in the high bits of first byte:
 
-- `0xxxxxxx` → 1 byte total
-- `10xxxxxx` → 2 bytes total
-- `110xxxxx` → 3 bytes total
-- `1110xxxx` → 4 bytes total
-- `11110xxx` → 5 bytes total
+- `0xxxxxxx` -> 1 byte total
+- `10xxxxxx` -> 2 bytes total
+- `110xxxxx` -> 3 bytes total
+- `1110xxxx` -> 4 bytes total
+- `11110xxx` -> 5 bytes total
 
 Payload bits from following bytes are concatenated little-endian style (low bits first).
 
@@ -543,12 +543,12 @@ Generated archive size: **58 bytes**.
 F5 2E B0 9C | 05 | 12 | 80 | 00 00 00 00 00 00 00 | 9E 53
 ```
 
-- `F5 2E B0 9C` → magic word (LE) = `0x9CB02EF5`.
-- `05` → format version 5.
-- `12` → chunk-size code 18 (exponent encoding: `2^18 = 262144` bytes, i.e. 256 KiB).
-- `80` → checksum enabled (`HAS_CHECKSUM=1`, algo id 0).
+- `F5 2E B0 9C` -> magic word (LE) = `0x9CB02EF5`.
+- `05` -> format version 5.
+- `12` -> chunk-size code 18 (exponent encoding: `2^18 = 262144` bytes, i.e. 256 KiB).
+- `80` -> checksum enabled (`HAS_CHECKSUM=1`, algo id 0).
 - next 7 bytes are reserved zeros.
-- `9E 53` → header CRC16.
+- `9E 53` -> header CRC16.
 
 #### B) Data Block #0 (RAW)
 

--- a/docs/WHITEPAPER.md
+++ b/docs/WHITEPAPER.md
@@ -458,11 +458,11 @@ ZXC supports multiple integrity verification algorithms (though currently standa
 The default `rapidhash` algorithm is based on wyhash and was developed by Nicolas De Carli. It is designed to fully exploit hardware performance while maintaining top-tier mathematical distribution qualities.
 
 ### 5.10 Seekable Archives (Random Access)
-ZXC supports **O(log N)** random-access decompression without decoding the entire stream. This is achieved by appending an optional **Seek Table** (a `SEK` block) at the end of the archive, immediately before the file footer.
+ZXC supports **O(1)** random-access decompression without decoding the entire stream. This is achieved by appending an optional **Seek Table** (a `SEK` block) at the end of the archive, immediately before the file footer.
 
-*   **Structure**: The seek table contains an array of 8-byte entries (compressed size + decompressed size) for every block in the archive.
-*   **Performance**: Reading backward from the file footer instantly locates the seek table. A binary search on the `decompressed` prefix-sums quickly identifies the exact target block.
-*   **Use Cases**: This feature transforms ZXC from a sequential stream into a random-access volume format, perfect for **Compressed Filesystems (SquashFS)**, **Game Assets (VFS)**, and **Big Data Parquet/Log analysis**.
+*   **Structure**: The seek table contains an array of 4-byte entries (compressed block size, LE uint32) for every block in the archive.
+*   **Performance**: Reading backward from the file footer instantly locates the seek table. Since blocks have a fixed power-of-2 size, the target block is found by a single division (`block_index = offset / block_size`), with no binary search required.
+*   **Use Cases**: This feature transforms ZXC from a sequential stream into a random-access volume format.
 
 ## 6. System Architecture (Threading)
 

--- a/docs/WHITEPAPER.md
+++ b/docs/WHITEPAPER.md
@@ -8,7 +8,7 @@
 
 ## 1. Executive Summary
 
-In modern software delivery pipelines-specifically **Mobile Gaming**, **Embedded Systems**, and **FOTA (Firmware Over-The-Air)**—data is typically generated on high-performance x86 workstations but consumed on energy-constrained ARM devices.
+In modern software delivery pipelines-specifically **Mobile Gaming**, **Embedded Systems**, and **FOTA (Firmware Over-The-Air)**-data is typically generated on high-performance x86 workstations but consumed on energy-constrained ARM devices.
 
 Standard industry codecs like LZ4 offer excellent performance but fail to exploit the "Write-Once, Read-Many" (WORM) nature of these pipelines. **ZXC** is a lossless codec designed to bridge this gap. By utilizing an **asymmetric compression model**, ZXC achieves a **>40% increase in decompression speed on ARM** compared to LZ4, while simultaneously reducing storage footprints. On x86 development architecture, ZXC maintains competitive throughput, ensuring no disruption to build pipelines.
 

--- a/docs/WHITEPAPER.md
+++ b/docs/WHITEPAPER.md
@@ -8,7 +8,7 @@
 
 ## 1. Executive Summary
 
-In modern software delivery pipelines—specifically **Mobile Gaming**, **Embedded Systems**, and **FOTA (Firmware Over-The-Air)**—data is typically generated on high-performance x86 workstations but consumed on energy-constrained ARM devices.
+In modern software delivery pipelines-specifically **Mobile Gaming**, **Embedded Systems**, and **FOTA (Firmware Over-The-Air)**—data is typically generated on high-performance x86 workstations but consumed on energy-constrained ARM devices.
 
 Standard industry codecs like LZ4 offer excellent performance but fail to exploit the "Write-Once, Read-Many" (WORM) nature of these pipelines. **ZXC** is a lossless codec designed to bridge this gap. By utilizing an **asymmetric compression model**, ZXC achieves a **>40% increase in decompression speed on ARM** compared to LZ4, while simultaneously reducing storage footprints. On x86 development architecture, ZXC maintains competitive throughput, ensuring no disruption to build pipelines.
 

--- a/docs/WHITEPAPER.md
+++ b/docs/WHITEPAPER.md
@@ -457,6 +457,13 @@ ZXC supports multiple integrity verification algorithms (though currently standa
 #### Credit
 The default `rapidhash` algorithm is based on wyhash and was developed by Nicolas De Carli. It is designed to fully exploit hardware performance while maintaining top-tier mathematical distribution qualities.
 
+### 5.10 Seekable Archives (Random Access)
+ZXC supports **O(log N)** random-access decompression without decoding the entire stream. This is achieved by appending an optional **Seek Table** (a `SEK` block) at the end of the archive, immediately before the file footer.
+
+*   **Structure**: The seek table contains an array of 8-byte entries (compressed size + decompressed size) for every block in the archive.
+*   **Performance**: Reading backward from the file footer instantly locates the seek table. A binary search on the `decompressed` prefix-sums quickly identifies the exact target block.
+*   **Use Cases**: This feature transforms ZXC from a sequential stream into a random-access volume format, perfect for **Compressed Filesystems (SquashFS)**, **Game Assets (VFS)**, and **Big Data Parquet/Log analysis**.
+
 ## 6. System Architecture (Threading)
 
 ZXC leverages a threaded **Producer-Consumer** model to saturate modern multi-core CPUs.

--- a/docs/man/zxc.1.md
+++ b/docs/man/zxc.1.md
@@ -59,7 +59,7 @@ By default, **zxc** compresses a single *INPUT-FILE*. If no *OUTPUT-FILE* is pro
 : Explicitly disable checksum generation.
 
 **-S**, **--seekable**
-: Append a seek table to the archive during compression. This transforms the file into a random-access format (Seekable Archive), allowing the decoder to instantly locate and decompress specific blocks in `O(log N)` time without reading the entire file. Ideal for compressed filesystems, game assets, and log analysis.
+: Append a seek table to the archive during compression. This transforms the file into a random-access format (Seekable Archive), allowing the decoder to instantly locate and decompress specific blocks in `O(1)` time without reading the entire file. Ideal for compressed filesystems, game assets, and log analysis.
 
 **-k**, **--keep**
 : Keep the input file after compression or decompression. (Currently, the input file is preserved by default, but this flag ensures compatibility with future changes).

--- a/docs/man/zxc.1.md
+++ b/docs/man/zxc.1.md
@@ -58,6 +58,9 @@ By default, **zxc** compresses a single *INPUT-FILE*. If no *OUTPUT-FILE* is pro
 **-N**, **--no-checksum**
 : Explicitly disable checksum generation.
 
+**-S**, **--seekable**
+: Append a seek table to the archive during compression. This transforms the file into a random-access format (Seekable Archive), allowing the decoder to instantly locate and decompress specific blocks in `O(log N)` time without reading the entire file. Ideal for compressed filesystems, game assets, and log analysis.
+
 **-k**, **--keep**
 : Keep the input file after compression or decompression. (Currently, the input file is preserved by default, but this flag ensures compatibility with future changes).
 

--- a/include/zxc_seekable.h
+++ b/include/zxc_seekable.h
@@ -151,7 +151,7 @@ ZXC_EXPORT int64_t zxc_seekable_decompress_range(zxc_seekable* s, void* dst,
 /**
  * @brief Multi-threaded variant of zxc_seekable_decompress_range().
  *
- * Decompresses blocks in parallel using a fork–join thread pool.  Each worker
+ * Decompresses blocks in parallel using a fork-join thread pool.  Each worker
  * thread owns its own decompression context and reads compressed data via
  * @c pread() (POSIX) or @c ReadFile() (Windows) for lock-free concurrent I/O.
  *

--- a/include/zxc_seekable.h
+++ b/include/zxc_seekable.h
@@ -162,28 +162,26 @@ ZXC_EXPORT void zxc_seekable_free(zxc_seekable* s);
  * @brief Writes a seek table to the destination buffer.
  *
  * This is a low-level helper used internally by the seekable compression
- * paths.  It writes: block_header(8) + N entries(8 or 12 each) + tail(4).
+ * paths.  It writes: block_header(8) + N entries(8 each) + tail(4).
  *
  * @param[out] dst             Destination buffer.
  * @param[in]  dst_capacity    Capacity of @p dst in bytes.
  * @param[in]  comp_sizes      Array of compressed block sizes.
  * @param[in]  decomp_sizes    Array of decompressed block sizes.
  * @param[in]  num_blocks      Number of blocks.
- * @param[in]  has_checksums   Non-zero if per-block checksums are stored.
  * @return Number of bytes written, or a negative @ref zxc_error_t on failure.
  */
 ZXC_EXPORT int64_t zxc_write_seek_table(uint8_t* dst, size_t dst_capacity,
                                         const uint32_t* comp_sizes, const uint32_t* decomp_sizes,
-                                        uint32_t num_blocks, int has_checksums);
+                                        uint32_t num_blocks);
 
 /**
  * @brief Returns the encoded size of a seek table for the given block count.
  *
  * @param[in] num_blocks     Number of blocks.
- * @param[in] has_checksums  Non-zero if per-block checksums are stored.
  * @return Total byte size of the seek table.
  */
-ZXC_EXPORT size_t zxc_seek_table_size(uint32_t num_blocks, int has_checksums);
+ZXC_EXPORT size_t zxc_seek_table_size(uint32_t num_blocks);
 
 /** @} */ /* end of seekable_api */
 

--- a/include/zxc_seekable.h
+++ b/include/zxc_seekable.h
@@ -189,18 +189,19 @@ ZXC_EXPORT void zxc_seekable_free(zxc_seekable* s);
  * @brief Writes a seek table to the destination buffer.
  *
  * This is a low-level helper used internally by the seekable compression
- * paths.  It writes: block_header(8) + N entries(8 each) + tail(4).
+ * paths.  It writes: block_header(8) + N entries(4 each).
+ * Each entry stores only @c comp_size; decompressed sizes are derived at
+ * read time from the file header's block_size.
  *
  * @param[out] dst             Destination buffer.
  * @param[in]  dst_capacity    Capacity of @p dst in bytes.
  * @param[in]  comp_sizes      Array of compressed block sizes.
- * @param[in]  decomp_sizes    Array of decompressed block sizes.
  * @param[in]  num_blocks      Number of blocks.
  * @return Number of bytes written, or a negative @ref zxc_error_t on failure.
  */
 ZXC_EXPORT int64_t zxc_write_seek_table(uint8_t* dst, const size_t dst_capacity,
-                                        const uint32_t* comp_sizes, const uint32_t* decomp_sizes,
-                                        const uint32_t num_blocks);
+                                         const uint32_t* comp_sizes,
+                                         const uint32_t num_blocks);
 
 /**
  * @brief Returns the encoded size of a seek table for the given block count.

--- a/include/zxc_seekable.h
+++ b/include/zxc_seekable.h
@@ -200,8 +200,7 @@ ZXC_EXPORT void zxc_seekable_free(zxc_seekable* s);
  * @return Number of bytes written, or a negative @ref zxc_error_t on failure.
  */
 ZXC_EXPORT int64_t zxc_write_seek_table(uint8_t* dst, const size_t dst_capacity,
-                                         const uint32_t* comp_sizes,
-                                         const uint32_t num_blocks);
+                                        const uint32_t* comp_sizes, const uint32_t num_blocks);
 
 /**
  * @brief Returns the encoded size of a seek table for the given block count.

--- a/include/zxc_seekable.h
+++ b/include/zxc_seekable.h
@@ -1,0 +1,194 @@
+/*
+ * ZXC - High-performance lossless compression
+ *
+ * Copyright (c) 2025-2026 Bertrand Lebonnois and contributors.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/**
+ * @file zxc_seekable.h
+ * @brief Seekable compression and random-access decompression API.
+ *
+ * This header provides functions to produce seekable ZXC archives and to
+ * decompress arbitrary byte ranges without reading the entire file.
+ *
+ * A seekable archive embeds a Seek Table block (block_type = @c ZXC_BLOCK_SEK)
+ * after the EOF block, recording the compressed and decompressed size of every
+ * block.  The table is detected at read time by reading the @c num_blocks tail
+ * (last 4 bytes before the file footer) and validating the block header.
+ * Standard (non-seekable) decompressors ignore the seek table entirely.
+ *
+ * @par Creating a seekable archive
+ * @code
+ * zxc_compress_opts_t opts = { .level = 3, .seekable = 1 };
+ * int64_t csize = zxc_compress(src, src_size, dst, dst_cap, &opts);
+ * @endcode
+ *
+ * @par Random-access decompression
+ * @code
+ * zxc_seekable* s = zxc_seekable_open(compressed, csize);
+ * int64_t n = zxc_seekable_decompress_range(s, out, out_cap, offset, len);
+ * zxc_seekable_free(s);
+ * @endcode
+ *
+ * @see zxc_buffer.h  for the standard one-shot API.
+ * @see zxc_stream.h  for multi-threaded streaming.
+ */
+
+#ifndef ZXC_SEEKABLE_H
+#define ZXC_SEEKABLE_H
+
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+
+#include "zxc_export.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @defgroup seekable_api Seekable API
+ * @brief Random-access compression and decompression.
+ * @{
+ */
+
+/* ========================================================================= */
+/*  Seekable Reader (Random-Access Decompression)                            */
+/* ========================================================================= */
+
+/**
+ * @brief Opaque handle for a seekable ZXC archive.
+ *
+ * Created by zxc_seekable_open() or zxc_seekable_open_file().
+ * Must be freed with zxc_seekable_free().
+ */
+typedef struct zxc_seekable_s zxc_seekable;
+
+/**
+ * @brief Opens a seekable archive from a memory buffer.
+ *
+ * Parses the seek table from the end of the buffer and builds the internal
+ * block index.  The buffer must remain valid for the lifetime of the handle.
+ *
+ * @param[in] src       Pointer to the compressed data.
+ * @param[in] src_size  Size of the compressed data in bytes.
+ * @return Handle on success, or @c NULL if the buffer does not contain a
+ *         valid seekable archive (e.g. missing seek block, bad block type).
+ */
+ZXC_EXPORT zxc_seekable* zxc_seekable_open(const void* src, size_t src_size);
+
+/**
+ * @brief Opens a seekable archive from a FILE*.
+ *
+ * The file must be seekable (not stdin/pipe).  The current file position
+ * is saved and restored after parsing the seek table.  The FILE* must
+ * remain open for the lifetime of the handle.
+ *
+ * @param[in] f  File opened in "rb" mode.
+ * @return Handle on success, or @c NULL on error.
+ */
+ZXC_EXPORT zxc_seekable* zxc_seekable_open_file(FILE* f);
+
+/**
+ * @brief Returns the total number of blocks in the seekable archive.
+ *
+ * @param[in] s  Seekable handle.
+ * @return Number of data blocks (excluding EOF).
+ */
+ZXC_EXPORT uint32_t zxc_seekable_get_num_blocks(const zxc_seekable* s);
+
+/**
+ * @brief Returns the total decompressed size of the seekable archive.
+ *
+ * @param[in] s  Seekable handle.
+ * @return Total decompressed size in bytes.
+ */
+ZXC_EXPORT uint64_t zxc_seekable_get_decompressed_size(const zxc_seekable* s);
+
+/**
+ * @brief Returns the compressed size of a specific block.
+ *
+ * This is the "on-disk" size including block header, payload, and optional
+ * per-block checksum.
+ *
+ * @param[in] s          Seekable handle.
+ * @param[in] block_idx  Zero-based block index.
+ * @return Compressed block size, or 0 if @p block_idx is out of range.
+ */
+ZXC_EXPORT uint32_t zxc_seekable_get_block_comp_size(const zxc_seekable* s, uint32_t block_idx);
+
+/**
+ * @brief Returns the decompressed size of a specific block.
+ *
+ * @param[in] s          Seekable handle.
+ * @param[in] block_idx  Zero-based block index.
+ * @return Decompressed block size, or 0 if @p block_idx is out of range.
+ */
+ZXC_EXPORT uint32_t zxc_seekable_get_block_decomp_size(const zxc_seekable* s, uint32_t block_idx);
+
+/**
+ * @brief Decompresses an arbitrary byte range from the original data.
+ *
+ * Only the blocks overlapping [@p offset, @p offset + @p len) are read and
+ * decompressed.  This is the core random-access primitive.
+ *
+ * @param[in,out] s            Seekable handle.
+ * @param[out]    dst          Destination buffer.
+ * @param[in]     dst_capacity Capacity of @p dst (must be >= @p len).
+ * @param[in]     offset       Byte offset into the original uncompressed data.
+ * @param[in]     len          Number of bytes to decompress.
+ * @return Number of bytes written to @p dst (== @p len on success),
+ *         or a negative @ref zxc_error_t code on failure.
+ */
+ZXC_EXPORT int64_t zxc_seekable_decompress_range(zxc_seekable* s, void* dst, size_t dst_capacity,
+                                                 uint64_t offset, size_t len);
+
+/**
+ * @brief Frees a seekable handle and all associated resources.
+ *
+ * Safe to call with @c NULL.
+ *
+ * @param[in] s  Handle to free.
+ */
+ZXC_EXPORT void zxc_seekable_free(zxc_seekable* s);
+
+/* ========================================================================= */
+/*  Seek Table Writer (low-level)                                            */
+/* ========================================================================= */
+
+/**
+ * @brief Writes a seek table to the destination buffer.
+ *
+ * This is a low-level helper used internally by the seekable compression
+ * paths.  It writes: block_header(8) + N entries(8 or 12 each) + tail(4).
+ *
+ * @param[out] dst             Destination buffer.
+ * @param[in]  dst_capacity    Capacity of @p dst in bytes.
+ * @param[in]  comp_sizes      Array of compressed block sizes.
+ * @param[in]  decomp_sizes    Array of decompressed block sizes.
+ * @param[in]  num_blocks      Number of blocks.
+ * @param[in]  has_checksums   Non-zero if per-block checksums are stored.
+ * @return Number of bytes written, or a negative @ref zxc_error_t on failure.
+ */
+ZXC_EXPORT int64_t zxc_write_seek_table(uint8_t* dst, size_t dst_capacity,
+                                        const uint32_t* comp_sizes, const uint32_t* decomp_sizes,
+                                        uint32_t num_blocks, int has_checksums);
+
+/**
+ * @brief Returns the encoded size of a seek table for the given block count.
+ *
+ * @param[in] num_blocks     Number of blocks.
+ * @param[in] has_checksums  Non-zero if per-block checksums are stored.
+ * @return Total byte size of the seek table.
+ */
+ZXC_EXPORT size_t zxc_seek_table_size(uint32_t num_blocks, int has_checksums);
+
+/** @} */ /* end of seekable_api */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZXC_SEEKABLE_H */

--- a/include/zxc_seekable.h
+++ b/include/zxc_seekable.h
@@ -13,9 +13,10 @@
  * decompress arbitrary byte ranges without reading the entire file.
  *
  * A seekable archive embeds a Seek Table block (block_type = @c ZXC_BLOCK_SEK)
- * after the EOF block, recording the compressed and decompressed size of every
- * block.  The table is detected at read time by reading the @c num_blocks tail
- * (last 4 bytes before the file footer) and validating the block header.
+ * after the EOF block, recording the compressed size of every block.
+ * The table is detected at read time by deriving @c num_blocks from the file
+ * footer's total decompressed size and the header's block size, then seeking
+ * backward to validate the SEK block header.
  * Standard (non-seekable) decompressors ignore the seek table entirely.
  *
  * @par Creating a seekable archive

--- a/include/zxc_seekable.h
+++ b/include/zxc_seekable.h
@@ -77,7 +77,7 @@ typedef struct zxc_seekable_s zxc_seekable;
  * @return Handle on success, or @c NULL if the buffer does not contain a
  *         valid seekable archive (e.g. missing seek block, bad block type).
  */
-ZXC_EXPORT zxc_seekable* zxc_seekable_open(const void* src, size_t src_size);
+ZXC_EXPORT zxc_seekable* zxc_seekable_open(const void* src, const size_t src_size);
 
 /**
  * @brief Opens a seekable archive from a FILE*.
@@ -117,7 +117,8 @@ ZXC_EXPORT uint64_t zxc_seekable_get_decompressed_size(const zxc_seekable* s);
  * @param[in] block_idx  Zero-based block index.
  * @return Compressed block size, or 0 if @p block_idx is out of range.
  */
-ZXC_EXPORT uint32_t zxc_seekable_get_block_comp_size(const zxc_seekable* s, uint32_t block_idx);
+ZXC_EXPORT uint32_t zxc_seekable_get_block_comp_size(const zxc_seekable* s,
+                                                     const uint32_t block_idx);
 
 /**
  * @brief Returns the decompressed size of a specific block.
@@ -126,7 +127,8 @@ ZXC_EXPORT uint32_t zxc_seekable_get_block_comp_size(const zxc_seekable* s, uint
  * @param[in] block_idx  Zero-based block index.
  * @return Decompressed block size, or 0 if @p block_idx is out of range.
  */
-ZXC_EXPORT uint32_t zxc_seekable_get_block_decomp_size(const zxc_seekable* s, uint32_t block_idx);
+ZXC_EXPORT uint32_t zxc_seekable_get_block_decomp_size(const zxc_seekable* s,
+                                                       const uint32_t block_idx);
 
 /**
  * @brief Decompresses an arbitrary byte range from the original data.
@@ -142,8 +144,9 @@ ZXC_EXPORT uint32_t zxc_seekable_get_block_decomp_size(const zxc_seekable* s, ui
  * @return Number of bytes written to @p dst (== @p len on success),
  *         or a negative @ref zxc_error_t code on failure.
  */
-ZXC_EXPORT int64_t zxc_seekable_decompress_range(zxc_seekable* s, void* dst, size_t dst_capacity,
-                                                 uint64_t offset, size_t len);
+ZXC_EXPORT int64_t zxc_seekable_decompress_range(zxc_seekable* s, void* dst,
+                                                 const size_t dst_capacity, const uint64_t offset,
+                                                 const size_t len);
 
 /**
  * @brief Multi-threaded variant of zxc_seekable_decompress_range().
@@ -164,8 +167,10 @@ ZXC_EXPORT int64_t zxc_seekable_decompress_range(zxc_seekable* s, void* dst, siz
  * @return Number of bytes written to @p dst (== @p len on success),
  *         or a negative @ref zxc_error_t code on failure.
  */
-ZXC_EXPORT int64_t zxc_seekable_decompress_range_mt(zxc_seekable* s, void* dst, size_t dst_capacity,
-                                                    uint64_t offset, size_t len, int n_threads);
+ZXC_EXPORT int64_t zxc_seekable_decompress_range_mt(zxc_seekable* s, void* dst,
+                                                    const size_t dst_capacity,
+                                                    const uint64_t offset, const size_t len,
+                                                    int n_threads);
 
 /**
  * @brief Frees a seekable handle and all associated resources.
@@ -193,9 +198,9 @@ ZXC_EXPORT void zxc_seekable_free(zxc_seekable* s);
  * @param[in]  num_blocks      Number of blocks.
  * @return Number of bytes written, or a negative @ref zxc_error_t on failure.
  */
-ZXC_EXPORT int64_t zxc_write_seek_table(uint8_t* dst, size_t dst_capacity,
+ZXC_EXPORT int64_t zxc_write_seek_table(uint8_t* dst, const size_t dst_capacity,
                                         const uint32_t* comp_sizes, const uint32_t* decomp_sizes,
-                                        uint32_t num_blocks);
+                                        const uint32_t num_blocks);
 
 /**
  * @brief Returns the encoded size of a seek table for the given block count.
@@ -203,7 +208,7 @@ ZXC_EXPORT int64_t zxc_write_seek_table(uint8_t* dst, size_t dst_capacity,
  * @param[in] num_blocks     Number of blocks.
  * @return Total byte size of the seek table.
  */
-ZXC_EXPORT size_t zxc_seek_table_size(uint32_t num_blocks);
+ZXC_EXPORT size_t zxc_seek_table_size(const uint32_t num_blocks);
 
 /** @} */ /* end of seekable_api */
 

--- a/include/zxc_seekable.h
+++ b/include/zxc_seekable.h
@@ -146,6 +146,28 @@ ZXC_EXPORT int64_t zxc_seekable_decompress_range(zxc_seekable* s, void* dst, siz
                                                  uint64_t offset, size_t len);
 
 /**
+ * @brief Multi-threaded variant of zxc_seekable_decompress_range().
+ *
+ * Decompresses blocks in parallel using a fork–join thread pool.  Each worker
+ * thread owns its own decompression context and reads compressed data via
+ * @c pread() (POSIX) or @c ReadFile() (Windows) for lock-free concurrent I/O.
+ *
+ * Falls back to single-threaded mode when @p n_threads <= 1 or when the
+ * requested range spans a single block.
+ *
+ * @param[in,out] s            Seekable handle.
+ * @param[out]    dst          Destination buffer.
+ * @param[in]     dst_capacity Capacity of @p dst (must be >= @p len).
+ * @param[in]     offset       Byte offset into the original uncompressed data.
+ * @param[in]     len          Number of bytes to decompress.
+ * @param[in]     n_threads    Number of worker threads (0 = auto-detect CPU cores).
+ * @return Number of bytes written to @p dst (== @p len on success),
+ *         or a negative @ref zxc_error_t code on failure.
+ */
+ZXC_EXPORT int64_t zxc_seekable_decompress_range_mt(zxc_seekable* s, void* dst, size_t dst_capacity,
+                                                    uint64_t offset, size_t len, int n_threads);
+
+/**
  * @brief Frees a seekable handle and all associated resources.
  *
  * Safe to call with @c NULL.

--- a/include/zxc_stream.h
+++ b/include/zxc_stream.h
@@ -74,6 +74,7 @@ typedef struct {
     size_t block_size; /**< Block size in bytes (0 = default ZXC_BLOCK_SIZE_DEFAULT). Must be power
                           of 2, [4KB - 2MB]. */
     int checksum_enabled; /**< 1 to enable per-block and global checksums, 0 to disable. */
+    int seekable;         /**< 1 to append a seek table for random-access decompression. */
     zxc_progress_callback_t progress_cb; /**< Optional progress callback (NULL to disable). */
     void* user_data;                     /**< User context pointer passed to progress_cb. */
 } zxc_compress_opts_t;

--- a/src/cli/main.c
+++ b/src/cli/main.c
@@ -1279,7 +1279,7 @@ int main(int argc, char** argv) {
         fm = NULL;
 
         const uint64_t max_c = zxc_compress_bound(in_size);
-        c_dat = malloc(max_c);
+        c_dat = malloc((size_t)max_c);
         if (!c_dat) goto bench_cleanup;
 
 #ifdef _WIN32

--- a/src/cli/main.c
+++ b/src/cli/main.c
@@ -349,17 +349,18 @@ enum { OPT_VERSION = 1000, OPT_HELP };
 // Forward declaration for recursive mode
 static int process_single_file(const char* in_path, const char* out_path_override, zxc_mode_t mode,
                                int num_threads, int keep_input, int force, int to_stdout,
-                               int checksum, int level, size_t block_size, int json_output);
+                               int checksum, int level, size_t block_size, int json_output,
+                               int seekable);
 
 // Forward declaration for processing directory
 static int process_directory(const char* dir_path, zxc_mode_t mode, int num_threads, int keep_input,
                              int force, int to_stdout, int checksum, int level, size_t block_size,
-                             int json_output);
+                             int json_output, int seekable);
 
 // OS-specific implementation of directory processing
 static int process_directory(const char* dir_path, zxc_mode_t mode, int num_threads, int keep_input,
                              int force, int to_stdout, int checksum, int level, size_t block_size,
-                             int json_output) {
+                             int json_output, int seekable) {
     int overall_ret = 0;
 #ifdef _WIN32
     char search_path[MAX_PATH];
@@ -383,7 +384,8 @@ static int process_directory(const char* dir_path, zxc_mode_t mode, int num_thre
 
         if (find_data.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) {
             overall_ret |= process_directory(full_path, mode, num_threads, keep_input, force,
-                                             to_stdout, checksum, level, block_size, json_output);
+                                             to_stdout, checksum, level, block_size, json_output,
+                                             seekable);
         } else {
             // Check if it ends with .zxc to skip if compressing to avoid double compression
             if (mode == MODE_COMPRESS) {
@@ -394,7 +396,8 @@ static int process_directory(const char* dir_path, zxc_mode_t mode, int num_thre
             }
             overall_ret |=
                 process_single_file(full_path, NULL, mode, num_threads, keep_input, force,
-                                    to_stdout, checksum, level, block_size, json_output);
+                                    to_stdout, checksum, level, block_size, json_output,
+                                    seekable);
         }
     } while (FindNextFileA(hFind, &find_data) != 0);
 
@@ -431,7 +434,7 @@ static int process_directory(const char* dir_path, zxc_mode_t mode, int num_thre
             if (S_ISDIR(st.st_mode)) {
                 overall_ret |=
                     process_directory(full_path, mode, num_threads, keep_input, force, to_stdout,
-                                      checksum, level, block_size, json_output);
+                                      checksum, level, block_size, json_output, seekable);
             } else if (S_ISREG(st.st_mode)) {
                 // Check if it ends with .zxc to skip if compressing to avoid double compression
                 if (mode == MODE_COMPRESS) {
@@ -443,7 +446,8 @@ static int process_directory(const char* dir_path, zxc_mode_t mode, int num_thre
                 }
                 overall_ret |=
                     process_single_file(full_path, NULL, mode, num_threads, keep_input, force,
-                                        to_stdout, checksum, level, block_size, json_output);
+                                        to_stdout, checksum, level, block_size, json_output,
+                                        seekable);
             }
         }
         free(full_path);
@@ -474,6 +478,7 @@ void print_help(const char* app) {
         "  -T, --threads N   Number of threads (0=auto)\n"
         "  -C, --checksum    Enable checksum {default}\n"
         "  -N, --no-checksum Disable checksum\n"
+        "  -S, --seekable    Append seek table for random-access decompression\n"
         "  -k, --keep        Keep input file\n"
         "  -f, --force       Force overwrite\n"
         "  -c, --stdout      Write to stdout\n"
@@ -717,7 +722,7 @@ static int zxc_list_archive(const char* path, int json_output) {
 static int process_single_file(const char* in_path, const char* out_path_override, zxc_mode_t mode,
                                int num_threads, int keep_input, int force, int to_stdout,
                                int checksum_enabled, int level, size_t block_size,
-                               int json_output) {
+                               int json_output, int seekable) {
     FILE* f_in = stdin;
     FILE* f_out = stdout;
     char resolved_in_path[4096] = {0};
@@ -890,6 +895,7 @@ static int process_single_file(const char* in_path, const char* out_path_overrid
         zxc_log_v("Processing %s... (Compression Level %d)\n", in_path, level);
     }
     if (g_verbose) zxc_log("Checksum: %s\n", checksum_enabled ? "enabled" : "disabled");
+    if (g_verbose && seekable) zxc_log("Seekable: enabled\n");
 
     // Prepare progress context
     progress_ctx_t pctx = {.start_time = zxc_now(),
@@ -904,6 +910,7 @@ static int process_single_file(const char* in_path, const char* out_path_overrid
             .level = level,
             .block_size = block_size,
             .checksum_enabled = checksum_enabled,
+            .seekable = seekable,
             .progress_cb = show_progress ? cli_progress_callback : NULL,
             .user_data = &pctx,
         };
@@ -1010,6 +1017,7 @@ int main(int argc, char** argv) {
     int level = 3;
     int json_output = 0;
     size_t block_size = 0;
+    int seekable = 0;
 
     static const struct option long_options[] = {{"compress", no_argument, 0, 'z'},
                                                  {"decompress", no_argument, 0, 'd'},
@@ -1030,12 +1038,13 @@ int main(int argc, char** argv) {
                                                  {"multiple", no_argument, 0, 'm'},
                                                  {"recursive", no_argument, 0, 'r'},
                                                  {"block-size", required_argument, 0, 'B'},
+                                                 {"seekable", no_argument, 0, 'S'},
                                                  {0, 0, 0, 0}};
 
     int opt;
     int multiple_mode = 0;
     int recursive_mode = 0;
-    while ((opt = getopt_long(argc, argv, "12345b::B:cCdfhjklmrNqT:tvVz", long_options, NULL)) !=
+    while ((opt = getopt_long(argc, argv, "12345b::B:cCdfhjklmrNqST:tvVz", long_options, NULL)) !=
            -1) {
         switch (opt) {
             case 'z':
@@ -1112,6 +1121,9 @@ int main(int argc, char** argv) {
                 break;
             case 'm':
                 multiple_mode = 1;
+                break;
+            case 'S':
+                seekable = 1;
                 break;
             case 'r':
                 recursive_mode = 1;
@@ -1446,7 +1458,8 @@ int main(int argc, char** argv) {
         if (recursive_mode && current_arg && strcmp(current_arg, "-") != 0 &&
             zxc_is_directory(current_arg)) {
             overall_ret |= process_directory(current_arg, mode, num_threads, keep_input, force,
-                                             to_stdout, checksum, level, block_size, json_output);
+                                             to_stdout, checksum, level, block_size, json_output,
+                                             seekable);
         } else {
             const char* explicit_out_path = (!multiple_mode && optind + 1 < argc && current_arg &&
                                              strcmp(current_arg, "-") != 0 && !to_stdout)
@@ -1455,7 +1468,8 @@ int main(int argc, char** argv) {
 
             overall_ret |=
                 process_single_file(current_arg, explicit_out_path, mode, num_threads, keep_input,
-                                    force, to_stdout, checksum, level, block_size, json_output);
+                                    force, to_stdout, checksum, level, block_size, json_output,
+                                    seekable);
         }
 
         if (!multiple_mode) {

--- a/src/lib/zxc_common.c
+++ b/src/lib/zxc_common.c
@@ -592,7 +592,10 @@ uint64_t zxc_compress_bound(const size_t input_size) {
     uint64_t n = ((uint64_t)input_size + ZXC_BLOCK_SIZE_DEFAULT - 1) / ZXC_BLOCK_SIZE_DEFAULT;
     if (n == 0) n = 1;
     return ZXC_FILE_HEADER_SIZE + (n * (ZXC_BLOCK_HEADER_SIZE + ZXC_BLOCK_CHECKSUM_SIZE + 64)) +
-           (uint64_t)input_size + ZXC_BLOCK_HEADER_SIZE + ZXC_FILE_FOOTER_SIZE;
+           (uint64_t)input_size + ZXC_BLOCK_HEADER_SIZE + /* EOF block */
+           ZXC_BLOCK_HEADER_SIZE +                        /* SEK block header (seekable) */
+           (n * ZXC_SEEK_ENTRY_SIZE) +                    /* SEK entries: 4 bytes per block */
+           ZXC_FILE_FOOTER_SIZE;
 }
 
 /*

--- a/src/lib/zxc_common.c
+++ b/src/lib/zxc_common.c
@@ -581,7 +581,11 @@ int zxc_bitpack_stream_32(const uint32_t* RESTRICT src, const size_t count, uint
  * @brief Returns the maximum compressed size for a given input size.
  *
  * The result accounts for the file header, per-block headers, block
- * checksums, worst-case expansion, EOF block, and the file footer.
+ * checksums, worst-case expansion, EOF block, seekable overhead (SEK
+ * block), and the file footer.
+ *
+ * The block count is derived from @ref ZXC_BLOCK_SIZE_MIN (4 KB) to
+ * guarantee the bound holds for all valid block sizes and seekable mode.
  *
  * @param[in] input_size Uncompressed input size in bytes.
  * @return Upper bound on compressed size, or 0 if @p input_size would overflow.
@@ -589,7 +593,7 @@ int zxc_bitpack_stream_32(const uint32_t* RESTRICT src, const size_t count, uint
 uint64_t zxc_compress_bound(const size_t input_size) {
     // Guard UINT64_MAX / SIZE_MAX would overflow.
     if (UNLIKELY(input_size > (SIZE_MAX - (SIZE_MAX >> 8)))) return 0;
-    uint64_t n = ((uint64_t)input_size + ZXC_BLOCK_SIZE_DEFAULT - 1) / ZXC_BLOCK_SIZE_DEFAULT;
+    uint64_t n = ((uint64_t)input_size + ZXC_BLOCK_SIZE_MIN - 1) / ZXC_BLOCK_SIZE_MIN;
     if (n == 0) n = 1;
     return ZXC_FILE_HEADER_SIZE + (n * (ZXC_BLOCK_HEADER_SIZE + ZXC_BLOCK_CHECKSUM_SIZE + 64)) +
            (uint64_t)input_size + ZXC_BLOCK_HEADER_SIZE + /* EOF block */

--- a/src/lib/zxc_compress.c
+++ b/src/lib/zxc_compress.c
@@ -288,7 +288,8 @@ static ZXC_ALWAYS_INLINE zxc_match_t zxc_lz77_find_best_match(
                 uint8x8_t p1 = vpmin_u8(vget_low_u8(v_cmp), vget_high_u8(v_cmp));
                 uint8x8_t p2 = vpmin_u8(p1, p1);
                 uint8x8_t p3 = vpmin_u8(p2, p2);
-                uint8_t min_val = vget_lane_u8(p3, 0);
+                uint8x8_t p4 = vpmin_u8(p3, p3);
+                uint8_t min_val = vget_lane_u8(p4, 0);
                 if (min_val == 0xFF)
                     mlen += 16;
                 else {

--- a/src/lib/zxc_dispatch.c
+++ b/src/lib/zxc_dispatch.c
@@ -16,6 +16,7 @@
  */
 
 #include "../../include/zxc_error.h"
+#include "../../include/zxc_seekable.h"
 #include "zxc_internal.h"
 
 /*
@@ -347,6 +348,7 @@ int64_t zxc_compress(const void* RESTRICT src, const size_t src_size, void* REST
     if (UNLIKELY(!src || !dst || src_size == 0 || dst_capacity == 0)) return ZXC_ERROR_NULL_INPUT;
 
     const int checksum_enabled = opts ? opts->checksum_enabled : 0;
+    const int seekable = opts ? opts->seekable : 0;
     const int level = (opts && opts->level > 0) ? opts->level : ZXC_LEVEL_DEFAULT;
     const size_t block_size =
         (opts && opts->block_size > 0) ? opts->block_size : ZXC_BLOCK_SIZE_DEFAULT;
@@ -371,6 +373,23 @@ int64_t zxc_compress(const void* RESTRICT src, const size_t src_size, void* REST
     }
     op += h_val;
 
+    /* Seekable: dynamic arrays for per-block sizes */
+    uint32_t* seek_comp = NULL;
+    uint32_t* seek_decomp = NULL;
+    uint32_t seek_count = 0;
+    uint32_t seek_cap = 0;
+    if (seekable) {
+        seek_cap = (uint32_t)((src_size / block_size) + 2);
+        seek_comp = (uint32_t*)malloc(seek_cap * sizeof(uint32_t));
+        seek_decomp = (uint32_t*)malloc(seek_cap * sizeof(uint32_t));
+        if (UNLIKELY(!seek_comp || !seek_decomp)) {
+            free(seek_comp);
+            free(seek_decomp);
+            zxc_cctx_free(&ctx);
+            return ZXC_ERROR_MEMORY;
+        }
+    }
+
     size_t pos = 0;
     while (pos < src_size) {
         const size_t chunk_len = (src_size - pos > block_size) ? block_size : (src_size - pos);
@@ -378,6 +397,8 @@ int64_t zxc_compress(const void* RESTRICT src, const size_t src_size, void* REST
 
         const int res = zxc_compress_chunk_wrapper(&ctx, ip + pos, chunk_len, op, rem_cap);
         if (UNLIKELY(res < 0)) {
+            free(seek_comp);
+            free(seek_decomp);
             zxc_cctx_free(&ctx);
             return res;
         }
@@ -391,21 +412,59 @@ int64_t zxc_compress(const void* RESTRICT src, const size_t src_size, void* REST
             }
         }
 
+        /* Seekable: record block sizes */
+        if (seekable) {
+            if (UNLIKELY(seek_count >= seek_cap)) {
+                seek_cap = seek_cap * 2;
+                uint32_t* nc = (uint32_t*)realloc(seek_comp, seek_cap * sizeof(uint32_t));
+                uint32_t* nd = (uint32_t*)realloc(seek_decomp, seek_cap * sizeof(uint32_t));
+                if (UNLIKELY(!nc || !nd)) {
+                    free(nc ? nc : seek_comp);
+                    free(nd ? nd : seek_decomp);
+                    zxc_cctx_free(&ctx);
+                    return ZXC_ERROR_MEMORY;
+                }
+                seek_comp = nc;
+                seek_decomp = nd;
+            }
+            seek_comp[seek_count] = (uint32_t)res;
+            seek_decomp[seek_count] = (uint32_t)chunk_len;
+            seek_count++;
+        }
+
         op += res;
         pos += chunk_len;
     }
 
     zxc_cctx_free(&ctx);
 
-    // Write EOF Block (Checksum flag handled by Block Header, but we zero it out now)
+    // Write EOF Block
     const size_t rem_cap = (size_t)(op_end - op);
     const zxc_block_header_t eof_bh = {
         .block_type = ZXC_BLOCK_EOF, .block_flags = 0, .reserved = 0, .comp_size = 0};
     const int eof_val = zxc_write_block_header(op, rem_cap, &eof_bh);
-    if (UNLIKELY(eof_val < 0)) return eof_val;
+    if (UNLIKELY(eof_val < 0)) {
+        free(seek_comp);
+        free(seek_decomp);
+        return eof_val;
+    }
     op += eof_val;
 
-    if (UNLIKELY(rem_cap < (size_t)eof_val + ZXC_FILE_FOOTER_SIZE)) return ZXC_ERROR_DST_TOO_SMALL;
+    /* Seekable: write seek table between EOF block and footer */
+    if (seekable && seek_count > 0) {
+        const size_t st_cap = (size_t)(op_end - op);
+        const int64_t st_val =
+            zxc_write_seek_table(op, st_cap, seek_comp, seek_decomp, seek_count, 0);
+        free(seek_comp);
+        free(seek_decomp);
+        if (UNLIKELY(st_val < 0)) return (int64_t)st_val;
+        op += st_val;
+    } else {
+        free(seek_comp);
+        free(seek_decomp);
+    }
+
+    if (UNLIKELY((size_t)(op_end - op) < ZXC_FILE_FOOTER_SIZE)) return ZXC_ERROR_DST_TOO_SMALL;
 
     // Write 12-byte Footer: [Source Size (8)] + [Global Hash (4)]
     const int footer_val =
@@ -482,12 +541,13 @@ int64_t zxc_decompress(const void* RESTRICT src, const size_t src_size, void* RE
 
         // Handle EOF block separately (not a real chunk to decompress)
         if (UNLIKELY(bh.block_type == ZXC_BLOCK_EOF)) {
-            // Validate we have the footer after the header
-            if (UNLIKELY(rem_src < ZXC_BLOCK_HEADER_SIZE + ZXC_FILE_FOOTER_SIZE)) {
+            // Footer is always the last ZXC_FILE_FOOTER_SIZE bytes of the source,
+            // even when a seek table is inserted between EOF block and footer.
+            if (UNLIKELY(src_size < ZXC_FILE_FOOTER_SIZE)) {
                 zxc_cctx_free(&ctx);
                 return ZXC_ERROR_SRC_TOO_SMALL;
             }
-            const uint8_t* const footer = ip + ZXC_BLOCK_HEADER_SIZE;
+            const uint8_t* const footer = (const uint8_t*)src + src_size - ZXC_FILE_FOOTER_SIZE;
 
             // Validate source size matches what we decompressed
             const uint64_t stored_size = zxc_le64(footer);

--- a/src/lib/zxc_dispatch.c
+++ b/src/lib/zxc_dispatch.c
@@ -382,7 +382,12 @@ int64_t zxc_compress(const void* RESTRICT src, const size_t src_size, void* REST
     uint32_t seek_count = 0;
     uint32_t seek_cap = 0;
     if (seekable) {
-        seek_cap = (uint32_t)((src_size / block_size) + 2);
+        const size_t block_count = src_size / block_size;
+        if (UNLIKELY(block_count > (size_t)UINT32_MAX - 2)) {
+            zxc_cctx_free(&ctx);
+            return ZXC_ERROR_BAD_BLOCK_SIZE;
+        }
+        seek_cap = (uint32_t)(block_count + 2);
         seek_comp = (uint32_t*)malloc(seek_cap * sizeof(uint32_t));
         // LCOV_EXCL_START
         if (UNLIKELY(!seek_comp)) {

--- a/src/lib/zxc_dispatch.c
+++ b/src/lib/zxc_dispatch.c
@@ -373,18 +373,14 @@ int64_t zxc_compress(const void* RESTRICT src, const size_t src_size, void* REST
     }
     op += h_val;
 
-    /* Seekable: dynamic arrays for per-block sizes */
+    /* Seekable: dynamic array for per-block compressed sizes */
     uint32_t* seek_comp = NULL;
-    uint32_t* seek_decomp = NULL;
     uint32_t seek_count = 0;
     uint32_t seek_cap = 0;
     if (seekable) {
         seek_cap = (uint32_t)((src_size / block_size) + 2);
         seek_comp = (uint32_t*)malloc(seek_cap * sizeof(uint32_t));
-        seek_decomp = (uint32_t*)malloc(seek_cap * sizeof(uint32_t));
-        if (UNLIKELY(!seek_comp || !seek_decomp)) {
-            free(seek_comp);
-            free(seek_decomp);
+        if (UNLIKELY(!seek_comp)) {
             zxc_cctx_free(&ctx);
             return ZXC_ERROR_MEMORY;
         }
@@ -398,7 +394,6 @@ int64_t zxc_compress(const void* RESTRICT src, const size_t src_size, void* REST
         const int res = zxc_compress_chunk_wrapper(&ctx, ip + pos, chunk_len, op, rem_cap);
         if (UNLIKELY(res < 0)) {
             free(seek_comp);
-            free(seek_decomp);
             zxc_cctx_free(&ctx);
             return res;
         }
@@ -412,23 +407,19 @@ int64_t zxc_compress(const void* RESTRICT src, const size_t src_size, void* REST
             }
         }
 
-        /* Seekable: record block sizes */
+        /* Seekable: record compressed block size */
         if (seekable) {
             if (UNLIKELY(seek_count >= seek_cap)) {
                 seek_cap = seek_cap * 2;
                 uint32_t* nc = (uint32_t*)realloc(seek_comp, seek_cap * sizeof(uint32_t));
-                uint32_t* nd = (uint32_t*)realloc(seek_decomp, seek_cap * sizeof(uint32_t));
-                if (UNLIKELY(!nc || !nd)) {
-                    free(nc ? nc : seek_comp);
-                    free(nd ? nd : seek_decomp);
+                if (UNLIKELY(!nc)) {
+                    free(seek_comp);
                     zxc_cctx_free(&ctx);
                     return ZXC_ERROR_MEMORY;
                 }
                 seek_comp = nc;
-                seek_decomp = nd;
             }
             seek_comp[seek_count] = (uint32_t)res;
-            seek_decomp[seek_count] = (uint32_t)chunk_len;
             seek_count++;
         }
 
@@ -445,7 +436,6 @@ int64_t zxc_compress(const void* RESTRICT src, const size_t src_size, void* REST
     const int eof_val = zxc_write_block_header(op, rem_cap, &eof_bh);
     if (UNLIKELY(eof_val < 0)) {
         free(seek_comp);
-        free(seek_decomp);
         return eof_val;
     }
     op += eof_val;
@@ -453,14 +443,12 @@ int64_t zxc_compress(const void* RESTRICT src, const size_t src_size, void* REST
     /* Seekable: write seek table between EOF block and footer */
     if (seekable && seek_count > 0) {
         const size_t st_cap = (size_t)(op_end - op);
-        const int64_t st_val = zxc_write_seek_table(op, st_cap, seek_comp, seek_decomp, seek_count);
+        const int64_t st_val = zxc_write_seek_table(op, st_cap, seek_comp, seek_count);
         free(seek_comp);
-        free(seek_decomp);
         if (UNLIKELY(st_val < 0)) return (int64_t)st_val;
         op += st_val;
     } else {
         free(seek_comp);
-        free(seek_decomp);
     }
 
     if (UNLIKELY((size_t)(op_end - op) < ZXC_FILE_FOOTER_SIZE)) return ZXC_ERROR_DST_TOO_SMALL;

--- a/src/lib/zxc_dispatch.c
+++ b/src/lib/zxc_dispatch.c
@@ -453,8 +453,7 @@ int64_t zxc_compress(const void* RESTRICT src, const size_t src_size, void* REST
     /* Seekable: write seek table between EOF block and footer */
     if (seekable && seek_count > 0) {
         const size_t st_cap = (size_t)(op_end - op);
-        const int64_t st_val =
-            zxc_write_seek_table(op, st_cap, seek_comp, seek_decomp, seek_count, 0);
+        const int64_t st_val = zxc_write_seek_table(op, st_cap, seek_comp, seek_decomp, seek_count);
         free(seek_comp);
         free(seek_decomp);
         if (UNLIKELY(st_val < 0)) return (int64_t)st_val;

--- a/src/lib/zxc_dispatch.c
+++ b/src/lib/zxc_dispatch.c
@@ -362,15 +362,19 @@ int64_t zxc_compress(const void* RESTRICT src, const size_t src_size, void* REST
     uint32_t global_hash = 0;
     zxc_cctx_t ctx;
 
+    // LCOV_EXCL_START
     if (UNLIKELY(zxc_cctx_init(&ctx, block_size, 1, level, checksum_enabled) != ZXC_OK))
         return ZXC_ERROR_MEMORY;
+    // LCOV_EXCL_STOP
 
     const int h_val =
         zxc_write_file_header(op, (size_t)(op_end - op), block_size, checksum_enabled);
+    // LCOV_EXCL_START
     if (UNLIKELY(h_val < 0)) {
         zxc_cctx_free(&ctx);
         return h_val;
     }
+    // LCOV_EXCL_STOP
     op += h_val;
 
     /* Seekable: dynamic array for per-block compressed sizes */
@@ -380,10 +384,12 @@ int64_t zxc_compress(const void* RESTRICT src, const size_t src_size, void* REST
     if (seekable) {
         seek_cap = (uint32_t)((src_size / block_size) + 2);
         seek_comp = (uint32_t*)malloc(seek_cap * sizeof(uint32_t));
+        // LCOV_EXCL_START
         if (UNLIKELY(!seek_comp)) {
             zxc_cctx_free(&ctx);
             return ZXC_ERROR_MEMORY;
         }
+        // LCOV_EXCL_STOP
     }
 
     size_t pos = 0;
@@ -409,6 +415,7 @@ int64_t zxc_compress(const void* RESTRICT src, const size_t src_size, void* REST
 
         /* Seekable: record compressed block size */
         if (seekable) {
+            // LCOV_EXCL_START
             if (UNLIKELY(seek_count >= seek_cap)) {
                 seek_cap = seek_cap * 2;
                 uint32_t* nc = (uint32_t*)realloc(seek_comp, seek_cap * sizeof(uint32_t));
@@ -419,6 +426,7 @@ int64_t zxc_compress(const void* RESTRICT src, const size_t src_size, void* REST
                 }
                 seek_comp = nc;
             }
+            // LCOV_EXCL_STOP
             seek_comp[seek_count] = (uint32_t)res;
             seek_count++;
         }
@@ -434,10 +442,12 @@ int64_t zxc_compress(const void* RESTRICT src, const size_t src_size, void* REST
     const zxc_block_header_t eof_bh = {
         .block_type = ZXC_BLOCK_EOF, .block_flags = 0, .reserved = 0, .comp_size = 0};
     const int eof_val = zxc_write_block_header(op, rem_cap, &eof_bh);
+    // LCOV_EXCL_START
     if (UNLIKELY(eof_val < 0)) {
         free(seek_comp);
         return eof_val;
     }
+    // LCOV_EXCL_STOP
     op += eof_val;
 
     /* Seekable: write seek table between EOF block and footer */
@@ -445,18 +455,19 @@ int64_t zxc_compress(const void* RESTRICT src, const size_t src_size, void* REST
         const size_t st_cap = (size_t)(op_end - op);
         const int64_t st_val = zxc_write_seek_table(op, st_cap, seek_comp, seek_count);
         free(seek_comp);
-        if (UNLIKELY(st_val < 0)) return (int64_t)st_val;
+        if (UNLIKELY(st_val < 0)) return (int64_t)st_val;  // LCOV_EXCL_LINE
         op += st_val;
     } else {
         free(seek_comp);
     }
 
-    if (UNLIKELY((size_t)(op_end - op) < ZXC_FILE_FOOTER_SIZE)) return ZXC_ERROR_DST_TOO_SMALL;
+    if (UNLIKELY((size_t)(op_end - op) < ZXC_FILE_FOOTER_SIZE))
+        return ZXC_ERROR_DST_TOO_SMALL;  // LCOV_EXCL_LINE
 
     // Write 12-byte Footer: [Source Size (8)] + [Global Hash (4)]
     const int footer_val =
         zxc_write_file_footer(op, (size_t)(op_end - op), src_size, global_hash, checksum_enabled);
-    if (UNLIKELY(footer_val < 0)) return footer_val;
+    if (UNLIKELY(footer_val < 0)) return footer_val;  // LCOV_EXCL_LINE
     op += footer_val;
 
     return (int64_t)(op - op_start);
@@ -507,10 +518,12 @@ int64_t zxc_decompress(const void* RESTRICT src, const size_t src_size, void* RE
     if (ctx.work_buf_cap < work_sz) {
         free(ctx.work_buf);
         ctx.work_buf = (uint8_t*)malloc(work_sz);
+        // LCOV_EXCL_START
         if (UNLIKELY(!ctx.work_buf)) {
             zxc_cctx_free(&ctx);
             return ZXC_ERROR_MEMORY;
         }
+        // LCOV_EXCL_STOP
         ctx.work_buf_cap = work_sz;
     }
 
@@ -530,10 +543,12 @@ int64_t zxc_decompress(const void* RESTRICT src, const size_t src_size, void* RE
         if (UNLIKELY(bh.block_type == ZXC_BLOCK_EOF)) {
             // Footer is always the last ZXC_FILE_FOOTER_SIZE bytes of the source,
             // even when a seek table is inserted between EOF block and footer.
+            // LCOV_EXCL_START
             if (UNLIKELY(src_size < ZXC_FILE_FOOTER_SIZE)) {
                 zxc_cctx_free(&ctx);
                 return ZXC_ERROR_SRC_TOO_SMALL;
             }
+            // LCOV_EXCL_STOP
             const uint8_t* const footer = (const uint8_t*)src + src_size - ZXC_FILE_FOOTER_SIZE;
 
             // Validate source size matches what we decompressed
@@ -564,10 +579,12 @@ int64_t zxc_decompress(const void* RESTRICT src, const size_t src_size, void* RE
             // Safe path: decode into bounce buffer, then copy exact result.
             res = zxc_decompress_chunk_wrapper(&ctx, ip, rem_src, ctx.work_buf, runtime_chunk_size);
             if (LIKELY(res > 0)) {
+                // LCOV_EXCL_START
                 if (UNLIKELY((size_t)res > rem_cap)) {
                     zxc_cctx_free(&ctx);
                     return ZXC_ERROR_DST_TOO_SMALL;
                 }
+                // LCOV_EXCL_STOP
                 ZXC_MEMCPY(op, ctx.work_buf, (size_t)res);
             }
         }
@@ -634,7 +651,7 @@ struct zxc_cctx_s {
 
 zxc_cctx* zxc_create_cctx(const zxc_compress_opts_t* opts) {
     zxc_cctx* const cctx = (zxc_cctx*)calloc(1, sizeof(zxc_cctx));
-    if (UNLIKELY(!cctx)) return NULL;
+    if (UNLIKELY(!cctx)) return NULL;  // LCOV_EXCL_LINE
 
     /* Resolve and store sticky defaults. */
     cctx->stored_level = (opts && opts->level > 0) ? opts->level : ZXC_LEVEL_DEFAULT;
@@ -643,12 +660,14 @@ zxc_cctx* zxc_create_cctx(const zxc_compress_opts_t* opts) {
     cctx->stored_checksum = opts ? opts->checksum_enabled : 0;
 
     if (opts) {
+        // LCOV_EXCL_START
         if (UNLIKELY(!zxc_validate_block_size(cctx->stored_block_size) ||
                      zxc_cctx_init(&cctx->inner, cctx->stored_block_size, 1, cctx->stored_level,
                                    cctx->stored_checksum) != ZXC_OK)) {
             free(cctx);
             return NULL;
         }
+        // LCOV_EXCL_STOP
         cctx->last_block_size = cctx->stored_block_size;
         cctx->initialized = 1;
     }
@@ -685,8 +704,10 @@ int64_t zxc_compress_cctx(zxc_cctx* cctx, const void* RESTRICT src, const size_t
             zxc_cctx_free(&cctx->inner);
             cctx->initialized = 0;
         }
+        // LCOV_EXCL_START
         if (UNLIKELY(zxc_cctx_init(&cctx->inner, block_size, 1, level, checksum_enabled) != ZXC_OK))
             return ZXC_ERROR_MEMORY;
+        // LCOV_EXCL_STOP
         cctx->last_block_size = block_size;
         cctx->initialized = 1;
     } else {
@@ -705,7 +726,7 @@ int64_t zxc_compress_cctx(zxc_cctx* cctx, const void* RESTRICT src, const size_t
 
     const int h_val =
         zxc_write_file_header(op, (size_t)(op_end - op), block_size, checksum_enabled);
-    if (UNLIKELY(h_val < 0)) return h_val;
+    if (UNLIKELY(h_val < 0)) return h_val;  // LCOV_EXCL_LINE
     op += h_val;
 
     size_t pos = 0;
@@ -732,14 +753,15 @@ int64_t zxc_compress_cctx(zxc_cctx* cctx, const void* RESTRICT src, const size_t
     const zxc_block_header_t eof_bh = {
         .block_type = ZXC_BLOCK_EOF, .block_flags = 0, .reserved = 0, .comp_size = 0};
     const int eof_val = zxc_write_block_header(op, rem_cap, &eof_bh);
-    if (UNLIKELY(eof_val < 0)) return eof_val;
+    if (UNLIKELY(eof_val < 0)) return eof_val;  // LCOV_EXCL_LINE
     op += eof_val;
 
-    if (UNLIKELY(rem_cap < (size_t)eof_val + ZXC_FILE_FOOTER_SIZE)) return ZXC_ERROR_DST_TOO_SMALL;
+    if (UNLIKELY(rem_cap < (size_t)eof_val + ZXC_FILE_FOOTER_SIZE))
+        return ZXC_ERROR_DST_TOO_SMALL;  // LCOV_EXCL_LINE
 
     const int footer_val =
         zxc_write_file_footer(op, (size_t)(op_end - op), src_size, global_hash, checksum_enabled);
-    if (UNLIKELY(footer_val < 0)) return footer_val;
+    if (UNLIKELY(footer_val < 0)) return footer_val;  // LCOV_EXCL_LINE
     op += footer_val;
 
     return (int64_t)(op - op_start);
@@ -790,9 +812,11 @@ int64_t zxc_decompress_dctx(zxc_dctx* dctx, const void* RESTRICT src, const size
             zxc_cctx_free(&dctx->inner);
             dctx->initialized = 0;
         }
+        // LCOV_EXCL_START
         if (UNLIKELY(zxc_cctx_init(&dctx->inner, runtime_chunk_size, 0, 0,
                                    file_has_checksums && checksum_enabled) != ZXC_OK))
             return ZXC_ERROR_MEMORY;
+        // LCOV_EXCL_STOP
         dctx->last_block_size = runtime_chunk_size;
         dctx->initialized = 1;
     } else {
@@ -807,7 +831,7 @@ int64_t zxc_decompress_dctx(zxc_dctx* dctx, const void* RESTRICT src, const size
     if (ctx->work_buf_cap < work_sz) {
         free(ctx->work_buf);
         ctx->work_buf = (uint8_t*)malloc(work_sz);
-        if (UNLIKELY(!ctx->work_buf)) return ZXC_ERROR_MEMORY;
+        if (UNLIKELY(!ctx->work_buf)) return ZXC_ERROR_MEMORY;  // LCOV_EXCL_LINE
         ctx->work_buf_cap = work_sz;
     }
 
@@ -843,7 +867,8 @@ int64_t zxc_decompress_dctx(zxc_dctx* dctx, const void* RESTRICT src, const size
             // Safe path: decode into bounce buffer, then copy exact result.
             res = zxc_decompress_chunk_wrapper(ctx, ip, rem_src, ctx->work_buf, runtime_chunk_size);
             if (LIKELY(res > 0)) {
-                if (UNLIKELY((size_t)res > rem_cap)) return ZXC_ERROR_DST_TOO_SMALL;
+                if (UNLIKELY((size_t)res > rem_cap))
+                    return ZXC_ERROR_DST_TOO_SMALL;  // LCOV_EXCL_LINE
                 ZXC_MEMCPY(op, ctx->work_buf, (size_t)res);
             }
         }
@@ -889,9 +914,11 @@ int64_t zxc_compress_block(zxc_cctx* cctx, const void* RESTRICT src, const size_
             zxc_cctx_free(&cctx->inner);
             cctx->initialized = 0;
         }
+        // LCOV_EXCL_START
         if (UNLIKELY(zxc_cctx_init(&cctx->inner, effective_block_size, 1, level,
                                    checksum_enabled) != ZXC_OK))
             return ZXC_ERROR_MEMORY;
+        // LCOV_EXCL_STOP
         cctx->last_block_size = effective_block_size;
         cctx->initialized = 1;
     } else {
@@ -923,8 +950,10 @@ int64_t zxc_decompress_block(zxc_dctx* dctx, const void* RESTRICT src, const siz
             zxc_cctx_free(&dctx->inner);
             dctx->initialized = 0;
         }
+        // LCOV_EXCL_START
         if (UNLIKELY(zxc_cctx_init(&dctx->inner, block_size, 0, 0, checksum_enabled) != ZXC_OK))
             return ZXC_ERROR_MEMORY;
+        // LCOV_EXCL_STOP
         dctx->last_block_size = block_size;
         dctx->initialized = 1;
     } else {
@@ -938,7 +967,7 @@ int64_t zxc_decompress_block(zxc_dctx* dctx, const void* RESTRICT src, const siz
     if (ctx->work_buf_cap < work_sz) {
         free(ctx->work_buf);
         ctx->work_buf = (uint8_t*)malloc(work_sz);
-        if (UNLIKELY(!ctx->work_buf)) return ZXC_ERROR_MEMORY;
+        if (UNLIKELY(!ctx->work_buf)) return ZXC_ERROR_MEMORY;  // LCOV_EXCL_LINE
         ctx->work_buf_cap = work_sz;
     }
 

--- a/src/lib/zxc_driver.c
+++ b/src/lib/zxc_driver.c
@@ -676,7 +676,22 @@ static int64_t zxc_stream_engine_run(FILE* f_in, FILE* f_out, const int n_thread
     if (mode == 1 && seekable) {
         w_args.seek_cap = 64;
         w_args.seek_comp = (uint32_t*)malloc(w_args.seek_cap * sizeof(uint32_t));
-        /* malloc failure -> fall through without seekable (graceful degradation) */
+        // LCOV_EXCL_START
+        if (UNLIKELY(!w_args.seek_comp)) {
+            pthread_mutex_lock(&ctx.lock);
+            ctx.shutdown_workers = 1;
+            pthread_cond_broadcast(&ctx.cond_worker);
+            pthread_mutex_unlock(&ctx.lock);
+            for (int i = 0; i < started_workers; i++) pthread_join(workers[i], NULL);
+            pthread_cond_destroy(&ctx.cond_writer);
+            pthread_cond_destroy(&ctx.cond_worker);
+            pthread_cond_destroy(&ctx.cond_reader);
+            pthread_mutex_destroy(&ctx.lock);
+            free(workers);
+            zxc_aligned_free(mem_block);
+            return ZXC_ERROR_MEMORY;
+        }
+        // LCOV_EXCL_STOP
     }
 
     if (mode == 1 && f_out) {

--- a/src/lib/zxc_driver.c
+++ b/src/lib/zxc_driver.c
@@ -22,6 +22,7 @@
 #include "../../include/zxc_buffer.h"
 #include "../../include/zxc_error.h"
 #include "../../include/zxc_sans_io.h"
+#include "../../include/zxc_seekable.h"
 #include "../../include/zxc_stream.h"
 #include "zxc_internal.h"
 
@@ -300,6 +301,15 @@ typedef struct {
  *
  * @var writer_args_t::bytes_processed
  * The number of bytes processed so far, used for progress reporting.
+ *
+ * @var writer_args_t::seek_comp
+ * Array of compressed block sizes for seek table construction.
+ *
+ * @var writer_args_t::seek_count
+ * Number of entries in the seek table.
+ *
+ * @var writer_args_t::seek_cap
+ * Capacity of the seek table array.
  */
 typedef struct {
     zxc_stream_ctx_t* ctx;
@@ -307,6 +317,9 @@ typedef struct {
     int64_t total_bytes;
     uint32_t global_hash;
     uint64_t bytes_processed;  // For progress callback
+    uint32_t* seek_comp;
+    uint32_t seek_count;
+    uint32_t seek_cap;
 } writer_args_t;
 
 /**
@@ -458,6 +471,27 @@ static void* zxc_async_writer(void* arg) {
         }
         args->total_bytes += (int64_t)job->result_sz;
 
+        /* Seekable: record compressed block size */
+        if (args->seek_comp && ctx->compression_mode == 1) {
+            if (UNLIKELY(args->seek_count >= args->seek_cap)) {
+                args->seek_cap = args->seek_cap * 2;
+                uint32_t* nc =
+                    (uint32_t*)realloc(args->seek_comp, args->seek_cap * sizeof(uint32_t));
+                // LCOV_EXCL_START
+                if (UNLIKELY(!nc)) {
+                    ctx->io_error = 1;
+                    pthread_mutex_lock(&ctx->lock);
+                    job->status = JOB_STATUS_FREE;
+                    pthread_cond_signal(&ctx->cond_reader);
+                    pthread_mutex_unlock(&ctx->lock);
+                    break;
+                }
+                // LCOV_EXCL_STOP
+                args->seek_comp = nc;
+            }
+            args->seek_comp[args->seek_count++] = (uint32_t)job->result_sz;
+        }
+
         // Update progress callback
         if (ctx->progress_cb) {
             // LCOV_EXCL_START
@@ -515,7 +549,8 @@ static void* zxc_async_writer(void* arg) {
  */
 static int64_t zxc_stream_engine_run(FILE* f_in, FILE* f_out, const int n_threads, const int mode,
                                      const int level, const size_t block_size,
-                                     const int checksum_enabled, zxc_chunk_processor_t func,
+                                     const int checksum_enabled, const int seekable,
+                                     zxc_chunk_processor_t func,
                                      zxc_progress_callback_t progress_cb, void* user_data) {
     zxc_stream_ctx_t ctx;
     ZXC_MEMSET(&ctx, 0, sizeof(ctx));
@@ -635,7 +670,14 @@ static int64_t zxc_stream_engine_run(FILE* f_in, FILE* f_out, const int n_thread
         // LCOV_EXCL_STOP
     }
 
-    writer_args_t w_args = {&ctx, f_out, 0, 0, 0};
+    writer_args_t w_args = {&ctx, f_out, 0, 0, 0, NULL, 0, 0};
+
+    /* Seekable: allocate initial block-size tracking array */
+    if (mode == 1 && seekable) {
+        w_args.seek_cap = 64;
+        w_args.seek_comp = (uint32_t*)malloc(w_args.seek_cap * sizeof(uint32_t));
+        /* malloc failure → fall through without seekable (graceful degradation) */
+    }
 
     if (mode == 1 && f_out) {
         uint8_t h[ZXC_FILE_HEADER_SIZE];
@@ -769,37 +811,79 @@ static int64_t zxc_stream_engine_run(FILE* f_in, FILE* f_out, const int n_thread
     pthread_cond_destroy(&ctx.cond_reader);
     pthread_mutex_destroy(&ctx.lock);
 
-    // Write EOF Block if compression and no error
+    // Write EOF Block + optional Seek Table + Footer if compression and no error
     if (mode == 1 && !ctx.io_error && w_args.total_bytes >= 0) {
-        uint8_t final_buf[ZXC_BLOCK_HEADER_SIZE + ZXC_FILE_FOOTER_SIZE];
-        uint8_t* const eof_buf = final_buf;
-        uint8_t* const footer = final_buf + ZXC_BLOCK_HEADER_SIZE;
-
-        zxc_block_header_t eof_bh = {
+        /* EOF block */
+        uint8_t eof_buf[ZXC_BLOCK_HEADER_SIZE];
+        const zxc_block_header_t eof_bh = {
             .block_type = ZXC_BLOCK_EOF, .block_flags = 0, .reserved = 0, .comp_size = 0};
         zxc_write_block_header(eof_buf, ZXC_BLOCK_HEADER_SIZE, &eof_bh);
-        zxc_write_file_footer(footer, ZXC_FILE_FOOTER_SIZE, total_src_bytes, w_args.global_hash,
-                              checksum_enabled);
-
-        if (UNLIKELY(f_out && fwrite(final_buf, 1, sizeof(final_buf), f_out) != sizeof(final_buf)))
+        if (UNLIKELY(f_out &&
+                     fwrite(eof_buf, 1, ZXC_BLOCK_HEADER_SIZE, f_out) != ZXC_BLOCK_HEADER_SIZE))
             ctx.io_error = 1;
         else
-            w_args.total_bytes += sizeof(final_buf);
-    } else if (mode == 0 && !ctx.io_error) {
-        // Verification: Expect 12-byte footer
-        uint8_t footer[ZXC_FILE_FOOTER_SIZE];
-        if (UNLIKELY(fread(footer, 1, ZXC_FILE_FOOTER_SIZE, f_in) != ZXC_FILE_FOOTER_SIZE)) {
-            ctx.io_error = 1;
-        } else {
-            // Verify Footer Content: Source Size and Global Checksum
-            int valid = (zxc_le64(footer) == (uint64_t)w_args.total_bytes);
-            if (valid && checksum_enabled && ctx.file_has_checksum)
-                valid = (zxc_le32(footer + sizeof(uint64_t)) == d_global_hash);
+            w_args.total_bytes += ZXC_BLOCK_HEADER_SIZE;
 
-            if (UNLIKELY(!valid)) ctx.io_error = 1;
+        /* Seekable: write SEK block between EOF and footer */
+        if (!ctx.io_error && w_args.seek_comp && w_args.seek_count > 0) {
+            const size_t st_size = zxc_seek_table_size(w_args.seek_count);
+            uint8_t* const st_buf = (uint8_t*)malloc(st_size);
+            if (st_buf) {
+                const int64_t st_val =
+                    zxc_write_seek_table(st_buf, st_size, w_args.seek_comp, w_args.seek_count);
+                if (st_val > 0 && f_out &&
+                    fwrite(st_buf, 1, (size_t)st_val, f_out) == (size_t)st_val)
+                    w_args.total_bytes += st_val;
+                free(st_buf);
+            }
+        }
+
+        /* Footer */
+        uint8_t footer_buf[ZXC_FILE_FOOTER_SIZE];
+        zxc_write_file_footer(footer_buf, ZXC_FILE_FOOTER_SIZE, total_src_bytes, w_args.global_hash,
+                              checksum_enabled);
+        if (UNLIKELY(f_out &&
+                     fwrite(footer_buf, 1, ZXC_FILE_FOOTER_SIZE, f_out) != ZXC_FILE_FOOTER_SIZE))
+            ctx.io_error = 1;
+        else
+            w_args.total_bytes += ZXC_FILE_FOOTER_SIZE;
+    } else if (mode == 0 && !ctx.io_error) {
+        /* Skip optional SEK block(s) between EOF and footer */
+        uint8_t peek_buf[ZXC_BLOCK_HEADER_SIZE];
+        if (LIKELY(fread(peek_buf, 1, ZXC_BLOCK_HEADER_SIZE, f_in) == ZXC_BLOCK_HEADER_SIZE)) {
+            zxc_block_header_t peek_bh;
+            if (zxc_read_block_header(peek_buf, ZXC_BLOCK_HEADER_SIZE, &peek_bh) == ZXC_OK &&
+                peek_bh.block_type == ZXC_BLOCK_SEK) {
+                /* Skip the SEK payload */
+                if (UNLIKELY(fseeko(f_in, (long long)peek_bh.comp_size, SEEK_CUR) != 0))
+                    ctx.io_error = 1;
+                /* Now read the footer normally */
+            } else {
+                /* Not a SEK block — this IS the start of the footer; rewind */
+                if (UNLIKELY(fseeko(f_in, -(long long)ZXC_BLOCK_HEADER_SIZE, SEEK_CUR) != 0))
+                    ctx.io_error = 1;
+            }
+        } else {
+            ctx.io_error = 1;
+        }
+
+        // Verification: Expect 12-byte footer
+        if (!ctx.io_error) {
+            uint8_t footer[ZXC_FILE_FOOTER_SIZE];
+            if (UNLIKELY(fread(footer, 1, ZXC_FILE_FOOTER_SIZE, f_in) != ZXC_FILE_FOOTER_SIZE)) {
+                ctx.io_error = 1;
+            } else {
+                // Verify Footer Content: Source Size and Global Checksum
+                int valid = (zxc_le64(footer) == (uint64_t)w_args.total_bytes);
+                if (valid && checksum_enabled && ctx.file_has_checksum)
+                    valid = (zxc_le32(footer + sizeof(uint64_t)) == d_global_hash);
+
+                if (UNLIKELY(!valid)) ctx.io_error = 1;
+            }
         }
     }
 
+    free(w_args.seek_comp);
     free(workers);
     zxc_aligned_free(mem_block);
 
@@ -813,6 +897,7 @@ int64_t zxc_stream_compress(FILE* f_in, FILE* f_out, const zxc_compress_opts_t* 
 
     const int n_threads = opts ? opts->n_threads : 0;
     const int checksum_enabled = opts ? opts->checksum_enabled : 0;
+    const int seekable = opts ? opts->seekable : 0;
     const int level = (opts && opts->level > 0) ? opts->level : ZXC_LEVEL_DEFAULT;
     const size_t block_size =
         (opts && opts->block_size > 0) ? opts->block_size : ZXC_BLOCK_SIZE_DEFAULT;
@@ -822,7 +907,7 @@ int64_t zxc_stream_compress(FILE* f_in, FILE* f_out, const zxc_compress_opts_t* 
     if (UNLIKELY(!zxc_validate_block_size(block_size))) return ZXC_ERROR_BAD_BLOCK_SIZE;
 
     return zxc_stream_engine_run(f_in, f_out, n_threads, 1, level, block_size, checksum_enabled,
-                                 zxc_compress_chunk_wrapper, cb, ud);
+                                 seekable, zxc_compress_chunk_wrapper, cb, ud);
 }
 
 int64_t zxc_stream_decompress(FILE* f_in, FILE* f_out, const zxc_decompress_opts_t* opts) {
@@ -833,7 +918,7 @@ int64_t zxc_stream_decompress(FILE* f_in, FILE* f_out, const zxc_decompress_opts
     zxc_progress_callback_t cb = opts ? opts->progress_cb : NULL;
     void* ud = opts ? opts->user_data : NULL;
 
-    return zxc_stream_engine_run(f_in, f_out, n_threads, 0, 0, 0, checksum_enabled,
+    return zxc_stream_engine_run(f_in, f_out, n_threads, 0, 0, 0, checksum_enabled, 0,
                                  (zxc_chunk_processor_t)zxc_decompress_chunk_wrapper, cb, ud);
 }
 

--- a/src/lib/zxc_driver.c
+++ b/src/lib/zxc_driver.c
@@ -676,7 +676,7 @@ static int64_t zxc_stream_engine_run(FILE* f_in, FILE* f_out, const int n_thread
     if (mode == 1 && seekable) {
         w_args.seek_cap = 64;
         w_args.seek_comp = (uint32_t*)malloc(w_args.seek_cap * sizeof(uint32_t));
-        /* malloc failure → fall through without seekable (graceful degradation) */
+        /* malloc failure -> fall through without seekable (graceful degradation) */
     }
 
     if (mode == 1 && f_out) {
@@ -848,38 +848,51 @@ static int64_t zxc_stream_engine_run(FILE* f_in, FILE* f_out, const int n_thread
         else
             w_args.total_bytes += ZXC_FILE_FOOTER_SIZE;
     } else if (mode == 0 && !ctx.io_error) {
-        /* Skip optional SEK block(s) between EOF and footer */
+        /*
+         * After the EOF block, the stream may contain:
+         *   (a) [FOOTER 12B]                  - no seekable table
+         *   (b) [SEK header 8B] [payload] [FOOTER 12B] - seekable archive
+         */
         uint8_t peek_buf[ZXC_BLOCK_HEADER_SIZE];
-        if (LIKELY(fread(peek_buf, 1, ZXC_BLOCK_HEADER_SIZE, f_in) == ZXC_BLOCK_HEADER_SIZE)) {
+        uint8_t footer[ZXC_FILE_FOOTER_SIZE];
+
+        if (UNLIKELY(fread(peek_buf, 1, ZXC_BLOCK_HEADER_SIZE, f_in) != ZXC_BLOCK_HEADER_SIZE)) {
+            ctx.io_error = 1;
+        } else {
             zxc_block_header_t peek_bh;
-            if (zxc_read_block_header(peek_buf, ZXC_BLOCK_HEADER_SIZE, &peek_bh) == ZXC_OK &&
-                peek_bh.block_type == ZXC_BLOCK_SEK) {
-                /* Skip the SEK payload */
-                if (UNLIKELY(fseeko(f_in, (long long)peek_bh.comp_size, SEEK_CUR) != 0))
+            const int is_sek =
+                (zxc_read_block_header(peek_buf, ZXC_BLOCK_HEADER_SIZE, &peek_bh) == ZXC_OK &&
+                 peek_bh.block_type == ZXC_BLOCK_SEK);
+
+            if (is_sek) {
+                /* Drain the SEK payload (read + discard) */
+                size_t remaining = (size_t)peek_bh.comp_size;
+                uint8_t discard[512];
+                while (remaining > 0 && !ctx.io_error) {
+                    const size_t chunk = remaining < sizeof(discard) ? remaining : sizeof(discard);
+                    if (UNLIKELY(fread(discard, 1, chunk, f_in) != chunk)) ctx.io_error = 1;
+                    remaining -= chunk;
+                }
+                /* Read full 12-byte footer */
+                if (!ctx.io_error &&
+                    UNLIKELY(fread(footer, 1, ZXC_FILE_FOOTER_SIZE, f_in) != ZXC_FILE_FOOTER_SIZE))
                     ctx.io_error = 1;
-                /* Now read the footer normally */
             } else {
-                /* Not a SEK block — this IS the start of the footer; rewind */
-                if (UNLIKELY(fseeko(f_in, -(long long)ZXC_BLOCK_HEADER_SIZE, SEEK_CUR) != 0))
+                /* peek_buf contains the first 8 bytes of the 12-byte footer.
+                 * Read the remaining 4 bytes and assemble. */
+                ZXC_MEMCPY(footer, peek_buf, ZXC_BLOCK_HEADER_SIZE);
+                const size_t tail = ZXC_FILE_FOOTER_SIZE - ZXC_BLOCK_HEADER_SIZE; /* 4 */
+                if (UNLIKELY(fread(footer + ZXC_BLOCK_HEADER_SIZE, 1, tail, f_in) != tail))
                     ctx.io_error = 1;
             }
-        } else {
-            ctx.io_error = 1;
         }
 
-        // Verification: Expect 12-byte footer
+        /* Verify Footer Content: Source Size and Global Checksum */
         if (!ctx.io_error) {
-            uint8_t footer[ZXC_FILE_FOOTER_SIZE];
-            if (UNLIKELY(fread(footer, 1, ZXC_FILE_FOOTER_SIZE, f_in) != ZXC_FILE_FOOTER_SIZE)) {
-                ctx.io_error = 1;
-            } else {
-                // Verify Footer Content: Source Size and Global Checksum
-                int valid = (zxc_le64(footer) == (uint64_t)w_args.total_bytes);
-                if (valid && checksum_enabled && ctx.file_has_checksum)
-                    valid = (zxc_le32(footer + sizeof(uint64_t)) == d_global_hash);
-
-                if (UNLIKELY(!valid)) ctx.io_error = 1;
-            }
+            int valid = (zxc_le64(footer) == (uint64_t)w_args.total_bytes);
+            if (valid && checksum_enabled && ctx.file_has_checksum)
+                valid = (zxc_le32(footer + sizeof(uint64_t)) == d_global_hash);
+            if (UNLIKELY(!valid)) ctx.io_error = 1;
         }
     }
 

--- a/src/lib/zxc_driver.c
+++ b/src/lib/zxc_driver.c
@@ -568,10 +568,10 @@ static int64_t zxc_stream_engine_run(FILE* f_in, FILE* f_out, const int n_thread
     uint32_t d_global_hash = 0;
 
     const uint64_t max_out = zxc_compress_bound(runtime_chunk_sz);
-    const size_t raw_alloc_in = ((mode) ? runtime_chunk_sz : max_out) + ZXC_PAD_SIZE;
+    const size_t raw_alloc_in = (size_t)(((mode) ? runtime_chunk_sz : max_out) + ZXC_PAD_SIZE);
     const size_t alloc_in = (raw_alloc_in + ZXC_ALIGNMENT_MASK) & ~ZXC_ALIGNMENT_MASK;
 
-    const size_t raw_alloc_out = ((mode) ? max_out : runtime_chunk_sz) + ZXC_PAD_SIZE;
+    const size_t raw_alloc_out = (size_t)(((mode) ? max_out : runtime_chunk_sz) + ZXC_PAD_SIZE);
     const size_t alloc_out = (raw_alloc_out + ZXC_ALIGNMENT_MASK) & ~ZXC_ALIGNMENT_MASK;
 
     const size_t per_job_sz = sizeof(zxc_stream_job_t) + sizeof(int) + alloc_in + alloc_out;

--- a/src/lib/zxc_internal.h
+++ b/src/lib/zxc_internal.h
@@ -344,6 +344,28 @@ extern "C" {
 /** @brief File footer size: original_size(8) + global_checksum(4). */
 #define ZXC_FILE_FOOTER_SIZE 12
 
+/** @name Seekable Format Constants
+ *  @brief Seek table block appended between EOF block and footer.
+ *
+ *  The seek table is optional (opt-in at compression time) and allows
+ *  random-access decompression by recording per-block compressed and
+ *  decompressed sizes.  It uses a standard ZXC block header with
+ *  @c block_type = @ref ZXC_BLOCK_SEK.
+ *
+ *  Detection from the end of the file: the last 4 bytes before the
+ *  file footer contain @c num_blocks (u32 LE).  If non-zero, the reader
+ *  can compute the seek block size and validate the block header.
+ *  @{ */
+/** @brief Per-block entry size without checksum: comp(4) + decomp(4). */
+#define ZXC_SEEK_ENTRY_SIZE 8
+/** @brief Per-block entry size with checksum: comp(4) + decomp(4) + crc(4). */
+#define ZXC_SEEK_ENTRY_SIZE_CRC 12
+/** @brief Size of the seek table tail: num_blocks(4). */
+#define ZXC_SEEK_TAIL_SIZE 4
+/** @brief Bit in @c block_flags indicating per-block checksums in the seek table. */
+#define ZXC_SEEK_FLAG_CHECKSUM 0x01U
+/** @} */ /* end of Seekable Format Constants */
+
 /** @name GLO Token Constants
  *  @brief 4-bit literal length / 4-bit match length / 16-bit offset.
  *  @{ */
@@ -533,6 +555,8 @@ static ZXC_ALWAYS_INLINE zxc_lz77_params_t zxc_get_lz77_params(const int level) 
  *   Uses Delta Encoding + ZigZag + Bitpacking.
  * - `ZXC_BLOCK_GHI` (3): General-purpose high-velocity mode using LZ77 with advanced
  * techniques (lazy matching, step skipping) for maximum ratio. Includes 3 sections descriptors.
+ * - `ZXC_BLOCK_SEK` (254): Seek table block. Contains per-block compressed/decompressed sizes
+ *   for random-access decompression. Placed between EOF block and file footer.
  * - `ZXC_BLOCK_EOF` (255): End of file marker.
  */
 typedef enum {
@@ -540,6 +564,7 @@ typedef enum {
     ZXC_BLOCK_GLO = 1,
     ZXC_BLOCK_NUM = 2,
     ZXC_BLOCK_GHI = 3,
+    ZXC_BLOCK_SEK = 254,
     ZXC_BLOCK_EOF = 255
 } zxc_block_type_t;
 

--- a/src/lib/zxc_internal.h
+++ b/src/lib/zxc_internal.h
@@ -910,8 +910,15 @@ static ZXC_ALWAYS_INLINE int zxc_ctz64(const uint64_t x) {
     unsigned long r;
     _BitScanForward64(&r, x);
     return (int)r;
+#elif defined(_MSC_VER)
+    // Use two 32-bit scans to avoid fragile 64-bit De Bruijn multiplication.
+    unsigned long r;
+    const uint32_t lo = (uint32_t)x;
+    if (_BitScanForward(&r, lo)) return (int)r;
+    _BitScanForward(&r, (uint32_t)(x >> 32));
+    return 32 + (int)r;
 #else
-    // Fallback De Bruijn
+    // Fallback De Bruijn for non-GCC/non-MSVC compilers
     static const int Debruijn64[64] = {
         0,  1,  48, 2,  57, 49, 28, 3,  61, 58, 50, 42, 38, 29, 17, 4,  62, 55, 59, 36, 53, 51,
         43, 22, 45, 39, 33, 30, 24, 18, 12, 5,  63, 47, 56, 27, 60, 41, 37, 16, 54, 35, 52, 21,

--- a/src/lib/zxc_internal.h
+++ b/src/lib/zxc_internal.h
@@ -356,14 +356,10 @@ extern "C" {
  *  file footer contain @c num_blocks (u32 LE).  If non-zero, the reader
  *  can compute the seek block size and validate the block header.
  *  @{ */
-/** @brief Per-block entry size without checksum: comp(4) + decomp(4). */
+/** @brief Per-block entry size: comp(4) + decomp(4). */
 #define ZXC_SEEK_ENTRY_SIZE 8
-/** @brief Per-block entry size with checksum: comp(4) + decomp(4) + crc(4). */
-#define ZXC_SEEK_ENTRY_SIZE_CRC 12
 /** @brief Size of the seek table tail: num_blocks(4). */
 #define ZXC_SEEK_TAIL_SIZE 4
-/** @brief Bit in @c block_flags indicating per-block checksums in the seek table. */
-#define ZXC_SEEK_FLAG_CHECKSUM 0x01U
 /** @} */ /* end of Seekable Format Constants */
 
 /** @name GLO Token Constants

--- a/src/lib/zxc_internal.h
+++ b/src/lib/zxc_internal.h
@@ -352,14 +352,13 @@ extern "C" {
  *  decompressed sizes.  It uses a standard ZXC block header with
  *  @c block_type = @ref ZXC_BLOCK_SEK.
  *
- *  Detection from the end of the file: the last 4 bytes before the
- *  file footer contain @c num_blocks (u32 LE).  If non-zero, the reader
- *  can compute the seek block size and validate the block header.
+ *  Detection from the end of the file: the reader derives @c num_blocks
+ *  from the file footer (total decompressed size) and file header (block size).
+ *  It then seeks backward to validate the SEK block header.
  *  @{ */
-/** @brief Per-block entry size: comp(4) + decomp(4). */
-#define ZXC_SEEK_ENTRY_SIZE 8
-/** @brief Size of the seek table tail: num_blocks(4). */
-#define ZXC_SEEK_TAIL_SIZE 4
+/** @brief Per-block entry size: comp_size(4) only.  decomp_size is derived
+ *  from the file header's block_size (all blocks except the last are full). */
+#define ZXC_SEEK_ENTRY_SIZE 4
 /** @} */ /* end of Seekable Format Constants */
 
 /** @name GLO Token Constants

--- a/src/lib/zxc_seekable.c
+++ b/src/lib/zxc_seekable.c
@@ -37,7 +37,7 @@
 /*  Platform Threading & I/O Layer                                           */
 /* ========================================================================= */
 
-// LCOV_EXCL_START — Windows platform layer, not reachable on POSIX CI
+// LCOV_EXCL_START - Windows platform layer, not reachable on POSIX CI
 #if defined(_WIN32)
 #include <io.h>      /* _get_osfhandle, _fileno */
 #include <process.h> /* _beginthreadex */
@@ -311,9 +311,9 @@ zxc_seekable* zxc_seekable_open_file(FILE* f) {
     if (UNLIKELY(!f)) return NULL;
 
     const long long saved_pos = ftello(f);
-    if (UNLIKELY(saved_pos < 0)) return NULL; // LCOV_EXCL_LINE
+    if (UNLIKELY(saved_pos < 0)) return NULL;  // LCOV_EXCL_LINE
 
-    if (UNLIKELY(fseeko(f, 0, SEEK_END) != 0)) return NULL; // LCOV_EXCL_LINE
+    if (UNLIKELY(fseeko(f, 0, SEEK_END) != 0)) return NULL;  // LCOV_EXCL_LINE
     const long long file_size = ftello(f);
     // LCOV_EXCL_START
     if (UNLIKELY(file_size <= 0)) {
@@ -355,7 +355,7 @@ zxc_seekable* zxc_seekable_open_file(FILE* f) {
         return s;
     }
 
-    // LCOV_EXCL_START — large file path (>64MB), not reachable in unit tests
+    // LCOV_EXCL_START - large file path (>64MB), not reachable in unit tests
     /* Large file: read header + footer separately */
     uint8_t header[ZXC_FILE_HEADER_SIZE];
     if (UNLIKELY(fseeko(f, 0, SEEK_SET) != 0 ||
@@ -539,7 +539,7 @@ static int zxc_seek_read_block(const zxc_seekable* s, const uint32_t block_idx, 
             return ZXC_ERROR_IO;
         // LCOV_EXCL_STOP
     } else {
-        return ZXC_ERROR_NULL_INPUT; // LCOV_EXCL_LINE
+        return ZXC_ERROR_NULL_INPUT;  // LCOV_EXCL_LINE
     }
     return (int)csz;
 }
@@ -565,7 +565,7 @@ int64_t zxc_seekable_decompress_range(zxc_seekable* s, void* dst, const size_t d
     if (s->dctx.work_buf_cap < work_sz) {
         free(s->dctx.work_buf);
         s->dctx.work_buf = (uint8_t*)malloc(work_sz);
-        if (UNLIKELY(!s->dctx.work_buf)) return ZXC_ERROR_MEMORY; // LCOV_EXCL_LINE
+        if (UNLIKELY(!s->dctx.work_buf)) return ZXC_ERROR_MEMORY;  // LCOV_EXCL_LINE
         s->dctx.work_buf_cap = work_sz;
     }
 
@@ -582,7 +582,7 @@ int64_t zxc_seekable_decompress_range(zxc_seekable* s, void* dst, const size_t d
         if (s->comp_sizes[bi] > max_comp) max_comp = s->comp_sizes[bi];
     }
     uint8_t* const read_buf = (uint8_t*)malloc(max_comp + ZXC_PAD_SIZE);
-    if (UNLIKELY(!read_buf)) return ZXC_ERROR_MEMORY; // LCOV_EXCL_LINE
+    if (UNLIKELY(!read_buf)) return ZXC_ERROR_MEMORY;  // LCOV_EXCL_LINE
 
     for (uint32_t bi = blk_start; bi <= blk_end; bi++) {
         /* Read compressed block data */
@@ -657,7 +657,7 @@ static int zxc_seek_read_block_mt(const zxc_seekable* s, const uint32_t block_id
 #endif
         if (UNLIKELY(r < 0)) return r;
     } else {
-        return ZXC_ERROR_NULL_INPUT; // LCOV_EXCL_LINE
+        return ZXC_ERROR_NULL_INPUT;  // LCOV_EXCL_LINE
     }
     return (int)csz;
 }
@@ -765,7 +765,7 @@ int64_t zxc_seekable_decompress_range_mt(zxc_seekable* s, void* dst, const size_
 
     /* Allocate job descriptors */
     zxc_seek_mt_job_t* const jobs = (zxc_seek_mt_job_t*)calloc(num_jobs, sizeof(zxc_seek_mt_job_t));
-    if (UNLIKELY(!jobs)) return ZXC_ERROR_MEMORY; // LCOV_EXCL_LINE
+    if (UNLIKELY(!jobs)) return ZXC_ERROR_MEMORY;  // LCOV_EXCL_LINE
 
     /* Plan jobs: compute skip, copy_len, and dst pointer for each block */
     uint8_t* out = (uint8_t*)dst;

--- a/src/lib/zxc_seekable.c
+++ b/src/lib/zxc_seekable.c
@@ -17,7 +17,7 @@
  * On-disk layout of a SEK block:
  *
  *   [Block Header (8B)]   block_type=SEK, block_flags=0, comp_size=N*4
- *   [N × Entry (4B)]      comp_size(u32 LE) per block
+ *   [N x Entry (4B)]      comp_size(u32 LE) per block
  *
  * Detection from end of file:
  *   1. Read file header (first 16 bytes) => block_size
@@ -42,7 +42,7 @@
 #include <process.h> /* _beginthreadex */
 #include <windows.h>
 
-/* MSVC does not provide fseeko/ftello — map to 64-bit equivalents */
+/* MSVC does not provide fseeko/ftello - map to 64-bit equivalents */
 #if defined(_MSC_VER) && !defined(fseeko)
 #define fseeko _fseeki64
 #define ftello _ftelli64
@@ -173,7 +173,7 @@ int64_t zxc_write_seek_table(uint8_t* dst, const size_t dst_capacity, const uint
 /* ========================================================================= */
 
 struct zxc_seekable_s {
-    /* Source — exactly one is non-NULL */
+    /* Source - exactly one is non-NULL */
     const uint8_t* src;
     size_t src_size;
     FILE* file;
@@ -227,7 +227,7 @@ static zxc_seekable* zxc_seekable_parse(const uint8_t* data, const size_t data_s
     const uint8_t* const footer_ptr = data + data_size - ZXC_FILE_FOOTER_SIZE;
     const uint64_t total_decomp = zxc_le64(footer_ptr);
 
-    /* A value of 0 means empty file — no seek table */
+    /* A value of 0 means empty file - no seek table */
     if (UNLIKELY(total_decomp == 0)) return NULL;
 
     /* Step 3: derive num_blocks = ceil(total_decomp / block_size)
@@ -283,7 +283,7 @@ static zxc_seekable* zxc_seekable_parse(const uint8_t* data, const size_t data_s
         s->comp_sizes[i] = zxc_le32(ep);
         ep += sizeof(uint32_t);
 
-        /* Reject entries larger than the entire file — prevents prefix overflow */
+        /* Reject entries larger than the entire file - prevents prefix overflow */
         if (UNLIKELY(s->comp_sizes[i] > data_size)) {
             zxc_seekable_free(s);
             return NULL;
@@ -552,7 +552,7 @@ int64_t zxc_seekable_decompress_range(zxc_seekable* s, void* dst, const size_t d
         s->dctx.work_buf_cap = work_sz;
     }
 
-    /* Find block range — O(1) division */
+    /* Find block range - O(1) division */
     const uint32_t blk_start = zxc_seek_find_block(s->block_size, offset);
     const uint32_t blk_end = zxc_seek_find_block(s->block_size, offset + len - 1);
 
@@ -628,11 +628,11 @@ static int zxc_seek_read_block_mt(const zxc_seekable* s, const uint32_t block_id
     if (UNLIKELY(csz > buf_cap)) return ZXC_ERROR_DST_TOO_SMALL;
 
     if (s->src) {
-        /* Buffer mode — memcpy is inherently thread-safe on const data */
+        /* Buffer mode - memcpy is inherently thread-safe on const data */
         if (UNLIKELY(off + csz > s->src_size)) return ZXC_ERROR_SRC_TOO_SMALL;
         ZXC_MEMCPY(buf, s->src + off, csz);
     } else if (s->file) {
-        /* File mode — use pread for concurrent, lock-free reads */
+        /* File mode - use pread for concurrent, lock-free reads */
 #if defined(_WIN32)
         const int r = zxc_seek_pread(s->native_handle, buf, csz, off);
 #else
@@ -719,7 +719,7 @@ int64_t zxc_seekable_decompress_range_mt(zxc_seekable* s, void* dst, const size_
     if (UNLIKELY(dst_capacity < len)) return ZXC_ERROR_DST_TOO_SMALL;
     if (UNLIKELY(offset + len > s->total_decomp)) return ZXC_ERROR_SRC_TOO_SMALL;
 
-    /* Find block range — O(1) division */
+    /* Find block range - O(1) division */
     const uint32_t blk_start = zxc_seek_find_block(s->block_size, offset);
     const uint32_t blk_end = zxc_seek_find_block(s->block_size, offset + len - 1);
     const uint32_t num_jobs = blk_end - blk_start + 1;
@@ -784,7 +784,7 @@ int64_t zxc_seekable_decompress_range_mt(zxc_seekable* s, void* dst, const size_
         int launched = 0;
         for (int t = 0; t < wave_size; t++) {
             if (zxc_seek_thread_create(&threads[t], zxc_seek_mt_worker, &jobs[job_idx + t]) != 0) {
-                /* Failed to create thread — mark remaining jobs as errors */
+                /* Failed to create thread - mark remaining jobs as errors */
                 for (uint32_t j = job_idx + (uint32_t)t; j < num_jobs; j++)
                     jobs[j].result = ZXC_ERROR_MEMORY;
                 error = 1;

--- a/src/lib/zxc_seekable.c
+++ b/src/lib/zxc_seekable.c
@@ -599,7 +599,7 @@ int64_t zxc_seekable_decompress_range(zxc_seekable* s, void* dst, const size_t d
 }
 
 /* ========================================================================= */
-/*  Multi-Threaded Random-Access Decompression (Fork–Join)                   */
+/*  Multi-Threaded Random-Access Decompression (Fork-Join)                   */
 /* ========================================================================= */
 
 /**

--- a/src/lib/zxc_seekable.c
+++ b/src/lib/zxc_seekable.c
@@ -1,0 +1,554 @@
+/*
+ * ZXC - High-performance lossless compression
+ *
+ * Copyright (c) 2025-2026 Bertrand Lebonnois and contributors.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/**
+ * @file zxc_seekable.c
+ * @brief Seekable archive reader (random-access decompression) and seek table writer.
+ *
+ * The seek table is a standard ZXC block (type = ZXC_BLOCK_SEK) appended
+ * between the EOF block and the file footer.  It records the compressed and
+ * decompressed sizes of every block, enabling O(log N) lookup + O(block_size)
+ * decompression for any byte range.
+ *
+ * On-disk layout of a SEEK block:
+ *
+ *   [Block Header (8B)]   block_type=SEEK, block_flags, comp_size
+ *   [N × Entry]           comp_size(4) + decomp_size(4) [+ checksum(4)]
+ *   [num_blocks (4B LE)]  tail for backward detection
+ *
+ * Detection from end of file:
+ *   1. Read file footer (last 12 bytes)
+ *   2. Read 4 bytes before footer → num_blocks (u32 LE)
+ *   3. Compute seek block size, read backward to the block header
+ *   4. Validate block_type == ZXC_BLOCK_SEK
+ */
+
+#include "../../include/zxc_seekable.h"
+
+#include "../../include/zxc_error.h"
+#include "../../include/zxc_sans_io.h"
+#include "zxc_internal.h"
+
+/* ========================================================================= */
+/*  Seek Table Writer                                                        */
+/* ========================================================================= */
+
+size_t zxc_seek_table_size(const uint32_t num_blocks, const int has_checksums) {
+    const size_t entry_sz = has_checksums ? ZXC_SEEK_ENTRY_SIZE_CRC : ZXC_SEEK_ENTRY_SIZE;
+    return ZXC_BLOCK_HEADER_SIZE + (size_t)num_blocks * entry_sz + ZXC_SEEK_TAIL_SIZE;
+}
+
+int64_t zxc_write_seek_table(uint8_t* dst, const size_t dst_capacity, const uint32_t* comp_sizes,
+                             const uint32_t* decomp_sizes, const uint32_t num_blocks,
+                             const int has_checksums) {
+    const size_t total = zxc_seek_table_size(num_blocks, has_checksums);
+    if (UNLIKELY(dst_capacity < total)) return ZXC_ERROR_DST_TOO_SMALL;
+    if (UNLIKELY(!dst || !comp_sizes || !decomp_sizes)) return ZXC_ERROR_NULL_INPUT;
+
+    const size_t entry_sz = has_checksums ? ZXC_SEEK_ENTRY_SIZE_CRC : ZXC_SEEK_ENTRY_SIZE;
+    const uint32_t payload_size = (uint32_t)(num_blocks * entry_sz + ZXC_SEEK_TAIL_SIZE);
+
+    /* Write standard ZXC block header */
+    const zxc_block_header_t bh = {.block_type = ZXC_BLOCK_SEK,
+                                   .block_flags = has_checksums ? ZXC_SEEK_FLAG_CHECKSUM : 0,
+                                   .reserved = 0,
+                                   .comp_size = payload_size};
+    const int hdr_res = zxc_write_block_header(dst, dst_capacity, &bh);
+    if (UNLIKELY(hdr_res < 0)) return hdr_res;
+    uint8_t* p = dst + hdr_res;
+
+    /* Write entries: comp_size(4) + decomp_size(4) [+ checksum(4)] */
+    for (uint32_t i = 0; i < num_blocks; i++) {
+        zxc_store_le32(p, comp_sizes[i]);
+        p += sizeof(uint32_t);
+        zxc_store_le32(p, decomp_sizes[i]);
+        p += sizeof(uint32_t);
+        if (has_checksums) {
+            /* Checksum slot — zeroed for now (can be extended later) */
+            zxc_store_le32(p, 0);
+            p += sizeof(uint32_t);
+        }
+    }
+
+    /* Write tail: num_blocks (for backward detection) */
+    zxc_store_le32(p, num_blocks);
+    p += sizeof(uint32_t);
+
+    return (int64_t)(p - dst);
+}
+
+/* ========================================================================= */
+/*  Seekable Reader (Opaque Handle)                                          */
+/* ========================================================================= */
+
+struct zxc_seekable_s {
+    /* Source — exactly one is non-NULL */
+    const uint8_t* src;
+    size_t src_size;
+    FILE* file;
+
+    /* Parsed seek table */
+    uint32_t num_blocks;
+    uint32_t* comp_sizes;     /* array[num_blocks] */
+    uint32_t* decomp_sizes;   /* array[num_blocks] */
+    uint64_t* comp_offsets;   /* prefix-sum: byte offset in compressed file per block */
+    uint64_t* decomp_offsets; /* prefix-sum: byte offset in decompressed data per block */
+    uint64_t total_decomp;    /* sum of all decomp_sizes */
+    int has_checksums;        /* from block_flags */
+
+    /* File header info */
+    size_t block_size;
+    int file_has_checksums;
+
+    /* Reusable decompression context */
+    zxc_cctx_t dctx;
+    int dctx_initialized;
+};
+
+/**
+ * @brief Parses the seek table from raw bytes at the end of the archive.
+ *
+ * Detection (backward from end):
+ *   1. Skip file footer (last 12 bytes)
+ *   2. Read 4 bytes before footer → num_blocks
+ *   3. Read the block header at the computed offset
+ *   4. Validate block_type == ZXC_BLOCK_SEK
+ */
+static zxc_seekable* zxc_seekable_parse(const uint8_t* data, const size_t data_size) {
+    /* Minimum: file_header(16) + eof_block(8) + seek_block_header(8)
+     *          + seek_tail(4) + file_footer(12) = 48 */
+    const size_t MIN_SEEKABLE_SIZE = ZXC_FILE_HEADER_SIZE + ZXC_BLOCK_HEADER_SIZE +
+                                     ZXC_BLOCK_HEADER_SIZE + ZXC_SEEK_TAIL_SIZE +
+                                     ZXC_FILE_FOOTER_SIZE;
+    if (UNLIKELY(data_size < MIN_SEEKABLE_SIZE)) return NULL;
+
+    /* Step 1: validate file header */
+    size_t block_size = 0;
+    int file_has_chk = 0;
+    if (UNLIKELY(zxc_read_file_header(data, data_size, &block_size, &file_has_chk) != ZXC_OK))
+        return NULL;
+
+    /* Step 2: read num_blocks from the tail (4 bytes before file footer) */
+    const uint8_t* const tail_ptr = data + data_size - ZXC_FILE_FOOTER_SIZE - ZXC_SEEK_TAIL_SIZE;
+    if (UNLIKELY(tail_ptr < data)) return NULL;
+    const uint32_t num_blocks = zxc_le32(tail_ptr);
+
+    /* A value of 0 means no seek table */
+    if (UNLIKELY(num_blocks == 0)) return NULL;
+
+    /* Step 3: determine entry size by reading the block header */
+    /* The seek block starts at: tail_ptr - entries - block_header */
+    /* We don't know entry_size yet, but the block header has block_flags. */
+    /* First, try default entry size (8), compute the header position,
+     * read block_flags to determine actual entry size, then re-validate. */
+
+    /* Try to locate the block header — we need to read it to know entry_size.
+     * Start with the assumption of no checksums (entry_size = 8). */
+    for (int pass = 0; pass < 2; pass++) {
+        const size_t entry_sz = (pass == 0) ? ZXC_SEEK_ENTRY_SIZE : ZXC_SEEK_ENTRY_SIZE_CRC;
+        const size_t entries_total = (size_t)num_blocks * entry_sz;
+        const uint8_t* const seek_block_start = tail_ptr - entries_total - ZXC_BLOCK_HEADER_SIZE;
+        if (UNLIKELY(seek_block_start < data)) continue;
+
+        /* Read block header at the computed position */
+        zxc_block_header_t bh;
+        if (UNLIKELY(
+                zxc_read_block_header(seek_block_start,
+                                      (size_t)(tail_ptr + ZXC_SEEK_TAIL_SIZE - seek_block_start),
+                                      &bh) != ZXC_OK))
+            continue;
+
+        /* Validate block type */
+        if (bh.block_type != ZXC_BLOCK_SEK) continue;
+
+        /* Validate comp_size consistency */
+        const uint32_t expected_payload = (uint32_t)(entries_total + ZXC_SEEK_TAIL_SIZE);
+        if (bh.comp_size != expected_payload) continue;
+
+        /* Validate entry_size matches the checksum flag */
+        const int has_crc = (bh.block_flags & ZXC_SEEK_FLAG_CHECKSUM) != 0;
+        if (has_crc && entry_sz != ZXC_SEEK_ENTRY_SIZE_CRC) continue;
+        if (!has_crc && entry_sz != ZXC_SEEK_ENTRY_SIZE) continue;
+
+        /* ✓ Found a valid seek block. Parse entries. */
+
+        zxc_seekable* const s = (zxc_seekable*)calloc(1, sizeof(zxc_seekable));
+        if (UNLIKELY(!s)) return NULL;
+
+        s->num_blocks = num_blocks;
+        s->has_checksums = has_crc;
+        s->block_size = block_size;
+        s->file_has_checksums = file_has_chk;
+        s->src = data;
+        s->src_size = data_size;
+
+        /* Allocate arrays */
+        s->comp_sizes = (uint32_t*)calloc(num_blocks, sizeof(uint32_t));
+        s->decomp_sizes = (uint32_t*)calloc(num_blocks, sizeof(uint32_t));
+        s->comp_offsets = (uint64_t*)calloc((size_t)num_blocks + 1, sizeof(uint64_t));
+        s->decomp_offsets = (uint64_t*)calloc((size_t)num_blocks + 1, sizeof(uint64_t));
+        if (UNLIKELY(!s->comp_sizes || !s->decomp_sizes || !s->comp_offsets ||
+                     !s->decomp_offsets)) {
+            zxc_seekable_free(s);
+            return NULL;
+        }
+
+        /* Parse entries and build prefix sums */
+        const uint8_t* ep = seek_block_start + ZXC_BLOCK_HEADER_SIZE;
+        uint64_t comp_acc = ZXC_FILE_HEADER_SIZE; /* blocks start after file header */
+        uint64_t decomp_acc = 0;
+        for (uint32_t i = 0; i < num_blocks; i++) {
+            s->comp_sizes[i] = zxc_le32(ep);
+            ep += sizeof(uint32_t);
+            s->decomp_sizes[i] = zxc_le32(ep);
+            ep += sizeof(uint32_t);
+            if (has_crc) ep += sizeof(uint32_t); /* skip checksum */
+
+            s->comp_offsets[i] = comp_acc;
+            s->decomp_offsets[i] = decomp_acc;
+            comp_acc += s->comp_sizes[i];
+            decomp_acc += s->decomp_sizes[i];
+        }
+        s->comp_offsets[num_blocks] = comp_acc;
+        s->decomp_offsets[num_blocks] = decomp_acc;
+        s->total_decomp = decomp_acc;
+
+        return s;
+    }
+
+    return NULL; /* No valid seek block found */
+}
+
+zxc_seekable* zxc_seekable_open(const void* src, const size_t src_size) {
+    if (UNLIKELY(!src || src_size == 0)) return NULL;
+    return zxc_seekable_parse((const uint8_t*)src, src_size);
+}
+
+zxc_seekable* zxc_seekable_open_file(FILE* f) {
+    if (UNLIKELY(!f)) return NULL;
+
+    const long long saved_pos = ftello(f);
+    if (UNLIKELY(saved_pos < 0)) return NULL;
+
+    if (UNLIKELY(fseeko(f, 0, SEEK_END) != 0)) return NULL;
+    const long long file_size = ftello(f);
+    if (UNLIKELY(file_size <= 0)) {
+        fseeko(f, saved_pos, SEEK_SET);
+        return NULL;
+    }
+
+    /* Read the tail: we need at most the seek table + footer.
+     * For safety, read the last 64 KB or the whole file if smaller. */
+    const size_t tail_size = ((size_t)file_size > 65536) ? 65536 : (size_t)file_size;
+    uint8_t* const tail = (uint8_t*)malloc(tail_size);
+    if (UNLIKELY(!tail)) {
+        fseeko(f, saved_pos, SEEK_SET);
+        return NULL;
+    }
+
+    if (UNLIKELY(fseeko(f, file_size - (long long)tail_size, SEEK_SET) != 0 ||
+                 fread(tail, 1, tail_size, f) != tail_size)) {
+        free(tail);
+        fseeko(f, saved_pos, SEEK_SET);
+        return NULL;
+    }
+    fseeko(f, saved_pos, SEEK_SET);
+
+    /* For file mode, we need the full file header too. Read it if not in tail. */
+    uint8_t header[ZXC_FILE_HEADER_SIZE];
+    if (tail_size < (size_t)file_size) {
+        if (UNLIKELY(fseeko(f, 0, SEEK_SET) != 0 ||
+                     fread(header, 1, ZXC_FILE_HEADER_SIZE, f) != ZXC_FILE_HEADER_SIZE)) {
+            free(tail);
+            fseeko(f, saved_pos, SEEK_SET);
+            return NULL;
+        }
+        fseeko(f, saved_pos, SEEK_SET);
+    }
+
+    /* Detect seek table from the tail */
+    if (UNLIKELY(tail_size < ZXC_FILE_FOOTER_SIZE + ZXC_SEEK_TAIL_SIZE)) {
+        free(tail);
+        return NULL;
+    }
+
+    /* Read num_blocks from tail */
+    const uint8_t* const nblk_ptr = tail + tail_size - ZXC_FILE_FOOTER_SIZE - ZXC_SEEK_TAIL_SIZE;
+    const uint32_t num_blocks = zxc_le32(nblk_ptr);
+    if (num_blocks == 0) {
+        free(tail);
+        return NULL;
+    }
+
+    /* Compute seek block size to check if tail buffer is large enough */
+    /* Try both entry sizes; the larger one gives an upper bound */
+    const size_t max_seek_size =
+        ZXC_BLOCK_HEADER_SIZE + (size_t)num_blocks * ZXC_SEEK_ENTRY_SIZE_CRC + ZXC_SEEK_TAIL_SIZE;
+
+    /* We need seek block + footer in the tail */
+    if (UNLIKELY(tail_size < max_seek_size + ZXC_FILE_FOOTER_SIZE)) {
+        /* Seek table is larger than our tail buffer — read the entire file */
+        free(tail);
+        uint8_t* const full = (uint8_t*)malloc((size_t)file_size);
+        if (UNLIKELY(!full)) return NULL;
+        if (UNLIKELY(fseeko(f, 0, SEEK_SET) != 0 ||
+                     fread(full, 1, (size_t)file_size, f) != (size_t)file_size)) {
+            free(full);
+            fseeko(f, saved_pos, SEEK_SET);
+            return NULL;
+        }
+        fseeko(f, saved_pos, SEEK_SET);
+        zxc_seekable* const s = zxc_seekable_parse(full, (size_t)file_size);
+        if (s) {
+            s->src = NULL;
+            s->src_size = (size_t)file_size;
+            s->file = f;
+        }
+        free(full);
+        return s;
+    }
+
+    /* File small enough or tail large enough — read the full file if <= 64 MB */
+    if ((size_t)file_size <= 64 * 1024 * 1024) {
+        uint8_t* const full = (uint8_t*)malloc((size_t)file_size);
+        if (UNLIKELY(!full)) {
+            free(tail);
+            return NULL;
+        }
+        if (UNLIKELY(fseeko(f, 0, SEEK_SET) != 0 ||
+                     fread(full, 1, (size_t)file_size, f) != (size_t)file_size)) {
+            free(full);
+            free(tail);
+            fseeko(f, saved_pos, SEEK_SET);
+            return NULL;
+        }
+        fseeko(f, saved_pos, SEEK_SET);
+        free(tail);
+        zxc_seekable* const s = zxc_seekable_parse(full, (size_t)file_size);
+        if (s) {
+            s->src = NULL;
+            s->src_size = (size_t)file_size;
+            s->file = f;
+        }
+        free(full);
+        return s;
+    }
+
+    /* Large file: parse seek table directly from the tail */
+    size_t bs = 0;
+    int fhc = 0;
+    if (UNLIKELY(zxc_read_file_header(header, ZXC_FILE_HEADER_SIZE, &bs, &fhc) != ZXC_OK)) {
+        free(tail);
+        return NULL;
+    }
+
+    /* We need to find the block header in the tail. Try both entry sizes. */
+    zxc_seekable* s = NULL;
+    for (int pass = 0; pass < 2 && !s; pass++) {
+        const size_t entry_sz = (pass == 0) ? ZXC_SEEK_ENTRY_SIZE : ZXC_SEEK_ENTRY_SIZE_CRC;
+        const size_t entries_total = (size_t)num_blocks * entry_sz;
+        const size_t seek_block_total = ZXC_BLOCK_HEADER_SIZE + entries_total + ZXC_SEEK_TAIL_SIZE;
+
+        if (tail_size < seek_block_total + ZXC_FILE_FOOTER_SIZE) continue;
+
+        /* Block header position in the tail */
+        const uint8_t* const bh_ptr = tail + tail_size - ZXC_FILE_FOOTER_SIZE - seek_block_total;
+
+        zxc_block_header_t bh;
+        if (zxc_read_block_header(bh_ptr, seek_block_total, &bh) != ZXC_OK) continue;
+        if (bh.block_type != ZXC_BLOCK_SEK) continue;
+        if (bh.comp_size != (uint32_t)(entries_total + ZXC_SEEK_TAIL_SIZE)) continue;
+
+        const int has_crc = (bh.block_flags & ZXC_SEEK_FLAG_CHECKSUM) != 0;
+        if (has_crc && entry_sz != ZXC_SEEK_ENTRY_SIZE_CRC) continue;
+        if (!has_crc && entry_sz != ZXC_SEEK_ENTRY_SIZE) continue;
+
+        s = (zxc_seekable*)calloc(1, sizeof(zxc_seekable));
+        if (UNLIKELY(!s)) break;
+        s->file = f;
+        s->src = NULL;
+        s->src_size = (size_t)file_size;
+        s->num_blocks = num_blocks;
+        s->has_checksums = has_crc;
+        s->block_size = bs;
+        s->file_has_checksums = fhc;
+
+        s->comp_sizes = (uint32_t*)calloc(num_blocks, sizeof(uint32_t));
+        s->decomp_sizes = (uint32_t*)calloc(num_blocks, sizeof(uint32_t));
+        s->comp_offsets = (uint64_t*)calloc((size_t)num_blocks + 1, sizeof(uint64_t));
+        s->decomp_offsets = (uint64_t*)calloc((size_t)num_blocks + 1, sizeof(uint64_t));
+        if (UNLIKELY(!s->comp_sizes || !s->decomp_sizes || !s->comp_offsets ||
+                     !s->decomp_offsets)) {
+            zxc_seekable_free(s);
+            s = NULL;
+            break;
+        }
+
+        const uint8_t* ep = bh_ptr + ZXC_BLOCK_HEADER_SIZE;
+        uint64_t comp_acc = ZXC_FILE_HEADER_SIZE;
+        uint64_t decomp_acc = 0;
+        for (uint32_t i = 0; i < num_blocks; i++) {
+            s->comp_sizes[i] = zxc_le32(ep);
+            ep += sizeof(uint32_t);
+            s->decomp_sizes[i] = zxc_le32(ep);
+            ep += sizeof(uint32_t);
+            if (has_crc) ep += sizeof(uint32_t);
+
+            s->comp_offsets[i] = comp_acc;
+            s->decomp_offsets[i] = decomp_acc;
+            comp_acc += s->comp_sizes[i];
+            decomp_acc += s->decomp_sizes[i];
+        }
+        s->comp_offsets[num_blocks] = comp_acc;
+        s->decomp_offsets[num_blocks] = decomp_acc;
+        s->total_decomp = decomp_acc;
+    }
+
+    free(tail);
+    return s;
+}
+
+uint32_t zxc_seekable_get_num_blocks(const zxc_seekable* s) { return s ? s->num_blocks : 0; }
+
+uint64_t zxc_seekable_get_decompressed_size(const zxc_seekable* s) {
+    return s ? s->total_decomp : 0;
+}
+
+uint32_t zxc_seekable_get_block_comp_size(const zxc_seekable* s, const uint32_t block_idx) {
+    if (UNLIKELY(!s || block_idx >= s->num_blocks)) return 0;
+    return s->comp_sizes[block_idx];
+}
+
+uint32_t zxc_seekable_get_block_decomp_size(const zxc_seekable* s, const uint32_t block_idx) {
+    if (UNLIKELY(!s || block_idx >= s->num_blocks)) return 0;
+    return s->decomp_sizes[block_idx];
+}
+
+/* ========================================================================= */
+/*  Random-Access Decompression                                              */
+/* ========================================================================= */
+
+/**
+ * @brief Binary search: find the block that contains @p offset.
+ * decomp_offsets[i] <= offset < decomp_offsets[i+1]
+ */
+static uint32_t zxc_seek_find_block(const uint64_t* decomp_offsets, const uint32_t num_blocks,
+                                    const uint64_t offset) {
+    uint32_t lo = 0, hi = num_blocks;
+    while (lo < hi) {
+        const uint32_t mid = lo + (hi - lo) / 2;
+        if (decomp_offsets[mid + 1] <= offset)
+            lo = mid + 1;
+        else
+            hi = mid;
+    }
+    return lo;
+}
+
+/**
+ * @brief Reads a compressed block from buffer or file.
+ */
+static int zxc_seek_read_block(const zxc_seekable* s, const uint32_t block_idx, uint8_t* buf,
+                               const size_t buf_cap) {
+    const uint64_t off = s->comp_offsets[block_idx];
+    const uint32_t csz = s->comp_sizes[block_idx];
+    if (UNLIKELY(csz > buf_cap)) return ZXC_ERROR_DST_TOO_SMALL;
+
+    if (s->src) {
+        /* Buffer mode */
+        if (UNLIKELY(off + csz > s->src_size)) return ZXC_ERROR_SRC_TOO_SMALL;
+        ZXC_MEMCPY(buf, s->src + off, csz);
+    } else if (s->file) {
+        /* File mode */
+        if (UNLIKELY(fseeko(s->file, (long long)off, SEEK_SET) != 0 ||
+                     fread(buf, 1, csz, s->file) != csz))
+            return ZXC_ERROR_IO;
+    } else {
+        return ZXC_ERROR_NULL_INPUT;
+    }
+    return (int)csz;
+}
+
+int64_t zxc_seekable_decompress_range(zxc_seekable* s, void* dst, const size_t dst_capacity,
+                                      const uint64_t offset, const size_t len) {
+    if (UNLIKELY(!s || !dst)) return ZXC_ERROR_NULL_INPUT;
+    if (UNLIKELY(len == 0)) return 0;
+    if (UNLIKELY(dst_capacity < len)) return ZXC_ERROR_DST_TOO_SMALL;
+    if (UNLIKELY(offset + len > s->total_decomp)) return ZXC_ERROR_SRC_TOO_SMALL;
+
+    /* Initialize decompression context on first use */
+    if (!s->dctx_initialized) {
+        if (UNLIKELY(zxc_cctx_init(&s->dctx, s->block_size, 0, 0, 0) != ZXC_OK))
+            return ZXC_ERROR_MEMORY;
+        s->dctx_initialized = 1;
+    }
+
+    /* Ensure work buffer is large enough */
+    const size_t work_sz = s->block_size + ZXC_PAD_SIZE;
+    if (s->dctx.work_buf_cap < work_sz) {
+        free(s->dctx.work_buf);
+        s->dctx.work_buf = (uint8_t*)malloc(work_sz);
+        if (UNLIKELY(!s->dctx.work_buf)) return ZXC_ERROR_MEMORY;
+        s->dctx.work_buf_cap = work_sz;
+    }
+
+    /* Find block range */
+    const uint32_t blk_start = zxc_seek_find_block(s->decomp_offsets, s->num_blocks, offset);
+    const uint32_t blk_end =
+        zxc_seek_find_block(s->decomp_offsets, s->num_blocks, offset + len - 1);
+
+    uint8_t* out = (uint8_t*)dst;
+    size_t remaining = len;
+
+    /* Allocate read buffer for compressed blocks */
+    size_t max_comp = 0;
+    for (uint32_t bi = blk_start; bi <= blk_end; bi++) {
+        if (s->comp_sizes[bi] > max_comp) max_comp = s->comp_sizes[bi];
+    }
+    uint8_t* const read_buf = (uint8_t*)malloc(max_comp + ZXC_PAD_SIZE);
+    if (UNLIKELY(!read_buf)) return ZXC_ERROR_MEMORY;
+
+    for (uint32_t bi = blk_start; bi <= blk_end; bi++) {
+        /* Read compressed block data */
+        const int read_res = zxc_seek_read_block(s, bi, read_buf, max_comp + ZXC_PAD_SIZE);
+        if (UNLIKELY(read_res < 0)) {
+            free(read_buf);
+            return read_res;
+        }
+
+        /* Decompress the block */
+        const int dec_res = zxc_decompress_chunk_wrapper(&s->dctx, read_buf, (size_t)read_res,
+                                                         s->dctx.work_buf, work_sz);
+        if (UNLIKELY(dec_res < 0)) {
+            free(read_buf);
+            return dec_res;
+        }
+
+        /* Calculate which portion of this block's decompressed data we need */
+        const uint64_t blk_decomp_start = s->decomp_offsets[bi];
+        const size_t skip = (offset > blk_decomp_start) ? (size_t)(offset - blk_decomp_start) : 0;
+        const size_t avail = (size_t)dec_res - skip;
+        const size_t copy = (avail < remaining) ? avail : remaining;
+
+        ZXC_MEMCPY(out, s->dctx.work_buf + skip, copy);
+        out += copy;
+        remaining -= copy;
+    }
+
+    free(read_buf);
+    return (int64_t)len;
+}
+
+void zxc_seekable_free(zxc_seekable* s) {
+    if (!s) return;
+    if (s->dctx_initialized) zxc_cctx_free(&s->dctx);
+    free(s->comp_sizes);
+    free(s->decomp_sizes);
+    free(s->comp_offsets);
+    free(s->decomp_offsets);
+    free(s);
+}

--- a/src/lib/zxc_seekable.c
+++ b/src/lib/zxc_seekable.c
@@ -16,15 +16,15 @@
  *
  * On-disk layout of a SEK block:
  *
- *   [Block Header (8B)]   block_type=SEK, block_flags=0, comp_size
- *   [N × Entry (8B)]      comp_size(4) + decomp_size(4)
- *   [num_blocks (4B LE)]  tail for backward detection
+ *   [Block Header (8B)]   block_type=SEK, block_flags=0, comp_size=N*4
+ *   [N × Entry (4B)]      comp_size(u32 LE) per block
  *
  * Detection from end of file:
- *   1. Read file footer (last 12 bytes)
- *   2. Read 4 bytes before footer → num_blocks (u32 LE)
- *   3. Compute seek block size, read backward to the block header
- *   4. Validate block_type == ZXC_BLOCK_SEK
+ *   1. Read file header (first 16 bytes) → block_size
+ *   2. Read file footer (last 12 bytes) → total_decompressed_size
+ *   3. Derive num_blocks = ceil(total_decomp / block_size)
+ *   4. Compute seek block size, read backward to the block header
+ *   5. Validate block_type == ZXC_BLOCK_SEK
  */
 
 #include "../../include/zxc_seekable.h"
@@ -179,9 +179,9 @@ struct zxc_seekable_s {
 
     /* Parsed seek table */
     uint32_t num_blocks;
-    uint32_t* comp_sizes;     /* array[num_blocks] */
-    uint64_t* comp_offsets;   /* prefix-sum: byte offset in compressed file per block */
-    uint64_t total_decomp;    /* total decompressed size (from footer) */
+    uint32_t* comp_sizes;   /* array[num_blocks] */
+    uint64_t* comp_offsets; /* prefix-sum: byte offset in compressed file per block */
+    uint64_t total_decomp;  /* total decompressed size (from footer) */
 
     /* File header info */
     size_t block_size;
@@ -222,12 +222,20 @@ static zxc_seekable* zxc_seekable_parse(const uint8_t* data, const size_t data_s
     /* A value of 0 means empty file — no seek table */
     if (UNLIKELY(total_decomp == 0)) return NULL;
 
-    /* Step 3: derive num_blocks = ceil(total_decomp / block_size) */
-    const uint32_t num_blocks = (uint32_t)((total_decomp + block_size - 1) / block_size);
+    /* Step 3: derive num_blocks = ceil(total_decomp / block_size)
+     * Guard against uint32_t overflow: max representable is ~4 billion blocks.
+     * With block_size >= 4096, total_decomp would need to exceed ~16 TB. */
+    const uint64_t num_blocks_64 = (total_decomp + block_size - 1) / block_size;
+    if (UNLIKELY(num_blocks_64 > UINT32_MAX)) return NULL;
+    const uint32_t num_blocks = (uint32_t)num_blocks_64;
 
-    /* Step 4: compute seek block position and validate */
-    const size_t entries_total = (size_t)num_blocks * ZXC_SEEK_ENTRY_SIZE;
+    /* Step 4: compute seek block position and validate.
+     * Guard against size_t multiplication overflow. */
+    const uint64_t entries_total_64 = (uint64_t)num_blocks * ZXC_SEEK_ENTRY_SIZE;
+    if (UNLIKELY(entries_total_64 > SIZE_MAX - ZXC_BLOCK_HEADER_SIZE)) return NULL;
+    const size_t entries_total = (size_t)entries_total_64;
     const size_t seek_block_total = ZXC_BLOCK_HEADER_SIZE + entries_total;
+    if (UNLIKELY(seek_block_total + ZXC_FILE_FOOTER_SIZE > data_size)) return NULL;
     const uint8_t* const seek_block_start =
         data + data_size - ZXC_FILE_FOOTER_SIZE - seek_block_total;
     if (UNLIKELY(seek_block_start < data)) return NULL;
@@ -258,12 +266,20 @@ static zxc_seekable* zxc_seekable_parse(const uint8_t* data, const size_t data_s
     }
     s->total_decomp = total_decomp;
 
-    /* Parse comp_sizes and build compressed prefix sums */
+    /* Parse comp_sizes and build compressed prefix sums.
+     * Validate each comp_size against data_size to prevent prefix-sum overflow
+     * and out-of-bounds reads during decompression. */
     const uint8_t* ep = seek_block_start + ZXC_BLOCK_HEADER_SIZE;
     uint64_t comp_acc = ZXC_FILE_HEADER_SIZE; /* blocks start after file header */
     for (uint32_t i = 0; i < num_blocks; i++) {
         s->comp_sizes[i] = zxc_le32(ep);
         ep += sizeof(uint32_t);
+
+        /* Reject entries larger than the entire file — prevents prefix overflow */
+        if (UNLIKELY(s->comp_sizes[i] > data_size)) {
+            zxc_seekable_free(s);
+            return NULL;
+        }
         s->comp_offsets[i] = comp_acc;
         comp_acc += s->comp_sizes[i];
     }
@@ -350,12 +366,24 @@ zxc_seekable* zxc_seekable_open_file(FILE* f) {
         return NULL;
     }
 
-    /* Derive num_blocks = ceil(total_decomp / block_size) */
-    const uint32_t num_blocks = (uint32_t)((total_decomp + bs - 1) / bs);
+    /* Derive num_blocks = ceil(total_decomp / block_size).
+     * Guard against uint32_t overflow. */
+    const uint64_t num_blocks_64 = (total_decomp + bs - 1) / bs;
+    if (UNLIKELY(num_blocks_64 > UINT32_MAX)) {
+        fseeko(f, saved_pos, SEEK_SET);
+        return NULL;
+    }
+    const uint32_t num_blocks = (uint32_t)num_blocks_64;
+
+    /* Guard against size_t multiplication overflow. */
+    const uint64_t entries_total_64 = (uint64_t)num_blocks * ZXC_SEEK_ENTRY_SIZE;
+    if (UNLIKELY(entries_total_64 > SIZE_MAX - ZXC_BLOCK_HEADER_SIZE)) {
+        fseeko(f, saved_pos, SEEK_SET);
+        return NULL;
+    }
 
     /* Read the full seek block */
-    const size_t seek_block_total =
-        ZXC_BLOCK_HEADER_SIZE + (size_t)num_blocks * ZXC_SEEK_ENTRY_SIZE;
+    const size_t seek_block_total = ZXC_BLOCK_HEADER_SIZE + (size_t)entries_total_64;
     uint8_t* const seek_buf = (uint8_t*)malloc(seek_block_total);
     if (UNLIKELY(!seek_buf)) {
         fseeko(f, saved_pos, SEEK_SET);
@@ -375,8 +403,7 @@ zxc_seekable* zxc_seekable_open_file(FILE* f) {
     /* Validate block header */
     zxc_block_header_t bh;
     if (UNLIKELY(zxc_read_block_header(seek_buf, seek_block_total, &bh) != ZXC_OK) ||
-        bh.block_type != ZXC_BLOCK_SEK ||
-        bh.comp_size != (uint32_t)((size_t)num_blocks * ZXC_SEEK_ENTRY_SIZE)) {
+        bh.block_type != ZXC_BLOCK_SEK || bh.comp_size != (uint32_t)entries_total_64) {
         free(seek_buf);
         return NULL;
     }
@@ -414,6 +441,13 @@ zxc_seekable* zxc_seekable_open_file(FILE* f) {
     for (uint32_t i = 0; i < num_blocks; i++) {
         s->comp_sizes[i] = zxc_le32(ep);
         ep += sizeof(uint32_t);
+
+        /* Reject entries larger than the entire file */
+        if (UNLIKELY(s->comp_sizes[i] > (uint64_t)file_size)) {
+            free(seek_buf);
+            zxc_seekable_free(s);
+            return NULL;
+        }
         s->comp_offsets[i] = comp_acc;
         comp_acc += s->comp_sizes[i];
     }

--- a/src/lib/zxc_seekable.c
+++ b/src/lib/zxc_seekable.c
@@ -63,7 +63,10 @@ static int zxc_seek_thread_create(zxc_thread_t* t, void* (*fn)(void*), void* arg
     wrapper->func = fn;
     wrapper->arg = arg;
     uintptr_t handle = _beginthreadex(NULL, 0, zxc_seek_thread_entry, wrapper, 0, NULL);
-    if (UNLIKELY(handle == 0)) { free(wrapper); return ZXC_ERROR_MEMORY; }
+    if (UNLIKELY(handle == 0)) {
+        free(wrapper);
+        return ZXC_ERROR_MEMORY;
+    }
     *t = (HANDLE)handle;
     return 0;
 }
@@ -589,12 +592,12 @@ int64_t zxc_seekable_decompress_range(zxc_seekable* s, void* dst, const size_t d
  * The main thread inspects @c result after join.
  */
 typedef struct {
-    const zxc_seekable* s;  /* shared handle (read-only) */
-    uint32_t block_idx;     /* block to decompress */
-    uint8_t* dst;           /* output pointer within caller's buffer */
-    size_t skip;            /* bytes to skip at start of decompressed block */
-    size_t copy_len;        /* bytes to copy into dst */
-    int result;             /* 0 = OK, < 0 = error */
+    const zxc_seekable* s; /* shared handle (read-only) */
+    uint32_t block_idx;    /* block to decompress */
+    uint8_t* dst;          /* output pointer within caller's buffer */
+    size_t skip;           /* bytes to skip at start of decompressed block */
+    size_t copy_len;       /* bytes to copy into dst */
+    int result;            /* 0 = OK, < 0 = error */
 } zxc_seek_mt_job_t;
 
 /**
@@ -692,8 +695,7 @@ static void* zxc_seek_mt_worker(void* arg) {
 }
 
 int64_t zxc_seekable_decompress_range_mt(zxc_seekable* s, void* dst, const size_t dst_capacity,
-                                         const uint64_t offset, const size_t len,
-                                         int n_threads) {
+                                         const uint64_t offset, const size_t len, int n_threads) {
     if (UNLIKELY(!s || !dst)) return ZXC_ERROR_NULL_INPUT;
     if (UNLIKELY(len == 0)) return 0;
     if (UNLIKELY(dst_capacity < len)) return ZXC_ERROR_DST_TOO_SMALL;
@@ -718,8 +720,7 @@ int64_t zxc_seekable_decompress_range_mt(zxc_seekable* s, void* dst, const size_
     if (n_threads > ZXC_MAX_THREADS) n_threads = ZXC_MAX_THREADS;
 
     /* Allocate job descriptors */
-    zxc_seek_mt_job_t* const jobs =
-        (zxc_seek_mt_job_t*)calloc(num_jobs, sizeof(zxc_seek_mt_job_t));
+    zxc_seek_mt_job_t* const jobs = (zxc_seek_mt_job_t*)calloc(num_jobs, sizeof(zxc_seek_mt_job_t));
     if (UNLIKELY(!jobs)) return ZXC_ERROR_MEMORY;
 
     /* Plan jobs: compute skip, copy_len, and dst pointer for each block */

--- a/src/lib/zxc_seekable.c
+++ b/src/lib/zxc_seekable.c
@@ -175,7 +175,7 @@ int64_t zxc_write_seek_table(uint8_t* dst, const size_t dst_capacity, const uint
 struct zxc_seekable_s {
     /* Source - exactly one is non-NULL */
     const uint8_t* src;
-    size_t src_size;
+    uint64_t src_size;
     FILE* file;
 
     /* Native file descriptor for thread-safe pread() I/O */
@@ -191,8 +191,10 @@ struct zxc_seekable_s {
     uint64_t* comp_offsets; /* prefix-sum: byte offset in compressed file per block */
     uint64_t total_decomp;  /* total decompressed size (from footer) */
 
-    /* File header info */
-    size_t block_size;
+    /* File header info - block_size is always a power of 2 in [4KB, 2MB],
+     * fits in 21 bits.  Using uint32_t avoids size_t width differences
+     * between ILP32 and LP64 that caused ARM32 failures. */
+    uint32_t block_size;
     int file_has_checksums;
 
     /* Reusable decompression context (single-threaded path only) */
@@ -218,10 +220,11 @@ static zxc_seekable* zxc_seekable_parse(const uint8_t* data, const size_t data_s
     if (UNLIKELY(data_size < MIN_SEEKABLE_SIZE)) return NULL;
 
     /* Step 1: validate file header => block_size */
-    size_t block_size = 0;
+    size_t block_size_sz = 0;
     int file_has_chk = 0;
-    if (UNLIKELY(zxc_read_file_header(data, data_size, &block_size, &file_has_chk) != ZXC_OK))
+    if (UNLIKELY(zxc_read_file_header(data, data_size, &block_size_sz, &file_has_chk) != ZXC_OK))
         return NULL;
+    const uint32_t block_size = (uint32_t)block_size_sz;
 
     /* Step 2: read total decompressed size from the file footer */
     const uint8_t* const footer_ptr = data + data_size - ZXC_FILE_FOOTER_SIZE;
@@ -230,15 +233,12 @@ static zxc_seekable* zxc_seekable_parse(const uint8_t* data, const size_t data_s
     /* A value of 0 means empty file - no seek table */
     if (UNLIKELY(total_decomp == 0)) return NULL;
 
-    /* Step 3: derive num_blocks = ceil(total_decomp / block_size)
-     * Guard against uint32_t overflow: max representable is ~4 billion blocks.
-     * With block_size >= 4096, total_decomp would need to exceed ~16 TB. */
+    /* Step 3: derive num_blocks = ceil(total_decomp / block_size) */
     const uint64_t num_blocks_64 = (total_decomp + block_size - 1) / block_size;
     if (UNLIKELY(num_blocks_64 > UINT32_MAX)) return NULL;
     const uint32_t num_blocks = (uint32_t)num_blocks_64;
 
-    /* Step 4: compute seek block position and validate.
-     * Guard against size_t multiplication overflow. */
+    /* Step 4: compute seek block position and validate. */
     const uint64_t entries_total_64 = (uint64_t)num_blocks * ZXC_SEEK_ENTRY_SIZE;
     if (UNLIKELY(entries_total_64 > SIZE_MAX - ZXC_BLOCK_HEADER_SIZE)) return NULL;
     const size_t entries_total = (size_t)entries_total_64;
@@ -263,7 +263,7 @@ static zxc_seekable* zxc_seekable_parse(const uint8_t* data, const size_t data_s
     s->block_size = block_size;
     s->file_has_checksums = file_has_chk;
     s->src = data;
-    s->src_size = data_size;
+    s->src_size = (uint64_t)data_size;
 
     /* Allocate arrays */
     s->comp_sizes = (uint32_t*)calloc(num_blocks, sizeof(uint32_t));
@@ -284,7 +284,7 @@ static zxc_seekable* zxc_seekable_parse(const uint8_t* data, const size_t data_s
         ep += sizeof(uint32_t);
 
         /* Reject entries larger than the entire file - prevents prefix overflow */
-        if (UNLIKELY(s->comp_sizes[i] > data_size)) {
+        if (UNLIKELY(s->comp_sizes[i] > (uint64_t)data_size)) {
             zxc_seekable_free(s);
             return NULL;
         }
@@ -333,7 +333,7 @@ zxc_seekable* zxc_seekable_open_file(FILE* f) {
         zxc_seekable* const s = zxc_seekable_parse(full, (size_t)file_size);
         if (s) {
             s->src = NULL;
-            s->src_size = (size_t)file_size;
+            s->src_size = (uint64_t)file_size;
             s->file = f;
 #if defined(_WIN32)
             s->native_handle = (HANDLE)(intptr_t)_get_osfhandle(_fileno(f));
@@ -353,12 +353,13 @@ zxc_seekable* zxc_seekable_open_file(FILE* f) {
         return NULL;
     }
 
-    size_t bs = 0;
+    size_t bs_sz = 0;
     int fhc = 0;
-    if (UNLIKELY(zxc_read_file_header(header, ZXC_FILE_HEADER_SIZE, &bs, &fhc) != ZXC_OK)) {
+    if (UNLIKELY(zxc_read_file_header(header, ZXC_FILE_HEADER_SIZE, &bs_sz, &fhc) != ZXC_OK)) {
         fseeko(f, saved_pos, SEEK_SET);
         return NULL;
     }
+    const uint32_t bs = (uint32_t)bs_sz;
 
     /* Read footer (12 bytes) to get total_decomp_size */
     uint8_t footer_buf[ZXC_FILE_FOOTER_SIZE];
@@ -430,7 +431,7 @@ zxc_seekable* zxc_seekable_open_file(FILE* f) {
 #else
     s->fd = fileno(f);
 #endif
-    s->src_size = (size_t)file_size;
+    s->src_size = (uint64_t)file_size;
     s->num_blocks = num_blocks;
     s->block_size = bs;
     s->file_has_checksums = fhc;
@@ -478,9 +479,9 @@ uint32_t zxc_seekable_get_block_comp_size(const zxc_seekable* s, const uint32_t 
 
 uint32_t zxc_seekable_get_block_decomp_size(const zxc_seekable* s, const uint32_t block_idx) {
     if (UNLIKELY(!s || block_idx >= s->num_blocks)) return 0;
-    const uint64_t start = (uint64_t)block_idx * s->block_size;
+    const uint64_t start = (uint64_t)block_idx * (uint64_t)s->block_size;
     const uint64_t remaining = s->total_decomp - start;
-    return (remaining >= s->block_size) ? (uint32_t)s->block_size : (uint32_t)remaining;
+    return (remaining >= (uint64_t)s->block_size) ? s->block_size : (uint32_t)remaining;
 }
 
 /* ========================================================================= */
@@ -488,21 +489,21 @@ uint32_t zxc_seekable_get_block_decomp_size(const zxc_seekable* s, const uint32_
 /* ========================================================================= */
 
 /** @brief O(1) block lookup: block_index = offset / block_size. */
-static uint32_t zxc_seek_find_block(const size_t block_size, const uint64_t offset) {
-    return (uint32_t)(offset / block_size);
+static uint32_t zxc_seek_find_block(const uint32_t block_size, const uint64_t offset) {
+    return (uint32_t)(offset / (uint64_t)block_size);
 }
 
 /** @brief O(1) decompressed offset for block @p idx. */
-static uint64_t zxc_seek_decomp_offset(const size_t block_size, const uint32_t idx) {
-    return (uint64_t)idx * block_size;
+static uint64_t zxc_seek_decomp_offset(const uint32_t block_size, const uint32_t idx) {
+    return (uint64_t)idx * (uint64_t)block_size;
 }
 
 /** @brief O(1) decompressed size for block @p idx. */
-static uint32_t zxc_seek_decomp_size(const size_t block_size, const uint64_t total_decomp,
+static uint32_t zxc_seek_decomp_size(const uint32_t block_size, const uint64_t total_decomp,
                                      const uint32_t idx) {
-    const uint64_t start = (uint64_t)idx * block_size;
+    const uint64_t start = (uint64_t)idx * (uint64_t)block_size;
     const uint64_t remaining = total_decomp - start;
-    return (remaining >= block_size) ? (uint32_t)block_size : (uint32_t)remaining;
+    return (remaining >= (uint64_t)block_size) ? block_size : (uint32_t)remaining;
 }
 
 /**
@@ -538,13 +539,13 @@ int64_t zxc_seekable_decompress_range(zxc_seekable* s, void* dst, const size_t d
 
     /* Initialize decompression context on first use */
     if (!s->dctx_initialized) {
-        if (UNLIKELY(zxc_cctx_init(&s->dctx, s->block_size, 0, 0, 0) != ZXC_OK))
+        if (UNLIKELY(zxc_cctx_init(&s->dctx, (size_t)s->block_size, 0, 0, 0) != ZXC_OK))
             return ZXC_ERROR_MEMORY;
         s->dctx_initialized = 1;
     }
 
     /* Ensure work buffer is large enough */
-    const size_t work_sz = s->block_size + ZXC_PAD_SIZE;
+    const size_t work_sz = (size_t)s->block_size + ZXC_PAD_SIZE;
     if (s->dctx.work_buf_cap < work_sz) {
         free(s->dctx.work_buf);
         s->dctx.work_buf = (uint8_t*)malloc(work_sz);
@@ -661,13 +662,13 @@ static void* zxc_seek_mt_worker(void* arg) {
 
     /* Thread-local decompression context (mode=0 for decompress-only) */
     zxc_cctx_t dctx;
-    if (UNLIKELY(zxc_cctx_init(&dctx, s->block_size, 0, 0, 0) != ZXC_OK)) {
+    if (UNLIKELY(zxc_cctx_init(&dctx, (size_t)s->block_size, 0, 0, 0) != ZXC_OK)) {
         job->result = ZXC_ERROR_MEMORY;
         return NULL;
     }
 
     /* Allocate work buffer for decompressed output */
-    const size_t work_sz = s->block_size + ZXC_PAD_SIZE;
+    const size_t work_sz = (size_t)s->block_size + ZXC_PAD_SIZE;
     dctx.work_buf = (uint8_t*)malloc(work_sz);
     if (UNLIKELY(!dctx.work_buf)) {
         zxc_cctx_free(&dctx);

--- a/src/lib/zxc_seekable.c
+++ b/src/lib/zxc_seekable.c
@@ -38,7 +38,15 @@
 /* ========================================================================= */
 
 #if defined(_WIN32)
+#include <io.h>      /* _get_osfhandle, _fileno */
+#include <process.h> /* _beginthreadex */
 #include <windows.h>
+
+/* MSVC does not provide fseeko/ftello — map to 64-bit equivalents */
+#if defined(_MSC_VER) && !defined(fseeko)
+#define fseeko _fseeki64
+#define ftello _ftelli64
+#endif
 
 /* Map POSIX threading primitives to Windows equivalents */
 typedef HANDLE zxc_thread_t;
@@ -328,7 +336,7 @@ zxc_seekable* zxc_seekable_open_file(FILE* f) {
             s->src_size = (size_t)file_size;
             s->file = f;
 #if defined(_WIN32)
-            s->native_handle = (HANDLE)_get_osfhandle(_fileno(f));
+            s->native_handle = (HANDLE)(intptr_t)_get_osfhandle(_fileno(f));
 #else
             s->fd = fileno(f);
 #endif
@@ -418,7 +426,7 @@ zxc_seekable* zxc_seekable_open_file(FILE* f) {
     s->file = f;
     s->src = NULL;
 #if defined(_WIN32)
-    s->native_handle = (HANDLE)_get_osfhandle(_fileno(f));
+    s->native_handle = (HANDLE)(intptr_t)_get_osfhandle(_fileno(f));
 #else
     s->fd = fileno(f);
 #endif

--- a/src/lib/zxc_seekable.c
+++ b/src/lib/zxc_seekable.c
@@ -769,14 +769,12 @@ static void* zxc_seek_mt_worker(void* arg) {
         job->result = dec_res;
         return NULL;
     }
-    // LCOV_EXCL_STOP
-
-    /* Validate decompressed size covers the skip offset */
-    if (UNLIKELY((size_t)dec_res < job->skip)) {
+    if (UNLIKELY((size_t)dec_res < job->skip + job->copy_len)) {
         zxc_cctx_free(&dctx);
         job->result = ZXC_ERROR_CORRUPT_DATA;
         return NULL;
     }
+    // LCOV_EXCL_STOP
 
     /* Copy the requested portion directly into the caller's output buffer */
     ZXC_MEMCPY(job->dst, dctx.work_buf + job->skip, job->copy_len);

--- a/src/lib/zxc_seekable.c
+++ b/src/lib/zxc_seekable.c
@@ -133,16 +133,16 @@ static int zxc_seek_pread(int fd, void* buf, size_t count, uint64_t offset) {
 /* ========================================================================= */
 
 size_t zxc_seek_table_size(const uint32_t num_blocks) {
-    return ZXC_BLOCK_HEADER_SIZE + (size_t)num_blocks * ZXC_SEEK_ENTRY_SIZE + ZXC_SEEK_TAIL_SIZE;
+    return ZXC_BLOCK_HEADER_SIZE + (size_t)num_blocks * ZXC_SEEK_ENTRY_SIZE;
 }
 
 int64_t zxc_write_seek_table(uint8_t* dst, const size_t dst_capacity, const uint32_t* comp_sizes,
-                             const uint32_t* decomp_sizes, const uint32_t num_blocks) {
+                             const uint32_t num_blocks) {
     const size_t total = zxc_seek_table_size(num_blocks);
     if (UNLIKELY(dst_capacity < total)) return ZXC_ERROR_DST_TOO_SMALL;
-    if (UNLIKELY(!dst || !comp_sizes || !decomp_sizes)) return ZXC_ERROR_NULL_INPUT;
+    if (UNLIKELY(!dst || !comp_sizes)) return ZXC_ERROR_NULL_INPUT;
 
-    const uint32_t payload_size = (uint32_t)(num_blocks * ZXC_SEEK_ENTRY_SIZE + ZXC_SEEK_TAIL_SIZE);
+    const uint32_t payload_size = (uint32_t)(num_blocks * ZXC_SEEK_ENTRY_SIZE);
 
     /* Write standard ZXC block header */
     const zxc_block_header_t bh = {
@@ -151,17 +151,11 @@ int64_t zxc_write_seek_table(uint8_t* dst, const size_t dst_capacity, const uint
     if (UNLIKELY(hdr_res < 0)) return hdr_res;
     uint8_t* p = dst + hdr_res;
 
-    /* Write entries: comp_size(4) + decomp_size(4) */
+    /* Write entries: comp_size(4) only */
     for (uint32_t i = 0; i < num_blocks; i++) {
         zxc_store_le32(p, comp_sizes[i]);
         p += sizeof(uint32_t);
-        zxc_store_le32(p, decomp_sizes[i]);
-        p += sizeof(uint32_t);
     }
-
-    /* Write tail: num_blocks (for backward detection) */
-    zxc_store_le32(p, num_blocks);
-    p += sizeof(uint32_t);
 
     return (int64_t)(p - dst);
 }
@@ -186,10 +180,8 @@ struct zxc_seekable_s {
     /* Parsed seek table */
     uint32_t num_blocks;
     uint32_t* comp_sizes;     /* array[num_blocks] */
-    uint32_t* decomp_sizes;   /* array[num_blocks] */
     uint64_t* comp_offsets;   /* prefix-sum: byte offset in compressed file per block */
-    uint64_t* decomp_offsets; /* prefix-sum: byte offset in decompressed data per block */
-    uint64_t total_decomp;    /* sum of all decomp_sizes */
+    uint64_t total_decomp;    /* total decompressed size (from footer) */
 
     /* File header info */
     size_t block_size;
@@ -204,52 +196,50 @@ struct zxc_seekable_s {
  * @brief Parses the seek table from raw bytes at the end of the archive.
  *
  * Detection (backward from end):
- *   1. Skip file footer (last 12 bytes)
- *   2. Read 4 bytes before footer → num_blocks
- *   3. Read the block header at the computed offset
- *   4. Validate block_type == ZXC_BLOCK_SEK
+ *   1. Read file header → block_size
+ *   2. Read file footer → total_decomp_size
+ *   3. Derive num_blocks = ceil(total_decomp_size / block_size)
+ *   4. Compute expected seek block position, validate block_type == SEK
+ *   5. Read comp_sizes; derive decomp_sizes from block_size
  */
 static zxc_seekable* zxc_seekable_parse(const uint8_t* data, const size_t data_size) {
     /* Minimum: file_header(16) + eof_block(8) + seek_block_header(8)
-     *          + seek_tail(4) + file_footer(12) = 48 */
-    const size_t MIN_SEEKABLE_SIZE = ZXC_FILE_HEADER_SIZE + ZXC_BLOCK_HEADER_SIZE +
-                                     ZXC_BLOCK_HEADER_SIZE + ZXC_SEEK_TAIL_SIZE +
-                                     ZXC_FILE_FOOTER_SIZE;
+     *          + file_footer(12) = 44 */
+    const size_t MIN_SEEKABLE_SIZE =
+        ZXC_FILE_HEADER_SIZE + ZXC_BLOCK_HEADER_SIZE + ZXC_BLOCK_HEADER_SIZE + ZXC_FILE_FOOTER_SIZE;
     if (UNLIKELY(data_size < MIN_SEEKABLE_SIZE)) return NULL;
 
-    /* Step 1: validate file header */
+    /* Step 1: validate file header → block_size */
     size_t block_size = 0;
     int file_has_chk = 0;
     if (UNLIKELY(zxc_read_file_header(data, data_size, &block_size, &file_has_chk) != ZXC_OK))
         return NULL;
 
-    /* Step 2: read num_blocks from the tail (4 bytes before file footer) */
-    const uint8_t* const tail_ptr = data + data_size - ZXC_FILE_FOOTER_SIZE - ZXC_SEEK_TAIL_SIZE;
-    if (UNLIKELY(tail_ptr < data)) return NULL;
-    const uint32_t num_blocks = zxc_le32(tail_ptr);
+    /* Step 2: read total decompressed size from the file footer */
+    const uint8_t* const footer_ptr = data + data_size - ZXC_FILE_FOOTER_SIZE;
+    const uint64_t total_decomp = zxc_le64(footer_ptr);
 
-    /* A value of 0 means no seek table */
-    if (UNLIKELY(num_blocks == 0)) return NULL;
+    /* A value of 0 means empty file — no seek table */
+    if (UNLIKELY(total_decomp == 0)) return NULL;
 
-    /* Step 3: compute seek block position and validate */
+    /* Step 3: derive num_blocks = ceil(total_decomp / block_size) */
+    const uint32_t num_blocks = (uint32_t)((total_decomp + block_size - 1) / block_size);
+
+    /* Step 4: compute seek block position and validate */
     const size_t entries_total = (size_t)num_blocks * ZXC_SEEK_ENTRY_SIZE;
-    const uint8_t* const seek_block_start = tail_ptr - entries_total - ZXC_BLOCK_HEADER_SIZE;
+    const size_t seek_block_total = ZXC_BLOCK_HEADER_SIZE + entries_total;
+    const uint8_t* const seek_block_start =
+        data + data_size - ZXC_FILE_FOOTER_SIZE - seek_block_total;
     if (UNLIKELY(seek_block_start < data)) return NULL;
 
-    /* Read block header at the computed position */
+    /* Read and validate SEK block header */
     zxc_block_header_t bh;
-    const size_t seek_block_total = ZXC_BLOCK_HEADER_SIZE + entries_total + ZXC_SEEK_TAIL_SIZE;
     if (UNLIKELY(zxc_read_block_header(seek_block_start, seek_block_total, &bh) != ZXC_OK))
         return NULL;
-
-    /* Validate block type */
     if (UNLIKELY(bh.block_type != ZXC_BLOCK_SEK)) return NULL;
+    if (UNLIKELY(bh.comp_size != (uint32_t)entries_total)) return NULL;
 
-    /* Validate comp_size consistency */
-    const uint32_t expected_payload = (uint32_t)(entries_total + ZXC_SEEK_TAIL_SIZE);
-    if (UNLIKELY(bh.comp_size != expected_payload)) return NULL;
-
-    /* Step 4: allocate handle and parse entries */
+    /* Step 5: allocate handle and parse entries */
     zxc_seekable* const s = (zxc_seekable*)calloc(1, sizeof(zxc_seekable));
     if (UNLIKELY(!s)) return NULL;
 
@@ -261,32 +251,23 @@ static zxc_seekable* zxc_seekable_parse(const uint8_t* data, const size_t data_s
 
     /* Allocate arrays */
     s->comp_sizes = (uint32_t*)calloc(num_blocks, sizeof(uint32_t));
-    s->decomp_sizes = (uint32_t*)calloc(num_blocks, sizeof(uint32_t));
     s->comp_offsets = (uint64_t*)calloc((size_t)num_blocks + 1, sizeof(uint64_t));
-    s->decomp_offsets = (uint64_t*)calloc((size_t)num_blocks + 1, sizeof(uint64_t));
-    if (UNLIKELY(!s->comp_sizes || !s->decomp_sizes || !s->comp_offsets || !s->decomp_offsets)) {
+    if (UNLIKELY(!s->comp_sizes || !s->comp_offsets)) {
         zxc_seekable_free(s);
         return NULL;
     }
+    s->total_decomp = total_decomp;
 
-    /* Parse entries and build prefix sums */
+    /* Parse comp_sizes and build compressed prefix sums */
     const uint8_t* ep = seek_block_start + ZXC_BLOCK_HEADER_SIZE;
     uint64_t comp_acc = ZXC_FILE_HEADER_SIZE; /* blocks start after file header */
-    uint64_t decomp_acc = 0;
     for (uint32_t i = 0; i < num_blocks; i++) {
         s->comp_sizes[i] = zxc_le32(ep);
         ep += sizeof(uint32_t);
-        s->decomp_sizes[i] = zxc_le32(ep);
-        ep += sizeof(uint32_t);
-
         s->comp_offsets[i] = comp_acc;
-        s->decomp_offsets[i] = decomp_acc;
         comp_acc += s->comp_sizes[i];
-        decomp_acc += s->decomp_sizes[i];
     }
     s->comp_offsets[num_blocks] = comp_acc;
-    s->decomp_offsets[num_blocks] = decomp_acc;
-    s->total_decomp = decomp_acc;
 
     return s;
 }
@@ -340,7 +321,7 @@ zxc_seekable* zxc_seekable_open_file(FILE* f) {
         return s;
     }
 
-    /* Large file: read header + tail separately */
+    /* Large file: read header + footer separately */
     uint8_t header[ZXC_FILE_HEADER_SIZE];
     if (UNLIKELY(fseeko(f, 0, SEEK_SET) != 0 ||
                  fread(header, 1, ZXC_FILE_HEADER_SIZE, f) != ZXC_FILE_HEADER_SIZE)) {
@@ -355,24 +336,26 @@ zxc_seekable* zxc_seekable_open_file(FILE* f) {
         return NULL;
     }
 
-    /* Read tail: footer(12) + tail(4) to get num_blocks */
-    const size_t tail_read = ZXC_FILE_FOOTER_SIZE + ZXC_SEEK_TAIL_SIZE;
-    uint8_t tail_buf[16]; /* 12 + 4 = 16 */
-    if (UNLIKELY(fseeko(f, file_size - (long long)tail_read, SEEK_SET) != 0 ||
-                 fread(tail_buf, 1, tail_read, f) != tail_read)) {
+    /* Read footer (12 bytes) to get total_decomp_size */
+    uint8_t footer_buf[ZXC_FILE_FOOTER_SIZE];
+    if (UNLIKELY(fseeko(f, file_size - (long long)ZXC_FILE_FOOTER_SIZE, SEEK_SET) != 0 ||
+                 fread(footer_buf, 1, ZXC_FILE_FOOTER_SIZE, f) != ZXC_FILE_FOOTER_SIZE)) {
         fseeko(f, saved_pos, SEEK_SET);
         return NULL;
     }
 
-    const uint32_t num_blocks = zxc_le32(tail_buf); /* first 4 bytes = num_blocks tail */
-    if (UNLIKELY(num_blocks == 0)) {
+    const uint64_t total_decomp = zxc_le64(footer_buf);
+    if (UNLIKELY(total_decomp == 0)) {
         fseeko(f, saved_pos, SEEK_SET);
         return NULL;
     }
+
+    /* Derive num_blocks = ceil(total_decomp / block_size) */
+    const uint32_t num_blocks = (uint32_t)((total_decomp + bs - 1) / bs);
 
     /* Read the full seek block */
     const size_t seek_block_total =
-        ZXC_BLOCK_HEADER_SIZE + (size_t)num_blocks * ZXC_SEEK_ENTRY_SIZE + ZXC_SEEK_TAIL_SIZE;
+        ZXC_BLOCK_HEADER_SIZE + (size_t)num_blocks * ZXC_SEEK_ENTRY_SIZE;
     uint8_t* const seek_buf = (uint8_t*)malloc(seek_block_total);
     if (UNLIKELY(!seek_buf)) {
         fseeko(f, saved_pos, SEEK_SET);
@@ -393,7 +376,7 @@ zxc_seekable* zxc_seekable_open_file(FILE* f) {
     zxc_block_header_t bh;
     if (UNLIKELY(zxc_read_block_header(seek_buf, seek_block_total, &bh) != ZXC_OK) ||
         bh.block_type != ZXC_BLOCK_SEK ||
-        bh.comp_size != (uint32_t)((size_t)num_blocks * ZXC_SEEK_ENTRY_SIZE + ZXC_SEEK_TAIL_SIZE)) {
+        bh.comp_size != (uint32_t)((size_t)num_blocks * ZXC_SEEK_ENTRY_SIZE)) {
         free(seek_buf);
         return NULL;
     }
@@ -418,32 +401,23 @@ zxc_seekable* zxc_seekable_open_file(FILE* f) {
     s->file_has_checksums = fhc;
 
     s->comp_sizes = (uint32_t*)calloc(num_blocks, sizeof(uint32_t));
-    s->decomp_sizes = (uint32_t*)calloc(num_blocks, sizeof(uint32_t));
     s->comp_offsets = (uint64_t*)calloc((size_t)num_blocks + 1, sizeof(uint64_t));
-    s->decomp_offsets = (uint64_t*)calloc((size_t)num_blocks + 1, sizeof(uint64_t));
-    if (UNLIKELY(!s->comp_sizes || !s->decomp_sizes || !s->comp_offsets || !s->decomp_offsets)) {
+    if (UNLIKELY(!s->comp_sizes || !s->comp_offsets)) {
         free(seek_buf);
         zxc_seekable_free(s);
         return NULL;
     }
+    s->total_decomp = total_decomp;
 
     const uint8_t* ep = seek_buf + ZXC_BLOCK_HEADER_SIZE;
     uint64_t comp_acc = ZXC_FILE_HEADER_SIZE;
-    uint64_t decomp_acc = 0;
     for (uint32_t i = 0; i < num_blocks; i++) {
         s->comp_sizes[i] = zxc_le32(ep);
         ep += sizeof(uint32_t);
-        s->decomp_sizes[i] = zxc_le32(ep);
-        ep += sizeof(uint32_t);
-
         s->comp_offsets[i] = comp_acc;
-        s->decomp_offsets[i] = decomp_acc;
         comp_acc += s->comp_sizes[i];
-        decomp_acc += s->decomp_sizes[i];
     }
     s->comp_offsets[num_blocks] = comp_acc;
-    s->decomp_offsets[num_blocks] = decomp_acc;
-    s->total_decomp = decomp_acc;
 
     free(seek_buf);
     return s;
@@ -462,28 +436,31 @@ uint32_t zxc_seekable_get_block_comp_size(const zxc_seekable* s, const uint32_t 
 
 uint32_t zxc_seekable_get_block_decomp_size(const zxc_seekable* s, const uint32_t block_idx) {
     if (UNLIKELY(!s || block_idx >= s->num_blocks)) return 0;
-    return s->decomp_sizes[block_idx];
+    const uint64_t start = (uint64_t)block_idx * s->block_size;
+    const uint64_t remaining = s->total_decomp - start;
+    return (remaining >= s->block_size) ? (uint32_t)s->block_size : (uint32_t)remaining;
 }
 
 /* ========================================================================= */
 /*  Random-Access Decompression                                              */
 /* ========================================================================= */
 
-/**
- * @brief Binary search: find the block that contains @p offset.
- * decomp_offsets[i] <= offset < decomp_offsets[i+1]
- */
-static uint32_t zxc_seek_find_block(const uint64_t* decomp_offsets, const uint32_t num_blocks,
-                                    const uint64_t offset) {
-    uint32_t lo = 0, hi = num_blocks;
-    while (lo < hi) {
-        const uint32_t mid = lo + (hi - lo) / 2;
-        if (decomp_offsets[mid + 1] <= offset)
-            lo = mid + 1;
-        else
-            hi = mid;
-    }
-    return lo;
+/** @brief O(1) block lookup: block_index = offset / block_size. */
+static uint32_t zxc_seek_find_block(const size_t block_size, const uint64_t offset) {
+    return (uint32_t)(offset / block_size);
+}
+
+/** @brief O(1) decompressed offset for block @p idx. */
+static uint64_t zxc_seek_decomp_offset(const size_t block_size, const uint32_t idx) {
+    return (uint64_t)idx * block_size;
+}
+
+/** @brief O(1) decompressed size for block @p idx. */
+static uint32_t zxc_seek_decomp_size(const size_t block_size, const uint64_t total_decomp,
+                                     const uint32_t idx) {
+    const uint64_t start = (uint64_t)idx * block_size;
+    const uint64_t remaining = total_decomp - start;
+    return (remaining >= block_size) ? (uint32_t)block_size : (uint32_t)remaining;
 }
 
 /**
@@ -533,10 +510,9 @@ int64_t zxc_seekable_decompress_range(zxc_seekable* s, void* dst, const size_t d
         s->dctx.work_buf_cap = work_sz;
     }
 
-    /* Find block range */
-    const uint32_t blk_start = zxc_seek_find_block(s->decomp_offsets, s->num_blocks, offset);
-    const uint32_t blk_end =
-        zxc_seek_find_block(s->decomp_offsets, s->num_blocks, offset + len - 1);
+    /* Find block range — O(1) division */
+    const uint32_t blk_start = zxc_seek_find_block(s->block_size, offset);
+    const uint32_t blk_end = zxc_seek_find_block(s->block_size, offset + len - 1);
 
     uint8_t* out = (uint8_t*)dst;
     size_t remaining = len;
@@ -566,7 +542,7 @@ int64_t zxc_seekable_decompress_range(zxc_seekable* s, void* dst, const size_t d
         }
 
         /* Calculate which portion of this block's decompressed data we need */
-        const uint64_t blk_decomp_start = s->decomp_offsets[bi];
+        const uint64_t blk_decomp_start = zxc_seek_decomp_offset(s->block_size, bi);
         const size_t skip = (offset > blk_decomp_start) ? (size_t)(offset - blk_decomp_start) : 0;
         const size_t avail = (size_t)dec_res - skip;
         const size_t copy = (avail < remaining) ? avail : remaining;
@@ -701,10 +677,9 @@ int64_t zxc_seekable_decompress_range_mt(zxc_seekable* s, void* dst, const size_
     if (UNLIKELY(dst_capacity < len)) return ZXC_ERROR_DST_TOO_SMALL;
     if (UNLIKELY(offset + len > s->total_decomp)) return ZXC_ERROR_SRC_TOO_SMALL;
 
-    /* Find block range */
-    const uint32_t blk_start = zxc_seek_find_block(s->decomp_offsets, s->num_blocks, offset);
-    const uint32_t blk_end =
-        zxc_seek_find_block(s->decomp_offsets, s->num_blocks, offset + len - 1);
+    /* Find block range — O(1) division */
+    const uint32_t blk_start = zxc_seek_find_block(s->block_size, offset);
+    const uint32_t blk_end = zxc_seek_find_block(s->block_size, offset + len - 1);
     const uint32_t num_jobs = blk_end - blk_start + 1;
 
     /* Fallback to single-threaded path for trivial cases */
@@ -728,9 +703,9 @@ int64_t zxc_seekable_decompress_range_mt(zxc_seekable* s, void* dst, const size_
     size_t remaining = len;
     for (uint32_t i = 0; i < num_jobs; i++) {
         const uint32_t bi = blk_start + i;
-        const uint64_t blk_decomp_start = s->decomp_offsets[bi];
+        const uint64_t blk_decomp_start = zxc_seek_decomp_offset(s->block_size, bi);
         const size_t skip = (offset > blk_decomp_start) ? (size_t)(offset - blk_decomp_start) : 0;
-        const size_t blk_decomp_sz = s->decomp_sizes[bi];
+        const size_t blk_decomp_sz = zxc_seek_decomp_size(s->block_size, s->total_decomp, bi);
         const size_t avail = blk_decomp_sz - skip;
         const size_t copy = (avail < remaining) ? avail : remaining;
 
@@ -806,8 +781,6 @@ void zxc_seekable_free(zxc_seekable* s) {
     if (!s) return;
     if (s->dctx_initialized) zxc_cctx_free(&s->dctx);
     free(s->comp_sizes);
-    free(s->decomp_sizes);
     free(s->comp_offsets);
-    free(s->decomp_offsets);
     free(s);
 }

--- a/src/lib/zxc_seekable.c
+++ b/src/lib/zxc_seekable.c
@@ -320,7 +320,13 @@ zxc_seekable* zxc_seekable_open_file(FILE* f) {
     const long long saved_pos = ftello(f);
     if (UNLIKELY(saved_pos < 0)) return NULL;  // LCOV_EXCL_LINE
 
-    if (UNLIKELY(fseeko(f, 0, SEEK_END) != 0)) return NULL;  // LCOV_EXCL_LINE
+    // LCOV_EXCL_START
+    if (UNLIKELY(fseeko(f, 0, SEEK_END) != 0)) {
+        fseeko(f, saved_pos, SEEK_SET);
+        return NULL;
+    }
+    // LCOV_EXCL_STOP
+
     const long long file_size = ftello(f);
     // LCOV_EXCL_START
     if (UNLIKELY(file_size <= 0)) {

--- a/src/lib/zxc_seekable.c
+++ b/src/lib/zxc_seekable.c
@@ -148,11 +148,13 @@ size_t zxc_seek_table_size(const uint32_t num_blocks) {
 
 int64_t zxc_write_seek_table(uint8_t* dst, const size_t dst_capacity, const uint32_t* comp_sizes,
                              const uint32_t num_blocks) {
+    if (UNLIKELY(num_blocks > UINT32_MAX / ZXC_SEEK_ENTRY_SIZE)) return ZXC_ERROR_OVERFLOW;
+
     const size_t total = zxc_seek_table_size(num_blocks);
     if (UNLIKELY(dst_capacity < total)) return ZXC_ERROR_DST_TOO_SMALL;
     if (UNLIKELY(!dst || !comp_sizes)) return ZXC_ERROR_NULL_INPUT;
 
-    const uint32_t payload_size = (uint32_t)(num_blocks * ZXC_SEEK_ENTRY_SIZE);
+    const uint32_t payload_size = num_blocks * ZXC_SEEK_ENTRY_SIZE;
 
     /* Write standard ZXC block header */
     const zxc_block_header_t bh = {

--- a/src/lib/zxc_seekable.c
+++ b/src/lib/zxc_seekable.c
@@ -20,8 +20,8 @@
  *   [N × Entry (4B)]      comp_size(u32 LE) per block
  *
  * Detection from end of file:
- *   1. Read file header (first 16 bytes) → block_size
- *   2. Read file footer (last 12 bytes) → total_decompressed_size
+ *   1. Read file header (first 16 bytes) => block_size
+ *   2. Read file footer (last 12 bytes) => total_decompressed_size
  *   3. Derive num_blocks = ceil(total_decomp / block_size)
  *   4. Compute seek block size, read backward to the block header
  *   5. Validate block_type == ZXC_BLOCK_SEK
@@ -196,8 +196,8 @@ struct zxc_seekable_s {
  * @brief Parses the seek table from raw bytes at the end of the archive.
  *
  * Detection (backward from end):
- *   1. Read file header → block_size
- *   2. Read file footer → total_decomp_size
+ *   1. Read file header => block_size
+ *   2. Read file footer => total_decomp_size
  *   3. Derive num_blocks = ceil(total_decomp_size / block_size)
  *   4. Compute expected seek block position, validate block_type == SEK
  *   5. Read comp_sizes; derive decomp_sizes from block_size
@@ -209,7 +209,7 @@ static zxc_seekable* zxc_seekable_parse(const uint8_t* data, const size_t data_s
         ZXC_FILE_HEADER_SIZE + ZXC_BLOCK_HEADER_SIZE + ZXC_BLOCK_HEADER_SIZE + ZXC_FILE_FOOTER_SIZE;
     if (UNLIKELY(data_size < MIN_SEEKABLE_SIZE)) return NULL;
 
-    /* Step 1: validate file header → block_size */
+    /* Step 1: validate file header => block_size */
     size_t block_size = 0;
     int file_has_chk = 0;
     if (UNLIKELY(zxc_read_file_header(data, data_size, &block_size, &file_has_chk) != ZXC_OK))
@@ -716,13 +716,13 @@ int64_t zxc_seekable_decompress_range_mt(zxc_seekable* s, void* dst, const size_
     const uint32_t blk_end = zxc_seek_find_block(s->block_size, offset + len - 1);
     const uint32_t num_jobs = blk_end - blk_start + 1;
 
+    /* Auto-detect thread count (0 = use all available cores) */
+    if (n_threads == 0) n_threads = zxc_seek_get_num_procs();
+
     /* Fallback to single-threaded path for trivial cases */
     if (n_threads <= 1 || num_jobs <= 1) {
         return zxc_seekable_decompress_range(s, dst, dst_capacity, offset, len);
     }
-
-    /* Auto-detect thread count */
-    if (n_threads == 0) n_threads = zxc_seek_get_num_procs();
 
     /* Cap threads to number of blocks and max limit */
     if ((uint32_t)n_threads > num_jobs) n_threads = (int)num_jobs;

--- a/src/lib/zxc_seekable.c
+++ b/src/lib/zxc_seekable.c
@@ -37,6 +37,7 @@
 /*  Platform Threading & I/O Layer                                           */
 /* ========================================================================= */
 
+// LCOV_EXCL_START — Windows platform layer, not reachable on POSIX CI
 #if defined(_WIN32)
 #include <io.h>      /* _get_osfhandle, _fileno */
 #include <process.h> /* _beginthreadex */
@@ -105,6 +106,7 @@ static int zxc_seek_pread(HANDLE hFile, void* buf, size_t count, uint64_t offset
     if (!ReadFile(hFile, buf, (DWORD)count, &bytes_read, &ov)) return ZXC_ERROR_IO;
     return (bytes_read == (DWORD)count) ? (int)count : ZXC_ERROR_IO;
 }
+// LCOV_EXCL_STOP
 
 #else /* POSIX */
 #include <pthread.h>
@@ -257,7 +259,9 @@ static zxc_seekable* zxc_seekable_parse(const uint8_t* data, const size_t data_s
 
     /* Step 5: allocate handle and parse entries */
     zxc_seekable* const s = (zxc_seekable*)calloc(1, sizeof(zxc_seekable));
+    // LCOV_EXCL_START
     if (UNLIKELY(!s)) return NULL;
+    // LCOV_EXCL_STOP
 
     s->num_blocks = num_blocks;
     s->block_size = block_size;
@@ -268,10 +272,12 @@ static zxc_seekable* zxc_seekable_parse(const uint8_t* data, const size_t data_s
     /* Allocate arrays */
     s->comp_sizes = (uint32_t*)calloc(num_blocks, sizeof(uint32_t));
     s->comp_offsets = (uint64_t*)calloc((size_t)num_blocks + 1, sizeof(uint64_t));
+    // LCOV_EXCL_START
     if (UNLIKELY(!s->comp_sizes || !s->comp_offsets)) {
         zxc_seekable_free(s);
         return NULL;
     }
+    // LCOV_EXCL_STOP
     s->total_decomp = total_decomp;
 
     /* Parse comp_sizes and build compressed prefix sums.
@@ -305,20 +311,23 @@ zxc_seekable* zxc_seekable_open_file(FILE* f) {
     if (UNLIKELY(!f)) return NULL;
 
     const long long saved_pos = ftello(f);
-    if (UNLIKELY(saved_pos < 0)) return NULL;
+    if (UNLIKELY(saved_pos < 0)) return NULL; // LCOV_EXCL_LINE
 
-    if (UNLIKELY(fseeko(f, 0, SEEK_END) != 0)) return NULL;
+    if (UNLIKELY(fseeko(f, 0, SEEK_END) != 0)) return NULL; // LCOV_EXCL_LINE
     const long long file_size = ftello(f);
+    // LCOV_EXCL_START
     if (UNLIKELY(file_size <= 0)) {
         fseeko(f, saved_pos, SEEK_SET);
         return NULL;
     }
+    // LCOV_EXCL_STOP
 
     /* For simplicity and correctness: read the file into memory.
      * The seek table parsing needs the file header + the tail section. */
     if ((size_t)file_size <= 64 * 1024 * 1024) {
         /* File <= 64 MB: read it all into memory */
         uint8_t* const full = (uint8_t*)malloc((size_t)file_size);
+        // LCOV_EXCL_START
         if (UNLIKELY(!full)) {
             fseeko(f, saved_pos, SEEK_SET);
             return NULL;
@@ -329,6 +338,7 @@ zxc_seekable* zxc_seekable_open_file(FILE* f) {
             fseeko(f, saved_pos, SEEK_SET);
             return NULL;
         }
+        // LCOV_EXCL_STOP
         fseeko(f, saved_pos, SEEK_SET);
         zxc_seekable* const s = zxc_seekable_parse(full, (size_t)file_size);
         if (s) {
@@ -345,6 +355,7 @@ zxc_seekable* zxc_seekable_open_file(FILE* f) {
         return s;
     }
 
+    // LCOV_EXCL_START — large file path (>64MB), not reachable in unit tests
     /* Large file: read header + footer separately */
     uint8_t header[ZXC_FILE_HEADER_SIZE];
     if (UNLIKELY(fseeko(f, 0, SEEK_SET) != 0 ||
@@ -464,6 +475,7 @@ zxc_seekable* zxc_seekable_open_file(FILE* f) {
 
     free(seek_buf);
     return s;
+    // LCOV_EXCL_STOP
 }
 
 uint32_t zxc_seekable_get_num_blocks(const zxc_seekable* s) { return s ? s->num_blocks : 0; }
@@ -521,11 +533,13 @@ static int zxc_seek_read_block(const zxc_seekable* s, const uint32_t block_idx, 
         ZXC_MEMCPY(buf, s->src + off, csz);
     } else if (s->file) {
         /* File mode */
+        // LCOV_EXCL_START
         if (UNLIKELY(fseeko(s->file, (long long)off, SEEK_SET) != 0 ||
                      fread(buf, 1, csz, s->file) != csz))
             return ZXC_ERROR_IO;
+        // LCOV_EXCL_STOP
     } else {
-        return ZXC_ERROR_NULL_INPUT;
+        return ZXC_ERROR_NULL_INPUT; // LCOV_EXCL_LINE
     }
     return (int)csz;
 }
@@ -539,8 +553,10 @@ int64_t zxc_seekable_decompress_range(zxc_seekable* s, void* dst, const size_t d
 
     /* Initialize decompression context on first use */
     if (!s->dctx_initialized) {
+        // LCOV_EXCL_START
         if (UNLIKELY(zxc_cctx_init(&s->dctx, (size_t)s->block_size, 0, 0, 0) != ZXC_OK))
             return ZXC_ERROR_MEMORY;
+        // LCOV_EXCL_STOP
         s->dctx_initialized = 1;
     }
 
@@ -549,7 +565,7 @@ int64_t zxc_seekable_decompress_range(zxc_seekable* s, void* dst, const size_t d
     if (s->dctx.work_buf_cap < work_sz) {
         free(s->dctx.work_buf);
         s->dctx.work_buf = (uint8_t*)malloc(work_sz);
-        if (UNLIKELY(!s->dctx.work_buf)) return ZXC_ERROR_MEMORY;
+        if (UNLIKELY(!s->dctx.work_buf)) return ZXC_ERROR_MEMORY; // LCOV_EXCL_LINE
         s->dctx.work_buf_cap = work_sz;
     }
 
@@ -566,7 +582,7 @@ int64_t zxc_seekable_decompress_range(zxc_seekable* s, void* dst, const size_t d
         if (s->comp_sizes[bi] > max_comp) max_comp = s->comp_sizes[bi];
     }
     uint8_t* const read_buf = (uint8_t*)malloc(max_comp + ZXC_PAD_SIZE);
-    if (UNLIKELY(!read_buf)) return ZXC_ERROR_MEMORY;
+    if (UNLIKELY(!read_buf)) return ZXC_ERROR_MEMORY; // LCOV_EXCL_LINE
 
     for (uint32_t bi = blk_start; bi <= blk_end; bi++) {
         /* Read compressed block data */
@@ -641,7 +657,7 @@ static int zxc_seek_read_block_mt(const zxc_seekable* s, const uint32_t block_id
 #endif
         if (UNLIKELY(r < 0)) return r;
     } else {
-        return ZXC_ERROR_NULL_INPUT;
+        return ZXC_ERROR_NULL_INPUT; // LCOV_EXCL_LINE
     }
     return (int)csz;
 }
@@ -662,48 +678,58 @@ static void* zxc_seek_mt_worker(void* arg) {
 
     /* Thread-local decompression context (mode=0 for decompress-only) */
     zxc_cctx_t dctx;
+    // LCOV_EXCL_START
     if (UNLIKELY(zxc_cctx_init(&dctx, (size_t)s->block_size, 0, 0, 0) != ZXC_OK)) {
         job->result = ZXC_ERROR_MEMORY;
         return NULL;
     }
+    // LCOV_EXCL_STOP
 
     /* Allocate work buffer for decompressed output */
     const size_t work_sz = (size_t)s->block_size + ZXC_PAD_SIZE;
     dctx.work_buf = (uint8_t*)malloc(work_sz);
+    // LCOV_EXCL_START
     if (UNLIKELY(!dctx.work_buf)) {
         zxc_cctx_free(&dctx);
         job->result = ZXC_ERROR_MEMORY;
         return NULL;
     }
+    // LCOV_EXCL_STOP
     dctx.work_buf_cap = work_sz;
 
     /* Read compressed block */
     const uint32_t csz = s->comp_sizes[bi];
     uint8_t* const read_buf = (uint8_t*)malloc(csz + ZXC_PAD_SIZE);
+    // LCOV_EXCL_START
     if (UNLIKELY(!read_buf)) {
         zxc_cctx_free(&dctx);
         job->result = ZXC_ERROR_MEMORY;
         return NULL;
     }
+    // LCOV_EXCL_STOP
 
     const int read_res = zxc_seek_read_block_mt(s, bi, read_buf, csz + ZXC_PAD_SIZE);
+    // LCOV_EXCL_START
     if (UNLIKELY(read_res < 0)) {
         free(read_buf);
         zxc_cctx_free(&dctx);
         job->result = read_res;
         return NULL;
     }
+    // LCOV_EXCL_STOP
 
     /* Decompress */
     const int dec_res =
         zxc_decompress_chunk_wrapper(&dctx, read_buf, (size_t)read_res, dctx.work_buf, work_sz);
     free(read_buf);
 
+    // LCOV_EXCL_START
     if (UNLIKELY(dec_res < 0)) {
         zxc_cctx_free(&dctx);
         job->result = dec_res;
         return NULL;
     }
+    // LCOV_EXCL_STOP
 
     /* Copy the requested portion directly into the caller's output buffer */
     ZXC_MEMCPY(job->dst, dctx.work_buf + job->skip, job->copy_len);
@@ -739,7 +765,7 @@ int64_t zxc_seekable_decompress_range_mt(zxc_seekable* s, void* dst, const size_
 
     /* Allocate job descriptors */
     zxc_seek_mt_job_t* const jobs = (zxc_seek_mt_job_t*)calloc(num_jobs, sizeof(zxc_seek_mt_job_t));
-    if (UNLIKELY(!jobs)) return ZXC_ERROR_MEMORY;
+    if (UNLIKELY(!jobs)) return ZXC_ERROR_MEMORY; // LCOV_EXCL_LINE
 
     /* Plan jobs: compute skip, copy_len, and dst pointer for each block */
     uint8_t* out = (uint8_t*)dst;
@@ -765,10 +791,12 @@ int64_t zxc_seekable_decompress_range_mt(zxc_seekable* s, void* dst, const size_
 
     /* Launch worker threads (fork phase) */
     zxc_thread_t* const threads = (zxc_thread_t*)malloc((size_t)n_threads * sizeof(zxc_thread_t));
+    // LCOV_EXCL_START
     if (UNLIKELY(!threads)) {
         free(jobs);
         return ZXC_ERROR_MEMORY;
     }
+    // LCOV_EXCL_STOP
 
     /*
      * Distribute jobs across threads round-robin style.
@@ -784,6 +812,7 @@ int64_t zxc_seekable_decompress_range_mt(zxc_seekable* s, void* dst, const size_
 
         int launched = 0;
         for (int t = 0; t < wave_size; t++) {
+            // LCOV_EXCL_START
             if (zxc_seek_thread_create(&threads[t], zxc_seek_mt_worker, &jobs[job_idx + t]) != 0) {
                 /* Failed to create thread - mark remaining jobs as errors */
                 for (uint32_t j = job_idx + (uint32_t)t; j < num_jobs; j++)
@@ -791,6 +820,7 @@ int64_t zxc_seekable_decompress_range_mt(zxc_seekable* s, void* dst, const size_
                 error = 1;
                 break;
             }
+            // LCOV_EXCL_STOP
             launched++;
         }
 

--- a/src/lib/zxc_seekable.c
+++ b/src/lib/zxc_seekable.c
@@ -291,8 +291,9 @@ static zxc_seekable* zxc_seekable_parse(const uint8_t* data, const size_t data_s
         s->comp_sizes[i] = zxc_le32(ep);
         ep += sizeof(uint32_t);
 
-        /* Reject entries larger than the entire file - prevents prefix overflow */
-        if (UNLIKELY(s->comp_sizes[i] > (uint64_t)data_size)) {
+        /* Reject entries below minimum (block header) or larger than the file */
+        if (UNLIKELY(s->comp_sizes[i] < ZXC_BLOCK_HEADER_SIZE ||
+                     s->comp_sizes[i] > (uint64_t)data_size)) {
             zxc_seekable_free(s);
             return NULL;
         }
@@ -305,6 +306,28 @@ static zxc_seekable* zxc_seekable_parse(const uint8_t* data, const size_t data_s
         }
     }
     s->comp_offsets[num_blocks] = comp_acc;
+
+    /* Verify prefix-sum lands exactly at the EOF block position.
+     * Expected layout: [header 16][data blocks][EOF 8][SEK block][footer 12]
+     * So comp_acc (end of data blocks) + EOF(8) == seek_block_start. */
+    const uint64_t expected_eof_offset =
+        (uint64_t)(seek_block_start - data) - ZXC_BLOCK_HEADER_SIZE;
+    if (UNLIKELY(comp_acc != expected_eof_offset)) {
+        zxc_seekable_free(s);
+        return NULL;
+    }
+
+    /* Validate that an actual EOF block header exists at the computed offset */
+    if (UNLIKELY(comp_acc + ZXC_BLOCK_HEADER_SIZE > data_size)) {
+        zxc_seekable_free(s);
+        return NULL;
+    }
+    zxc_block_header_t eof_bh;
+    if (UNLIKELY(zxc_read_block_header(data + comp_acc, ZXC_BLOCK_HEADER_SIZE, &eof_bh) != ZXC_OK ||
+                 eof_bh.block_type != ZXC_BLOCK_EOF)) {
+        zxc_seekable_free(s);
+        return NULL;
+    }
 
     return s;
 }

--- a/src/lib/zxc_seekable.c
+++ b/src/lib/zxc_seekable.c
@@ -194,8 +194,7 @@ struct zxc_seekable_s {
     uint64_t total_decomp;  /* total decompressed size (from footer) */
 
     /* File header info - block_size is always a power of 2 in [4KB, 2MB],
-     * fits in 21 bits.  Using uint32_t avoids size_t width differences
-     * between ILP32 and LP64 that caused ARM32 failures. */
+     * fits in 21 bits. */
     uint32_t block_size;
     int file_has_checksums;
 
@@ -227,6 +226,7 @@ static zxc_seekable* zxc_seekable_parse(const uint8_t* data, const size_t data_s
     if (UNLIKELY(zxc_read_file_header(data, data_size, &block_size_sz, &file_has_chk) != ZXC_OK))
         return NULL;
     const uint32_t block_size = (uint32_t)block_size_sz;
+    if (UNLIKELY(block_size == 0)) return NULL;  // LCOV_EXCL_LINE
 
     /* Step 2: read total decompressed size from the file footer */
     const uint8_t* const footer_ptr = data + data_size - ZXC_FILE_FOOTER_SIZE;
@@ -241,7 +241,7 @@ static zxc_seekable* zxc_seekable_parse(const uint8_t* data, const size_t data_s
     const uint32_t num_blocks = (uint32_t)num_blocks_64;
 
     /* Step 4: compute seek block position and validate. */
-    const uint64_t entries_total_64 = (uint64_t)num_blocks * ZXC_SEEK_ENTRY_SIZE;
+    const uint64_t entries_total_64 = num_blocks_64 * ZXC_SEEK_ENTRY_SIZE;
     if (UNLIKELY(entries_total_64 > SIZE_MAX - ZXC_BLOCK_HEADER_SIZE)) return NULL;
     const size_t entries_total = (size_t)entries_total_64;
     const size_t seek_block_total = ZXC_BLOCK_HEADER_SIZE + entries_total;
@@ -296,6 +296,11 @@ static zxc_seekable* zxc_seekable_parse(const uint8_t* data, const size_t data_s
         }
         s->comp_offsets[i] = comp_acc;
         comp_acc += s->comp_sizes[i];
+        /* Reject if cumulative offset exceeds file size (inconsistent table) */
+        if (UNLIKELY(comp_acc > (uint64_t)data_size)) {
+            zxc_seekable_free(s);
+            return NULL;
+        }
     }
     s->comp_offsets[num_blocks] = comp_acc;
 
@@ -323,7 +328,7 @@ zxc_seekable* zxc_seekable_open_file(FILE* f) {
     // LCOV_EXCL_STOP
 
     /* For simplicity and correctness: read the file into memory.
-     * The seek table parsing needs the file header + the tail section. */
+     * The seek table parsing needs the file header. */
     if ((size_t)file_size <= 64 * 1024 * 1024) {
         /* File <= 64 MB: read it all into memory */
         uint8_t* const full = (uint8_t*)malloc((size_t)file_size);

--- a/src/lib/zxc_seekable.c
+++ b/src/lib/zxc_seekable.c
@@ -14,10 +14,10 @@
  * decompressed sizes of every block, enabling O(log N) lookup + O(block_size)
  * decompression for any byte range.
  *
- * On-disk layout of a SEEK block:
+ * On-disk layout of a SEK block:
  *
- *   [Block Header (8B)]   block_type=SEEK, block_flags, comp_size
- *   [N × Entry]           comp_size(4) + decomp_size(4) [+ checksum(4)]
+ *   [Block Header (8B)]   block_type=SEK, block_flags=0, comp_size
+ *   [N × Entry (8B)]      comp_size(4) + decomp_size(4)
  *   [num_blocks (4B LE)]  tail for backward detection
  *
  * Detection from end of file:
@@ -37,41 +37,31 @@
 /*  Seek Table Writer                                                        */
 /* ========================================================================= */
 
-size_t zxc_seek_table_size(const uint32_t num_blocks, const int has_checksums) {
-    const size_t entry_sz = has_checksums ? ZXC_SEEK_ENTRY_SIZE_CRC : ZXC_SEEK_ENTRY_SIZE;
-    return ZXC_BLOCK_HEADER_SIZE + (size_t)num_blocks * entry_sz + ZXC_SEEK_TAIL_SIZE;
+size_t zxc_seek_table_size(const uint32_t num_blocks) {
+    return ZXC_BLOCK_HEADER_SIZE + (size_t)num_blocks * ZXC_SEEK_ENTRY_SIZE + ZXC_SEEK_TAIL_SIZE;
 }
 
 int64_t zxc_write_seek_table(uint8_t* dst, const size_t dst_capacity, const uint32_t* comp_sizes,
-                             const uint32_t* decomp_sizes, const uint32_t num_blocks,
-                             const int has_checksums) {
-    const size_t total = zxc_seek_table_size(num_blocks, has_checksums);
+                             const uint32_t* decomp_sizes, const uint32_t num_blocks) {
+    const size_t total = zxc_seek_table_size(num_blocks);
     if (UNLIKELY(dst_capacity < total)) return ZXC_ERROR_DST_TOO_SMALL;
     if (UNLIKELY(!dst || !comp_sizes || !decomp_sizes)) return ZXC_ERROR_NULL_INPUT;
 
-    const size_t entry_sz = has_checksums ? ZXC_SEEK_ENTRY_SIZE_CRC : ZXC_SEEK_ENTRY_SIZE;
-    const uint32_t payload_size = (uint32_t)(num_blocks * entry_sz + ZXC_SEEK_TAIL_SIZE);
+    const uint32_t payload_size = (uint32_t)(num_blocks * ZXC_SEEK_ENTRY_SIZE + ZXC_SEEK_TAIL_SIZE);
 
     /* Write standard ZXC block header */
-    const zxc_block_header_t bh = {.block_type = ZXC_BLOCK_SEK,
-                                   .block_flags = has_checksums ? ZXC_SEEK_FLAG_CHECKSUM : 0,
-                                   .reserved = 0,
-                                   .comp_size = payload_size};
+    const zxc_block_header_t bh = {
+        .block_type = ZXC_BLOCK_SEK, .block_flags = 0, .reserved = 0, .comp_size = payload_size};
     const int hdr_res = zxc_write_block_header(dst, dst_capacity, &bh);
     if (UNLIKELY(hdr_res < 0)) return hdr_res;
     uint8_t* p = dst + hdr_res;
 
-    /* Write entries: comp_size(4) + decomp_size(4) [+ checksum(4)] */
+    /* Write entries: comp_size(4) + decomp_size(4) */
     for (uint32_t i = 0; i < num_blocks; i++) {
         zxc_store_le32(p, comp_sizes[i]);
         p += sizeof(uint32_t);
         zxc_store_le32(p, decomp_sizes[i]);
         p += sizeof(uint32_t);
-        if (has_checksums) {
-            /* Checksum slot — zeroed for now (can be extended later) */
-            zxc_store_le32(p, 0);
-            p += sizeof(uint32_t);
-        }
     }
 
     /* Write tail: num_blocks (for backward detection) */
@@ -98,7 +88,6 @@ struct zxc_seekable_s {
     uint64_t* comp_offsets;   /* prefix-sum: byte offset in compressed file per block */
     uint64_t* decomp_offsets; /* prefix-sum: byte offset in decompressed data per block */
     uint64_t total_decomp;    /* sum of all decomp_sizes */
-    int has_checksums;        /* from block_flags */
 
     /* File header info */
     size_t block_size;
@@ -140,87 +129,64 @@ static zxc_seekable* zxc_seekable_parse(const uint8_t* data, const size_t data_s
     /* A value of 0 means no seek table */
     if (UNLIKELY(num_blocks == 0)) return NULL;
 
-    /* Step 3: determine entry size by reading the block header */
-    /* The seek block starts at: tail_ptr - entries - block_header */
-    /* We don't know entry_size yet, but the block header has block_flags. */
-    /* First, try default entry size (8), compute the header position,
-     * read block_flags to determine actual entry size, then re-validate. */
+    /* Step 3: compute seek block position and validate */
+    const size_t entries_total = (size_t)num_blocks * ZXC_SEEK_ENTRY_SIZE;
+    const uint8_t* const seek_block_start = tail_ptr - entries_total - ZXC_BLOCK_HEADER_SIZE;
+    if (UNLIKELY(seek_block_start < data)) return NULL;
 
-    /* Try to locate the block header — we need to read it to know entry_size.
-     * Start with the assumption of no checksums (entry_size = 8). */
-    for (int pass = 0; pass < 2; pass++) {
-        const size_t entry_sz = (pass == 0) ? ZXC_SEEK_ENTRY_SIZE : ZXC_SEEK_ENTRY_SIZE_CRC;
-        const size_t entries_total = (size_t)num_blocks * entry_sz;
-        const uint8_t* const seek_block_start = tail_ptr - entries_total - ZXC_BLOCK_HEADER_SIZE;
-        if (UNLIKELY(seek_block_start < data)) continue;
+    /* Read block header at the computed position */
+    zxc_block_header_t bh;
+    const size_t seek_block_total = ZXC_BLOCK_HEADER_SIZE + entries_total + ZXC_SEEK_TAIL_SIZE;
+    if (UNLIKELY(zxc_read_block_header(seek_block_start, seek_block_total, &bh) != ZXC_OK))
+        return NULL;
 
-        /* Read block header at the computed position */
-        zxc_block_header_t bh;
-        if (UNLIKELY(
-                zxc_read_block_header(seek_block_start,
-                                      (size_t)(tail_ptr + ZXC_SEEK_TAIL_SIZE - seek_block_start),
-                                      &bh) != ZXC_OK))
-            continue;
+    /* Validate block type */
+    if (UNLIKELY(bh.block_type != ZXC_BLOCK_SEK)) return NULL;
 
-        /* Validate block type */
-        if (bh.block_type != ZXC_BLOCK_SEK) continue;
+    /* Validate comp_size consistency */
+    const uint32_t expected_payload = (uint32_t)(entries_total + ZXC_SEEK_TAIL_SIZE);
+    if (UNLIKELY(bh.comp_size != expected_payload)) return NULL;
 
-        /* Validate comp_size consistency */
-        const uint32_t expected_payload = (uint32_t)(entries_total + ZXC_SEEK_TAIL_SIZE);
-        if (bh.comp_size != expected_payload) continue;
+    /* Step 4: allocate handle and parse entries */
+    zxc_seekable* const s = (zxc_seekable*)calloc(1, sizeof(zxc_seekable));
+    if (UNLIKELY(!s)) return NULL;
 
-        /* Validate entry_size matches the checksum flag */
-        const int has_crc = (bh.block_flags & ZXC_SEEK_FLAG_CHECKSUM) != 0;
-        if (has_crc && entry_sz != ZXC_SEEK_ENTRY_SIZE_CRC) continue;
-        if (!has_crc && entry_sz != ZXC_SEEK_ENTRY_SIZE) continue;
+    s->num_blocks = num_blocks;
+    s->block_size = block_size;
+    s->file_has_checksums = file_has_chk;
+    s->src = data;
+    s->src_size = data_size;
 
-        /* ✓ Found a valid seek block. Parse entries. */
-
-        zxc_seekable* const s = (zxc_seekable*)calloc(1, sizeof(zxc_seekable));
-        if (UNLIKELY(!s)) return NULL;
-
-        s->num_blocks = num_blocks;
-        s->has_checksums = has_crc;
-        s->block_size = block_size;
-        s->file_has_checksums = file_has_chk;
-        s->src = data;
-        s->src_size = data_size;
-
-        /* Allocate arrays */
-        s->comp_sizes = (uint32_t*)calloc(num_blocks, sizeof(uint32_t));
-        s->decomp_sizes = (uint32_t*)calloc(num_blocks, sizeof(uint32_t));
-        s->comp_offsets = (uint64_t*)calloc((size_t)num_blocks + 1, sizeof(uint64_t));
-        s->decomp_offsets = (uint64_t*)calloc((size_t)num_blocks + 1, sizeof(uint64_t));
-        if (UNLIKELY(!s->comp_sizes || !s->decomp_sizes || !s->comp_offsets ||
-                     !s->decomp_offsets)) {
-            zxc_seekable_free(s);
-            return NULL;
-        }
-
-        /* Parse entries and build prefix sums */
-        const uint8_t* ep = seek_block_start + ZXC_BLOCK_HEADER_SIZE;
-        uint64_t comp_acc = ZXC_FILE_HEADER_SIZE; /* blocks start after file header */
-        uint64_t decomp_acc = 0;
-        for (uint32_t i = 0; i < num_blocks; i++) {
-            s->comp_sizes[i] = zxc_le32(ep);
-            ep += sizeof(uint32_t);
-            s->decomp_sizes[i] = zxc_le32(ep);
-            ep += sizeof(uint32_t);
-            if (has_crc) ep += sizeof(uint32_t); /* skip checksum */
-
-            s->comp_offsets[i] = comp_acc;
-            s->decomp_offsets[i] = decomp_acc;
-            comp_acc += s->comp_sizes[i];
-            decomp_acc += s->decomp_sizes[i];
-        }
-        s->comp_offsets[num_blocks] = comp_acc;
-        s->decomp_offsets[num_blocks] = decomp_acc;
-        s->total_decomp = decomp_acc;
-
-        return s;
+    /* Allocate arrays */
+    s->comp_sizes = (uint32_t*)calloc(num_blocks, sizeof(uint32_t));
+    s->decomp_sizes = (uint32_t*)calloc(num_blocks, sizeof(uint32_t));
+    s->comp_offsets = (uint64_t*)calloc((size_t)num_blocks + 1, sizeof(uint64_t));
+    s->decomp_offsets = (uint64_t*)calloc((size_t)num_blocks + 1, sizeof(uint64_t));
+    if (UNLIKELY(!s->comp_sizes || !s->decomp_sizes || !s->comp_offsets || !s->decomp_offsets)) {
+        zxc_seekable_free(s);
+        return NULL;
     }
 
-    return NULL; /* No valid seek block found */
+    /* Parse entries and build prefix sums */
+    const uint8_t* ep = seek_block_start + ZXC_BLOCK_HEADER_SIZE;
+    uint64_t comp_acc = ZXC_FILE_HEADER_SIZE; /* blocks start after file header */
+    uint64_t decomp_acc = 0;
+    for (uint32_t i = 0; i < num_blocks; i++) {
+        s->comp_sizes[i] = zxc_le32(ep);
+        ep += sizeof(uint32_t);
+        s->decomp_sizes[i] = zxc_le32(ep);
+        ep += sizeof(uint32_t);
+
+        s->comp_offsets[i] = comp_acc;
+        s->decomp_offsets[i] = decomp_acc;
+        comp_acc += s->comp_sizes[i];
+        decomp_acc += s->decomp_sizes[i];
+    }
+    s->comp_offsets[num_blocks] = comp_acc;
+    s->decomp_offsets[num_blocks] = decomp_acc;
+    s->total_decomp = decomp_acc;
+
+    return s;
 }
 
 zxc_seekable* zxc_seekable_open(const void* src, const size_t src_size) {
@@ -241,174 +207,133 @@ zxc_seekable* zxc_seekable_open_file(FILE* f) {
         return NULL;
     }
 
-    /* Read the tail: we need at most the seek table + footer.
-     * For safety, read the last 64 KB or the whole file if smaller. */
-    const size_t tail_size = ((size_t)file_size > 65536) ? 65536 : (size_t)file_size;
-    uint8_t* const tail = (uint8_t*)malloc(tail_size);
-    if (UNLIKELY(!tail)) {
+    /* For simplicity and correctness: read the file into memory.
+     * The seek table parsing needs the file header + the tail section. */
+    if ((size_t)file_size <= 64 * 1024 * 1024) {
+        /* File <= 64 MB: read it all into memory */
+        uint8_t* const full = (uint8_t*)malloc((size_t)file_size);
+        if (UNLIKELY(!full)) {
+            fseeko(f, saved_pos, SEEK_SET);
+            return NULL;
+        }
+        if (UNLIKELY(fseeko(f, 0, SEEK_SET) != 0 ||
+                     fread(full, 1, (size_t)file_size, f) != (size_t)file_size)) {
+            free(full);
+            fseeko(f, saved_pos, SEEK_SET);
+            return NULL;
+        }
+        fseeko(f, saved_pos, SEEK_SET);
+        zxc_seekable* const s = zxc_seekable_parse(full, (size_t)file_size);
+        if (s) {
+            s->src = NULL;
+            s->src_size = (size_t)file_size;
+            s->file = f;
+        }
+        free(full);
+        return s;
+    }
+
+    /* Large file: read header + tail separately */
+    uint8_t header[ZXC_FILE_HEADER_SIZE];
+    if (UNLIKELY(fseeko(f, 0, SEEK_SET) != 0 ||
+                 fread(header, 1, ZXC_FILE_HEADER_SIZE, f) != ZXC_FILE_HEADER_SIZE)) {
         fseeko(f, saved_pos, SEEK_SET);
         return NULL;
     }
 
-    if (UNLIKELY(fseeko(f, file_size - (long long)tail_size, SEEK_SET) != 0 ||
-                 fread(tail, 1, tail_size, f) != tail_size)) {
-        free(tail);
+    size_t bs = 0;
+    int fhc = 0;
+    if (UNLIKELY(zxc_read_file_header(header, ZXC_FILE_HEADER_SIZE, &bs, &fhc) != ZXC_OK)) {
+        fseeko(f, saved_pos, SEEK_SET);
+        return NULL;
+    }
+
+    /* Read tail: footer(12) + tail(4) to get num_blocks */
+    const size_t tail_read = ZXC_FILE_FOOTER_SIZE + ZXC_SEEK_TAIL_SIZE;
+    uint8_t tail_buf[16]; /* 12 + 4 = 16 */
+    if (UNLIKELY(fseeko(f, file_size - (long long)tail_read, SEEK_SET) != 0 ||
+                 fread(tail_buf, 1, tail_read, f) != tail_read)) {
+        fseeko(f, saved_pos, SEEK_SET);
+        return NULL;
+    }
+
+    const uint32_t num_blocks = zxc_le32(tail_buf); /* first 4 bytes = num_blocks tail */
+    if (UNLIKELY(num_blocks == 0)) {
+        fseeko(f, saved_pos, SEEK_SET);
+        return NULL;
+    }
+
+    /* Read the full seek block */
+    const size_t seek_block_total =
+        ZXC_BLOCK_HEADER_SIZE + (size_t)num_blocks * ZXC_SEEK_ENTRY_SIZE + ZXC_SEEK_TAIL_SIZE;
+    uint8_t* const seek_buf = (uint8_t*)malloc(seek_block_total);
+    if (UNLIKELY(!seek_buf)) {
+        fseeko(f, saved_pos, SEEK_SET);
+        return NULL;
+    }
+
+    const long long seek_offset =
+        file_size - (long long)ZXC_FILE_FOOTER_SIZE - (long long)seek_block_total;
+    if (UNLIKELY(seek_offset < 0 || fseeko(f, seek_offset, SEEK_SET) != 0 ||
+                 fread(seek_buf, 1, seek_block_total, f) != seek_block_total)) {
+        free(seek_buf);
         fseeko(f, saved_pos, SEEK_SET);
         return NULL;
     }
     fseeko(f, saved_pos, SEEK_SET);
 
-    /* For file mode, we need the full file header too. Read it if not in tail. */
-    uint8_t header[ZXC_FILE_HEADER_SIZE];
-    if (tail_size < (size_t)file_size) {
-        if (UNLIKELY(fseeko(f, 0, SEEK_SET) != 0 ||
-                     fread(header, 1, ZXC_FILE_HEADER_SIZE, f) != ZXC_FILE_HEADER_SIZE)) {
-            free(tail);
-            fseeko(f, saved_pos, SEEK_SET);
-            return NULL;
-        }
-        fseeko(f, saved_pos, SEEK_SET);
-    }
-
-    /* Detect seek table from the tail */
-    if (UNLIKELY(tail_size < ZXC_FILE_FOOTER_SIZE + ZXC_SEEK_TAIL_SIZE)) {
-        free(tail);
+    /* Validate block header */
+    zxc_block_header_t bh;
+    if (UNLIKELY(zxc_read_block_header(seek_buf, seek_block_total, &bh) != ZXC_OK) ||
+        bh.block_type != ZXC_BLOCK_SEK ||
+        bh.comp_size != (uint32_t)((size_t)num_blocks * ZXC_SEEK_ENTRY_SIZE + ZXC_SEEK_TAIL_SIZE)) {
+        free(seek_buf);
         return NULL;
     }
 
-    /* Read num_blocks from tail */
-    const uint8_t* const nblk_ptr = tail + tail_size - ZXC_FILE_FOOTER_SIZE - ZXC_SEEK_TAIL_SIZE;
-    const uint32_t num_blocks = zxc_le32(nblk_ptr);
-    if (num_blocks == 0) {
-        free(tail);
+    /* Build seekable handle */
+    zxc_seekable* const s = (zxc_seekable*)calloc(1, sizeof(zxc_seekable));
+    if (UNLIKELY(!s)) {
+        free(seek_buf);
         return NULL;
     }
 
-    /* Compute seek block size to check if tail buffer is large enough */
-    /* Try both entry sizes; the larger one gives an upper bound */
-    const size_t max_seek_size =
-        ZXC_BLOCK_HEADER_SIZE + (size_t)num_blocks * ZXC_SEEK_ENTRY_SIZE_CRC + ZXC_SEEK_TAIL_SIZE;
+    s->file = f;
+    s->src = NULL;
+    s->src_size = (size_t)file_size;
+    s->num_blocks = num_blocks;
+    s->block_size = bs;
+    s->file_has_checksums = fhc;
 
-    /* We need seek block + footer in the tail */
-    if (UNLIKELY(tail_size < max_seek_size + ZXC_FILE_FOOTER_SIZE)) {
-        /* Seek table is larger than our tail buffer — read the entire file */
-        free(tail);
-        uint8_t* const full = (uint8_t*)malloc((size_t)file_size);
-        if (UNLIKELY(!full)) return NULL;
-        if (UNLIKELY(fseeko(f, 0, SEEK_SET) != 0 ||
-                     fread(full, 1, (size_t)file_size, f) != (size_t)file_size)) {
-            free(full);
-            fseeko(f, saved_pos, SEEK_SET);
-            return NULL;
-        }
-        fseeko(f, saved_pos, SEEK_SET);
-        zxc_seekable* const s = zxc_seekable_parse(full, (size_t)file_size);
-        if (s) {
-            s->src = NULL;
-            s->src_size = (size_t)file_size;
-            s->file = f;
-        }
-        free(full);
-        return s;
-    }
-
-    /* File small enough or tail large enough — read the full file if <= 64 MB */
-    if ((size_t)file_size <= 64 * 1024 * 1024) {
-        uint8_t* const full = (uint8_t*)malloc((size_t)file_size);
-        if (UNLIKELY(!full)) {
-            free(tail);
-            return NULL;
-        }
-        if (UNLIKELY(fseeko(f, 0, SEEK_SET) != 0 ||
-                     fread(full, 1, (size_t)file_size, f) != (size_t)file_size)) {
-            free(full);
-            free(tail);
-            fseeko(f, saved_pos, SEEK_SET);
-            return NULL;
-        }
-        fseeko(f, saved_pos, SEEK_SET);
-        free(tail);
-        zxc_seekable* const s = zxc_seekable_parse(full, (size_t)file_size);
-        if (s) {
-            s->src = NULL;
-            s->src_size = (size_t)file_size;
-            s->file = f;
-        }
-        free(full);
-        return s;
-    }
-
-    /* Large file: parse seek table directly from the tail */
-    size_t bs = 0;
-    int fhc = 0;
-    if (UNLIKELY(zxc_read_file_header(header, ZXC_FILE_HEADER_SIZE, &bs, &fhc) != ZXC_OK)) {
-        free(tail);
+    s->comp_sizes = (uint32_t*)calloc(num_blocks, sizeof(uint32_t));
+    s->decomp_sizes = (uint32_t*)calloc(num_blocks, sizeof(uint32_t));
+    s->comp_offsets = (uint64_t*)calloc((size_t)num_blocks + 1, sizeof(uint64_t));
+    s->decomp_offsets = (uint64_t*)calloc((size_t)num_blocks + 1, sizeof(uint64_t));
+    if (UNLIKELY(!s->comp_sizes || !s->decomp_sizes || !s->comp_offsets || !s->decomp_offsets)) {
+        free(seek_buf);
+        zxc_seekable_free(s);
         return NULL;
     }
 
-    /* We need to find the block header in the tail. Try both entry sizes. */
-    zxc_seekable* s = NULL;
-    for (int pass = 0; pass < 2 && !s; pass++) {
-        const size_t entry_sz = (pass == 0) ? ZXC_SEEK_ENTRY_SIZE : ZXC_SEEK_ENTRY_SIZE_CRC;
-        const size_t entries_total = (size_t)num_blocks * entry_sz;
-        const size_t seek_block_total = ZXC_BLOCK_HEADER_SIZE + entries_total + ZXC_SEEK_TAIL_SIZE;
+    const uint8_t* ep = seek_buf + ZXC_BLOCK_HEADER_SIZE;
+    uint64_t comp_acc = ZXC_FILE_HEADER_SIZE;
+    uint64_t decomp_acc = 0;
+    for (uint32_t i = 0; i < num_blocks; i++) {
+        s->comp_sizes[i] = zxc_le32(ep);
+        ep += sizeof(uint32_t);
+        s->decomp_sizes[i] = zxc_le32(ep);
+        ep += sizeof(uint32_t);
 
-        if (tail_size < seek_block_total + ZXC_FILE_FOOTER_SIZE) continue;
-
-        /* Block header position in the tail */
-        const uint8_t* const bh_ptr = tail + tail_size - ZXC_FILE_FOOTER_SIZE - seek_block_total;
-
-        zxc_block_header_t bh;
-        if (zxc_read_block_header(bh_ptr, seek_block_total, &bh) != ZXC_OK) continue;
-        if (bh.block_type != ZXC_BLOCK_SEK) continue;
-        if (bh.comp_size != (uint32_t)(entries_total + ZXC_SEEK_TAIL_SIZE)) continue;
-
-        const int has_crc = (bh.block_flags & ZXC_SEEK_FLAG_CHECKSUM) != 0;
-        if (has_crc && entry_sz != ZXC_SEEK_ENTRY_SIZE_CRC) continue;
-        if (!has_crc && entry_sz != ZXC_SEEK_ENTRY_SIZE) continue;
-
-        s = (zxc_seekable*)calloc(1, sizeof(zxc_seekable));
-        if (UNLIKELY(!s)) break;
-        s->file = f;
-        s->src = NULL;
-        s->src_size = (size_t)file_size;
-        s->num_blocks = num_blocks;
-        s->has_checksums = has_crc;
-        s->block_size = bs;
-        s->file_has_checksums = fhc;
-
-        s->comp_sizes = (uint32_t*)calloc(num_blocks, sizeof(uint32_t));
-        s->decomp_sizes = (uint32_t*)calloc(num_blocks, sizeof(uint32_t));
-        s->comp_offsets = (uint64_t*)calloc((size_t)num_blocks + 1, sizeof(uint64_t));
-        s->decomp_offsets = (uint64_t*)calloc((size_t)num_blocks + 1, sizeof(uint64_t));
-        if (UNLIKELY(!s->comp_sizes || !s->decomp_sizes || !s->comp_offsets ||
-                     !s->decomp_offsets)) {
-            zxc_seekable_free(s);
-            s = NULL;
-            break;
-        }
-
-        const uint8_t* ep = bh_ptr + ZXC_BLOCK_HEADER_SIZE;
-        uint64_t comp_acc = ZXC_FILE_HEADER_SIZE;
-        uint64_t decomp_acc = 0;
-        for (uint32_t i = 0; i < num_blocks; i++) {
-            s->comp_sizes[i] = zxc_le32(ep);
-            ep += sizeof(uint32_t);
-            s->decomp_sizes[i] = zxc_le32(ep);
-            ep += sizeof(uint32_t);
-            if (has_crc) ep += sizeof(uint32_t);
-
-            s->comp_offsets[i] = comp_acc;
-            s->decomp_offsets[i] = decomp_acc;
-            comp_acc += s->comp_sizes[i];
-            decomp_acc += s->decomp_sizes[i];
-        }
-        s->comp_offsets[num_blocks] = comp_acc;
-        s->decomp_offsets[num_blocks] = decomp_acc;
-        s->total_decomp = decomp_acc;
+        s->comp_offsets[i] = comp_acc;
+        s->decomp_offsets[i] = decomp_acc;
+        comp_acc += s->comp_sizes[i];
+        decomp_acc += s->decomp_sizes[i];
     }
+    s->comp_offsets[num_blocks] = comp_acc;
+    s->decomp_offsets[num_blocks] = decomp_acc;
+    s->total_decomp = decomp_acc;
 
-    free(tail);
+    free(seek_buf);
     return s;
 }
 

--- a/src/lib/zxc_seekable.c
+++ b/src/lib/zxc_seekable.c
@@ -11,7 +11,7 @@
  *
  * The seek table is a standard ZXC block (type = ZXC_BLOCK_SEK) appended
  * between the EOF block and the file footer.  It records the compressed and
- * decompressed sizes of every block, enabling O(log N) lookup + O(block_size)
+ * decompressed sizes of every block, enabling O(1) lookup + O(block_size)
  * decompression for any byte range.
  *
  * On-disk layout of a SEK block:

--- a/src/lib/zxc_seekable.c
+++ b/src/lib/zxc_seekable.c
@@ -639,6 +639,10 @@ int64_t zxc_seekable_decompress_range(zxc_seekable* s, void* dst, const size_t d
         /* Calculate which portion of this block's decompressed data we need */
         const uint64_t blk_decomp_start = zxc_seek_decomp_offset(s->block_size, bi);
         const size_t skip = (offset > blk_decomp_start) ? (size_t)(offset - blk_decomp_start) : 0;
+        if (UNLIKELY((size_t)dec_res < skip)) {
+            free(read_buf);
+            return ZXC_ERROR_CORRUPT_DATA;
+        }
         const size_t avail = (size_t)dec_res - skip;
         const size_t copy = (avail < remaining) ? avail : remaining;
 
@@ -767,6 +771,13 @@ static void* zxc_seek_mt_worker(void* arg) {
     }
     // LCOV_EXCL_STOP
 
+    /* Validate decompressed size covers the skip offset */
+    if (UNLIKELY((size_t)dec_res < job->skip)) {
+        zxc_cctx_free(&dctx);
+        job->result = ZXC_ERROR_CORRUPT_DATA;
+        return NULL;
+    }
+
     /* Copy the requested portion directly into the caller's output buffer */
     ZXC_MEMCPY(job->dst, dctx.work_buf + job->skip, job->copy_len);
 
@@ -811,6 +822,10 @@ int64_t zxc_seekable_decompress_range_mt(zxc_seekable* s, void* dst, const size_
         const uint64_t blk_decomp_start = zxc_seek_decomp_offset(s->block_size, bi);
         const size_t skip = (offset > blk_decomp_start) ? (size_t)(offset - blk_decomp_start) : 0;
         const size_t blk_decomp_sz = zxc_seek_decomp_size(s->block_size, s->total_decomp, bi);
+        if (UNLIKELY(blk_decomp_sz < skip)) {
+            free(jobs);
+            return ZXC_ERROR_CORRUPT_DATA;
+        }
         const size_t avail = blk_decomp_sz - skip;
         const size_t copy = (avail < remaining) ? avail : remaining;
 

--- a/src/lib/zxc_seekable.c
+++ b/src/lib/zxc_seekable.c
@@ -34,6 +34,98 @@
 #include "zxc_internal.h"
 
 /* ========================================================================= */
+/*  Platform Threading & I/O Layer                                           */
+/* ========================================================================= */
+
+#if defined(_WIN32)
+#include <windows.h>
+
+/* Map POSIX threading primitives to Windows equivalents */
+typedef HANDLE zxc_thread_t;
+
+typedef struct {
+    void* (*func)(void*);
+    void* arg;
+} zxc_seek_thread_arg_t;
+
+static unsigned __stdcall zxc_seek_thread_entry(void* p) {
+    zxc_seek_thread_arg_t* a = (zxc_seek_thread_arg_t*)p;
+    void* (*f)(void*) = a->func;
+    void* arg = a->arg;
+    free(a);
+    f(arg);
+    return 0;
+}
+
+static int zxc_seek_thread_create(zxc_thread_t* t, void* (*fn)(void*), void* arg) {
+    zxc_seek_thread_arg_t* wrapper = malloc(sizeof(zxc_seek_thread_arg_t));
+    if (UNLIKELY(!wrapper)) return ZXC_ERROR_MEMORY;
+    wrapper->func = fn;
+    wrapper->arg = arg;
+    uintptr_t handle = _beginthreadex(NULL, 0, zxc_seek_thread_entry, wrapper, 0, NULL);
+    if (UNLIKELY(handle == 0)) { free(wrapper); return ZXC_ERROR_MEMORY; }
+    *t = (HANDLE)handle;
+    return 0;
+}
+
+static void zxc_seek_thread_join(zxc_thread_t t) {
+    WaitForSingleObject(t, INFINITE);
+    CloseHandle(t);
+}
+
+static int zxc_seek_get_num_procs(void) {
+    SYSTEM_INFO si;
+    GetSystemInfo(&si);
+    return (int)si.dwNumberOfProcessors;
+}
+
+/**
+ * @brief Thread-safe positional read (Windows).
+ *
+ * Uses ReadFile + Overlapped to read at a specific offset without moving the
+ * file pointer, making it safe for concurrent access from multiple threads.
+ */
+static int zxc_seek_pread(HANDLE hFile, void* buf, size_t count, uint64_t offset) {
+    OVERLAPPED ov;
+    ZXC_MEMSET(&ov, 0, sizeof(ov));
+    ov.Offset = (DWORD)(offset & 0xFFFFFFFF);
+    ov.OffsetHigh = (DWORD)(offset >> 32);
+    DWORD bytes_read = 0;
+    if (!ReadFile(hFile, buf, (DWORD)count, &bytes_read, &ov)) return ZXC_ERROR_IO;
+    return (bytes_read == (DWORD)count) ? (int)count : ZXC_ERROR_IO;
+}
+
+#else /* POSIX */
+#include <pthread.h>
+#include <unistd.h>
+
+typedef pthread_t zxc_thread_t;
+
+static int zxc_seek_thread_create(zxc_thread_t* t, void* (*fn)(void*), void* arg) {
+    return pthread_create(t, NULL, fn, arg) == 0 ? 0 : ZXC_ERROR_MEMORY;
+}
+
+static void zxc_seek_thread_join(zxc_thread_t t) { pthread_join(t, NULL); }
+
+static int zxc_seek_get_num_procs(void) {
+    const long n = sysconf(_SC_NPROCESSORS_ONLN);
+    return (n > 0) ? (int)n : 1;
+}
+
+/**
+ * @brief Thread-safe positional read (POSIX).
+ *
+ * Uses pread() which reads at a given offset without modifying the file
+ * descriptor's current position, making it inherently thread-safe.
+ */
+static int zxc_seek_pread(int fd, void* buf, size_t count, uint64_t offset) {
+    const ssize_t r = pread(fd, buf, count, (off_t)offset);
+    return (r == (ssize_t)count) ? (int)count : ZXC_ERROR_IO;
+}
+
+#endif /* _WIN32 */
+
+/* ========================================================================= */
 /*  Seek Table Writer                                                        */
 /* ========================================================================= */
 
@@ -81,6 +173,13 @@ struct zxc_seekable_s {
     size_t src_size;
     FILE* file;
 
+    /* Native file descriptor for thread-safe pread() I/O */
+#if defined(_WIN32)
+    HANDLE native_handle; /* from GetOSFileHandle or _get_osfhandle */
+#else
+    int fd; /* from fileno() */
+#endif
+
     /* Parsed seek table */
     uint32_t num_blocks;
     uint32_t* comp_sizes;     /* array[num_blocks] */
@@ -93,7 +192,7 @@ struct zxc_seekable_s {
     size_t block_size;
     int file_has_checksums;
 
-    /* Reusable decompression context */
+    /* Reusable decompression context (single-threaded path only) */
     zxc_cctx_t dctx;
     int dctx_initialized;
 };
@@ -228,6 +327,11 @@ zxc_seekable* zxc_seekable_open_file(FILE* f) {
             s->src = NULL;
             s->src_size = (size_t)file_size;
             s->file = f;
+#if defined(_WIN32)
+            s->native_handle = (HANDLE)_get_osfhandle(_fileno(f));
+#else
+            s->fd = fileno(f);
+#endif
         }
         free(full);
         return s;
@@ -300,6 +404,11 @@ zxc_seekable* zxc_seekable_open_file(FILE* f) {
 
     s->file = f;
     s->src = NULL;
+#if defined(_WIN32)
+    s->native_handle = (HANDLE)_get_osfhandle(_fileno(f));
+#else
+    s->fd = fileno(f);
+#endif
     s->src_size = (size_t)file_size;
     s->num_blocks = num_blocks;
     s->block_size = bs;
@@ -466,6 +575,230 @@ int64_t zxc_seekable_decompress_range(zxc_seekable* s, void* dst, const size_t d
 
     free(read_buf);
     return (int64_t)len;
+}
+
+/* ========================================================================= */
+/*  Multi-Threaded Random-Access Decompression (Fork–Join)                   */
+/* ========================================================================= */
+
+/**
+ * @brief Per-block job descriptor for multi-threaded decompression.
+ *
+ * Each worker thread receives a pointer to one of these, performs the read +
+ * decompress + memcpy sequence, and writes the result code into @c result.
+ * The main thread inspects @c result after join.
+ */
+typedef struct {
+    const zxc_seekable* s;  /* shared handle (read-only) */
+    uint32_t block_idx;     /* block to decompress */
+    uint8_t* dst;           /* output pointer within caller's buffer */
+    size_t skip;            /* bytes to skip at start of decompressed block */
+    size_t copy_len;        /* bytes to copy into dst */
+    int result;             /* 0 = OK, < 0 = error */
+} zxc_seek_mt_job_t;
+
+/**
+ * @brief Thread-safe block read using pread (for file mode) or memcpy (buffer mode).
+ */
+static int zxc_seek_read_block_mt(const zxc_seekable* s, const uint32_t block_idx, uint8_t* buf,
+                                  const size_t buf_cap) {
+    const uint64_t off = s->comp_offsets[block_idx];
+    const uint32_t csz = s->comp_sizes[block_idx];
+    if (UNLIKELY(csz > buf_cap)) return ZXC_ERROR_DST_TOO_SMALL;
+
+    if (s->src) {
+        /* Buffer mode — memcpy is inherently thread-safe on const data */
+        if (UNLIKELY(off + csz > s->src_size)) return ZXC_ERROR_SRC_TOO_SMALL;
+        ZXC_MEMCPY(buf, s->src + off, csz);
+    } else if (s->file) {
+        /* File mode — use pread for concurrent, lock-free reads */
+#if defined(_WIN32)
+        const int r = zxc_seek_pread(s->native_handle, buf, csz, off);
+#else
+        const int r = zxc_seek_pread(s->fd, buf, csz, off);
+#endif
+        if (UNLIKELY(r < 0)) return r;
+    } else {
+        return ZXC_ERROR_NULL_INPUT;
+    }
+    return (int)csz;
+}
+
+/**
+ * @brief Worker thread entry point for multi-threaded seekable decompression.
+ *
+ * Each worker:
+ *   1. Allocates a thread-local decompression context.
+ *   2. Reads the compressed block via pread (thread-safe).
+ *   3. Decompresses into a local work buffer.
+ *   4. Copies the requested sub-range into the caller's output buffer.
+ */
+static void* zxc_seek_mt_worker(void* arg) {
+    zxc_seek_mt_job_t* const job = (zxc_seek_mt_job_t*)arg;
+    const zxc_seekable* const s = job->s;
+    const uint32_t bi = job->block_idx;
+
+    /* Thread-local decompression context (mode=0 for decompress-only) */
+    zxc_cctx_t dctx;
+    if (UNLIKELY(zxc_cctx_init(&dctx, s->block_size, 0, 0, 0) != ZXC_OK)) {
+        job->result = ZXC_ERROR_MEMORY;
+        return NULL;
+    }
+
+    /* Allocate work buffer for decompressed output */
+    const size_t work_sz = s->block_size + ZXC_PAD_SIZE;
+    dctx.work_buf = (uint8_t*)malloc(work_sz);
+    if (UNLIKELY(!dctx.work_buf)) {
+        zxc_cctx_free(&dctx);
+        job->result = ZXC_ERROR_MEMORY;
+        return NULL;
+    }
+    dctx.work_buf_cap = work_sz;
+
+    /* Read compressed block */
+    const uint32_t csz = s->comp_sizes[bi];
+    uint8_t* const read_buf = (uint8_t*)malloc(csz + ZXC_PAD_SIZE);
+    if (UNLIKELY(!read_buf)) {
+        zxc_cctx_free(&dctx);
+        job->result = ZXC_ERROR_MEMORY;
+        return NULL;
+    }
+
+    const int read_res = zxc_seek_read_block_mt(s, bi, read_buf, csz + ZXC_PAD_SIZE);
+    if (UNLIKELY(read_res < 0)) {
+        free(read_buf);
+        zxc_cctx_free(&dctx);
+        job->result = read_res;
+        return NULL;
+    }
+
+    /* Decompress */
+    const int dec_res =
+        zxc_decompress_chunk_wrapper(&dctx, read_buf, (size_t)read_res, dctx.work_buf, work_sz);
+    free(read_buf);
+
+    if (UNLIKELY(dec_res < 0)) {
+        zxc_cctx_free(&dctx);
+        job->result = dec_res;
+        return NULL;
+    }
+
+    /* Copy the requested portion directly into the caller's output buffer */
+    ZXC_MEMCPY(job->dst, dctx.work_buf + job->skip, job->copy_len);
+
+    zxc_cctx_free(&dctx);
+    job->result = 0;
+    return NULL;
+}
+
+int64_t zxc_seekable_decompress_range_mt(zxc_seekable* s, void* dst, const size_t dst_capacity,
+                                         const uint64_t offset, const size_t len,
+                                         int n_threads) {
+    if (UNLIKELY(!s || !dst)) return ZXC_ERROR_NULL_INPUT;
+    if (UNLIKELY(len == 0)) return 0;
+    if (UNLIKELY(dst_capacity < len)) return ZXC_ERROR_DST_TOO_SMALL;
+    if (UNLIKELY(offset + len > s->total_decomp)) return ZXC_ERROR_SRC_TOO_SMALL;
+
+    /* Find block range */
+    const uint32_t blk_start = zxc_seek_find_block(s->decomp_offsets, s->num_blocks, offset);
+    const uint32_t blk_end =
+        zxc_seek_find_block(s->decomp_offsets, s->num_blocks, offset + len - 1);
+    const uint32_t num_jobs = blk_end - blk_start + 1;
+
+    /* Fallback to single-threaded path for trivial cases */
+    if (n_threads <= 1 || num_jobs <= 1) {
+        return zxc_seekable_decompress_range(s, dst, dst_capacity, offset, len);
+    }
+
+    /* Auto-detect thread count */
+    if (n_threads == 0) n_threads = zxc_seek_get_num_procs();
+
+    /* Cap threads to number of blocks and max limit */
+    if ((uint32_t)n_threads > num_jobs) n_threads = (int)num_jobs;
+    if (n_threads > ZXC_MAX_THREADS) n_threads = ZXC_MAX_THREADS;
+
+    /* Allocate job descriptors */
+    zxc_seek_mt_job_t* const jobs =
+        (zxc_seek_mt_job_t*)calloc(num_jobs, sizeof(zxc_seek_mt_job_t));
+    if (UNLIKELY(!jobs)) return ZXC_ERROR_MEMORY;
+
+    /* Plan jobs: compute skip, copy_len, and dst pointer for each block */
+    uint8_t* out = (uint8_t*)dst;
+    size_t remaining = len;
+    for (uint32_t i = 0; i < num_jobs; i++) {
+        const uint32_t bi = blk_start + i;
+        const uint64_t blk_decomp_start = s->decomp_offsets[bi];
+        const size_t skip = (offset > blk_decomp_start) ? (size_t)(offset - blk_decomp_start) : 0;
+        const size_t blk_decomp_sz = s->decomp_sizes[bi];
+        const size_t avail = blk_decomp_sz - skip;
+        const size_t copy = (avail < remaining) ? avail : remaining;
+
+        jobs[i].s = s;
+        jobs[i].block_idx = bi;
+        jobs[i].dst = out;
+        jobs[i].skip = skip;
+        jobs[i].copy_len = copy;
+        jobs[i].result = 0;
+
+        out += copy;
+        remaining -= copy;
+    }
+
+    /* Launch worker threads (fork phase) */
+    zxc_thread_t* const threads = (zxc_thread_t*)malloc((size_t)n_threads * sizeof(zxc_thread_t));
+    if (UNLIKELY(!threads)) {
+        free(jobs);
+        return ZXC_ERROR_MEMORY;
+    }
+
+    /*
+     * Distribute jobs across threads round-robin style.
+     * If num_jobs > n_threads, some threads handle multiple blocks sequentially.
+     * We process jobs in waves: spawn n_threads at a time, join, repeat.
+     */
+    int error = 0;
+    uint32_t job_idx = 0;
+
+    while (job_idx < num_jobs && !error) {
+        const int wave_size =
+            ((int)(num_jobs - job_idx) < n_threads) ? (int)(num_jobs - job_idx) : n_threads;
+
+        int launched = 0;
+        for (int t = 0; t < wave_size; t++) {
+            if (zxc_seek_thread_create(&threads[t], zxc_seek_mt_worker, &jobs[job_idx + t]) != 0) {
+                /* Failed to create thread — mark remaining jobs as errors */
+                for (uint32_t j = job_idx + (uint32_t)t; j < num_jobs; j++)
+                    jobs[j].result = ZXC_ERROR_MEMORY;
+                error = 1;
+                break;
+            }
+            launched++;
+        }
+
+        /* Join phase */
+        for (int t = 0; t < launched; t++) {
+            zxc_seek_thread_join(threads[t]);
+            if (jobs[job_idx + t].result < 0) error = 1;
+        }
+
+        job_idx += (uint32_t)launched;
+    }
+
+    free(threads);
+
+    /* Check for errors */
+    int64_t result = (int64_t)len;
+    if (error) {
+        for (uint32_t i = 0; i < num_jobs; i++) {
+            if (jobs[i].result < 0) {
+                result = (int64_t)jobs[i].result;
+                break;
+            }
+        }
+    }
+
+    free(jobs);
+    return result;
 }
 
 void zxc_seekable_free(zxc_seekable* s) {

--- a/src/lib/zxc_seekable.c
+++ b/src/lib/zxc_seekable.c
@@ -10,9 +10,9 @@
  * @brief Seekable archive reader (random-access decompression) and seek table writer.
  *
  * The seek table is a standard ZXC block (type = ZXC_BLOCK_SEK) appended
- * between the EOF block and the file footer.  It records the compressed and
- * decompressed sizes of every block, enabling O(1) lookup + O(block_size)
- * decompression for any byte range.
+ * between the EOF block and the file footer.  It records the compressed size
+ * of every block (decompressed sizes are derived from the header's block_size),
+ * enabling O(1) lookup + O(block_size) decompression for any byte range.
  *
  * On-disk layout of a SEK block:
  *

--- a/tests/test.c
+++ b/tests/test.c
@@ -31,6 +31,8 @@ static FILE* create_restricted_file(const char* path) {
 
 #include "../include/zxc_buffer.h"
 #include "../include/zxc_error.h"
+#include "../include/zxc_sans_io.h"
+#include "../include/zxc_seekable.h"
 #include "../include/zxc_stream.h"
 #include "../src/lib/zxc_internal.h"
 
@@ -2431,6 +2433,304 @@ int test_library_info_api() {
     return 1;
 }
 
+/* ========================================================================= */
+/*  Seekable Tests                                                           */
+/* ========================================================================= */
+
+static void fill_seek_data(uint8_t* buf, size_t size, uint8_t seed) {
+    for (size_t i = 0; i < size; i++) {
+        buf[i] = (uint8_t)(seed + (i * 17) + (i >> 8));
+    }
+}
+
+int test_seekable_table_sizes() {
+    printf("=== TEST: Seekable - Table Sizes ===\n");
+
+    /* block_header(8) + 10*8 + tail(4) = 92 */
+    if (zxc_seek_table_size(10, 0) != 92) {
+        printf("Failed: no-checksum size\n");
+        return 0;
+    }
+    /* block_header(8) + 10*12 + tail(4) = 132 */
+    if (zxc_seek_table_size(10, 1) != 132) {
+        printf("Failed: checksum size\n");
+        return 0;
+    }
+    /* block_header(8) + 0 + tail(4) = 12 */
+    if (zxc_seek_table_size(0, 0) != 12) {
+        printf("Failed: zero blocks size\n");
+        return 0;
+    }
+
+    printf("PASS\n\n");
+    return 1;
+}
+
+int test_seekable_table_write() {
+    printf("=== TEST: Seekable - Table Write/Validate ===\n");
+
+    const uint32_t comp[] = {100, 200, 150};
+    const uint32_t decomp[] = {1000, 2000, 1500};
+    const size_t sz = zxc_seek_table_size(3, 0);
+    uint8_t* buf = malloc(sz);
+    if (!buf) return 0;
+
+    const int64_t written = zxc_write_seek_table(buf, sz, comp, decomp, 3, 0);
+    if (written != (int64_t)sz) {
+        printf("Failed: write size mismatch\n");
+        free(buf);
+        return 0;
+    }
+
+    /* Validate block_type == SEK in the block header */
+    if (buf[0] != ZXC_BLOCK_SEK) {
+        printf("Failed: bad block_type (%u)\n", buf[0]);
+        free(buf);
+        return 0;
+    }
+
+    /* Validate num_blocks in the tail (last 4 bytes) */
+    if (zxc_le32(buf + sz - 4) != 3) {
+        printf("Failed: bad num_blocks\n");
+        free(buf);
+        return 0;
+    }
+
+    free(buf);
+    printf("PASS\n\n");
+    return 1;
+}
+
+int test_seekable_roundtrip() {
+    printf("=== TEST: Seekable - Compress/Decompress Roundtrip ===\n");
+
+    const size_t SRC_SIZE = 256 * 1024;
+    uint8_t* src = malloc(SRC_SIZE);
+    if (!src) return 0;
+    fill_seek_data(src, SRC_SIZE, 42);
+
+    const size_t dst_cap = zxc_compress_bound(SRC_SIZE) + 1024;
+    uint8_t* dst = malloc(dst_cap);
+    uint8_t* dec = malloc(SRC_SIZE);
+    if (!dst || !dec) { free(src); free(dst); free(dec); return 0; }
+
+    zxc_compress_opts_t opts = {.level = ZXC_LEVEL_DEFAULT, .block_size = 64 * 1024,
+                                .checksum_enabled = 1, .seekable = 1};
+    const int64_t csize = zxc_compress(src, SRC_SIZE, dst, dst_cap, &opts);
+    if (csize <= 0) { printf("Failed: compress\n"); free(src); free(dst); free(dec); return 0; }
+
+    /* Full decompression with standard API (backward compatibility) */
+    zxc_decompress_opts_t dopts = {.checksum_enabled = 1};
+    const int64_t dsize = zxc_decompress(dst, (size_t)csize, dec, SRC_SIZE, &dopts);
+    if (dsize != (int64_t)SRC_SIZE || memcmp(src, dec, SRC_SIZE) != 0) {
+        printf("Failed: decompress mismatch\n");
+        free(src); free(dst); free(dec);
+        return 0;
+    }
+
+    free(src); free(dst); free(dec);
+    printf("PASS\n\n");
+    return 1;
+}
+
+int test_seekable_open_query() {
+    printf("=== TEST: Seekable - Open and Query ===\n");
+
+    const size_t SRC_SIZE = 200 * 1024;
+    uint8_t* src = malloc(SRC_SIZE);
+    if (!src) return 0;
+    fill_seek_data(src, SRC_SIZE, 99);
+
+    const size_t dst_cap = zxc_compress_bound(SRC_SIZE) + 1024;
+    uint8_t* dst = malloc(dst_cap);
+    if (!dst) { free(src); return 0; }
+
+    zxc_compress_opts_t opts = {.level = 2, .block_size = 64 * 1024, .seekable = 1};
+    const int64_t csize = zxc_compress(src, SRC_SIZE, dst, dst_cap, &opts);
+    if (csize <= 0) { printf("Failed: compress\n"); free(src); free(dst); return 0; }
+
+    zxc_seekable* s = zxc_seekable_open(dst, (size_t)csize);
+    if (!s) { printf("Failed: open\n"); free(src); free(dst); return 0; }
+
+    const uint32_t nb = zxc_seekable_get_num_blocks(s);
+    if (nb < 3) { printf("Failed: expected >= 3 blocks, got %u\n", nb); zxc_seekable_free(s); free(src); free(dst); return 0; }
+
+    const uint64_t total = zxc_seekable_get_decompressed_size(s);
+    if (total != SRC_SIZE) { printf("Failed: decomp size\n"); zxc_seekable_free(s); free(src); free(dst); return 0; }
+
+    uint64_t sum = 0;
+    for (uint32_t i = 0; i < nb; i++) {
+        sum += zxc_seekable_get_block_decomp_size(s, i);
+        if (zxc_seekable_get_block_comp_size(s, i) == 0) {
+            printf("Failed: zero comp size\n"); zxc_seekable_free(s); free(src); free(dst); return 0;
+        }
+    }
+    if (sum != SRC_SIZE) { printf("Failed: block sizes sum\n"); zxc_seekable_free(s); free(src); free(dst); return 0; }
+
+    zxc_seekable_free(s);
+    free(src); free(dst);
+    printf("PASS\n\n");
+    return 1;
+}
+
+int test_seekable_random_access() {
+    printf("=== TEST: Seekable - Random Access ===\n");
+
+    const size_t SRC_SIZE = 300 * 1024;
+    uint8_t* src = malloc(SRC_SIZE);
+    if (!src) return 0;
+    fill_seek_data(src, SRC_SIZE, 77);
+
+    const size_t dst_cap = zxc_compress_bound(SRC_SIZE) + 1024;
+    uint8_t* dst = malloc(dst_cap);
+    if (!dst) { free(src); return 0; }
+
+    zxc_compress_opts_t opts = {.level = 3, .block_size = 64 * 1024, .seekable = 1};
+    const int64_t csize = zxc_compress(src, SRC_SIZE, dst, dst_cap, &opts);
+    if (csize <= 0) { printf("Failed: compress\n"); free(src); free(dst); return 0; }
+
+    zxc_seekable* s = zxc_seekable_open(dst, (size_t)csize);
+    if (!s) { printf("Failed: open\n"); free(src); free(dst); return 0; }
+
+    /* First 1000 bytes */
+    uint8_t out1[1000];
+    int64_t r = zxc_seekable_decompress_range(s, out1, 1000, 0, 1000);
+    if (r != 1000 || memcmp(src, out1, 1000) != 0) {
+        printf("Failed: first 1000 bytes\n"); zxc_seekable_free(s); free(src); free(dst); return 0;
+    }
+
+    /* Middle range spanning multiple blocks */
+    const uint64_t off = 100 * 1024;
+    const size_t len = 80 * 1024;
+    uint8_t* out2 = malloc(len);
+    if (!out2) { zxc_seekable_free(s); free(src); free(dst); return 0; }
+    r = zxc_seekable_decompress_range(s, out2, len, off, len);
+    if (r != (int64_t)len || memcmp(src + off, out2, len) != 0) {
+        printf("Failed: mid-range\n"); free(out2); zxc_seekable_free(s); free(src); free(dst); return 0;
+    }
+    free(out2);
+
+    /* Last bytes */
+    uint8_t out3[512];
+    r = zxc_seekable_decompress_range(s, out3, 512, SRC_SIZE - 512, 512);
+    if (r != 512 || memcmp(src + SRC_SIZE - 512, out3, 512) != 0) {
+        printf("Failed: tail\n"); zxc_seekable_free(s); free(src); free(dst); return 0;
+    }
+
+    /* Entire file */
+    uint8_t* out4 = malloc(SRC_SIZE);
+    if (!out4) { zxc_seekable_free(s); free(src); free(dst); return 0; }
+    r = zxc_seekable_decompress_range(s, out4, SRC_SIZE, 0, SRC_SIZE);
+    if (r != (int64_t)SRC_SIZE || memcmp(src, out4, SRC_SIZE) != 0) {
+        printf("Failed: full range\n"); free(out4); zxc_seekable_free(s); free(src); free(dst); return 0;
+    }
+    free(out4);
+
+    /* Zero length */
+    uint8_t dummy;
+    r = zxc_seekable_decompress_range(s, &dummy, 1, 0, 0);
+    if (r != 0) { printf("Failed: zero-length\n"); zxc_seekable_free(s); free(src); free(dst); return 0; }
+
+    zxc_seekable_free(s);
+    free(src); free(dst);
+    printf("PASS\n\n");
+    return 1;
+}
+
+int test_seekable_non_seekable_reject() {
+    printf("=== TEST: Seekable - Non-Seekable Archive Rejected ===\n");
+
+    const size_t SRC_SIZE = 10000;
+    uint8_t* src = malloc(SRC_SIZE);
+    if (!src) return 0;
+    fill_seek_data(src, SRC_SIZE, 11);
+
+    const size_t dst_cap = zxc_compress_bound(SRC_SIZE);
+    uint8_t* dst = malloc(dst_cap);
+    if (!dst) { free(src); return 0; }
+
+    zxc_compress_opts_t opts = {.level = 1, .seekable = 0};
+    const int64_t csize = zxc_compress(src, SRC_SIZE, dst, dst_cap, &opts);
+    if (csize <= 0) { printf("Failed: compress\n"); free(src); free(dst); return 0; }
+
+    zxc_seekable* s = zxc_seekable_open(dst, (size_t)csize);
+    if (s != NULL) {
+        printf("Failed: expected NULL for non-seekable\n");
+        zxc_seekable_free(s); free(src); free(dst); return 0;
+    }
+
+    free(src); free(dst);
+    printf("PASS\n\n");
+    return 1;
+}
+
+int test_seekable_single_block() {
+    printf("=== TEST: Seekable - Single Block ===\n");
+
+    const size_t SRC_SIZE = 1024;
+    uint8_t* src = malloc(SRC_SIZE);
+    if (!src) return 0;
+    fill_seek_data(src, SRC_SIZE, 55);
+
+    const size_t dst_cap = zxc_compress_bound(SRC_SIZE) + 256;
+    uint8_t* dst = malloc(dst_cap);
+    if (!dst) { free(src); return 0; }
+
+    zxc_compress_opts_t opts = {.level = 1, .seekable = 1};
+    const int64_t csize = zxc_compress(src, SRC_SIZE, dst, dst_cap, &opts);
+    if (csize <= 0) { printf("Failed: compress\n"); free(src); free(dst); return 0; }
+
+    zxc_seekable* s = zxc_seekable_open(dst, (size_t)csize);
+    if (!s) { printf("Failed: open\n"); free(src); free(dst); return 0; }
+    if (zxc_seekable_get_num_blocks(s) != 1) {
+        printf("Failed: expected 1 block\n"); zxc_seekable_free(s); free(src); free(dst); return 0;
+    }
+
+    uint8_t out[100];
+    int64_t r = zxc_seekable_decompress_range(s, out, 100, 500, 100);
+    if (r != 100 || memcmp(src + 500, out, 100) != 0) {
+        printf("Failed: range data\n"); zxc_seekable_free(s); free(src); free(dst); return 0;
+    }
+
+    zxc_seekable_free(s);
+    free(src); free(dst);
+    printf("PASS\n\n");
+    return 1;
+}
+
+int test_seekable_all_levels() {
+    printf("=== TEST: Seekable - All Compression Levels ===\n");
+
+    const size_t SRC_SIZE = 128 * 1024;
+    uint8_t* src = malloc(SRC_SIZE);
+    if (!src) return 0;
+    fill_seek_data(src, SRC_SIZE, 33);
+
+    const size_t dst_cap = zxc_compress_bound(SRC_SIZE) + 1024;
+    uint8_t* dst = malloc(dst_cap);
+    uint8_t* dec = malloc(SRC_SIZE);
+    if (!dst || !dec) { free(src); free(dst); free(dec); return 0; }
+
+    for (int lvl = 1; lvl <= 5; lvl++) {
+        zxc_compress_opts_t opts = {.level = lvl, .block_size = 32 * 1024, .seekable = 1};
+        const int64_t csize = zxc_compress(src, SRC_SIZE, dst, dst_cap, &opts);
+        if (csize <= 0) { printf("Failed: compress level %d\n", lvl); free(src); free(dst); free(dec); return 0; }
+
+        zxc_seekable* s = zxc_seekable_open(dst, (size_t)csize);
+        if (!s) { printf("Failed: open level %d\n", lvl); free(src); free(dst); free(dec); return 0; }
+
+        int64_t r = zxc_seekable_decompress_range(s, dec, SRC_SIZE, 0, SRC_SIZE);
+        if (r != (int64_t)SRC_SIZE || memcmp(src, dec, SRC_SIZE) != 0) {
+            printf("Failed: level %d data mismatch\n", lvl); zxc_seekable_free(s); free(src); free(dst); free(dec); return 0;
+        }
+        zxc_seekable_free(s);
+    }
+
+    free(src); free(dst); free(dec);
+    printf("PASS\n\n");
+    return 1;
+}
+
 int main() {
     srand(42);  // Fixed seed for reproducibility
     int total_failures = 0;
@@ -2566,6 +2866,16 @@ int main() {
     if (!test_opaque_context_api()) total_failures++;
     if (!test_block_api()) total_failures++;
     if (!test_library_info_api()) total_failures++;
+
+    // --- SEEKABLE TESTS ---
+    if (!test_seekable_table_sizes()) total_failures++;
+    if (!test_seekable_table_write()) total_failures++;
+    if (!test_seekable_roundtrip()) total_failures++;
+    if (!test_seekable_open_query()) total_failures++;
+    if (!test_seekable_random_access()) total_failures++;
+    if (!test_seekable_non_seekable_reject()) total_failures++;
+    if (!test_seekable_single_block()) total_failures++;
+    if (!test_seekable_all_levels()) total_failures++;
 
     if (total_failures > 0) {
         printf("FAILED: %d tests failed.\n", total_failures);

--- a/tests/test.c
+++ b/tests/test.c
@@ -2726,6 +2726,154 @@ int test_seekable_all_levels() {
     return 1;
 }
 
+/* ========================================================================= */
+/*  Multi-Threaded Seekable Tests                                            */
+/* ========================================================================= */
+
+int test_seekable_mt_roundtrip() {
+    printf("=== TEST: Seekable MT - Roundtrip (4 threads) ===\n");
+
+    const size_t SRC_SIZE = 512 * 1024;
+    uint8_t* src = malloc(SRC_SIZE);
+    if (!src) return 0;
+    fill_seek_data(src, SRC_SIZE, 55);
+
+    const size_t dst_cap = zxc_compress_bound(SRC_SIZE) + 1024;
+    uint8_t* dst = malloc(dst_cap);
+    uint8_t* dec = malloc(SRC_SIZE);
+    if (!dst || !dec) { free(src); free(dst); free(dec); return 0; }
+
+    /* Compress with small blocks to create many blocks */
+    zxc_compress_opts_t opts = {.level = 3, .block_size = 64 * 1024, .seekable = 1};
+    const int64_t csize = zxc_compress(src, SRC_SIZE, dst, dst_cap, &opts);
+    if (csize <= 0) { printf("Failed: compress\n"); free(src); free(dst); free(dec); return 0; }
+
+    zxc_seekable* s = zxc_seekable_open(dst, (size_t)csize);
+    if (!s) { printf("Failed: open\n"); free(src); free(dst); free(dec); return 0; }
+
+    /* Full decompression with 4 threads */
+    int64_t r = zxc_seekable_decompress_range_mt(s, dec, SRC_SIZE, 0, SRC_SIZE, 4);
+    if (r != (int64_t)SRC_SIZE || memcmp(src, dec, SRC_SIZE) != 0) {
+        printf("Failed: MT decompress mismatch\n");
+        zxc_seekable_free(s); free(src); free(dst); free(dec);
+        return 0;
+    }
+
+    zxc_seekable_free(s);
+    free(src); free(dst); free(dec);
+    printf("PASS\n\n");
+    return 1;
+}
+
+int test_seekable_mt_single_block() {
+    printf("=== TEST: Seekable MT - Single Block Fallback ===\n");
+
+    const size_t SRC_SIZE = 32 * 1024;
+    uint8_t* src = malloc(SRC_SIZE);
+    if (!src) return 0;
+    fill_seek_data(src, SRC_SIZE, 88);
+
+    const size_t dst_cap = zxc_compress_bound(SRC_SIZE) + 1024;
+    uint8_t* dst = malloc(dst_cap);
+    uint8_t* dec = malloc(SRC_SIZE);
+    if (!dst || !dec) { free(src); free(dst); free(dec); return 0; }
+
+    /* Compress with block_size >= SRC_SIZE → only 1 block */
+    zxc_compress_opts_t opts = {.level = 3, .block_size = 64 * 1024, .seekable = 1};
+    const int64_t csize = zxc_compress(src, SRC_SIZE, dst, dst_cap, &opts);
+    if (csize <= 0) { printf("Failed: compress\n"); free(src); free(dst); free(dec); return 0; }
+
+    zxc_seekable* s = zxc_seekable_open(dst, (size_t)csize);
+    if (!s) { printf("Failed: open\n"); free(src); free(dst); free(dec); return 0; }
+
+    /* Should fallback to ST since only 1 block */
+    int64_t r = zxc_seekable_decompress_range_mt(s, dec, SRC_SIZE, 0, SRC_SIZE, 4);
+    if (r != (int64_t)SRC_SIZE || memcmp(src, dec, SRC_SIZE) != 0) {
+        printf("Failed: single-block MT mismatch\n");
+        zxc_seekable_free(s); free(src); free(dst); free(dec);
+        return 0;
+    }
+
+    zxc_seekable_free(s);
+    free(src); free(dst); free(dec);
+    printf("PASS\n\n");
+    return 1;
+}
+
+int test_seekable_mt_random_access() {
+    printf("=== TEST: Seekable MT - Random Access ===\n");
+
+    const size_t SRC_SIZE = 512 * 1024;
+    uint8_t* src = malloc(SRC_SIZE);
+    if (!src) return 0;
+    fill_seek_data(src, SRC_SIZE, 11);
+
+    const size_t dst_cap = zxc_compress_bound(SRC_SIZE) + 1024;
+    uint8_t* dst = malloc(dst_cap);
+    if (!dst) { free(src); return 0; }
+
+    zxc_compress_opts_t opts = {.level = 3, .block_size = 64 * 1024, .seekable = 1};
+    const int64_t csize = zxc_compress(src, SRC_SIZE, dst, dst_cap, &opts);
+    if (csize <= 0) { printf("Failed: compress\n"); free(src); free(dst); return 0; }
+
+    zxc_seekable* s = zxc_seekable_open(dst, (size_t)csize);
+    if (!s) { printf("Failed: open\n"); free(src); free(dst); return 0; }
+
+    /* Mid-range spanning 3+ blocks with MT */
+    const uint64_t off = 100 * 1024;
+    const size_t len = 200 * 1024;
+    uint8_t* out = malloc(len);
+    if (!out) { zxc_seekable_free(s); free(src); free(dst); return 0; }
+
+    int64_t r = zxc_seekable_decompress_range_mt(s, out, len, off, len, 4);
+    if (r != (int64_t)len || memcmp(src + off, out, len) != 0) {
+        printf("Failed: MT random access mismatch\n");
+        free(out); zxc_seekable_free(s); free(src); free(dst);
+        return 0;
+    }
+
+    free(out);
+    zxc_seekable_free(s);
+    free(src); free(dst);
+    printf("PASS\n\n");
+    return 1;
+}
+
+int test_seekable_mt_full_file() {
+    printf("=== TEST: Seekable MT - Full File (auto threads) ===\n");
+
+    const size_t SRC_SIZE = 1024 * 1024; /* 1 MB */
+    uint8_t* src = malloc(SRC_SIZE);
+    if (!src) return 0;
+    fill_seek_data(src, SRC_SIZE, 7);
+
+    const size_t dst_cap = zxc_compress_bound(SRC_SIZE) + 1024;
+    uint8_t* dst = malloc(dst_cap);
+    uint8_t* dec = malloc(SRC_SIZE);
+    if (!dst || !dec) { free(src); free(dst); free(dec); return 0; }
+
+    /* 16 blocks of 64K */
+    zxc_compress_opts_t opts = {.level = 3, .block_size = 64 * 1024, .seekable = 1};
+    const int64_t csize = zxc_compress(src, SRC_SIZE, dst, dst_cap, &opts);
+    if (csize <= 0) { printf("Failed: compress\n"); free(src); free(dst); free(dec); return 0; }
+
+    zxc_seekable* s = zxc_seekable_open(dst, (size_t)csize);
+    if (!s) { printf("Failed: open\n"); free(src); free(dst); free(dec); return 0; }
+
+    /* Decompress with auto-detect threads (n_threads=0) */
+    int64_t r = zxc_seekable_decompress_range_mt(s, dec, SRC_SIZE, 0, SRC_SIZE, 0);
+    if (r != (int64_t)SRC_SIZE || memcmp(src, dec, SRC_SIZE) != 0) {
+        printf("Failed: MT full file mismatch\n");
+        zxc_seekable_free(s); free(src); free(dst); free(dec);
+        return 0;
+    }
+
+    zxc_seekable_free(s);
+    free(src); free(dst); free(dec);
+    printf("PASS\n\n");
+    return 1;
+}
+
 int main() {
     srand(42);  // Fixed seed for reproducibility
     int total_failures = 0;
@@ -2758,6 +2906,7 @@ int main() {
 
     gen_num_data_large(buffer, BUF_SIZE);
     if (!test_round_trip("NUM Block (Large Deltas)", buffer, BUF_SIZE, 3, 0)) total_failures++;
+
 
     gen_random_data(buffer, 50);
     if (!test_round_trip("Small Input (50 bytes)", buffer, 50, 3, 0)) total_failures++;
@@ -2871,6 +3020,12 @@ int main() {
     if (!test_seekable_non_seekable_reject()) total_failures++;
     if (!test_seekable_single_block()) total_failures++;
     if (!test_seekable_all_levels()) total_failures++;
+
+    // --- SEEKABLE MT TESTS ---
+    if (!test_seekable_mt_roundtrip()) total_failures++;
+    if (!test_seekable_mt_single_block()) total_failures++;
+    if (!test_seekable_mt_random_access()) total_failures++;
+    if (!test_seekable_mt_full_file()) total_failures++;
 
     if (total_failures > 0) {
         printf("FAILED: %d tests failed.\n", total_failures);

--- a/tests/test.c
+++ b/tests/test.c
@@ -2851,6 +2851,72 @@ int test_seekable_all_levels() {
     return 1;
 }
 
+int test_seekable_many_blocks() {
+    printf("=== TEST: Seekable - Many Small Blocks ===\n");
+
+    /* Use minimum block size (4KB) with 256KB data => 64 blocks.
+     * This stresses the seekable block tracking array (dispatch lines 410-424)
+     * and ensures the seek table handles high block counts correctly. */
+    const size_t SRC_SIZE = 256 * 1024;
+    uint8_t* src = malloc(SRC_SIZE);
+    if (!src) return 0;
+    fill_seek_data(src, SRC_SIZE, 77);
+
+    const size_t dst_cap = (size_t)zxc_compress_bound(SRC_SIZE) + 4096;
+    uint8_t* dst = malloc(dst_cap);
+    uint8_t* dec = malloc(SRC_SIZE);
+    if (!dst || !dec) { free(src); free(dst); free(dec); return 0; }
+
+    /* Compress with minimum block_size = 4096 */
+    zxc_compress_opts_t opts = {.level = ZXC_LEVEL_DEFAULT, .block_size = 4096,
+                                .checksum_enabled = 1, .seekable = 1};
+    const int64_t csize = zxc_compress(src, SRC_SIZE, dst, dst_cap, &opts);
+    if (csize <= 0) {
+        printf("Failed: compress (%lld)\n", (long long)csize);
+        free(src); free(dst); free(dec); return 0;
+    }
+
+    /* Open and verify block count = 64 */
+    zxc_seekable* s = zxc_seekable_open(dst, (size_t)csize);
+    if (!s) { printf("Failed: open\n"); free(src); free(dst); free(dec); return 0; }
+
+    const uint32_t n_blocks = zxc_seekable_get_num_blocks(s);
+    if (n_blocks != 64) {
+        printf("Failed: expected 64 blocks, got %u\n", n_blocks);
+        zxc_seekable_free(s); free(src); free(dst); free(dec); return 0;
+    }
+
+    /* Full decompress via seekable API */
+    int64_t r = zxc_seekable_decompress_range(s, dec, SRC_SIZE, 0, SRC_SIZE);
+    if (r != (int64_t)SRC_SIZE || memcmp(src, dec, SRC_SIZE) != 0) {
+        printf("Failed: full decompress mismatch (r=%lld)\n", (long long)r);
+        zxc_seekable_free(s); free(src); free(dst); free(dec); return 0;
+    }
+
+    /* Random access: read 100 bytes from the middle of block 32 */
+    const uint64_t mid_off = 32 * 4096 + 2000;
+    uint8_t spot[100];
+    r = zxc_seekable_decompress_range(s, spot, 100, mid_off, 100);
+    if (r != 100 || memcmp(src + mid_off, spot, 100) != 0) {
+        printf("Failed: random access at offset %llu\n", (unsigned long long)mid_off);
+        zxc_seekable_free(s); free(src); free(dst); free(dec); return 0;
+    }
+
+    /* Cross-block read: span block boundary (last 50B of block 15 + first 50B of block 16) */
+    const uint64_t cross_off = 16 * 4096 - 50;
+    uint8_t cross[100];
+    r = zxc_seekable_decompress_range(s, cross, 100, cross_off, 100);
+    if (r != 100 || memcmp(src + cross_off, cross, 100) != 0) {
+        printf("Failed: cross-block read at offset %llu\n", (unsigned long long)cross_off);
+        zxc_seekable_free(s); free(src); free(dst); free(dec); return 0;
+    }
+
+    zxc_seekable_free(s);
+    free(src); free(dst); free(dec);
+    printf("PASS\n\n");
+    return 1;
+}
+
 /* ========================================================================= */
 /*  Multi-Threaded Seekable Tests                                            */
 /* ========================================================================= */
@@ -3145,6 +3211,7 @@ int main() {
     if (!test_seekable_non_seekable_reject()) total_failures++;
     if (!test_seekable_single_block()) total_failures++;
     if (!test_seekable_all_levels()) total_failures++;
+    if (!test_seekable_many_blocks()) total_failures++;
 
     // --- SEEKABLE MT TESTS ---
     if (!test_seekable_mt_roundtrip()) total_failures++;

--- a/tests/test.c
+++ b/tests/test.c
@@ -2512,6 +2512,53 @@ int test_seekable_roundtrip() {
                                 .checksum_enabled = 1, .seekable = 1};
     const int64_t csize = zxc_compress(src, SRC_SIZE, dst, dst_cap, &opts);
     if (csize <= 0) { printf("Failed: compress\n"); free(src); free(dst); free(dec); return 0; }
+    /* Sub-test A0: CONTROL - same data with default block_size (256KB) */
+    {
+        const size_t SMALL = 60 * 1024;
+        memset(dec, 0, SMALL);
+        zxc_compress_opts_t opts_ctrl = {.level = ZXC_LEVEL_DEFAULT, .block_size = 256 * 1024,
+                                         .checksum_enabled = 1, .seekable = 0};
+        const int64_t c0 = zxc_compress(src, SMALL, dst, dst_cap, &opts_ctrl);
+        if (c0 <= 0) { printf("Failed: A0 compress\n"); free(src); free(dst); free(dec); return 0; }
+        zxc_decompress_opts_t d0 = {.checksum_enabled = 1};
+        const int64_t d0s = zxc_decompress(dst, (size_t)c0, dec, SMALL, &d0);
+        if (d0s != (int64_t)SMALL || memcmp(src, dec, SMALL) != 0) {
+            printf("Failed: A0 control (256KB block) mismatch\n");
+            free(src); free(dst); free(dec); return 0;
+        }
+        printf("  sub-test A0 (control 256KB block, 60KB): OK\n");
+    }
+    /* Sub-test A1: per-level isolation with block_size=64KB */
+    {
+        const size_t SMALL = 60 * 1024;
+        for (int lvl = 1; lvl <= 5; lvl++) {
+            memset(dec, 0, SMALL);
+            zxc_compress_opts_t opts_l = {.level = lvl, .block_size = 64 * 1024,
+                                          .checksum_enabled = 1, .seekable = 0};
+            const int64_t cl = zxc_compress(src, SMALL, dst, dst_cap, &opts_l);
+            if (cl <= 0) {
+                printf("Failed: A1 level %d compress\n", lvl);
+                free(src); free(dst); free(dec); return 0;
+            }
+            zxc_decompress_opts_t dl = {.checksum_enabled = 1};
+            const int64_t dls = zxc_decompress(dst, (size_t)cl, dec, SMALL, &dl);
+            if (dls != (int64_t)SMALL || memcmp(src, dec, SMALL) != 0) {
+                printf("  A1 level %d: FAIL at ", lvl);
+                if (dls == (int64_t)SMALL) {
+                    for (size_t i = 0; i < SMALL; i++) {
+                        if (src[i] != dec[i]) {
+                            printf("byte %zu: src=0x%02x dec=0x%02x\n", i, src[i], dec[i]);
+                            break;
+                        }
+                    }
+                } else {
+                    printf("size %lld\n", (long long)dls);
+                }
+                free(src); free(dst); free(dec); return 0;
+            }
+            printf("  A1 level %d (64KB block): OK\n", lvl);
+        }
+    }
     /* Sub-test A: single block (data < block_size), safe path (dst=SMALL) */
     {
         const size_t SMALL = 60 * 1024; /* fits in one 64KB block */
@@ -2540,10 +2587,10 @@ int test_seekable_roundtrip() {
         }
         printf("  sub-test A (safe path, 60KB): OK\n");
     }
-    /* Sub-test A2: same data but oversized dst → fast path in decompressor */
+    /* Sub-test A2: same data but oversized dst => fast path in decompressor */
     {
         const size_t SMALL = 60 * 1024;
-        const size_t BIG_DST = 128 * 1024;  /* oversized → fast path */
+        const size_t BIG_DST = 128 * 1024;  /* oversized => fast path */
         uint8_t* dec2 = calloc(1, BIG_DST);
         if (!dec2) { free(src); free(dst); free(dec); return 0; }
         zxc_compress_opts_t opts_a2 = {.level = ZXC_LEVEL_DEFAULT, .block_size = 64 * 1024,

--- a/tests/test.c
+++ b/tests/test.c
@@ -2512,21 +2512,57 @@ int test_seekable_roundtrip() {
                                 .checksum_enabled = 1, .seekable = 1};
     const int64_t csize = zxc_compress(src, SRC_SIZE, dst, dst_cap, &opts);
     if (csize <= 0) { printf("Failed: compress\n"); free(src); free(dst); free(dec); return 0; }
-    /* Sub-test A0: CONTROL - same data with default block_size (256KB) */
+    /* Sub-test A0: CONTROL - compare gen_lz_data vs fill_seek_data with same params */
     {
         const size_t SMALL = 60 * 1024;
+        uint8_t* src2 = malloc(SMALL);
+        if (!src2) { free(src); free(dst); free(dec); return 0; }
+        gen_lz_data(src2, SMALL);
+
+        /* A0a: gen_lz_data (should always pass) */
         memset(dec, 0, SMALL);
         zxc_compress_opts_t opts_ctrl = {.level = ZXC_LEVEL_DEFAULT, .block_size = 256 * 1024,
                                          .checksum_enabled = 1, .seekable = 0};
-        const int64_t c0 = zxc_compress(src, SMALL, dst, dst_cap, &opts_ctrl);
-        if (c0 <= 0) { printf("Failed: A0 compress\n"); free(src); free(dst); free(dec); return 0; }
+        int64_t c0 = zxc_compress(src2, SMALL, dst, dst_cap, &opts_ctrl);
+        if (c0 <= 0) { printf("Failed: A0a compress\n"); free(src2); free(src); free(dst); free(dec); return 0; }
+        printf("  A0a compressed %zu -> %lld (block type=%d)\n", SMALL, (long long)c0, (int)dst[16]);
         zxc_decompress_opts_t d0 = {.checksum_enabled = 1};
-        const int64_t d0s = zxc_decompress(dst, (size_t)c0, dec, SMALL, &d0);
-        if (d0s != (int64_t)SMALL || memcmp(src, dec, SMALL) != 0) {
-            printf("Failed: A0 control (256KB block) mismatch\n");
-            free(src); free(dst); free(dec); return 0;
+        int64_t d0s = zxc_decompress(dst, (size_t)c0, dec, SMALL, &d0);
+        if (d0s != (int64_t)SMALL || memcmp(src2, dec, SMALL) != 0) {
+            printf("Failed: A0a gen_lz_data mismatch (THIS IS UNEXPECTED)\n");
+            if (d0s == (int64_t)SMALL) {
+                for (size_t i = 0; i < SMALL; i++) {
+                    if (src2[i] != dec[i]) { printf("  first diff at byte %zu: src=0x%02x dec=0x%02x\n", i, src2[i], dec[i]); break; }
+                }
+            }
+            free(src2); free(src); free(dst); free(dec); return 0;
         }
-        printf("  sub-test A0 (control 256KB block, 60KB): OK\n");
+        printf("  sub-test A0a (gen_lz_data 256KB block): OK\n");
+
+        /* A0b: fill_seek_data with same params */
+        memset(dec, 0, SMALL);
+        c0 = zxc_compress(src, SMALL, dst, dst_cap, &opts_ctrl);
+        if (c0 <= 0) { printf("Failed: A0b compress\n"); free(src2); free(src); free(dst); free(dec); return 0; }
+        printf("  A0b compressed %zu -> %lld (block type=%d)\n", SMALL, (long long)c0, (int)dst[16]);
+        d0s = zxc_decompress(dst, (size_t)c0, dec, SMALL, &d0);
+        if (d0s != (int64_t)SMALL || memcmp(src, dec, SMALL) != 0) {
+            printf("  A0b fill_seek_data mismatch!\n");
+            if (d0s == (int64_t)SMALL) {
+                int diff_count = 0;
+                for (size_t i = 0; i < SMALL && diff_count < 5; i++) {
+                    if (src[i] != dec[i]) {
+                        printf("  diff at byte %zu: src=0x%02x dec=0x%02x (delta=%+d)\n",
+                               i, src[i], dec[i], (int)dec[i] - (int)src[i]);
+                        diff_count++;
+                    }
+                }
+            } else {
+                printf("  dsize=%lld\n", (long long)d0s);
+            }
+            free(src2); free(src); free(dst); free(dec); return 0;
+        }
+        printf("  sub-test A0b (fill_seek_data 256KB block): OK\n");
+        free(src2);
     }
     /* Sub-test A1: per-level isolation with block_size=64KB */
     {

--- a/tests/test.c
+++ b/tests/test.c
@@ -3139,6 +3139,364 @@ int test_seekable_mt_full_file() {
     return 1;
 }
 
+/* Cross-boundary range: decompresses bytes that span exactly two blocks */
+int test_seekable_cross_boundary() {
+    printf("=== TEST: Seekable - Cross-Boundary Range ===\n");
+
+    const size_t BLK = 64 * 1024;
+    const size_t SRC_SIZE = BLK * 4; /* 4 blocks */
+    uint8_t* src = malloc(SRC_SIZE);
+    if (!src) return 0;
+    fill_seek_data(src, SRC_SIZE, 123);
+
+    const size_t dst_cap = (size_t)zxc_compress_bound(SRC_SIZE) + 1024;
+    uint8_t* dst = malloc(dst_cap);
+    if (!dst) { free(src); return 0; }
+
+    zxc_compress_opts_t opts = {.level = 3, .block_size = BLK, .seekable = 1};
+    const int64_t csize = zxc_compress(src, SRC_SIZE, dst, dst_cap, &opts);
+    if (csize <= 0) { printf("Failed: compress\n"); free(src); free(dst); return 0; }
+
+    zxc_seekable* s = zxc_seekable_open(dst, (size_t)csize);
+    if (!s) { printf("Failed: open\n"); free(src); free(dst); return 0; }
+
+    /* Read 200 bytes starting 100 bytes before the block 0/1 boundary */
+    const uint64_t boundary = BLK;
+    const uint64_t off = boundary - 100;
+    const size_t len = 200;
+    uint8_t out[200];
+
+    int64_t r = zxc_seekable_decompress_range(s, out, sizeof(out), off, len);
+    if (r != (int64_t)len) {
+        printf("Failed: cross-boundary range returned %lld\n", (long long)r);
+        zxc_seekable_free(s); free(src); free(dst); return 0;
+    }
+    if (memcmp(out, src + off, len) != 0) {
+        printf("Failed: cross-boundary data mismatch\n");
+        zxc_seekable_free(s); free(src); free(dst); return 0;
+    }
+
+    /* Also test a range spanning 3 blocks */
+    const uint64_t off3 = BLK * 2 - 100;
+    const size_t len3 = BLK + 200;
+    uint8_t* out3 = malloc(len3);
+    if (!out3) { zxc_seekable_free(s); free(src); free(dst); return 0; }
+
+    r = zxc_seekable_decompress_range(s, out3, len3, off3, len3);
+    if (r != (int64_t)len3 || memcmp(out3, src + off3, len3) != 0) {
+        printf("Failed: 3-block span mismatch\n");
+        free(out3); zxc_seekable_free(s); free(src); free(dst); return 0;
+    }
+
+    free(out3);
+    zxc_seekable_free(s);
+    free(src); free(dst);
+    printf("PASS\n\n");
+    return 1;
+}
+
+/* Open with truncated data should return NULL */
+int test_seekable_truncated_input() {
+    printf("=== TEST: Seekable - Truncated Input Rejected ===\n");
+
+    const size_t SRC_SIZE = 64 * 1024;
+    uint8_t* src = malloc(SRC_SIZE);
+    if (!src) return 0;
+    fill_seek_data(src, SRC_SIZE, 44);
+
+    const size_t dst_cap = (size_t)zxc_compress_bound(SRC_SIZE) + 256;
+    uint8_t* dst = malloc(dst_cap);
+    if (!dst) { free(src); return 0; }
+
+    zxc_compress_opts_t opts = {.level = 1, .seekable = 1};
+    const int64_t csize = zxc_compress(src, SRC_SIZE, dst, dst_cap, &opts);
+    if (csize <= 0) { printf("Failed: compress\n"); free(src); free(dst); return 0; }
+
+    /* Truncate to half */
+    zxc_seekable* s = zxc_seekable_open(dst, (size_t)(csize / 2));
+    if (s != NULL) {
+        printf("Failed: should reject truncated data\n");
+        zxc_seekable_free(s); free(src); free(dst); return 0;
+    }
+
+    /* Truncate to just header */
+    s = zxc_seekable_open(dst, 16);
+    if (s != NULL) {
+        printf("Failed: should reject header-only data\n");
+        zxc_seekable_free(s); free(src); free(dst); return 0;
+    }
+
+    /* Zero bytes */
+    s = zxc_seekable_open(dst, 0);
+    if (s != NULL) {
+        printf("Failed: should reject zero-length data\n");
+        zxc_seekable_free(s); free(src); free(dst); return 0;
+    }
+
+    free(src); free(dst);
+    printf("PASS\n\n");
+    return 1;
+}
+
+/* Corrupted SEK block: ensure no crash (no UB) */
+int test_seekable_corrupted_sek() {
+    printf("=== TEST: Seekable - Corrupted SEK Block ===\n");
+
+    const size_t SRC_SIZE = 64 * 1024;
+    uint8_t* src = malloc(SRC_SIZE);
+    if (!src) return 0;
+    fill_seek_data(src, SRC_SIZE, 66);
+
+    const size_t dst_cap = (size_t)zxc_compress_bound(SRC_SIZE) + 256;
+    uint8_t* dst = malloc(dst_cap);
+    if (!dst) { free(src); return 0; }
+
+    zxc_compress_opts_t opts = {.level = 1, .seekable = 1};
+    const int64_t csize = zxc_compress(src, SRC_SIZE, dst, dst_cap, &opts);
+    if (csize <= 0) { printf("Failed: compress\n"); free(src); free(dst); return 0; }
+
+    /* Corrupt a byte in the SEK payload area (before footer) */
+    uint8_t* corrupt = malloc((size_t)csize);
+    if (!corrupt) { free(src); free(dst); return 0; }
+    memcpy(corrupt, dst, (size_t)csize);
+    corrupt[csize - 14] ^= 0xFF;
+
+    zxc_seekable* s = zxc_seekable_open(corrupt, (size_t)csize);
+    /* May succeed or fail - just ensure no crash */
+    if (s) {
+        uint8_t out[100];
+        (void)zxc_seekable_decompress_range(s, out, sizeof(out), 0, 100);
+        zxc_seekable_free(s);
+    }
+
+    free(corrupt); free(src); free(dst);
+    printf("PASS\n\n");
+    return 1;
+}
+
+/* Range beyond file end should return error */
+int test_seekable_range_out_of_bounds() {
+    printf("=== TEST: Seekable - Out-of-Bounds Range ===\n");
+
+    const size_t SRC_SIZE = 32 * 1024;
+    uint8_t* src = malloc(SRC_SIZE);
+    if (!src) return 0;
+    fill_seek_data(src, SRC_SIZE, 22);
+
+    const size_t dst_cap = (size_t)zxc_compress_bound(SRC_SIZE) + 256;
+    uint8_t* dst = malloc(dst_cap);
+    if (!dst) { free(src); return 0; }
+
+    zxc_compress_opts_t opts = {.level = 1, .seekable = 1};
+    const int64_t csize = zxc_compress(src, SRC_SIZE, dst, dst_cap, &opts);
+    if (csize <= 0) { printf("Failed: compress\n"); free(src); free(dst); return 0; }
+
+    zxc_seekable* s = zxc_seekable_open(dst, (size_t)csize);
+    if (!s) { printf("Failed: open\n"); free(src); free(dst); return 0; }
+
+    uint8_t out[256];
+    /* offset past EOF */
+    int64_t r = zxc_seekable_decompress_range(s, out, sizeof(out), SRC_SIZE + 100, 100);
+    if (r > 0) {
+        printf("Failed: should reject offset past EOF (got %lld)\n", (long long)r);
+        zxc_seekable_free(s); free(src); free(dst); return 0;
+    }
+
+    /* offset valid but length extends past EOF */
+    r = zxc_seekable_decompress_range(s, out, sizeof(out), SRC_SIZE - 50, 200);
+    if (r > 0) {
+        printf("Failed: should reject range extending past EOF (got %lld)\n", (long long)r);
+        zxc_seekable_free(s); free(src); free(dst); return 0;
+    }
+
+    zxc_seekable_free(s);
+    free(src); free(dst);
+    printf("PASS\n\n");
+    return 1;
+}
+
+/* dst_capacity too small for requested range */
+int test_seekable_dst_too_small() {
+    printf("=== TEST: Seekable - Dst Too Small ===\n");
+
+    const size_t SRC_SIZE = 32 * 1024;
+    uint8_t* src = malloc(SRC_SIZE);
+    if (!src) return 0;
+    fill_seek_data(src, SRC_SIZE, 91);
+
+    const size_t dst_cap = (size_t)zxc_compress_bound(SRC_SIZE) + 256;
+    uint8_t* dst = malloc(dst_cap);
+    if (!dst) { free(src); return 0; }
+
+    zxc_compress_opts_t opts = {.level = 1, .seekable = 1};
+    const int64_t csize = zxc_compress(src, SRC_SIZE, dst, dst_cap, &opts);
+    if (csize <= 0) { printf("Failed: compress\n"); free(src); free(dst); return 0; }
+
+    zxc_seekable* s = zxc_seekable_open(dst, (size_t)csize);
+    if (!s) { printf("Failed: open\n"); free(src); free(dst); return 0; }
+
+    uint8_t out[10];
+    int64_t r = zxc_seekable_decompress_range(s, out, 10, 0, 1000);
+    if (r > 0) {
+        printf("Failed: should reject insufficient dst capacity (got %lld)\n", (long long)r);
+        zxc_seekable_free(s); free(src); free(dst); return 0;
+    }
+
+    zxc_seekable_free(s);
+    free(src); free(dst);
+    printf("PASS\n\n");
+    return 1;
+}
+
+/* Empty file with seekable=1 */
+/* Empty file with seekable=1: buffer API rejects NULL src, verify graceful rejection.
+ * Also verify via streaming API (which supports empty files). */
+int test_seekable_empty_file() {
+    printf("=== TEST: Seekable - Empty File ===\n");
+
+    const size_t dst_cap = (size_t)zxc_compress_bound(0) + 256;
+    uint8_t* dst = malloc(dst_cap);
+    if (!dst) return 0;
+
+    /* Buffer API: NULL src with size 0 is rejected with ZXC_ERROR_NULL_INPUT */
+    zxc_compress_opts_t opts = {.level = 3, .seekable = 1};
+    const int64_t csize = zxc_compress(NULL, 0, dst, dst_cap, &opts);
+    if (csize >= 0) {
+        printf("Failed: expected NULL_INPUT rejection (got %lld)\n", (long long)csize);
+        free(dst); return 0;
+    }
+
+    /* Streaming API: empty file via tmpfile() should work */
+    FILE* fin = tmpfile();
+    FILE* fout = tmpfile();
+    if (fin && fout) {
+        int64_t stream_sz = zxc_stream_compress(fin, fout, &opts);
+        if (stream_sz < 0) {
+            printf("Failed: stream compress empty (got %lld)\n", (long long)stream_sz);
+            fclose(fin); fclose(fout); free(dst); return 0;
+        }
+        /* Decompress the stream output */
+        rewind(fout);
+        FILE* fdec = tmpfile();
+        if (fdec) {
+            zxc_decompress_opts_t dopts = {.checksum_enabled = 0};
+            int64_t dsz = zxc_stream_decompress(fout, fdec, &dopts);
+            if (dsz != 0) {
+                printf("Failed: stream decompress empty should return 0 (got %lld)\n",
+                       (long long)dsz);
+                fclose(fin); fclose(fout); fclose(fdec); free(dst); return 0;
+            }
+            fclose(fdec);
+        }
+        fclose(fin); fclose(fout);
+    }
+
+    free(dst);
+    printf("PASS\n\n");
+    return 1;
+}
+
+/* Seekable without checksum (seekable=1, checksum_enabled=0) */
+int test_seekable_no_checksum() {
+    printf("=== TEST: Seekable - No Checksum ===\n");
+
+    const size_t SRC_SIZE = 256 * 1024;
+    uint8_t* src = malloc(SRC_SIZE);
+    if (!src) return 0;
+    fill_seek_data(src, SRC_SIZE, 31);
+
+    const size_t dst_cap = (size_t)zxc_compress_bound(SRC_SIZE) + 1024;
+    uint8_t* dst = malloc(dst_cap);
+    if (!dst) { free(src); return 0; }
+
+    zxc_compress_opts_t opts = {
+        .level = 3, .block_size = 64 * 1024, .seekable = 1, .checksum_enabled = 0};
+    const int64_t csize = zxc_compress(src, SRC_SIZE, dst, dst_cap, &opts);
+    if (csize <= 0) { printf("Failed: compress\n"); free(src); free(dst); return 0; }
+
+    zxc_seekable* s = zxc_seekable_open(dst, (size_t)csize);
+    if (!s) { printf("Failed: open\n"); free(src); free(dst); return 0; }
+
+    uint8_t out[512];
+    const uint64_t off = 64 * 1024 + 100;
+    int64_t r = zxc_seekable_decompress_range(s, out, sizeof(out), off, 512);
+    if (r != 512 || memcmp(out, src + off, 512) != 0) {
+        printf("Failed: no-checksum range mismatch\n");
+        zxc_seekable_free(s); free(src); free(dst); return 0;
+    }
+
+    /* Full decompress also works */
+    uint8_t* full = malloc(SRC_SIZE);
+    if (!full) { zxc_seekable_free(s); free(src); free(dst); return 0; }
+    zxc_decompress_opts_t dopts = {.checksum_enabled = 0};
+    int64_t dsize = zxc_decompress(dst, (size_t)csize, full, SRC_SIZE, &dopts);
+    if (dsize != (int64_t)SRC_SIZE || memcmp(src, full, SRC_SIZE) != 0) {
+        printf("Failed: full decompress mismatch\n");
+        free(full); zxc_seekable_free(s); free(src); free(dst); return 0;
+    }
+
+    free(full);
+    zxc_seekable_free(s);
+    free(src); free(dst);
+    printf("PASS\n\n");
+    return 1;
+}
+
+/* Seekable with checksum (seekable=1, checksum_enabled=1) */
+int test_seekable_with_checksum() {
+    printf("=== TEST: Seekable - With Checksum ===\n");
+
+    const size_t SRC_SIZE = 256 * 1024;
+    uint8_t* src = malloc(SRC_SIZE);
+    if (!src) return 0;
+    fill_seek_data(src, SRC_SIZE, 47);
+
+    const size_t dst_cap = (size_t)zxc_compress_bound(SRC_SIZE) + 1024;
+    uint8_t* dst = malloc(dst_cap);
+    if (!dst) { free(src); return 0; }
+
+    zxc_compress_opts_t opts = {
+        .level = 3, .block_size = 64 * 1024, .seekable = 1, .checksum_enabled = 1};
+    const int64_t csize = zxc_compress(src, SRC_SIZE, dst, dst_cap, &opts);
+    if (csize <= 0) { printf("Failed: compress\n"); free(src); free(dst); return 0; }
+
+    /* Seekable random access */
+    zxc_seekable* s = zxc_seekable_open(dst, (size_t)csize);
+    if (!s) { printf("Failed: open\n"); free(src); free(dst); return 0; }
+
+    /* Range from block 0 */
+    uint8_t out[512];
+    int64_t r = zxc_seekable_decompress_range(s, out, sizeof(out), 0, 512);
+    if (r != 512 || memcmp(out, src, 512) != 0) {
+        printf("Failed: checksum range head mismatch\n");
+        zxc_seekable_free(s); free(src); free(dst); return 0;
+    }
+
+    /* Range spanning blocks 1-2 */
+    const uint64_t off = 64 * 1024 + 100;
+    r = zxc_seekable_decompress_range(s, out, sizeof(out), off, 512);
+    if (r != 512 || memcmp(out, src + off, 512) != 0) {
+        printf("Failed: checksum range mid mismatch\n");
+        zxc_seekable_free(s); free(src); free(dst); return 0;
+    }
+
+    /* Full decompress with checksum verification */
+    uint8_t* full = malloc(SRC_SIZE);
+    if (!full) { zxc_seekable_free(s); free(src); free(dst); return 0; }
+    zxc_decompress_opts_t dopts = {.checksum_enabled = 1};
+    int64_t dsize = zxc_decompress(dst, (size_t)csize, full, SRC_SIZE, &dopts);
+    if (dsize != (int64_t)SRC_SIZE || memcmp(src, full, SRC_SIZE) != 0) {
+        printf("Failed: full decompress with checksum mismatch\n");
+        free(full); zxc_seekable_free(s); free(src); free(dst); return 0;
+    }
+
+    free(full);
+    zxc_seekable_free(s);
+    free(src); free(dst);
+    printf("PASS\n\n");
+    return 1;
+}
+
 int main() {
     srand(42);  // Fixed seed for reproducibility
     int total_failures = 0;
@@ -3293,6 +3651,16 @@ int main() {
     if (!test_seekable_mt_single_block()) total_failures++;
     if (!test_seekable_mt_random_access()) total_failures++;
     if (!test_seekable_mt_full_file()) total_failures++;
+
+    // --- SEEKABLE EDGE-CASE TESTS ---
+    if (!test_seekable_cross_boundary()) total_failures++;
+    if (!test_seekable_truncated_input()) total_failures++;
+    if (!test_seekable_corrupted_sek()) total_failures++;
+    if (!test_seekable_range_out_of_bounds()) total_failures++;
+    if (!test_seekable_dst_too_small()) total_failures++;
+    if (!test_seekable_empty_file()) total_failures++;
+    if (!test_seekable_no_checksum()) total_failures++;
+    if (!test_seekable_with_checksum()) total_failures++;
 
     if (total_failures > 0) {
         printf("FAILED: %d tests failed.\n", total_failures);

--- a/tests/test.c
+++ b/tests/test.c
@@ -2512,90 +2512,7 @@ int test_seekable_roundtrip() {
                                 .checksum_enabled = 1, .seekable = 1};
     const int64_t csize = zxc_compress(src, SRC_SIZE, dst, dst_cap, &opts);
     if (csize <= 0) { printf("Failed: compress\n"); free(src); free(dst); free(dec); return 0; }
-    /* Sub-test A0: CONTROL - compare gen_lz_data vs fill_seek_data with same params */
-    {
-        const size_t SMALL = 60 * 1024;
-        uint8_t* src2 = malloc(SMALL);
-        if (!src2) { free(src); free(dst); free(dec); return 0; }
-        gen_lz_data(src2, SMALL);
-
-        /* A0a: gen_lz_data (should always pass) */
-        memset(dec, 0, SMALL);
-        zxc_compress_opts_t opts_ctrl = {.level = ZXC_LEVEL_DEFAULT, .block_size = 256 * 1024,
-                                         .checksum_enabled = 1, .seekable = 0};
-        int64_t c0 = zxc_compress(src2, SMALL, dst, dst_cap, &opts_ctrl);
-        if (c0 <= 0) { printf("Failed: A0a compress\n"); free(src2); free(src); free(dst); free(dec); return 0; }
-        printf("  A0a compressed %zu -> %lld (block type=%d)\n", SMALL, (long long)c0, (int)dst[16]);
-        zxc_decompress_opts_t d0 = {.checksum_enabled = 1};
-        int64_t d0s = zxc_decompress(dst, (size_t)c0, dec, SMALL, &d0);
-        if (d0s != (int64_t)SMALL || memcmp(src2, dec, SMALL) != 0) {
-            printf("Failed: A0a gen_lz_data mismatch (THIS IS UNEXPECTED)\n");
-            if (d0s == (int64_t)SMALL) {
-                for (size_t i = 0; i < SMALL; i++) {
-                    if (src2[i] != dec[i]) { printf("  first diff at byte %zu: src=0x%02x dec=0x%02x\n", i, src2[i], dec[i]); break; }
-                }
-            }
-            free(src2); free(src); free(dst); free(dec); return 0;
-        }
-        printf("  sub-test A0a (gen_lz_data 256KB block): OK\n");
-
-        /* A0b: fill_seek_data with same params */
-        memset(dec, 0, SMALL);
-        c0 = zxc_compress(src, SMALL, dst, dst_cap, &opts_ctrl);
-        if (c0 <= 0) { printf("Failed: A0b compress\n"); free(src2); free(src); free(dst); free(dec); return 0; }
-        printf("  A0b compressed %zu -> %lld (block type=%d)\n", SMALL, (long long)c0, (int)dst[16]);
-        d0s = zxc_decompress(dst, (size_t)c0, dec, SMALL, &d0);
-        if (d0s != (int64_t)SMALL || memcmp(src, dec, SMALL) != 0) {
-            printf("  A0b fill_seek_data mismatch!\n");
-            if (d0s == (int64_t)SMALL) {
-                int diff_count = 0;
-                for (size_t i = 0; i < SMALL && diff_count < 5; i++) {
-                    if (src[i] != dec[i]) {
-                        printf("  diff at byte %zu: src=0x%02x dec=0x%02x (delta=%+d)\n",
-                               i, src[i], dec[i], (int)dec[i] - (int)src[i]);
-                        diff_count++;
-                    }
-                }
-            } else {
-                printf("  dsize=%lld\n", (long long)d0s);
-            }
-            free(src2); free(src); free(dst); free(dec); return 0;
-        }
-        printf("  sub-test A0b (fill_seek_data 256KB block): OK\n");
-        free(src2);
-    }
-    /* Sub-test A1: per-level isolation with block_size=64KB */
-    {
-        const size_t SMALL = 60 * 1024;
-        for (int lvl = 1; lvl <= 5; lvl++) {
-            memset(dec, 0, SMALL);
-            zxc_compress_opts_t opts_l = {.level = lvl, .block_size = 64 * 1024,
-                                          .checksum_enabled = 1, .seekable = 0};
-            const int64_t cl = zxc_compress(src, SMALL, dst, dst_cap, &opts_l);
-            if (cl <= 0) {
-                printf("Failed: A1 level %d compress\n", lvl);
-                free(src); free(dst); free(dec); return 0;
-            }
-            zxc_decompress_opts_t dl = {.checksum_enabled = 1};
-            const int64_t dls = zxc_decompress(dst, (size_t)cl, dec, SMALL, &dl);
-            if (dls != (int64_t)SMALL || memcmp(src, dec, SMALL) != 0) {
-                printf("  A1 level %d: FAIL at ", lvl);
-                if (dls == (int64_t)SMALL) {
-                    for (size_t i = 0; i < SMALL; i++) {
-                        if (src[i] != dec[i]) {
-                            printf("byte %zu: src=0x%02x dec=0x%02x\n", i, src[i], dec[i]);
-                            break;
-                        }
-                    }
-                } else {
-                    printf("size %lld\n", (long long)dls);
-                }
-                free(src); free(dst); free(dec); return 0;
-            }
-            printf("  A1 level %d (64KB block): OK\n", lvl);
-        }
-    }
-    /* Sub-test A: single block (data < block_size), safe path (dst=SMALL) */
+    /* Sub-test A: single block (data < block_size) roundtrip */
     {
         const size_t SMALL = 60 * 1024; /* fits in one 64KB block */
         memset(dec, 0, SMALL);
@@ -2609,7 +2526,7 @@ int test_seekable_roundtrip() {
         zxc_decompress_opts_t ad = {.checksum_enabled = 1};
         const int64_t a_dsize = zxc_decompress(dst, (size_t)a_csize, dec, SMALL, &ad);
         if (a_dsize != (int64_t)SMALL || memcmp(src, dec, SMALL) != 0) {
-            printf("Failed: sub-test A safe-path (dsize=%lld)\n", (long long)a_dsize);
+            printf("Failed: single-block 64KB roundtrip (dsize=%lld)\n", (long long)a_dsize);
             if (a_dsize == (int64_t)SMALL) {
                 for (size_t i = 0; i < SMALL; i++) {
                     if (src[i] != dec[i]) {
@@ -2621,38 +2538,7 @@ int test_seekable_roundtrip() {
             }
             free(src); free(dst); free(dec); return 0;
         }
-        printf("  sub-test A (safe path, 60KB): OK\n");
-    }
-    /* Sub-test A2: same data but oversized dst => fast path in decompressor */
-    {
-        const size_t SMALL = 60 * 1024;
-        const size_t BIG_DST = 128 * 1024;  /* oversized => fast path */
-        uint8_t* dec2 = calloc(1, BIG_DST);
-        if (!dec2) { free(src); free(dst); free(dec); return 0; }
-        zxc_compress_opts_t opts_a2 = {.level = ZXC_LEVEL_DEFAULT, .block_size = 64 * 1024,
-                                       .checksum_enabled = 1, .seekable = 0};
-        const int64_t a2_csize = zxc_compress(src, SMALL, dst, dst_cap, &opts_a2);
-        if (a2_csize <= 0) {
-            printf("Failed: sub-test A2 compress\n");
-            free(dec2); free(src); free(dst); free(dec); return 0;
-        }
-        zxc_decompress_opts_t ad2 = {.checksum_enabled = 1};
-        const int64_t a2_dsize = zxc_decompress(dst, (size_t)a2_csize, dec2, BIG_DST, &ad2);
-        if (a2_dsize != (int64_t)SMALL || memcmp(src, dec2, SMALL) != 0) {
-            printf("Failed: sub-test A2 fast-path (dsize=%lld)\n", (long long)a2_dsize);
-            if (a2_dsize == (int64_t)SMALL) {
-                for (size_t i = 0; i < SMALL; i++) {
-                    if (src[i] != dec2[i]) {
-                        printf("  first diff at byte %zu: src=0x%02x dec=0x%02x\n",
-                               i, src[i], dec2[i]);
-                        break;
-                    }
-                }
-            }
-            free(dec2); free(src); free(dst); free(dec); return 0;
-        }
-        free(dec2);
-        printf("  sub-test A2 (fast path, 60KB): OK\n");
+        printf("  sub-test A (single block, 60KB): OK\n");
     }
     /* Sub-test B: exactly 2 blocks (128KB with 64KB block_size) */
     {

--- a/tests/test.c
+++ b/tests/test.c
@@ -2513,11 +2513,60 @@ int test_seekable_roundtrip() {
     const int64_t csize = zxc_compress(src, SRC_SIZE, dst, dst_cap, &opts);
     if (csize <= 0) { printf("Failed: compress\n"); free(src); free(dst); free(dec); return 0; }
 
+    /* Sanity: non-seekable compress with same block_size must round-trip */
+    {
+        memset(dec, 0, SRC_SIZE);
+        zxc_compress_opts_t opts_ns = {.level = ZXC_LEVEL_DEFAULT, .block_size = 64 * 1024,
+                                       .checksum_enabled = 1, .seekable = 0};
+        const int64_t ns_csize = zxc_compress(src, SRC_SIZE, dst, dst_cap, &opts_ns);
+        if (ns_csize <= 0) {
+            printf("Failed: non-seekable compress (%lld)\n", (long long)ns_csize);
+            free(src); free(dst); free(dec);
+            return 0;
+        }
+        zxc_decompress_opts_t nd = {.checksum_enabled = 1};
+        const int64_t ns_dsize = zxc_decompress(dst, (size_t)ns_csize, dec, SRC_SIZE, &nd);
+        if (ns_dsize != (int64_t)SRC_SIZE || memcmp(src, dec, SRC_SIZE) != 0) {
+            printf("Failed: non-seekable 64KB block_size roundtrip (dsize=%lld)\n",
+                   (long long)ns_dsize);
+            if (ns_dsize == (int64_t)SRC_SIZE) {
+                for (size_t i = 0; i < SRC_SIZE; i++) {
+                    if (src[i] != dec[i]) {
+                        printf("  first diff at byte %zu: src=0x%02x dec=0x%02x\n",
+                               i, src[i], dec[i]);
+                        break;
+                    }
+                }
+            }
+            free(src); free(dst); free(dec);
+            return 0;
+        }
+    }
+
+    /* Re-compress with seekable=1 for the actual test */
+    memset(dec, 0, SRC_SIZE);
+    const int64_t csize2 = zxc_compress(src, SRC_SIZE, dst, dst_cap, &opts);
+    if (csize2 <= 0) {
+        printf("Failed: seekable re-compress (%lld)\n", (long long)csize2);
+        free(src); free(dst); free(dec);
+        return 0;
+    }
+
     /* Full decompression with standard API (backward compatibility) */
     zxc_decompress_opts_t dopts = {.checksum_enabled = 1};
-    const int64_t dsize = zxc_decompress(dst, (size_t)csize, dec, SRC_SIZE, &dopts);
+    const int64_t dsize = zxc_decompress(dst, (size_t)csize2, dec, SRC_SIZE, &dopts);
     if (dsize != (int64_t)SRC_SIZE || memcmp(src, dec, SRC_SIZE) != 0) {
-        printf("Failed: decompress mismatch\n");
+        printf("Failed: decompress mismatch (csize=%lld dsize=%lld expected=%zu)\n",
+               (long long)csize2, (long long)dsize, SRC_SIZE);
+        if (dsize == (int64_t)SRC_SIZE) {
+            for (size_t i = 0; i < SRC_SIZE; i++) {
+                if (src[i] != dec[i]) {
+                    printf("  first diff at byte %zu: src=0x%02x dec=0x%02x\n",
+                           i, src[i], dec[i]);
+                    break;
+                }
+            }
+        }
         free(src); free(dst); free(dec);
         return 0;
     }
@@ -2590,7 +2639,17 @@ int test_seekable_random_access() {
     uint8_t out1[1000];
     int64_t r = zxc_seekable_decompress_range(s, out1, 1000, 0, 1000);
     if (r != 1000 || memcmp(src, out1, 1000) != 0) {
-        printf("Failed: first 1000 bytes\n"); zxc_seekable_free(s); free(src); free(dst); return 0;
+        printf("Failed: first 1000 bytes (r=%lld)\n", (long long)r);
+        if (r == 1000) {
+            for (int i = 0; i < 1000; i++) {
+                if (src[i] != out1[i]) {
+                    printf("  first diff at byte %d: src=0x%02x out=0x%02x\n",
+                           i, src[i], out1[i]);
+                    break;
+                }
+            }
+        }
+        zxc_seekable_free(s); free(src); free(dst); return 0;
     }
 
     /* Middle range spanning multiple blocks */
@@ -2715,7 +2774,18 @@ int test_seekable_all_levels() {
 
         int64_t r = zxc_seekable_decompress_range(s, dec, SRC_SIZE, 0, SRC_SIZE);
         if (r != (int64_t)SRC_SIZE || memcmp(src, dec, SRC_SIZE) != 0) {
-            printf("Failed: level %d data mismatch\n", lvl); zxc_seekable_free(s); free(src); free(dst); free(dec); return 0;
+            printf("Failed: level %d data mismatch (r=%lld expected=%zu)\n",
+                   lvl, (long long)r, SRC_SIZE);
+            if (r == (int64_t)SRC_SIZE) {
+                for (size_t i = 0; i < SRC_SIZE; i++) {
+                    if (src[i] != dec[i]) {
+                        printf("  first diff at byte %zu: src=0x%02x dec=0x%02x\n",
+                               i, src[i], dec[i]);
+                        break;
+                    }
+                }
+            }
+            zxc_seekable_free(s); free(src); free(dst); free(dec); return 0;
         }
         zxc_seekable_free(s);
     }

--- a/tests/test.c
+++ b/tests/test.c
@@ -2512,8 +2512,7 @@ int test_seekable_roundtrip() {
                                 .checksum_enabled = 1, .seekable = 1};
     const int64_t csize = zxc_compress(src, SRC_SIZE, dst, dst_cap, &opts);
     if (csize <= 0) { printf("Failed: compress\n"); free(src); free(dst); free(dec); return 0; }
-    /* Sanity: non-seekable compress with same block_size must round-trip */
-    /* Sub-test A: single block (data < block_size) */
+    /* Sub-test A: single block (data < block_size), safe path (dst=SMALL) */
     {
         const size_t SMALL = 60 * 1024; /* fits in one 64KB block */
         memset(dec, 0, SMALL);
@@ -2527,10 +2526,50 @@ int test_seekable_roundtrip() {
         zxc_decompress_opts_t ad = {.checksum_enabled = 1};
         const int64_t a_dsize = zxc_decompress(dst, (size_t)a_csize, dec, SMALL, &ad);
         if (a_dsize != (int64_t)SMALL || memcmp(src, dec, SMALL) != 0) {
-            printf("Failed: single-block 64KB roundtrip (dsize=%lld)\n", (long long)a_dsize);
+            printf("Failed: sub-test A safe-path (dsize=%lld)\n", (long long)a_dsize);
+            if (a_dsize == (int64_t)SMALL) {
+                for (size_t i = 0; i < SMALL; i++) {
+                    if (src[i] != dec[i]) {
+                        printf("  first diff at byte %zu: src=0x%02x dec=0x%02x\n",
+                               i, src[i], dec[i]);
+                        break;
+                    }
+                }
+            }
             free(src); free(dst); free(dec); return 0;
         }
-        printf("  sub-test A (1 block, 60KB): OK\n");
+        printf("  sub-test A (safe path, 60KB): OK\n");
+    }
+    /* Sub-test A2: same data but oversized dst → fast path in decompressor */
+    {
+        const size_t SMALL = 60 * 1024;
+        const size_t BIG_DST = 128 * 1024;  /* oversized → fast path */
+        uint8_t* dec2 = calloc(1, BIG_DST);
+        if (!dec2) { free(src); free(dst); free(dec); return 0; }
+        zxc_compress_opts_t opts_a2 = {.level = ZXC_LEVEL_DEFAULT, .block_size = 64 * 1024,
+                                       .checksum_enabled = 1, .seekable = 0};
+        const int64_t a2_csize = zxc_compress(src, SMALL, dst, dst_cap, &opts_a2);
+        if (a2_csize <= 0) {
+            printf("Failed: sub-test A2 compress\n");
+            free(dec2); free(src); free(dst); free(dec); return 0;
+        }
+        zxc_decompress_opts_t ad2 = {.checksum_enabled = 1};
+        const int64_t a2_dsize = zxc_decompress(dst, (size_t)a2_csize, dec2, BIG_DST, &ad2);
+        if (a2_dsize != (int64_t)SMALL || memcmp(src, dec2, SMALL) != 0) {
+            printf("Failed: sub-test A2 fast-path (dsize=%lld)\n", (long long)a2_dsize);
+            if (a2_dsize == (int64_t)SMALL) {
+                for (size_t i = 0; i < SMALL; i++) {
+                    if (src[i] != dec2[i]) {
+                        printf("  first diff at byte %zu: src=0x%02x dec=0x%02x\n",
+                               i, src[i], dec2[i]);
+                        break;
+                    }
+                }
+            }
+            free(dec2); free(src); free(dst); free(dec); return 0;
+        }
+        free(dec2);
+        printf("  sub-test A2 (fast path, 60KB): OK\n");
     }
     /* Sub-test B: exactly 2 blocks (128KB with 64KB block_size) */
     {
@@ -2560,7 +2599,7 @@ int test_seekable_roundtrip() {
         }
         printf("  sub-test B (2 blocks, 128KB): OK\n");
     }
-    /* Sub-test C: full 256KB (4 blocks × 64KB) */
+    /* Sub-test C: full 256KB (4 blocks x 64KB) */
     {
         memset(dec, 0, SRC_SIZE);
         zxc_compress_opts_t opts_ns = {.level = ZXC_LEVEL_DEFAULT, .block_size = 64 * 1024,

--- a/tests/test.c
+++ b/tests/test.c
@@ -2777,7 +2777,7 @@ int test_seekable_mt_single_block() {
     uint8_t* dec = malloc(SRC_SIZE);
     if (!dst || !dec) { free(src); free(dst); free(dec); return 0; }
 
-    /* Compress with block_size >= SRC_SIZE → only 1 block */
+    /* Compress with block_size >= SRC_SIZE => only 1 block */
     zxc_compress_opts_t opts = {.level = 3, .block_size = 64 * 1024, .seekable = 1};
     const int64_t csize = zxc_compress(src, SRC_SIZE, dst, dst_cap, &opts);
     if (csize <= 0) { printf("Failed: compress\n"); free(src); free(dst); free(dec); return 0; }

--- a/tests/test.c
+++ b/tests/test.c
@@ -285,7 +285,7 @@ int test_max_compressed_size_logic() {
     printf("=== TEST: Unit - zxc_compress_bound ===\n");
 
     // Case 1: 0 bytes (must at least contain the header)
-    size_t sz0 = zxc_compress_bound(0);
+    size_t sz0 = (size_t)zxc_compress_bound(0);
     if (sz0 == 0) {
         printf("Failed: Size for 0 bytes should not be 0 (headers required)\n");
         return 0;
@@ -293,7 +293,7 @@ int test_max_compressed_size_logic() {
 
     // Case 2: Small input
     size_t input_val = 100;
-    size_t sz100 = zxc_compress_bound(input_val);
+    size_t sz100 = (size_t)zxc_compress_bound(input_val);
     if (sz100 < input_val) {
         printf("Failed: Output buffer size (%zu) too small for input (%zu)\n", sz100, input_val);
         return 0;
@@ -406,7 +406,7 @@ int test_truncated_input() {
     uint8_t src[1024];
     gen_lz_data(src, SRC_SIZE);
 
-    size_t cap = zxc_compress_bound(SRC_SIZE);
+    size_t cap = (size_t)zxc_compress_bound(SRC_SIZE);
     uint8_t* compressed = malloc(cap);
     uint8_t* decomp_buf = malloc(SRC_SIZE);
 
@@ -429,7 +429,7 @@ int test_truncated_input() {
     // 1. Cut off the Footer (last ZXC_FILE_FOOTER_SIZE bytes)
     if (comp_sz > ZXC_FILE_FOOTER_SIZE) {
         zxc_decompress_opts_t _do15 = {.checksum_enabled = 1};
-        if (zxc_decompress(compressed, comp_sz - ZXC_FILE_FOOTER_SIZE, decomp_buf, SRC_SIZE,
+        if (zxc_decompress(compressed, (size_t)(comp_sz - ZXC_FILE_FOOTER_SIZE), decomp_buf, SRC_SIZE,
                            &_do15) >= 0) {
             printf("Failed: Should fail when footer is missing\n");
             free(compressed);
@@ -440,7 +440,7 @@ int test_truncated_input() {
 
     // 2. Cut off half the file
     zxc_decompress_opts_t _do16 = {.checksum_enabled = 1};
-    if (zxc_decompress(compressed, comp_sz / 2, decomp_buf, SRC_SIZE, &_do16) >= 0) {
+    if (zxc_decompress(compressed, (size_t)(comp_sz / 2), decomp_buf, SRC_SIZE, &_do16) >= 0) {
         printf("Failed: Should fail when stream is truncated by half\n");
         free(compressed);
         free(decomp_buf);
@@ -449,7 +449,7 @@ int test_truncated_input() {
 
     // 3. Cut off just 1 byte
     zxc_decompress_opts_t _do17 = {.checksum_enabled = 1};
-    if (zxc_decompress(compressed, comp_sz - 1, decomp_buf, SRC_SIZE, &_do17) >= 0) {
+    if (zxc_decompress(compressed, (size_t)(comp_sz - 1), decomp_buf, SRC_SIZE, &_do17) >= 0) {
         printf("Failed: Should fail when stream is truncated by 1 byte\n");
         free(compressed);
         free(decomp_buf);
@@ -615,7 +615,7 @@ int test_buffer_api() {
     gen_lz_data(src, src_size);
 
     // 1. Calculate max compressed size
-    size_t max_dst_size = zxc_compress_bound(src_size);
+    size_t max_dst_size = (size_t)zxc_compress_bound(src_size);
     uint8_t* compressed = malloc(max_dst_size);
     int checksum_enabled = 1;
 
@@ -634,7 +634,7 @@ int test_buffer_api() {
     uint8_t* decompressed = malloc(src_size);
     zxc_decompress_opts_t _do24 = {.checksum_enabled = checksum_enabled};
     int64_t decompressed_size =
-        zxc_decompress(compressed, compressed_size, decompressed, src_size, &_do24);
+        zxc_decompress(compressed, (size_t)compressed_size, decompressed, src_size, &_do24);
 
     if (decompressed_size != (int64_t)src_size) {
         printf("Failed: zxc_decompress returned %lld, expected %zu\n", (long long)decompressed_size,
@@ -655,7 +655,7 @@ int test_buffer_api() {
     }
 
     // 5. Test error case: Destination too small
-    size_t small_capacity = compressed_size / 2;
+    size_t small_capacity = (size_t)(compressed_size / 2);
     zxc_compress_opts_t _co25 = {.level = 3, .checksum_enabled = checksum_enabled};
     int64_t small_res = zxc_compress(src, src_size, compressed, small_capacity, &_co25);
     if (small_res >= 0) {
@@ -761,7 +761,7 @@ int test_eof_block_structure() {
 
     const char* input = "test";
     size_t src_size = 4;
-    size_t max_dst_size = zxc_compress_bound(src_size);
+    size_t max_dst_size = (size_t)zxc_compress_bound(src_size);
     uint8_t* compressed = malloc(max_dst_size);
     if (!compressed) return 0;
 
@@ -899,7 +899,7 @@ int test_global_checksum_order() {
     // 3. Read compressed data to memory
     long comp_sz = ftell(f_comp);
     rewind(f_comp);
-    uint8_t* comp_buf = malloc(comp_sz);
+    uint8_t* comp_buf = malloc((size_t)comp_sz);
     if (fread(comp_buf, 1, comp_sz, f_comp) != (size_t)comp_sz) {
         printf("[FAIL] Failed to read compressed data\n");
         free(val_buf);
@@ -935,7 +935,7 @@ int test_global_checksum_order() {
 
     // 5. Swap Block 1 and Block 2
     // To safely swap, we need a new buffer
-    uint8_t* swapped_buf = malloc(comp_sz);
+    uint8_t* swapped_buf = malloc((size_t)comp_sz);
 
     // Copy File Header
     // Copy File Header
@@ -957,7 +957,7 @@ int test_global_checksum_order() {
 
     // 6. Write to File for Decompression
     FILE* f_bad = tmpfile();
-    fwrite(swapped_buf, 1, comp_sz, f_bad);
+    fwrite(swapped_buf, 1, (size_t)comp_sz, f_bad);
     rewind(f_bad);
 
     // 7. Attempt Decompression
@@ -991,7 +991,7 @@ int test_get_decompressed_size() {
     uint8_t* src = malloc(src_size);
     gen_lz_data(src, src_size);
 
-    size_t max_dst = zxc_compress_bound(src_size);
+    size_t max_dst = (size_t)zxc_compress_bound(src_size);
     uint8_t* compressed = malloc(max_dst);
 
     zxc_compress_opts_t _co29 = {.level = 3, .checksum_enabled = 0};
@@ -1003,7 +1003,7 @@ int test_get_decompressed_size() {
         return 0;
     }
 
-    size_t reported = zxc_get_decompressed_size(compressed, comp_size);
+    size_t reported = (size_t)zxc_get_decompressed_size(compressed, comp_size);
     if (reported != src_size) {
         printf("Failed: Expected %zu, got %zu\n", src_size, reported);
         free(src);
@@ -1237,7 +1237,7 @@ int test_buffer_error_codes() {
         const size_t src_sz = 256;
         uint8_t* src = malloc(src_sz);
         gen_lz_data(src, src_sz);
-        const size_t full_cap = zxc_compress_bound(src_sz);
+        const size_t full_cap = (size_t)zxc_compress_bound(src_sz);
         uint8_t* full_dst = malloc(full_cap);
         zxc_compress_opts_t _co36 = {.level = 3, .checksum_enabled = 0};
         const int64_t full_sz = zxc_compress(src, src_sz, full_dst, full_cap, &_co36);
@@ -1324,7 +1324,7 @@ int test_buffer_error_codes() {
     const size_t test_src_sz = 1024;
     uint8_t* test_src = malloc(test_src_sz);
     gen_lz_data(test_src, test_src_sz);
-    const size_t comp_cap = zxc_compress_bound(test_src_sz);
+    const size_t comp_cap = (size_t)zxc_compress_bound(test_src_sz);
     uint8_t* comp_buf = malloc(comp_cap);
     zxc_compress_opts_t _co42 = {.level = 3, .checksum_enabled = 1};
     const int64_t comp_sz = zxc_compress(test_src, test_src_sz, comp_buf, comp_cap, &_co42);
@@ -1337,13 +1337,13 @@ int test_buffer_error_codes() {
 
     // 12. Corrupt block header (damage the first block header byte after file header)
     {
-        uint8_t* corrupt = malloc(comp_sz);
-        memcpy(corrupt, comp_buf, comp_sz);
+        uint8_t* corrupt = malloc((size_t)comp_sz);
+        memcpy(corrupt, comp_buf, (size_t)comp_sz);
         // Corrupt the block type byte at offset ZXC_FILE_HEADER_SIZE
         corrupt[ZXC_FILE_HEADER_SIZE] = 0xFF;  // Invalid block type
         uint8_t* out = malloc(test_src_sz);
         zxc_decompress_opts_t _do43 = {.checksum_enabled = 1};
-        r = zxc_decompress(corrupt, comp_sz, out, test_src_sz, &_do43);
+        r = zxc_decompress(corrupt, (size_t)comp_sz, out, test_src_sz, &_do43);
         if (r >= 0) {
             printf("  [FAIL] corrupt block header: expected < 0, got %lld\n", (long long)r);
             free(corrupt);
@@ -1378,15 +1378,15 @@ int test_buffer_error_codes() {
 
     // 14. Stored size mismatch (corrupt the source size in footer)
     {
-        uint8_t* corrupt = malloc(comp_sz);
-        memcpy(corrupt, comp_buf, comp_sz);
+        uint8_t* corrupt = malloc((size_t)comp_sz);
+        memcpy(corrupt, comp_buf, (size_t)comp_sz);
         // Footer is at end: last 12 bytes = [src_size(8)] + [global_hash(4)]
         // Corrupt the source size field (add 1 to the first byte)
         const size_t footer_offset = (size_t)comp_sz - ZXC_FILE_FOOTER_SIZE;
         corrupt[footer_offset] ^= 0x01;  // Flip a bit in the stored source size
         uint8_t* out = malloc(test_src_sz);
         zxc_decompress_opts_t _do45 = {.checksum_enabled = 1};
-        r = zxc_decompress(corrupt, comp_sz, out, test_src_sz, &_do45);
+        r = zxc_decompress(corrupt, (size_t)comp_sz, out, test_src_sz, &_do45);
         if (r >= 0) {
             printf("  [FAIL] size mismatch: expected < 0, got %lld\n", (long long)r);
             free(corrupt);
@@ -1402,13 +1402,13 @@ int test_buffer_error_codes() {
 
     // 15. Global checksum failure (corrupt the global hash in footer)
     {
-        uint8_t* corrupt = malloc(comp_sz);
-        memcpy(corrupt, comp_buf, comp_sz);
+        uint8_t* corrupt = malloc((size_t)comp_sz);
+        memcpy(corrupt, comp_buf, (size_t)comp_sz);
         // Global hash is the last 4 bytes of the file
         corrupt[comp_sz - 1] ^= 0xFF;
         uint8_t* out = malloc(test_src_sz);
         zxc_decompress_opts_t _do46 = {.checksum_enabled = 1};
-        r = zxc_decompress(corrupt, comp_sz, out, test_src_sz, &_do46);
+        r = zxc_decompress(corrupt, (size_t)comp_sz, out, test_src_sz, &_do46);
         if (r != ZXC_ERROR_BAD_CHECKSUM) {
             printf("  [FAIL] bad global checksum: expected %d, got %lld\n", ZXC_ERROR_BAD_CHECKSUM,
                    (long long)r);
@@ -1427,7 +1427,7 @@ int test_buffer_error_codes() {
     {
         uint8_t* out = malloc(test_src_sz / 4);  // Way too small
         zxc_decompress_opts_t _do47 = {.checksum_enabled = 0};
-        r = zxc_decompress(comp_buf, comp_sz, out, test_src_sz / 4, &_do47);
+        r = zxc_decompress(comp_buf, (size_t)comp_sz, out, test_src_sz / 4, &_do47);
         if (r >= 0) {
             printf("  [FAIL] dst too small for decompress: expected < 0, got %lld\n", (long long)r);
             free(out);
@@ -1505,7 +1505,7 @@ int test_stream_get_decompressed_size_errors() {
         const size_t src_sz = 512;
         uint8_t* src = malloc(src_sz);
         gen_lz_data(src, src_sz);
-        const size_t cap = zxc_compress_bound(src_sz);
+        const size_t cap = (size_t)zxc_compress_bound(src_sz);
         uint8_t* comp = malloc(cap);
         zxc_compress_opts_t _co48 = {.level = 3, .checksum_enabled = 0};
         int64_t comp_sz = zxc_compress(src, src_sz, comp, cap, &_co48);
@@ -1917,7 +1917,7 @@ int test_buffer_api_scratch_buf() {
         uint8_t src[177];
         gen_lz_data(src, sz);
 
-        const size_t comp_cap = zxc_compress_bound(sz);
+        const size_t comp_cap = (size_t)zxc_compress_bound(sz);
         uint8_t* comp = malloc(comp_cap);
         zxc_compress_opts_t _co58 = {.level = 3, .checksum_enabled = 0};
         const int64_t comp_sz = zxc_compress(src, sz, comp, comp_cap, &_co58);
@@ -1929,7 +1929,7 @@ int test_buffer_api_scratch_buf() {
 
         uint8_t dec[177];
         zxc_decompress_opts_t _do59 = {.checksum_enabled = 0};
-        const int64_t dec_sz = zxc_decompress(comp, comp_sz, dec, sz, &_do59);
+        const int64_t dec_sz = zxc_decompress(comp, (size_t)comp_sz, dec, sz, &_do59);
         if (dec_sz != (int64_t)sz || memcmp(src, dec, sz) != 0) {
             printf("  [FAIL] roundtrip 177B\n");
             free(comp);
@@ -1945,7 +1945,7 @@ int test_buffer_api_scratch_buf() {
         uint8_t* src = malloc(sz);
         gen_lz_data(src, sz);
 
-        const size_t comp_cap = zxc_compress_bound(sz);
+        const size_t comp_cap = (size_t)zxc_compress_bound(sz);
         uint8_t* comp = malloc(comp_cap);
         zxc_compress_opts_t _co60 = {.level = 1, .checksum_enabled = 1};
         const int64_t comp_sz = zxc_compress(src, sz, comp, comp_cap, &_co60);
@@ -1958,7 +1958,7 @@ int test_buffer_api_scratch_buf() {
 
         uint8_t* dec = malloc(sz);  // exactly sz, no extra room
         zxc_decompress_opts_t _do61 = {.checksum_enabled = 1};
-        const int64_t dec_sz = zxc_decompress(comp, comp_sz, dec, sz, &_do61);
+        const int64_t dec_sz = zxc_decompress(comp, (size_t)comp_sz, dec, sz, &_do61);
         if (dec_sz != (int64_t)sz || memcmp(src, dec, sz) != 0) {
             printf("  [FAIL] exact-fit 1KB\n");
             free(src);
@@ -1975,7 +1975,7 @@ int test_buffer_api_scratch_buf() {
     // 3. Tiny data (1 byte)
     {
         const uint8_t src = 0x42;
-        const size_t comp_cap = zxc_compress_bound(1);
+        const size_t comp_cap = (size_t)zxc_compress_bound(1);
         uint8_t* comp = malloc(comp_cap);
         zxc_compress_opts_t _co62 = {.level = 1, .checksum_enabled = 0};
         const int64_t comp_sz = zxc_compress(&src, 1, comp, comp_cap, &_co62);
@@ -1987,7 +1987,7 @@ int test_buffer_api_scratch_buf() {
 
         uint8_t dec = 0;
         zxc_decompress_opts_t _do63 = {.checksum_enabled = 0};
-        const int64_t dec_sz = zxc_decompress(comp, comp_sz, &dec, 1, &_do63);
+        const int64_t dec_sz = zxc_decompress(comp, (size_t)comp_sz, &dec, 1, &_do63);
         if (dec_sz != 1 || dec != 0x42) {
             printf("  [FAIL] roundtrip 1B\n");
             free(comp);
@@ -2017,7 +2017,7 @@ int test_buffer_api_scratch_buf() {
         uint8_t* src = malloc(sz);
         gen_lz_data(src, sz);
 
-        const size_t comp_cap = zxc_compress_bound(sz);
+        const size_t comp_cap = (size_t)zxc_compress_bound(sz);
         uint8_t* comp = malloc(comp_cap);
         zxc_compress_opts_t _co65 = {.level = 1, .checksum_enabled = 0};
         const int64_t comp_sz = zxc_compress(src, sz, comp, comp_cap, &_co65);
@@ -2030,7 +2030,7 @@ int test_buffer_api_scratch_buf() {
 
         uint8_t tiny_dst[8];
         zxc_decompress_opts_t _do66 = {.checksum_enabled = 0};
-        const int64_t r = zxc_decompress(comp, comp_sz, tiny_dst, sizeof(tiny_dst), &_do66);
+        const int64_t r = zxc_decompress(comp, (size_t)comp_sz, tiny_dst, sizeof(tiny_dst), &_do66);
         if (r >= 0) {
             printf("  [FAIL] dst too small should return < 0\n");
             free(src);
@@ -2063,7 +2063,7 @@ int test_decompress_fast_vs_safe_path() {
     if (!src) return 0;
     gen_lz_data(src, src_sz);
 
-    const size_t comp_cap = zxc_compress_bound(src_sz);
+    const size_t comp_cap = (size_t)zxc_compress_bound(src_sz);
     uint8_t* comp = malloc(comp_cap);
     zxc_compress_opts_t _co67 = {.level = 3, .checksum_enabled = 1};
     const int64_t comp_sz = zxc_compress(src, src_sz, comp, comp_cap, &_co67);
@@ -2081,7 +2081,7 @@ int test_decompress_fast_vs_safe_path() {
         const size_t big_cap = src_sz + ZXC_BLOCK_SIZE_DEFAULT;  // way more than enough
         uint8_t* dst = malloc(big_cap);
         zxc_decompress_opts_t _do68 = {.checksum_enabled = 1};
-        const int64_t dec_sz = zxc_decompress(comp, comp_sz, dst, big_cap, &_do68);
+        const int64_t dec_sz = zxc_decompress(comp, (size_t)comp_sz, dst, big_cap, &_do68);
         if (dec_sz != (int64_t)src_sz) {
             printf("  [FAIL] fast path size: expected %zu, got %lld\n", src_sz, (long long)dec_sz);
             free(dst);
@@ -2108,7 +2108,7 @@ int test_decompress_fast_vs_safe_path() {
     {
         uint8_t* dst = malloc(src_sz);  // no slack at all
         zxc_decompress_opts_t _do69 = {.checksum_enabled = 1};
-        const int64_t dec_sz = zxc_decompress(comp, comp_sz, dst, src_sz, &_do69);
+        const int64_t dec_sz = zxc_decompress(comp, (size_t)comp_sz, dst, src_sz, &_do69);
         if (dec_sz != (int64_t)src_sz) {
             printf("  [FAIL] safe path size: expected %zu, got %lld\n", src_sz, (long long)dec_sz);
             free(dst);
@@ -2135,7 +2135,7 @@ int test_decompress_fast_vs_safe_path() {
         const size_t tight_cap = src_sz + ZXC_PAD_SIZE - 1;
         uint8_t* dst = malloc(tight_cap);
         zxc_decompress_opts_t _do70 = {.checksum_enabled = 1};
-        const int64_t dec_sz = zxc_decompress(comp, comp_sz, dst, tight_cap, &_do70);
+        const int64_t dec_sz = zxc_decompress(comp, (size_t)comp_sz, dst, tight_cap, &_do70);
         if (dec_sz != (int64_t)src_sz) {
             printf("  [FAIL] boundary size: expected %zu, got %lld\n", src_sz, (long long)dec_sz);
             free(dst);
@@ -2161,7 +2161,7 @@ int test_decompress_fast_vs_safe_path() {
         const size_t tiny_cap = ZXC_BLOCK_SIZE_DEFAULT / 2;  // Enough for half a block
         uint8_t* dst = malloc(tiny_cap);
         zxc_decompress_opts_t _do71 = {.checksum_enabled = 0};
-        const int64_t dec_sz = zxc_decompress(comp, comp_sz, dst, tiny_cap, &_do71);
+        const int64_t dec_sz = zxc_decompress(comp, (size_t)comp_sz, dst, tiny_cap, &_do71);
         if (dec_sz >= 0) {
             printf("  [FAIL] safe path dst-too-small should fail, got %lld\n", (long long)dec_sz);
             free(dst);
@@ -2338,7 +2338,7 @@ int test_opaque_context_api() {
 
     const size_t src_sz = 8192;
     uint8_t* src = malloc(src_sz);
-    const size_t comp_cap = zxc_compress_bound(src_sz);
+    const size_t comp_cap = (size_t)zxc_compress_bound(src_sz);
     uint8_t* comp = malloc(comp_cap);
     uint8_t* dec = malloc(src_sz);
 
@@ -2503,7 +2503,7 @@ int test_seekable_roundtrip() {
     if (!src) return 0;
     fill_seek_data(src, SRC_SIZE, 42);
 
-    const size_t dst_cap = zxc_compress_bound(SRC_SIZE) + 1024;
+    const size_t dst_cap = (size_t)zxc_compress_bound(SRC_SIZE) + 1024;
     uint8_t* dst = malloc(dst_cap);
     uint8_t* dec = malloc(SRC_SIZE);
     if (!dst || !dec) { free(src); free(dst); free(dec); return 0; }
@@ -2535,7 +2535,7 @@ int test_seekable_open_query() {
     if (!src) return 0;
     fill_seek_data(src, SRC_SIZE, 99);
 
-    const size_t dst_cap = zxc_compress_bound(SRC_SIZE) + 1024;
+    const size_t dst_cap = (size_t)zxc_compress_bound(SRC_SIZE) + 1024;
     uint8_t* dst = malloc(dst_cap);
     if (!dst) { free(src); return 0; }
 
@@ -2575,7 +2575,7 @@ int test_seekable_random_access() {
     if (!src) return 0;
     fill_seek_data(src, SRC_SIZE, 77);
 
-    const size_t dst_cap = zxc_compress_bound(SRC_SIZE) + 1024;
+    const size_t dst_cap = (size_t)zxc_compress_bound(SRC_SIZE) + 1024;
     uint8_t* dst = malloc(dst_cap);
     if (!dst) { free(src); return 0; }
 
@@ -2639,7 +2639,7 @@ int test_seekable_non_seekable_reject() {
     if (!src) return 0;
     fill_seek_data(src, SRC_SIZE, 11);
 
-    const size_t dst_cap = zxc_compress_bound(SRC_SIZE);
+    const size_t dst_cap = (size_t)zxc_compress_bound(SRC_SIZE);
     uint8_t* dst = malloc(dst_cap);
     if (!dst) { free(src); return 0; }
 
@@ -2666,7 +2666,7 @@ int test_seekable_single_block() {
     if (!src) return 0;
     fill_seek_data(src, SRC_SIZE, 55);
 
-    const size_t dst_cap = zxc_compress_bound(SRC_SIZE) + 256;
+    const size_t dst_cap = (size_t)zxc_compress_bound(SRC_SIZE) + 256;
     uint8_t* dst = malloc(dst_cap);
     if (!dst) { free(src); return 0; }
 
@@ -2700,7 +2700,7 @@ int test_seekable_all_levels() {
     if (!src) return 0;
     fill_seek_data(src, SRC_SIZE, 33);
 
-    const size_t dst_cap = zxc_compress_bound(SRC_SIZE) + 1024;
+    const size_t dst_cap = (size_t)zxc_compress_bound(SRC_SIZE) + 1024;
     uint8_t* dst = malloc(dst_cap);
     uint8_t* dec = malloc(SRC_SIZE);
     if (!dst || !dec) { free(src); free(dst); free(dec); return 0; }
@@ -2737,7 +2737,7 @@ int test_seekable_mt_roundtrip() {
     if (!src) return 0;
     fill_seek_data(src, SRC_SIZE, 55);
 
-    const size_t dst_cap = zxc_compress_bound(SRC_SIZE) + 1024;
+    const size_t dst_cap = (size_t)zxc_compress_bound(SRC_SIZE) + 1024;
     uint8_t* dst = malloc(dst_cap);
     uint8_t* dec = malloc(SRC_SIZE);
     if (!dst || !dec) { free(src); free(dst); free(dec); return 0; }
@@ -2772,7 +2772,7 @@ int test_seekable_mt_single_block() {
     if (!src) return 0;
     fill_seek_data(src, SRC_SIZE, 88);
 
-    const size_t dst_cap = zxc_compress_bound(SRC_SIZE) + 1024;
+    const size_t dst_cap = (size_t)zxc_compress_bound(SRC_SIZE) + 1024;
     uint8_t* dst = malloc(dst_cap);
     uint8_t* dec = malloc(SRC_SIZE);
     if (!dst || !dec) { free(src); free(dst); free(dec); return 0; }
@@ -2807,7 +2807,7 @@ int test_seekable_mt_random_access() {
     if (!src) return 0;
     fill_seek_data(src, SRC_SIZE, 11);
 
-    const size_t dst_cap = zxc_compress_bound(SRC_SIZE) + 1024;
+    const size_t dst_cap = (size_t)zxc_compress_bound(SRC_SIZE) + 1024;
     uint8_t* dst = malloc(dst_cap);
     if (!dst) { free(src); return 0; }
 
@@ -2846,7 +2846,7 @@ int test_seekable_mt_full_file() {
     if (!src) return 0;
     fill_seek_data(src, SRC_SIZE, 7);
 
-    const size_t dst_cap = zxc_compress_bound(SRC_SIZE) + 1024;
+    const size_t dst_cap = (size_t)zxc_compress_bound(SRC_SIZE) + 1024;
     uint8_t* dst = malloc(dst_cap);
     uint8_t* dec = malloc(SRC_SIZE);
     if (!dst || !dec) { free(src); free(dst); free(dec); return 0; }

--- a/tests/test.c
+++ b/tests/test.c
@@ -2917,6 +2917,80 @@ int test_seekable_many_blocks() {
     return 1;
 }
 
+int test_seekable_open_file() {
+    printf("=== TEST: Seekable - Open File ===\n");
+
+    /* Compress seekable data into a buffer, write to tmpfile, then open via file API */
+    const size_t SRC_SIZE = 128 * 1024;
+    uint8_t* src = malloc(SRC_SIZE);
+    if (!src) return 0;
+    fill_seek_data(src, SRC_SIZE, 99);
+
+    const size_t dst_cap = (size_t)zxc_compress_bound(SRC_SIZE) + 1024;
+    uint8_t* dst = malloc(dst_cap);
+    uint8_t* dec = malloc(SRC_SIZE);
+    if (!dst || !dec) { free(src); free(dst); free(dec); return 0; }
+
+    zxc_compress_opts_t opts = {.level = ZXC_LEVEL_DEFAULT, .block_size = 32 * 1024,
+                                .checksum_enabled = 1, .seekable = 1};
+    const int64_t csize = zxc_compress(src, SRC_SIZE, dst, dst_cap, &opts);
+    if (csize <= 0) {
+        printf("Failed: compress (%lld)\n", (long long)csize);
+        free(src); free(dst); free(dec); return 0;
+    }
+
+    /* Write compressed data to a temp file */
+    FILE* tf = tmpfile();
+    if (!tf) { printf("Failed: tmpfile\n"); free(src); free(dst); free(dec); return 0; }
+    if (fwrite(dst, 1, (size_t)csize, tf) != (size_t)csize) {
+        printf("Failed: fwrite\n"); fclose(tf); free(src); free(dst); free(dec); return 0;
+    }
+    fflush(tf);
+
+    /* Open via file API */
+    zxc_seekable* s = zxc_seekable_open_file(tf);
+    if (!s) {
+        printf("Failed: zxc_seekable_open_file returned NULL\n");
+        fclose(tf); free(src); free(dst); free(dec); return 0;
+    }
+
+    /* Verify block count: 128KB / 32KB = 4 blocks */
+    const uint32_t n_blocks = zxc_seekable_get_num_blocks(s);
+    if (n_blocks != 4) {
+        printf("Failed: expected 4 blocks, got %u\n", n_blocks);
+        zxc_seekable_free(s); fclose(tf); free(src); free(dst); free(dec); return 0;
+    }
+
+    /* Full decompress from file */
+    int64_t r = zxc_seekable_decompress_range(s, dec, SRC_SIZE, 0, SRC_SIZE);
+    if (r != (int64_t)SRC_SIZE || memcmp(src, dec, SRC_SIZE) != 0) {
+        printf("Failed: full decompress from file (r=%lld)\n", (long long)r);
+        zxc_seekable_free(s); fclose(tf); free(src); free(dst); free(dec); return 0;
+    }
+
+    /* Random access from file: read 200 bytes spanning block boundary */
+    const uint64_t cross_off = 32 * 1024 - 100;  /* last 100B of block 0 + first 100B of block 1 */
+    uint8_t cross[200];
+    r = zxc_seekable_decompress_range(s, cross, 200, cross_off, 200);
+    if (r != 200 || memcmp(src + cross_off, cross, 200) != 0) {
+        printf("Failed: cross-block read from file\n");
+        zxc_seekable_free(s); fclose(tf); free(src); free(dst); free(dec); return 0;
+    }
+
+    zxc_seekable_free(s);
+    fclose(tf);
+
+    /* NULL input rejection */
+    if (zxc_seekable_open_file(NULL) != NULL) {
+        printf("Failed: NULL not rejected\n");
+        free(src); free(dst); free(dec); return 0;
+    }
+
+    free(src); free(dst); free(dec);
+    printf("PASS\n\n");
+    return 1;
+}
+
 /* ========================================================================= */
 /*  Multi-Threaded Seekable Tests                                            */
 /* ========================================================================= */
@@ -3212,6 +3286,7 @@ int main() {
     if (!test_seekable_single_block()) total_failures++;
     if (!test_seekable_all_levels()) total_failures++;
     if (!test_seekable_many_blocks()) total_failures++;
+    if (!test_seekable_open_file()) total_failures++;
 
     // --- SEEKABLE MT TESTS ---
     if (!test_seekable_mt_roundtrip()) total_failures++;

--- a/tests/test.c
+++ b/tests/test.c
@@ -2446,13 +2446,13 @@ static void fill_seek_data(uint8_t* buf, size_t size, uint8_t seed) {
 int test_seekable_table_sizes() {
     printf("=== TEST: Seekable - Table Sizes ===\n");
 
-    /* block_header(8) + 10*8 + tail(4) = 92 */
-    if (zxc_seek_table_size(10) != 92) {
+    /* block_header(8) + 10*4 = 48 */
+    if (zxc_seek_table_size(10) != 48) {
         printf("Failed: size for 10 blocks\n");
         return 0;
     }
-    /* block_header(8) + 0 + tail(4) = 12 */
-    if (zxc_seek_table_size(0) != 12) {
+    /* block_header(8) + 0 = 8 */
+    if (zxc_seek_table_size(0) != 8) {
         printf("Failed: zero blocks size\n");
         return 0;
     }
@@ -2465,12 +2465,11 @@ int test_seekable_table_write() {
     printf("=== TEST: Seekable - Table Write/Validate ===\n");
 
     const uint32_t comp[] = {100, 200, 150};
-    const uint32_t decomp[] = {1000, 2000, 1500};
     const size_t sz = zxc_seek_table_size(3);
     uint8_t* buf = malloc(sz);
     if (!buf) return 0;
 
-    const int64_t written = zxc_write_seek_table(buf, sz, comp, decomp, 3);
+    const int64_t written = zxc_write_seek_table(buf, sz, comp, 3);
     if (written != (int64_t)sz) {
         printf("Failed: write size mismatch\n");
         free(buf);
@@ -2484,9 +2483,9 @@ int test_seekable_table_write() {
         return 0;
     }
 
-    /* Validate num_blocks in the tail (last 4 bytes) */
-    if (zxc_le32(buf + sz - 4) != 3) {
-        printf("Failed: bad num_blocks\n");
+    /* Validate first comp_size entry (after 8-byte block header) */
+    if (zxc_le32(buf + 8) != 100) {
+        printf("Failed: bad first comp_size\n");
         free(buf);
         return 0;
     }

--- a/tests/test.c
+++ b/tests/test.c
@@ -2447,17 +2447,12 @@ int test_seekable_table_sizes() {
     printf("=== TEST: Seekable - Table Sizes ===\n");
 
     /* block_header(8) + 10*8 + tail(4) = 92 */
-    if (zxc_seek_table_size(10, 0) != 92) {
-        printf("Failed: no-checksum size\n");
-        return 0;
-    }
-    /* block_header(8) + 10*12 + tail(4) = 132 */
-    if (zxc_seek_table_size(10, 1) != 132) {
-        printf("Failed: checksum size\n");
+    if (zxc_seek_table_size(10) != 92) {
+        printf("Failed: size for 10 blocks\n");
         return 0;
     }
     /* block_header(8) + 0 + tail(4) = 12 */
-    if (zxc_seek_table_size(0, 0) != 12) {
+    if (zxc_seek_table_size(0) != 12) {
         printf("Failed: zero blocks size\n");
         return 0;
     }
@@ -2471,11 +2466,11 @@ int test_seekable_table_write() {
 
     const uint32_t comp[] = {100, 200, 150};
     const uint32_t decomp[] = {1000, 2000, 1500};
-    const size_t sz = zxc_seek_table_size(3, 0);
+    const size_t sz = zxc_seek_table_size(3);
     uint8_t* buf = malloc(sz);
     if (!buf) return 0;
 
-    const int64_t written = zxc_write_seek_table(buf, sz, comp, decomp, 3, 0);
+    const int64_t written = zxc_write_seek_table(buf, sz, comp, decomp, 3);
     if (written != (int64_t)sz) {
         printf("Failed: write size mismatch\n");
         free(buf);

--- a/tests/test.c
+++ b/tests/test.c
@@ -2512,8 +2512,55 @@ int test_seekable_roundtrip() {
                                 .checksum_enabled = 1, .seekable = 1};
     const int64_t csize = zxc_compress(src, SRC_SIZE, dst, dst_cap, &opts);
     if (csize <= 0) { printf("Failed: compress\n"); free(src); free(dst); free(dec); return 0; }
-
     /* Sanity: non-seekable compress with same block_size must round-trip */
+    /* Sub-test A: single block (data < block_size) */
+    {
+        const size_t SMALL = 60 * 1024; /* fits in one 64KB block */
+        memset(dec, 0, SMALL);
+        zxc_compress_opts_t opts_a = {.level = ZXC_LEVEL_DEFAULT, .block_size = 64 * 1024,
+                                      .checksum_enabled = 1, .seekable = 0};
+        const int64_t a_csize = zxc_compress(src, SMALL, dst, dst_cap, &opts_a);
+        if (a_csize <= 0) {
+            printf("Failed: single-block 64KB compress (%lld)\n", (long long)a_csize);
+            free(src); free(dst); free(dec); return 0;
+        }
+        zxc_decompress_opts_t ad = {.checksum_enabled = 1};
+        const int64_t a_dsize = zxc_decompress(dst, (size_t)a_csize, dec, SMALL, &ad);
+        if (a_dsize != (int64_t)SMALL || memcmp(src, dec, SMALL) != 0) {
+            printf("Failed: single-block 64KB roundtrip (dsize=%lld)\n", (long long)a_dsize);
+            free(src); free(dst); free(dec); return 0;
+        }
+        printf("  sub-test A (1 block, 60KB): OK\n");
+    }
+    /* Sub-test B: exactly 2 blocks (128KB with 64KB block_size) */
+    {
+        const size_t TWO = 128 * 1024;
+        memset(dec, 0, TWO);
+        zxc_compress_opts_t opts_b = {.level = ZXC_LEVEL_DEFAULT, .block_size = 64 * 1024,
+                                      .checksum_enabled = 1, .seekable = 0};
+        const int64_t b_csize = zxc_compress(src, TWO, dst, dst_cap, &opts_b);
+        if (b_csize <= 0) {
+            printf("Failed: 2-block 64KB compress (%lld)\n", (long long)b_csize);
+            free(src); free(dst); free(dec); return 0;
+        }
+        zxc_decompress_opts_t bd = {.checksum_enabled = 1};
+        const int64_t b_dsize = zxc_decompress(dst, (size_t)b_csize, dec, TWO, &bd);
+        if (b_dsize != (int64_t)TWO || memcmp(src, dec, TWO) != 0) {
+            printf("Failed: 2-block 64KB roundtrip (dsize=%lld)\n", (long long)b_dsize);
+            if (b_dsize == (int64_t)TWO) {
+                for (size_t i = 0; i < TWO; i++) {
+                    if (src[i] != dec[i]) {
+                        printf("  first diff at byte %zu: src=0x%02x dec=0x%02x\n",
+                               i, src[i], dec[i]);
+                        break;
+                    }
+                }
+            }
+            free(src); free(dst); free(dec); return 0;
+        }
+        printf("  sub-test B (2 blocks, 128KB): OK\n");
+    }
+    /* Sub-test C: full 256KB (4 blocks × 64KB) */
     {
         memset(dec, 0, SRC_SIZE);
         zxc_compress_opts_t opts_ns = {.level = ZXC_LEVEL_DEFAULT, .block_size = 64 * 1024,
@@ -2541,6 +2588,7 @@ int test_seekable_roundtrip() {
             free(src); free(dst); free(dec);
             return 0;
         }
+        printf("  sub-test C (4 blocks, 256KB): OK\n");
     }
 
     /* Re-compress with seekable=1 for the actual test */

--- a/tests/test_cli.sh
+++ b/tests/test_cli.sh
@@ -781,6 +781,19 @@ else
     log_fail "Block size 4M should be rejected (max is 2M)"
 fi
 
+# 24. Seekable Format (-S)
+echo "Testing Seekable Format (-S)..."
+rm -f "$TEST_FILE_XC_ARG" "$TEST_FILE_DEC_BASH"
+"$ZXC_BIN" -S -c "$TEST_FILE_ARG" > "$TEST_FILE_XC_ARG"
+if [ ! -s "$TEST_FILE_XC_BASH" ]; then
+    log_fail "Seekable compression failed"
+fi
+"$ZXC_BIN" -d -c "$TEST_FILE_XC_ARG" > "$TEST_FILE_DEC_BASH"
+if cmp -s "$TEST_FILE" "$TEST_FILE_DEC_BASH"; then
+    log_pass "Seekable flag (-S)"
+else
+    log_fail "Seekable decompression mismatch"
+fi
+
 echo "All tests passed!"
 exit 0
-

--- a/tests/test_cli.sh
+++ b/tests/test_cli.sh
@@ -861,6 +861,34 @@ done
 if [ "$SEEK_ALL_OK" -eq 1 ]; then
     log_pass "Seekable across all levels (1-5)"
 fi
+# 24.7 Seekable pipe round-trip (no fseeko - validates SEK skip on stdin)
+echo "  Testing seekable pipe round-trip..."
+cat "$TEST_FILE" | "$ZXC_BIN" -S -c | "$ZXC_BIN" -dc > "$TEST_DIR/seekable_pipe.dec"
+if cmp -s "$TEST_FILE" "$TEST_DIR/seekable_pipe.dec"; then
+    log_pass "Seekable pipe round-trip"
+else
+    log_fail "Seekable pipe round-trip content mismatch"
+fi
+
+# 24.8 Seekable + no-checksum
+echo "  Testing seekable + no-checksum (-S -N)..."
+"$ZXC_BIN" -3 -S -N -c -k "$TEST_FILE_ARG" > "$TEST_DIR/seekable_nochk.zxc"
+"$ZXC_BIN" -d -c "$TEST_DIR/seekable_nochk.zxc" > "$TEST_DIR/seekable_nochk.dec"
+if cmp -s "$TEST_FILE" "$TEST_DIR/seekable_nochk.dec"; then
+    log_pass "Seekable + no-checksum (-S -N)"
+else
+    log_fail "Seekable + no-checksum round-trip failed"
+fi
+
+# 24.9 List command on seekable archive
+echo "  Testing list command on seekable archive..."
+"$ZXC_BIN" -3 -S -C -k -f "$TEST_FILE_ARG"
+OUT=$("$ZXC_BIN" -l "$TEST_FILE_XC_ARG")
+if [[ "$OUT" == *"Compressed"* ]] && [[ "$OUT" == *"Uncompressed"* ]]; then
+    log_pass "List command on seekable archive"
+else
+    log_fail "List command on seekable archive failed"
+fi
 
 echo "All tests passed!"
 exit 0

--- a/tests/test_cli.sh
+++ b/tests/test_cli.sh
@@ -788,7 +788,7 @@ echo "Testing Seekable Format (-S)..."
 echo "  Testing basic seekable round-trip..."
 rm -f "$TEST_FILE_XC_ARG" "$TEST_FILE_DEC_BASH"
 "$ZXC_BIN" -S -c "$TEST_FILE_ARG" > "$TEST_FILE_XC_ARG"
-if [ ! -s "$TEST_FILE_XC_BASH" ]; then
+if [ ! -s "$TEST_FILE_XC_ARG" ]; then
     log_fail "Seekable compression failed"
 fi
 "$ZXC_BIN" -d -c "$TEST_FILE_XC_ARG" > "$TEST_FILE_DEC_BASH"

--- a/tests/test_cli.sh
+++ b/tests/test_cli.sh
@@ -783,6 +783,9 @@ fi
 
 # 24. Seekable Format (-S)
 echo "Testing Seekable Format (-S)..."
+
+# 24.1 Basic seekable round-trip
+echo "  Testing basic seekable round-trip..."
 rm -f "$TEST_FILE_XC_ARG" "$TEST_FILE_DEC_BASH"
 "$ZXC_BIN" -S -c "$TEST_FILE_ARG" > "$TEST_FILE_XC_ARG"
 if [ ! -s "$TEST_FILE_XC_BASH" ]; then
@@ -790,9 +793,73 @@ if [ ! -s "$TEST_FILE_XC_BASH" ]; then
 fi
 "$ZXC_BIN" -d -c "$TEST_FILE_XC_ARG" > "$TEST_FILE_DEC_BASH"
 if cmp -s "$TEST_FILE" "$TEST_FILE_DEC_BASH"; then
-    log_pass "Seekable flag (-S)"
+    log_pass "Seekable basic round-trip (-S)"
 else
     log_fail "Seekable decompression mismatch"
+fi
+
+# 24.2 Seekable file must be larger than normal (SEK block overhead)
+echo "  Testing seekable overhead..."
+"$ZXC_BIN" -3 -c -k "$TEST_FILE_ARG" > "$TEST_DIR/normal.zxc"
+"$ZXC_BIN" -3 -S -c -k "$TEST_FILE_ARG" > "$TEST_DIR/seekable.zxc"
+SIZE_NORMAL=$(wc -c < "$TEST_DIR/normal.zxc" | tr -d ' ')
+SIZE_SEEKABLE=$(wc -c < "$TEST_DIR/seekable.zxc" | tr -d ' ')
+if [ "$SIZE_SEEKABLE" -gt "$SIZE_NORMAL" ]; then
+    OVERHEAD=$((SIZE_SEEKABLE - SIZE_NORMAL))
+    log_pass "Seekable overhead verified (+${OVERHEAD} bytes)"
+else
+    log_fail "Seekable file should be larger than normal (SEK block missing?)"
+fi
+
+# 24.3 Seekable with small block size (many blocks = larger seek table)
+echo "  Testing seekable with small blocks (-B 4K)..."
+"$ZXC_BIN" -3 -S -B 4K -c -k "$TEST_FILE_ARG" > "$TEST_DIR/seekable_4k.zxc"
+"$ZXC_BIN" -d -c "$TEST_DIR/seekable_4k.zxc" > "$TEST_DIR/seekable_4k.dec"
+if cmp -s "$TEST_FILE" "$TEST_DIR/seekable_4k.dec"; then
+    SIZE_4K=$(wc -c < "$TEST_DIR/seekable_4k.zxc" | tr -d ' ')
+    # With 4K blocks, overhead should be larger than with default 256K blocks
+    if [ "$SIZE_4K" -gt "$SIZE_SEEKABLE" ]; then
+        log_pass "Seekable small blocks (-B 4K, Size: $SIZE_4K, more entries)"
+    else
+        log_pass "Seekable small blocks (-B 4K, Size: $SIZE_4K)"
+    fi
+else
+    log_fail "Seekable small blocks round-trip failed"
+fi
+
+# 24.4 Seekable with checksum
+echo "  Testing seekable + checksum (-S -C)..."
+"$ZXC_BIN" -3 -S -C -c -k "$TEST_FILE_ARG" > "$TEST_DIR/seekable_chk.zxc"
+"$ZXC_BIN" -d -c "$TEST_DIR/seekable_chk.zxc" > "$TEST_DIR/seekable_chk.dec"
+if cmp -s "$TEST_FILE" "$TEST_DIR/seekable_chk.dec"; then
+    log_pass "Seekable + checksum (-S -C)"
+else
+    log_fail "Seekable + checksum round-trip failed"
+fi
+
+# 24.5 Seekable with multi-threading
+echo "  Testing seekable + threads (-S -T2)..."
+"$ZXC_BIN" -3 -S -T2 -c -k "$TEST_FILE_ARG" > "$TEST_DIR/seekable_mt.zxc"
+"$ZXC_BIN" -d -c "$TEST_DIR/seekable_mt.zxc" > "$TEST_DIR/seekable_mt.dec"
+if cmp -s "$TEST_FILE" "$TEST_DIR/seekable_mt.dec"; then
+    log_pass "Seekable + multi-threading (-S -T2)"
+else
+    log_fail "Seekable + multi-threading round-trip failed"
+fi
+
+# 24.6 Seekable across all levels
+echo "  Testing seekable across all levels..."
+SEEK_ALL_OK=1
+for LEVEL in 1 2 3 4 5; do
+    "$ZXC_BIN" -$LEVEL -S -c -k "$TEST_FILE_ARG" > "$TEST_DIR/seekable_lvl${LEVEL}.zxc"
+    "$ZXC_BIN" -d -c "$TEST_DIR/seekable_lvl${LEVEL}.zxc" > "$TEST_DIR/seekable_lvl${LEVEL}.dec"
+    if ! cmp -s "$TEST_FILE" "$TEST_DIR/seekable_lvl${LEVEL}.dec"; then
+        SEEK_ALL_OK=0
+        log_fail "Seekable level $LEVEL round-trip failed"
+    fi
+done
+if [ "$SEEK_ALL_OK" -eq 1 ]; then
+    log_pass "Seekable across all levels (1-5)"
 fi
 
 echo "All tests passed!"

--- a/wrappers/go/README.md
+++ b/wrappers/go/README.md
@@ -5,11 +5,11 @@ Designed for *Write Once, Read Many* workloads like ML datasets, game assets, an
 
 ## Features
 
-- **Blazing fast decompression** — ZXC is specifically optimised for read-heavy workloads.
-- **Buffer API** — compress/decompress `[]byte` slices in a single call.
-- **Streaming API** — multi-threaded file compression/decompression.
-- **Functional options** — clean, composable configuration (`WithLevel`, `WithChecksum`, `WithThreads`).
-- **Typed errors** — sentinel error values for every ZXC error code.
+- **Blazing fast decompression** - ZXC is specifically optimised for read-heavy workloads.
+- **Buffer API** - compress/decompress `[]byte` slices in a single call.
+- **Streaming API** - multi-threaded file compression/decompression.
+- **Functional options** - clean, composable configuration (`WithLevel`, `WithChecksum`, `WithThreads`).
+- **Typed errors** - sentinel error values for every ZXC error code.
 
 ## Prerequisites
 
@@ -90,4 +90,4 @@ CGO_ENABLED=1 CGO_LDFLAGS="-L../../build -lzxc -lpthread" go test -bench=. -benc
 
 ## License
 
-BSD-3-Clause — see [LICENSE](../../LICENSE).
+BSD-3-Clause - see [LICENSE](../../LICENSE).

--- a/wrappers/go/README.md
+++ b/wrappers/go/README.md
@@ -50,7 +50,7 @@ func main() {
     if err != nil {
         log.Fatal(err)
     }
-    fmt.Printf("Compressed %d → %d bytes\n", len(data), len(compressed))
+    fmt.Printf("Compressed %d => %d bytes\n", len(data), len(compressed))
 
     // Decompress
     original, err := zxc.Decompress(compressed)

--- a/wrappers/go/zxc.go
+++ b/wrappers/go/zxc.go
@@ -178,6 +178,7 @@ func errorFromCode(code C.int64_t) error {
 type options struct {
 	level    Level
 	checksum bool
+	seekable bool
 	threads  int
 }
 
@@ -206,6 +207,11 @@ func WithChecksum(enabled bool) Option {
 // A value of 0 means auto-detect the CPU core count.
 func WithThreads(n int) Option {
 	return func(o *options) { o.threads = n }
+}
+
+// WithSeekable enables seek table generation for random-access decompression.
+func WithSeekable(enabled bool) Option {
+	return func(o *options) { o.seekable = enabled }
 }
 
 func applyOptions(opts []Option) options {
@@ -442,6 +448,9 @@ func CompressFile(input, output string, opts ...Option) (int64, error) {
 	copts.level = C.int(o.level)
 	if o.checksum {
 		copts.checksum_enabled = 1
+	}
+	if o.seekable {
+		copts.seekable = 1
 	}
 
 	result := C.zxc_stream_compress(cIn, cOut, &copts)

--- a/wrappers/go/zxc_dup_unix.go
+++ b/wrappers/go/zxc_dup_unix.go
@@ -13,7 +13,7 @@ import (
 	"runtime"
 )
 
-// C mode strings — allocated once, never freed (intentional; they live for the
+// C mode strings - allocated once, never freed (intentional; they live for the
 // process lifetime and avoid per-call C.CString/C.free overhead).
 var (
 	cModeRead  = C.CString("rb")

--- a/wrappers/go/zxc_dup_windows.go
+++ b/wrappers/go/zxc_dup_windows.go
@@ -14,7 +14,7 @@ import (
 	"runtime"
 )
 
-// C mode strings — allocated once, never freed (intentional; they live for the
+// C mode strings - allocated once, never freed (intentional; they live for the
 // process lifetime and avoid per-call C.CString/C.free overhead).
 var (
 	cModeRead  = C.CString("rb")

--- a/wrappers/nodejs/lib/index.d.ts
+++ b/wrappers/nodejs/lib/index.d.ts
@@ -50,6 +50,8 @@ export interface CompressOptions {
     level?: number;
     /** Enable checksum verification. Defaults to false. */
     checksum?: boolean;
+    /** Enable seek table for random-access decompression. Defaults to false. */
+    seekable?: boolean;
 }
 
 export interface DecompressOptions {

--- a/wrappers/nodejs/lib/index.js
+++ b/wrappers/nodejs/lib/index.js
@@ -66,6 +66,7 @@ function compressBound(inputSize) {
  * @param {object} [options] - Compression options.
  * @param {number} [options.level=LEVEL_DEFAULT] - Compression level (1-5).
  * @param {boolean} [options.checksum=false] - Enable checksum verification.
+ * @param {boolean} [options.seekable=false] - Enable seek table for random-access decompression.
  * @returns {Buffer} Compressed data.
  */
 function compress(data, options = {}) {
@@ -75,12 +76,13 @@ function compress(data, options = {}) {
 
     const level = options.level !== undefined ? options.level : LEVEL_DEFAULT;
     const checksum = options.checksum !== undefined ? options.checksum : false;
+    const seekable = options.seekable !== undefined ? options.seekable : false;
 
     if (data.length === 0 && !checksum) {
         return Buffer.alloc(0);
     }
 
-    return native.compress(data, level, checksum);
+    return native.compress(data, level, checksum, seekable);
 }
 
 /**

--- a/wrappers/nodejs/src/zxc_addon.cc
+++ b/wrappers/nodejs/src/zxc_addon.cc
@@ -29,7 +29,7 @@ static Napi::Value CompressBound(const Napi::CallbackInfo& info) {
 }
 
 // =============================================================================
-// compress(buffer: Buffer, level?: number, checksum?: boolean): Buffer
+// compress(buffer: Buffer, level?: number, checksum?: boolean, seekable?: boolean): Buffer
 // =============================================================================
 static Napi::Value Compress(const Napi::CallbackInfo& info) {
     Napi::Env env = info.Env();
@@ -54,6 +54,11 @@ static Napi::Value Compress(const Napi::CallbackInfo& info) {
         checksum = info[2].As<Napi::Boolean>().Value() ? 1 : 0;
     }
 
+    int seekable = 0;
+    if (info.Length() >= 4 && info[3].IsBoolean()) {
+        seekable = info[3].As<Napi::Boolean>().Value() ? 1 : 0;
+    }
+
     // Handle empty input
     if (src_size == 0 && !checksum) {
         return Napi::Buffer<uint8_t>::New(env, 0);
@@ -65,6 +70,7 @@ static Napi::Value Compress(const Napi::CallbackInfo& info) {
     zxc_compress_opts_t opts = {0};
     opts.level = level;
     opts.checksum_enabled = checksum;
+    opts.seekable = seekable;
 
     int64_t nwritten =
         zxc_compress(src, src_size, dst_buf.Data(), static_cast<size_t>(bound), &opts);

--- a/wrappers/python/README.md
+++ b/wrappers/python/README.md
@@ -5,10 +5,10 @@ Designed for *Write Once, Read Many* workloads like ML datasets, game assets, an
 
 ## Features
 
-- **Blazing fast decompression** — ZXC is specifically optimized for read-heavy workloads.
-- **Buffer protocol support** — works with `bytes`, `bytearray`, `memoryview`, and even NumPy arrays.
-- **Releases the GIL** during compression/decompression — true parallelism with Python threads.
-- **Stream helpers** — compress/decompress file-like objects.
+- **Blazing fast decompression** - ZXC is specifically optimized for read-heavy workloads.
+- **Buffer protocol support** - works with `bytes`, `bytearray`, `memoryview`, and even NumPy arrays.
+- **Releases the GIL** during compression/decompression - true parallelism with Python threads.
+- **Stream helpers** - compress/decompress file-like objects.
 
 ## Installation (from source)
 

--- a/wrappers/python/src/zxc/__init__.py
+++ b/wrappers/python/src/zxc/__init__.py
@@ -125,7 +125,7 @@ def decompress(data, decompress_size=None, checksum=False) -> bytes:
 
     return pyzxc_decompress(data, decompress_size, checksum)
 
-def stream_compress(src, dst, n_threads=0, level=LEVEL_DEFAULT, checksum=False) -> int:
+def stream_compress(src, dst, n_threads=0, level=LEVEL_DEFAULT, checksum=False, seekable=False) -> int:
     """Compress data from src to dst (file-like objects).
 
     Args:
@@ -134,6 +134,7 @@ def stream_compress(src, dst, n_threads=0, level=LEVEL_DEFAULT, checksum=False) 
         n_threads: Number of threads to use for compression. 0 uses default.
         level: Compression level. Use constants like LEVEL_FASTEST, LEVEL_DEFAULT, etc.
         checksum: If True, append a checksum for integrity verification.
+        seekable: If True, append a seek table for random-access decompression.
 
     Returns:
         Number of bytes written to `dst`.
@@ -158,7 +159,7 @@ def stream_compress(src, dst, n_threads=0, level=LEVEL_DEFAULT, checksum=False) 
     if hasattr(dst, "flush"):
         dst.flush()
 
-    return pyzxc_stream_compress(src, dst, n_threads, level, checksum)
+    return pyzxc_stream_compress(src, dst, n_threads, level, checksum, seekable)
 
 def stream_decompress(src, dst, n_threads=0, checksum=False) -> int:
     """Decompress data from src to dst (file-like objects).

--- a/wrappers/python/src/zxc/_zxc.c
+++ b/wrappers/python/src/zxc/_zxc.c
@@ -264,11 +264,12 @@ static PyObject* pyzxc_stream_compress(PyObject* self, PyObject* args, PyObject*
     int nthreads = 0;
     int level = ZXC_LEVEL_DEFAULT;
     int checksum = 0;
+    int seekable = 0;
 
-    static char* kwlist[] = {"src", "dst", "n_threads", "level", "checksum", NULL};
+    static char* kwlist[] = {"src", "dst", "n_threads", "level", "checksum", "seekable", NULL};
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OO|iip", kwlist, &src, &dst, &nthreads, &level,
-                                     &checksum)) {
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OO|iipp", kwlist, &src, &dst, &nthreads, &level,
+                                     &checksum, &seekable)) {
         return NULL;
     }
 
@@ -308,6 +309,7 @@ static PyObject* pyzxc_stream_compress(PyObject* self, PyObject* args, PyObject*
     scopts.n_threads = nthreads;
     scopts.level = level;
     scopts.checksum_enabled = checksum;
+    scopts.seekable = seekable;
 
     Py_BEGIN_ALLOW_THREADS nwritten = zxc_stream_compress(fsrc, fdst, &scopts);
     Py_END_ALLOW_THREADS

--- a/wrappers/rust/zxc-sys/build.rs
+++ b/wrappers/rust/zxc-sys/build.rs
@@ -163,6 +163,7 @@ fn main() {
         .file(src_lib.join("zxc_common.c"))
         .file(src_lib.join("zxc_driver.c"))
         .file(src_lib.join("zxc_dispatch.c"))
+        .file(src_lib.join("zxc_seekable.c"))
         .opt_level(3)
         .warnings(false)
         .flag_if_supported("-pthread");

--- a/wrappers/rust/zxc-sys/src/lib.rs
+++ b/wrappers/rust/zxc-sys/src/lib.rs
@@ -157,6 +157,8 @@ pub struct zxc_compress_opts_t {
     pub block_size: usize,
     /// 1 to enable per-block and global checksums, 0 to disable.
     pub checksum_enabled: c_int,
+    /// 1 to append a seek table for random-access decompression, 0 to disable.
+    pub seekable: c_int,
     /// Progress callback (NULL to disable).
     pub progress_cb: *const c_void,
     /// User context pointer passed to progress_cb.
@@ -170,6 +172,7 @@ impl Default for zxc_compress_opts_t {
             level: 0,
             block_size: 0,
             checksum_enabled: 0,
+            seekable: 0,
             progress_cb: std::ptr::null(),
             user_data: std::ptr::null_mut(),
         }

--- a/wrappers/rust/zxc/README.md
+++ b/wrappers/rust/zxc/README.md
@@ -1,6 +1,6 @@
 # zxc
 
-Safe Rust bindings to the **ZXC compression library** — a fast LZ77-based compressor optimized for high decompression speed.
+Safe Rust bindings to the **ZXC compression library** - a fast LZ77-based compressor optimized for high decompression speed.
 
 [![Crates.io](https://img.shields.io/crates/v/zxc.svg)](https://crates.io/crates/zxc)
 [![Documentation](https://docs.rs/zxc/badge.svg)](https://docs.rs/zxc)
@@ -88,4 +88,4 @@ if let Some(size) = decompressed_size(&compressed) {
 
 ## License
 
-BSD-3-Clause — see [LICENSE](../../LICENSE) for details.
+BSD-3-Clause - see [LICENSE](../../LICENSE) for details.

--- a/wrappers/rust/zxc/src/lib.rs
+++ b/wrappers/rust/zxc/src/lib.rs
@@ -317,6 +317,7 @@ pub fn compress(data: &[u8], level: Level, checksum: Option<bool>) -> Result<Vec
     let opts = CompressOptions {
         level,
         checksum: checksum.unwrap_or(false),
+        seekable: false,
     };
     compress_with_options(data, &opts)
 }

--- a/wrappers/rust/zxc/src/lib.rs
+++ b/wrappers/rust/zxc/src/lib.rs
@@ -212,6 +212,9 @@ pub struct CompressOptions {
 
     /// Enable checksum for data integrity (default: `true`)
     pub checksum: bool,
+
+    /// Enable seek table for random-access decompression (default: `false`)
+    pub seekable: bool,
 }
 
 impl Default for CompressOptions {
@@ -219,6 +222,7 @@ impl Default for CompressOptions {
         Self {
             level: Level::Default,
             checksum: true,
+            seekable: false,
         }
     }
 }
@@ -235,6 +239,12 @@ impl CompressOptions {
     /// Disable checksum computation for faster compression.
     pub fn without_checksum(mut self) -> Self {
         self.checksum = false;
+        self
+    }
+
+    /// Enable seek table for random-access decompression.
+    pub fn with_seekable(mut self) -> Self {
+        self.seekable = true;
         self
     }
 }
@@ -356,6 +366,7 @@ unsafe fn impl_compress(
         let copts = zxc_sys::zxc_compress_opts_t {
             level: options.level as i32,
             checksum_enabled: options.checksum as i32,
+            seekable: options.seekable as i32,
             ..Default::default()
         };
         zxc_sys::zxc_compress(
@@ -562,6 +573,8 @@ pub struct StreamCompressOptions {
     pub threads: Option<usize>,
     /// Enable checksum for data integrity (default: `true`)
     pub checksum: bool,
+    /// Enable seek table for random-access decompression (default: `false`)
+    pub seekable: bool,
 }
 
 impl Default for StreamCompressOptions {
@@ -570,6 +583,7 @@ impl Default for StreamCompressOptions {
             level: Level::Default,
             threads: None,
             checksum: true,
+            seekable: false,
         }
     }
 }
@@ -592,6 +606,12 @@ impl StreamCompressOptions {
     /// Disable checksum computation.
     pub fn without_checksum(mut self) -> Self {
         self.checksum = false;
+        self
+    }
+
+    /// Enable seek table for random-access decompression.
+    pub fn with_seekable(mut self) -> Self {
+        self.seekable = true;
         self
     }
 }

--- a/wrappers/wasm/test.mjs
+++ b/wrappers/wasm/test.mjs
@@ -136,9 +136,9 @@ async function main() {
             const dstPtr = Module._malloc(bound);
             Module.HEAPU8.set(input, srcPtr);
 
-            // Build opts struct: {n_threads=0, level, block_size=0, checksum=1, ...}
-            const optsPtr = Module._malloc(24);
-            for (let i = 0; i < 24; i++) Module.HEAPU8[optsPtr + i] = 0;
+            // Build opts struct: {n_threads=0, level, block_size=0, checksum=1, seekable=0, ...}
+            const optsPtr = Module._malloc(28);
+            for (let i = 0; i < 28; i++) Module.HEAPU8[optsPtr + i] = 0;
             Module.HEAP32[(optsPtr >> 2) + 1] = level;  // level
             Module.HEAP32[(optsPtr >> 2) + 3] = 1;      // checksum_enabled
 

--- a/wrappers/wasm/zxc_wasm.js
+++ b/wrappers/wasm/zxc_wasm.js
@@ -57,11 +57,12 @@ export default async function createZXC(moduleOverrides) {
     const _free   = Module._free;
 
     // --- Options struct layout -----------------------------------------------
-    // zxc_compress_opts_t:
+    // zxc_compress_opts_t (WASM32 layout):
     //   int n_threads (4)  | int level (4)  | size_t block_size (4 in wasm32)
-    //   int checksum_enabled (4) | ptr progress_cb (4) | ptr user_data (4)
-    // Total: 24 bytes in WASM32
-    const COMPRESS_OPTS_SIZE = 24;
+    //   int checksum_enabled (4) | int seekable (4)
+    //   ptr progress_cb (4) | ptr user_data (4)
+    // Total: 28 bytes in WASM32
+    const COMPRESS_OPTS_SIZE = 28;
 
     // zxc_decompress_opts_t:
     //   int n_threads (4) | int checksum_enabled (4) | ptr progress_cb (4) | ptr user_data (4)
@@ -72,7 +73,7 @@ export default async function createZXC(moduleOverrides) {
      * Write a zxc_compress_opts_t struct into WASM memory.
      * @returns {number} Pointer to the struct (caller must free).
      */
-    function _writeCompressOpts(level, checksum) {
+    function _writeCompressOpts(level, checksum, seekable) {
         const ptr = _malloc(COMPRESS_OPTS_SIZE);
         // Zero-fill first
         for (let i = 0; i < COMPRESS_OPTS_SIZE; i++) {
@@ -86,7 +87,9 @@ export default async function createZXC(moduleOverrides) {
         Module.HEAPU32[(ptr >> 2) + 2] = 0;
         // checksum_enabled (offset 12)
         Module.HEAP32[(ptr >> 2) + 3] = checksum ? 1 : 0;
-        // progress_cb = NULL (offset 16), user_data = NULL (offset 20)
+        // seekable (offset 16)
+        Module.HEAP32[(ptr >> 2) + 4] = seekable ? 1 : 0;
+        // progress_cb = NULL (offset 20), user_data = NULL (offset 24)
         return ptr;
     }
 
@@ -116,19 +119,21 @@ export default async function createZXC(moduleOverrides) {
      * @param {object} [opts] - Options.
      * @param {number} [opts.level=3] - Compression level (1-5).
      * @param {boolean} [opts.checksum=false] - Enable checksums.
+     * @param {boolean} [opts.seekable=false] - Append seek table for random-access.
      * @returns {Uint8Array} Compressed data.
      * @throws {Error} On compression failure.
      */
     function compress(data, opts) {
         const level    = (opts && opts.level)    || _default_level();
         const checksum = (opts && opts.checksum) || false;
+        const seekable = (opts && opts.seekable) || false;
 
         const bound = _compress_bound(data.length);
         if (bound === 0) throw new Error('ZXC: compress_bound returned 0');
 
         const srcPtr = _malloc(data.length);
         const dstPtr = _malloc(bound);
-        const optsPtr = _writeCompressOpts(level, checksum);
+        const optsPtr = _writeCompressOpts(level, checksum, seekable);
 
         try {
             Module.HEAPU8.set(data, srcPtr);
@@ -216,8 +221,9 @@ export default async function createZXC(moduleOverrides) {
     function createCompressContext(opts) {
         const level    = (opts && opts.level)    || _default_level();
         const checksum = (opts && opts.checksum) || false;
+        const seekable = (opts && opts.seekable) || false;
 
-        const optsPtr = _writeCompressOpts(level, checksum);
+        const optsPtr = _writeCompressOpts(level, checksum, seekable);
         const cctx = _create_cctx(optsPtr);
         _free(optsPtr);
 


### PR DESCRIPTION
Introduces a major new feature: **seekable ZXC archives**. This enhancement transforms ZXC from a purely sequential stream format into a random-access volume.

**Key Changes:**
- **Seekable Archive Format:** Implements an optional `SEK` block (type 254) appended after the `EOF` block and before the file footer. This block contains a table of compressed block sizes, enabling `O(1)` random access to any block within the archive.
- **Random-Access Decompression API:** Introduces a new API in `zxc_seekable.h` that allows opening seekable archives and decompressing arbitrary byte ranges.
- **Multi-threaded Support:** Provides a multi-threaded variant for parallel decompression of blocks, leveraging `pread` for efficient concurrent I/O.
- **CLI Integration:** Adds a new command-line option (`-S`, `--seekable`) to the `zxc` tool, allowing users to create seekable archives during compression.
- **Documentation:** Updates the format specification, whitepaper, and man page to thoroughly describe the new format, its benefits, and usage.
- **ABI Version Bump:** Increments `ZXC_SOVERSION` to 3, reflecting the significant changes to the library's functionality and format.

This feature is ideal for use cases such as compressed filesystems, game asset archives, and big data analysis, where quick access to specific data ranges without decompressing the entire file is crucial. The implementation includes robust error handling, overflow guards, and comprehensive test coverage.