### PR TITLE
Adds configurable checksum algorithm support

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -191,6 +191,8 @@ typedef struct {
     int    level;             // Compression level 1–5 (0 = default).
     size_t block_size;        // Block size in bytes (0 = 256 KB default).
     int    checksum_enabled;  // 1 = enable checksums, 0 = disable.
+    int    checksum_algo;     // Checksum algorithm (0 = RapidHash default).
+    int    seekable;          // 1 = append seek table for random access.
     zxc_progress_callback_t progress_cb;  // Optional callback (NULL to disable).
     void*  user_data;                     // Passed through to progress_cb.
 } zxc_compress_opts_t;
@@ -469,7 +471,8 @@ ZXC_EXPORT int zxc_cctx_init(
     size_t      chunk_size,
     int         mode,              // 1 = compression, 0 = decompression
     int         level,
-    int         checksum_enabled
+    int         checksum_enabled,
+    int         checksum_algo      // 0 = ZXC_CHECKSUM_RAPIDHASH (default)
 );
 ```
 
@@ -492,7 +495,8 @@ ZXC_EXPORT int zxc_write_file_header(
     uint8_t* dst,
     size_t   dst_capacity,
     size_t   chunk_size,
-    int      has_checksum
+    int      has_checksum,
+    int      checksum_algo         // 0 = ZXC_CHECKSUM_RAPIDHASH (default)
 );
 ```
 
@@ -506,7 +510,8 @@ ZXC_EXPORT int zxc_read_file_header(
     const uint8_t* src,
     size_t         src_size,
     size_t*        out_block_size,    // optional
-    int*           out_has_checksum   // optional
+    int*           out_has_checksum,  // optional
+    int*           out_checksum_algo  // optional
 );
 ```
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -472,7 +472,7 @@ ZXC_EXPORT int zxc_cctx_init(
     int         mode,              // 1 = compression, 0 = decompression
     int         level,
     int         checksum_enabled,
-    int         checksum_algo      // 0 = ZXC_CHECKSUM_RAPIDHASH (default)
+    int         checksum_algo      // 0 = ZXC_CHECKSUM_ALGO_RAPIDHASH (default)
 );
 ```
 
@@ -496,7 +496,7 @@ ZXC_EXPORT int zxc_write_file_header(
     size_t   dst_capacity,
     size_t   chunk_size,
     int      has_checksum,
-    int      checksum_algo         // 0 = ZXC_CHECKSUM_RAPIDHASH (default)
+    int      checksum_algo         // 0 = ZXC_CHECKSUM_ALGO_RAPIDHASH (default)
 );
 ```
 

--- a/include/zxc_sans_io.h
+++ b/include/zxc_sans_io.h
@@ -153,7 +153,9 @@ ZXC_EXPORT void zxc_cctx_free(zxc_cctx_t* ctx);
  * @param[in] checksum_algo Checksum algorithm ID written into bits 0-3 of the Flags byte
  *                          (see @ref zxc_checksum_algo_t). Ignored when @p has_checksum is 0.
  * @return The number of bytes written (ZXC_FILE_HEADER_SIZE) on success,
- *         or ZXC_ERROR_DST_TOO_SMALL if the destination capacity is insufficient.
+ *         ZXC_ERROR_DST_TOO_SMALL if the destination capacity is insufficient,
+ *         or ZXC_ERROR_BAD_HEADER if @p has_checksum is set and @p checksum_algo
+ *         is not a supported algorithm.
  */
 ZXC_EXPORT int zxc_write_file_header(uint8_t* dst, const size_t dst_capacity,
                                      const size_t chunk_size, const int has_checksum,

--- a/include/zxc_sans_io.h
+++ b/include/zxc_sans_io.h
@@ -98,6 +98,7 @@ typedef struct {
     uint8_t* work_buf;     /**< Padded scratch buffer for buffer-API decompression. */
     size_t work_buf_cap;   /**< Capacity of the work buffer. */
     int checksum_enabled;  /**< 1 if checksum calculation/verification is enabled. */
+    int checksum_algo;     /**< Checksum algorithm ID (see @ref zxc_checksum_algo_t). */
     int compression_level; /**< Compression level. */
 
     /* Block-size derived parameters (computed once at init). */
@@ -119,11 +120,13 @@ typedef struct {
  * @param[in] mode The operation mode (1 for compression, 0 for decompression).
  * @param[in] level The desired compression level to be stored in the context.
  * @param[in] checksum_enabled 1 to enable checksums, 0 to disable.
+ * @param[in] checksum_algo    Checksum algorithm ID (see @ref zxc_checksum_algo_t).
+ *                             Pass 0 for the default (RapidHash).
  * @return ZXC_OK on success, or a negative zxc_error_t code (e.g., ZXC_ERROR_MEMORY) if memory
  * allocation fails.
  */
 ZXC_EXPORT int zxc_cctx_init(zxc_cctx_t* ctx, const size_t chunk_size, const int mode,
-                             const int level, const int checksum_enabled);
+                             const int level, const int checksum_enabled, const int checksum_algo);
 
 /**
  * @brief Frees resources associated with a ZXC compression context.
@@ -147,11 +150,14 @@ ZXC_EXPORT void zxc_cctx_free(zxc_cctx_t* ctx);
  * @param[in] dst_capacity The total capacity of the destination buffer in bytes.
  * @param[in] chunk_size    The block size to encode in the header.
  * @param[in] has_checksum  Flag indicating whether the checksum bit should be set.
+ * @param[in] checksum_algo Checksum algorithm ID written into bits 0-3 of the Flags byte
+ *                          (see @ref zxc_checksum_algo_t). Ignored when @p has_checksum is 0.
  * @return The number of bytes written (ZXC_FILE_HEADER_SIZE) on success,
  *         or ZXC_ERROR_DST_TOO_SMALL if the destination capacity is insufficient.
  */
 ZXC_EXPORT int zxc_write_file_header(uint8_t* dst, const size_t dst_capacity,
-                                     const size_t chunk_size, const int has_checksum);
+                                     const size_t chunk_size, const int has_checksum,
+                                     const int checksum_algo);
 
 /**
  * @brief Validates and reads the ZXC file header from a source buffer.
@@ -164,11 +170,15 @@ ZXC_EXPORT int zxc_write_file_header(uint8_t* dst, const size_t dst_capacity,
  * @param[in] src_size Size of the source buffer in bytes.
  * @param[out] out_block_size    Optional pointer to receive the recommended block size.
  * @param[out] out_has_checksum  Optional pointer to receive the checksum flag.
+ * @param[out] out_checksum_algo Optional pointer to receive the checksum algorithm ID
+ *                               (see @ref zxc_checksum_algo_t). Always set when non-NULL,
+ *                               even when @p out_has_checksum is 0.
  * @return ZXC_OK on success, or a negative error code (e.g., ZXC_ERROR_SRC_TOO_SMALL,
  * ZXC_ERROR_BAD_MAGIC, ZXC_ERROR_BAD_VERSION).
  */
 ZXC_EXPORT int zxc_read_file_header(const uint8_t* src, const size_t src_size,
-                                    size_t* out_block_size, int* out_has_checksum);
+                                    size_t* out_block_size, int* out_has_checksum,
+                                    int* out_checksum_algo);
 
 /**
  * @struct zxc_block_header_t

--- a/include/zxc_stream.h
+++ b/include/zxc_stream.h
@@ -74,6 +74,8 @@ typedef struct {
     size_t block_size; /**< Block size in bytes (0 = default ZXC_BLOCK_SIZE_DEFAULT). Must be power
                           of 2, [4KB - 2MB]. */
     int checksum_enabled; /**< 1 to enable per-block and global checksums, 0 to disable. */
+    int checksum_algo;    /**< Checksum algorithm (see @ref zxc_checksum_algo_t).
+                             0 = ZXC_CHECKSUM_ALGO_RAPIDHASH (default, zero-init safe). */
     int seekable;         /**< 1 to append a seek table for random-access decompression. */
     zxc_progress_callback_t progress_cb; /**< Optional progress callback (NULL to disable). */
     void* user_data;                     /**< User context pointer passed to progress_cb. */

--- a/src/lib/zxc_common.c
+++ b/src/lib/zxc_common.c
@@ -73,13 +73,12 @@ void zxc_aligned_free(void* ptr) {
  */
 int zxc_cctx_init(zxc_cctx_t* RESTRICT ctx, const size_t chunk_size, const int mode,
                   const int level, const int checksum_enabled, const int checksum_algo) {
-    (void)checksum_algo;
-
     ZXC_MEMSET(ctx, 0, sizeof(zxc_cctx_t));
 
     ctx->checksum_enabled = checksum_enabled;
-    /* Only RapidHash is implemented; silently clamp to the sole valid value. */
-    ctx->checksum_algo = ZXC_CHECKSUM_ALGO_RAPIDHASH;
+    /* Only RapidHash (0) is implemented; reject unsupported algorithms. */
+    if (UNLIKELY(checksum_algo != ZXC_CHECKSUM_ALGO_RAPIDHASH)) return ZXC_ERROR_BAD_HEADER;
+    ctx->checksum_algo = checksum_algo;
 
     /* Compute block-size derived parameters. */
     ctx->chunk_size = chunk_size;
@@ -201,8 +200,9 @@ void zxc_cctx_free(zxc_cctx_t* ctx) {
 int zxc_write_file_header(uint8_t* RESTRICT dst, const size_t dst_capacity, const size_t chunk_size,
                           const int has_checksum, const int checksum_algo) {
     if (UNLIKELY(dst_capacity < ZXC_FILE_HEADER_SIZE)) return ZXC_ERROR_DST_TOO_SMALL;
-    /* Only RapidHash is supported; reject anything else early. */
-    if (UNLIKELY(checksum_algo != ZXC_CHECKSUM_ALGO_RAPIDHASH)) return ZXC_ERROR_BAD_HEADER;
+    /* Only validate the checksum algorithm when checksums are enabled. */
+    if (UNLIKELY(has_checksum && checksum_algo != ZXC_CHECKSUM_ALGO_RAPIDHASH))
+        return ZXC_ERROR_BAD_HEADER;
 
     zxc_store_le32(dst, ZXC_MAGIC_WORD);
     dst[4] = ZXC_FILE_FORMAT_VERSION;

--- a/src/lib/zxc_common.c
+++ b/src/lib/zxc_common.c
@@ -73,10 +73,13 @@ void zxc_aligned_free(void* ptr) {
  */
 int zxc_cctx_init(zxc_cctx_t* RESTRICT ctx, const size_t chunk_size, const int mode,
                   const int level, const int checksum_enabled, const int checksum_algo) {
+    (void)checksum_algo;
+
     ZXC_MEMSET(ctx, 0, sizeof(zxc_cctx_t));
 
     ctx->checksum_enabled = checksum_enabled;
-    ctx->checksum_algo = checksum_algo;
+    /* Only RapidHash is implemented; silently clamp to the sole valid value. */
+    ctx->checksum_algo = ZXC_CHECKSUM_ALGO_RAPIDHASH;
 
     /* Compute block-size derived parameters. */
     ctx->chunk_size = chunk_size;
@@ -198,6 +201,8 @@ void zxc_cctx_free(zxc_cctx_t* ctx) {
 int zxc_write_file_header(uint8_t* RESTRICT dst, const size_t dst_capacity, const size_t chunk_size,
                           const int has_checksum, const int checksum_algo) {
     if (UNLIKELY(dst_capacity < ZXC_FILE_HEADER_SIZE)) return ZXC_ERROR_DST_TOO_SMALL;
+    /* Only RapidHash is supported; reject anything else early. */
+    if (UNLIKELY(checksum_algo != ZXC_CHECKSUM_ALGO_RAPIDHASH)) return ZXC_ERROR_BAD_HEADER;
 
     zxc_store_le32(dst, ZXC_MAGIC_WORD);
     dst[4] = ZXC_FILE_FORMAT_VERSION;
@@ -263,8 +268,14 @@ int zxc_read_file_header(const uint8_t* RESTRICT src, const size_t src_size,
         *out_block_size = block_size;
     }
     // Flags are at offset 6
-    if (out_has_checksum) *out_has_checksum = (src[6] & ZXC_FILE_FLAG_HAS_CHECKSUM) ? 1 : 0;
-    if (out_checksum_algo) *out_checksum_algo = (int)(src[6] & ZXC_FILE_CHECKSUM_ALGO_MASK);
+    const int has_chk = (src[6] & ZXC_FILE_FLAG_HAS_CHECKSUM) ? 1 : 0;
+    const int algo_id = (int)(src[6] & ZXC_FILE_CHECKSUM_ALGO_MASK);
+
+    /* Reject files that require a checksum algorithm we do not implement. */
+    if (UNLIKELY(has_chk && algo_id != ZXC_CHECKSUM_ALGO_RAPIDHASH)) return ZXC_ERROR_BAD_HEADER;
+
+    if (out_has_checksum) *out_has_checksum = has_chk;
+    if (out_checksum_algo) *out_checksum_algo = algo_id;
 
     return ZXC_OK;
 }

--- a/src/lib/zxc_common.c
+++ b/src/lib/zxc_common.c
@@ -72,10 +72,11 @@ void zxc_aligned_free(void* ptr) {
  * @return @ref ZXC_OK on success, or @ref ZXC_ERROR_MEMORY on allocation failure.
  */
 int zxc_cctx_init(zxc_cctx_t* RESTRICT ctx, const size_t chunk_size, const int mode,
-                  const int level, const int checksum_enabled) {
+                  const int level, const int checksum_enabled, const int checksum_algo) {
     ZXC_MEMSET(ctx, 0, sizeof(zxc_cctx_t));
 
     ctx->checksum_enabled = checksum_enabled;
+    ctx->checksum_algo = checksum_algo;
 
     /* Compute block-size derived parameters. */
     ctx->chunk_size = chunk_size;
@@ -195,7 +196,7 @@ void zxc_cctx_free(zxc_cctx_t* ctx) {
  *         or a negative @ref zxc_error_t code.
  */
 int zxc_write_file_header(uint8_t* RESTRICT dst, const size_t dst_capacity, const size_t chunk_size,
-                          const int has_checksum) {
+                          const int has_checksum, const int checksum_algo) {
     if (UNLIKELY(dst_capacity < ZXC_FILE_HEADER_SIZE)) return ZXC_ERROR_DST_TOO_SMALL;
 
     zxc_store_le32(dst, ZXC_MAGIC_WORD);
@@ -205,7 +206,10 @@ int zxc_write_file_header(uint8_t* RESTRICT dst, const size_t dst_capacity, cons
     dst[5] = (uint8_t)zxc_log2_u32((uint32_t)chunk_size);
 
     // Flags are at offset 6
-    dst[6] = has_checksum ? (ZXC_FILE_FLAG_HAS_CHECKSUM | ZXC_CHECKSUM_RAPIDHASH) : 0;
+    dst[6] =
+        has_checksum
+            ? (ZXC_FILE_FLAG_HAS_CHECKSUM | ((uint8_t)checksum_algo & ZXC_FILE_CHECKSUM_ALGO_MASK))
+            : 0U;
 
     // Bytes 7-13: Reserved (must be 0, 7 bytes)
     ZXC_MEMSET(dst + 7, 0, 7);
@@ -231,7 +235,8 @@ int zxc_write_file_header(uint8_t* RESTRICT dst, const size_t dst_capacity, cons
  * @return @ref ZXC_OK on success, or a negative @ref zxc_error_t code.
  */
 int zxc_read_file_header(const uint8_t* RESTRICT src, const size_t src_size,
-                         size_t* RESTRICT out_block_size, int* RESTRICT out_has_checksum) {
+                         size_t* RESTRICT out_block_size, int* RESTRICT out_has_checksum,
+                         int* RESTRICT out_checksum_algo) {
     if (UNLIKELY(src_size < ZXC_FILE_HEADER_SIZE)) return ZXC_ERROR_SRC_TOO_SMALL;
     if (UNLIKELY(zxc_le32(src) != ZXC_MAGIC_WORD)) return ZXC_ERROR_BAD_MAGIC;
     if (UNLIKELY(src[4] != ZXC_FILE_FORMAT_VERSION)) return ZXC_ERROR_BAD_VERSION;
@@ -259,6 +264,7 @@ int zxc_read_file_header(const uint8_t* RESTRICT src, const size_t src_size,
     }
     // Flags are at offset 6
     if (out_has_checksum) *out_has_checksum = (src[6] & ZXC_FILE_FLAG_HAS_CHECKSUM) ? 1 : 0;
+    if (out_checksum_algo) *out_checksum_algo = (int)(src[6] & ZXC_FILE_CHECKSUM_ALGO_MASK);
 
     return ZXC_OK;
 }

--- a/src/lib/zxc_compress.c
+++ b/src/lib/zxc_compress.c
@@ -1479,7 +1479,7 @@ int zxc_compress_chunk_wrapper(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRICT
 
         uint32_t payload_sz = (uint32_t)(w - ZXC_BLOCK_HEADER_SIZE);
         uint32_t crc =
-            zxc_checksum(dst + ZXC_BLOCK_HEADER_SIZE, payload_sz, ZXC_CHECKSUM_RAPIDHASH);
+            zxc_checksum(dst + ZXC_BLOCK_HEADER_SIZE, payload_sz, (uint8_t)ctx->checksum_algo);
         zxc_store_le32(dst + w, crc);
         w += ZXC_BLOCK_CHECKSUM_SIZE;
     }

--- a/src/lib/zxc_decompress.c
+++ b/src/lib/zxc_decompress.c
@@ -1569,7 +1569,7 @@ int zxc_decompress_chunk_wrapper(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRI
 
     if (has_crc) {
         const uint32_t stored = zxc_le32(data + comp_sz);
-        const uint32_t calc = zxc_checksum(data, comp_sz, ZXC_CHECKSUM_RAPIDHASH);
+        const uint32_t calc = zxc_checksum(data, comp_sz, (uint8_t)ctx->checksum_algo);
         if (UNLIKELY(stored != calc)) return ZXC_ERROR_BAD_CHECKSUM;
     }
 

--- a/src/lib/zxc_dispatch.c
+++ b/src/lib/zxc_dispatch.c
@@ -348,6 +348,8 @@ int64_t zxc_compress(const void* RESTRICT src, const size_t src_size, void* REST
     if (UNLIKELY(!src || !dst || src_size == 0 || dst_capacity == 0)) return ZXC_ERROR_NULL_INPUT;
 
     const int checksum_enabled = opts ? opts->checksum_enabled : 0;
+    const int checksum_algo =
+        (opts && opts->checksum_algo) ? opts->checksum_algo : ZXC_CHECKSUM_RAPIDHASH;
     const int seekable = opts ? opts->seekable : 0;
     const int level = (opts && opts->level > 0) ? opts->level : ZXC_LEVEL_DEFAULT;
     const size_t block_size =
@@ -362,14 +364,13 @@ int64_t zxc_compress(const void* RESTRICT src, const size_t src_size, void* REST
     uint32_t global_hash = 0;
     zxc_cctx_t ctx;
 
-    // LCOV_EXCL_START
-    if (UNLIKELY(zxc_cctx_init(&ctx, block_size, 1, level, checksum_enabled) != ZXC_OK))
+    if (UNLIKELY(zxc_cctx_init(&ctx, block_size, 1, level, checksum_enabled, checksum_algo) !=
+                 ZXC_OK))
         return ZXC_ERROR_MEMORY;
     // LCOV_EXCL_STOP
 
-    const int h_val =
-        zxc_write_file_header(op, (size_t)(op_end - op), block_size, checksum_enabled);
-    // LCOV_EXCL_START
+    const int h_val = zxc_write_file_header(op, (size_t)(op_end - op), block_size, checksum_enabled,
+                                            checksum_algo);
     if (UNLIKELY(h_val < 0)) {
         zxc_cctx_free(&ctx);
         return h_val;
@@ -507,11 +508,13 @@ int64_t zxc_decompress(const void* RESTRICT src, const size_t src_size, void* RE
     zxc_cctx_t ctx;
 
     int file_has_checksums = 0;
+    int file_checksum_algo = ZXC_CHECKSUM_RAPIDHASH;
     // File header verification and context initialization
-    if (UNLIKELY(zxc_read_file_header(ip, src_size, &runtime_chunk_size, &file_has_checksums) !=
-                     ZXC_OK ||
+    if (UNLIKELY(zxc_read_file_header(ip, src_size, &runtime_chunk_size, &file_has_checksums,
+                                      &file_checksum_algo) != ZXC_OK ||
                  zxc_cctx_init(&ctx, runtime_chunk_size, 0, 0,
-                               file_has_checksums && checksum_enabled) != ZXC_OK)) {
+                               file_has_checksums && checksum_enabled,
+                               file_checksum_algo) != ZXC_OK)) {
         return ZXC_ERROR_BAD_HEADER;
     }
 
@@ -651,6 +654,7 @@ struct zxc_cctx_s {
     /* Sticky options (remembered from create or last compress call). */
     int stored_level;
     int stored_checksum;
+    int stored_algo;
     size_t stored_block_size;
 };
 
@@ -663,12 +667,14 @@ zxc_cctx* zxc_create_cctx(const zxc_compress_opts_t* opts) {
     cctx->stored_block_size =
         (opts && opts->block_size > 0) ? opts->block_size : ZXC_BLOCK_SIZE_DEFAULT;
     cctx->stored_checksum = opts ? opts->checksum_enabled : 0;
+    cctx->stored_algo =
+        (opts && opts->checksum_algo) ? opts->checksum_algo : ZXC_CHECKSUM_RAPIDHASH;
 
     if (opts) {
         // LCOV_EXCL_START
         if (UNLIKELY(!zxc_validate_block_size(cctx->stored_block_size) ||
                      zxc_cctx_init(&cctx->inner, cctx->stored_block_size, 1, cctx->stored_level,
-                                   cctx->stored_checksum) != ZXC_OK)) {
+                                   cctx->stored_checksum, cctx->stored_algo) != ZXC_OK)) {
             free(cctx);
             return NULL;
         }
@@ -693,6 +699,8 @@ int64_t zxc_compress_cctx(zxc_cctx* cctx, const void* RESTRICT src, const size_t
     if (UNLIKELY(!src || !dst || src_size == 0 || dst_capacity == 0)) return ZXC_ERROR_NULL_INPUT;
 
     const int checksum_enabled = opts ? opts->checksum_enabled : cctx->stored_checksum;
+    const int checksum_algo =
+        (opts && opts->checksum_algo) ? opts->checksum_algo : cctx->stored_algo;
     const int level = (opts && opts->level > 0) ? opts->level : cctx->stored_level;
     const size_t block_size =
         (opts && opts->block_size > 0) ? opts->block_size : cctx->stored_block_size;
@@ -700,6 +708,7 @@ int64_t zxc_compress_cctx(zxc_cctx* cctx, const void* RESTRICT src, const size_t
     cctx->stored_level = level;
     cctx->stored_block_size = block_size;
     cctx->stored_checksum = checksum_enabled;
+    cctx->stored_algo = checksum_algo;
 
     if (UNLIKELY(!zxc_validate_block_size(block_size))) return ZXC_ERROR_BAD_BLOCK_SIZE;
 
@@ -709,8 +718,8 @@ int64_t zxc_compress_cctx(zxc_cctx* cctx, const void* RESTRICT src, const size_t
             zxc_cctx_free(&cctx->inner);
             cctx->initialized = 0;
         }
-        // LCOV_EXCL_START
-        if (UNLIKELY(zxc_cctx_init(&cctx->inner, block_size, 1, level, checksum_enabled) != ZXC_OK))
+        if (UNLIKELY(zxc_cctx_init(&cctx->inner, block_size, 1, level, checksum_enabled,
+                                   checksum_algo) != ZXC_OK))
             return ZXC_ERROR_MEMORY;
         // LCOV_EXCL_STOP
         cctx->last_block_size = block_size;
@@ -719,6 +728,7 @@ int64_t zxc_compress_cctx(zxc_cctx* cctx, const void* RESTRICT src, const size_t
         /* Same block_size: update level + checksum without realloc. */
         cctx->inner.compression_level = level;
         cctx->inner.checksum_enabled = checksum_enabled;
+        cctx->inner.checksum_algo = checksum_algo;
     }
 
     zxc_cctx_t* const ctx = &cctx->inner;
@@ -729,8 +739,8 @@ int64_t zxc_compress_cctx(zxc_cctx* cctx, const void* RESTRICT src, const size_t
     const uint8_t* const ip = (const uint8_t*)src;
     uint32_t global_hash = 0;
 
-    const int h_val =
-        zxc_write_file_header(op, (size_t)(op_end - op), block_size, checksum_enabled);
+    const int h_val = zxc_write_file_header(op, (size_t)(op_end - op), block_size, checksum_enabled,
+                                            checksum_algo);
     if (UNLIKELY(h_val < 0)) return h_val;  // LCOV_EXCL_LINE
     op += h_val;
 
@@ -806,9 +816,10 @@ int64_t zxc_decompress_dctx(zxc_dctx* dctx, const void* RESTRICT src, const size
     const uint8_t* const op_end = op + dst_capacity;
     size_t runtime_chunk_size = 0;
     int file_has_checksums = 0;
+    int file_checksum_algo = ZXC_CHECKSUM_RAPIDHASH;
 
-    if (UNLIKELY(zxc_read_file_header(ip, src_size, &runtime_chunk_size, &file_has_checksums) !=
-                 ZXC_OK))
+    if (UNLIKELY(zxc_read_file_header(ip, src_size, &runtime_chunk_size, &file_has_checksums,
+                                      &file_checksum_algo) != ZXC_OK))
         return ZXC_ERROR_BAD_HEADER;
 
     /* Re-init only when block size changed. */
@@ -819,13 +830,15 @@ int64_t zxc_decompress_dctx(zxc_dctx* dctx, const void* RESTRICT src, const size
         }
         // LCOV_EXCL_START
         if (UNLIKELY(zxc_cctx_init(&dctx->inner, runtime_chunk_size, 0, 0,
-                                   file_has_checksums && checksum_enabled) != ZXC_OK))
+                                   file_has_checksums && checksum_enabled,
+                                   file_checksum_algo) != ZXC_OK))
             return ZXC_ERROR_MEMORY;
         // LCOV_EXCL_STOP
         dctx->last_block_size = runtime_chunk_size;
         dctx->initialized = 1;
     } else {
         dctx->inner.checksum_enabled = file_has_checksums && checksum_enabled;
+        dctx->inner.checksum_algo = file_checksum_algo;
     }
 
     zxc_cctx_t* const ctx = &dctx->inner;
@@ -903,6 +916,8 @@ int64_t zxc_compress_block(zxc_cctx* cctx, const void* RESTRICT src, const size_
         return ZXC_ERROR_NULL_INPUT;
 
     const int checksum_enabled = opts ? opts->checksum_enabled : cctx->stored_checksum;
+    const int checksum_algo =
+        (opts && opts->checksum_algo) ? opts->checksum_algo : cctx->stored_algo;
     const int level = (opts && opts->level > 0) ? opts->level : cctx->stored_level;
     /* For block API, block_size == src_size (the caller compresses one block at a time). */
     const size_t block_size =
@@ -912,6 +927,7 @@ int64_t zxc_compress_block(zxc_cctx* cctx, const void* RESTRICT src, const size_
     cctx->stored_level = level;
     cctx->stored_block_size = effective_block_size;
     cctx->stored_checksum = checksum_enabled;
+    cctx->stored_algo = checksum_algo;
 
     /* Re-init only when block_size changed. */
     if (!cctx->initialized || cctx->last_block_size != effective_block_size) {
@@ -920,8 +936,8 @@ int64_t zxc_compress_block(zxc_cctx* cctx, const void* RESTRICT src, const size_
             cctx->initialized = 0;
         }
         // LCOV_EXCL_START
-        if (UNLIKELY(zxc_cctx_init(&cctx->inner, effective_block_size, 1, level,
-                                   checksum_enabled) != ZXC_OK))
+        if (UNLIKELY(zxc_cctx_init(&cctx->inner, effective_block_size, 1, level, checksum_enabled,
+                                   checksum_algo) != ZXC_OK))
             return ZXC_ERROR_MEMORY;
         // LCOV_EXCL_STOP
         cctx->last_block_size = effective_block_size;
@@ -929,6 +945,7 @@ int64_t zxc_compress_block(zxc_cctx* cctx, const void* RESTRICT src, const size_
     } else {
         cctx->inner.compression_level = level;
         cctx->inner.checksum_enabled = checksum_enabled;
+        cctx->inner.checksum_algo = checksum_algo;
     }
 
     const int res = zxc_compress_chunk_wrapper(&cctx->inner, (const uint8_t*)src, src_size,
@@ -956,7 +973,8 @@ int64_t zxc_decompress_block(zxc_dctx* dctx, const void* RESTRICT src, const siz
             dctx->initialized = 0;
         }
         // LCOV_EXCL_START
-        if (UNLIKELY(zxc_cctx_init(&dctx->inner, block_size, 0, 0, checksum_enabled) != ZXC_OK))
+        /* Block API has no file header to read algo from; default to rapidhash. */
+        if (UNLIKELY(zxc_cctx_init(&dctx->inner, block_size, 0, 0, checksum_enabled, 0) != ZXC_OK))
             return ZXC_ERROR_MEMORY;
         // LCOV_EXCL_STOP
         dctx->last_block_size = block_size;

--- a/src/lib/zxc_dispatch.c
+++ b/src/lib/zxc_dispatch.c
@@ -349,7 +349,7 @@ int64_t zxc_compress(const void* RESTRICT src, const size_t src_size, void* REST
 
     const int checksum_enabled = opts ? opts->checksum_enabled : 0;
     const int checksum_algo =
-        (opts && opts->checksum_algo) ? opts->checksum_algo : ZXC_CHECKSUM_RAPIDHASH;
+        (opts && opts->checksum_algo) ? opts->checksum_algo : ZXC_CHECKSUM_ALGO_RAPIDHASH;
     const int seekable = opts ? opts->seekable : 0;
     const int level = (opts && opts->level > 0) ? opts->level : ZXC_LEVEL_DEFAULT;
     const size_t block_size =
@@ -510,7 +510,7 @@ int64_t zxc_decompress(const void* RESTRICT src, const size_t src_size, void* RE
     zxc_cctx_t ctx;
 
     int file_has_checksums = 0;
-    int file_checksum_algo = ZXC_CHECKSUM_RAPIDHASH;
+    int file_checksum_algo = ZXC_CHECKSUM_ALGO_RAPIDHASH;
     // File header verification and context initialization
     if (UNLIKELY(zxc_read_file_header(ip, src_size, &runtime_chunk_size, &file_has_checksums,
                                       &file_checksum_algo) != ZXC_OK ||
@@ -670,7 +670,7 @@ zxc_cctx* zxc_create_cctx(const zxc_compress_opts_t* opts) {
         (opts && opts->block_size > 0) ? opts->block_size : ZXC_BLOCK_SIZE_DEFAULT;
     cctx->stored_checksum = opts ? opts->checksum_enabled : 0;
     cctx->stored_algo =
-        (opts && opts->checksum_algo) ? opts->checksum_algo : ZXC_CHECKSUM_RAPIDHASH;
+        (opts && opts->checksum_algo) ? opts->checksum_algo : ZXC_CHECKSUM_ALGO_RAPIDHASH;
 
     if (opts) {
         // LCOV_EXCL_START
@@ -819,7 +819,7 @@ int64_t zxc_decompress_dctx(zxc_dctx* dctx, const void* RESTRICT src, const size
     const uint8_t* const op_end = op + dst_capacity;
     size_t runtime_chunk_size = 0;
     int file_has_checksums = 0;
-    int file_checksum_algo = ZXC_CHECKSUM_RAPIDHASH;
+    int file_checksum_algo = ZXC_CHECKSUM_ALGO_RAPIDHASH;
 
     if (UNLIKELY(zxc_read_file_header(ip, src_size, &runtime_chunk_size, &file_has_checksums,
                                       &file_checksum_algo) != ZXC_OK))

--- a/src/lib/zxc_dispatch.c
+++ b/src/lib/zxc_dispatch.c
@@ -364,6 +364,7 @@ int64_t zxc_compress(const void* RESTRICT src, const size_t src_size, void* REST
     uint32_t global_hash = 0;
     zxc_cctx_t ctx;
 
+    // LCOV_EXCL_START
     if (UNLIKELY(zxc_cctx_init(&ctx, block_size, 1, level, checksum_enabled, checksum_algo) !=
                  ZXC_OK))
         return ZXC_ERROR_MEMORY;
@@ -371,6 +372,7 @@ int64_t zxc_compress(const void* RESTRICT src, const size_t src_size, void* REST
 
     const int h_val = zxc_write_file_header(op, (size_t)(op_end - op), block_size, checksum_enabled,
                                             checksum_algo);
+    // LCOV_EXCL_START
     if (UNLIKELY(h_val < 0)) {
         zxc_cctx_free(&ctx);
         return h_val;
@@ -718,6 +720,7 @@ int64_t zxc_compress_cctx(zxc_cctx* cctx, const void* RESTRICT src, const size_t
             zxc_cctx_free(&cctx->inner);
             cctx->initialized = 0;
         }
+        // LCOV_EXCL_START
         if (UNLIKELY(zxc_cctx_init(&cctx->inner, block_size, 1, level, checksum_enabled,
                                    checksum_algo) != ZXC_OK))
             return ZXC_ERROR_MEMORY;

--- a/src/lib/zxc_driver.c
+++ b/src/lib/zxc_driver.c
@@ -272,6 +272,7 @@ typedef struct {
     int compression_level;
     size_t chunk_size;
     int checksum_enabled;
+    int checksum_algo;
     int file_has_checksum;
     zxc_progress_callback_t progress_cb;
     void* progress_user_data;
@@ -359,7 +360,7 @@ static void* zxc_stream_worker(void* arg) {
                                 : (ctx->file_has_checksum && ctx->checksum_enabled);
 
     if (zxc_cctx_init(&cctx, ctx->chunk_size, ctx->compression_mode, ctx->compression_level,
-                      unified_chk) != ZXC_OK) {
+                      unified_chk, ctx->checksum_algo) != ZXC_OK) {
         // LCOV_EXCL_START
         zxc_cctx_free(&cctx);
         pthread_mutex_lock(&ctx->lock);
@@ -372,6 +373,7 @@ static void* zxc_stream_worker(void* arg) {
     }
 
     cctx.compression_level = ctx->compression_level;
+    cctx.checksum_algo = ctx->checksum_algo;
 
     while (1) {
         zxc_stream_job_t* job = NULL;
@@ -549,7 +551,7 @@ static void* zxc_async_writer(void* arg) {
  */
 static int64_t zxc_stream_engine_run(FILE* f_in, FILE* f_out, const int n_threads, const int mode,
                                      const int level, const size_t block_size,
-                                     const int checksum_enabled, const int seekable,
+                                     const int checksum_enabled, const int checksum_algo, const int seekable,
                                      zxc_chunk_processor_t func,
                                      zxc_progress_callback_t progress_cb, void* user_data) {
     zxc_stream_ctx_t ctx;
@@ -577,10 +579,14 @@ static int64_t zxc_stream_engine_run(FILE* f_in, FILE* f_out, const int n_thread
     if (mode == 0) {
         // Decompression Mode: Read and validate file header
         uint8_t h[ZXC_FILE_HEADER_SIZE];
+        int hdr_algo = 0;
         if (UNLIKELY(fread(h, 1, ZXC_FILE_HEADER_SIZE, f_in) != ZXC_FILE_HEADER_SIZE ||
-                     zxc_read_file_header(h, ZXC_FILE_HEADER_SIZE, &runtime_chunk_sz,
-                                          &file_has_chk) != ZXC_OK))
+                     zxc_read_file_header(h, ZXC_FILE_HEADER_SIZE, &runtime_chunk_sz, &file_has_chk,
+                                          &hdr_algo) != ZXC_OK))
             return ZXC_ERROR_BAD_HEADER;
+        ctx.checksum_algo = hdr_algo;
+    } else {
+        ctx.checksum_algo = checksum_algo;
     }
 
     int num_threads = (n_threads > 0) ? n_threads : (int)sysconf(_SC_NPROCESSORS_ONLN);
@@ -696,7 +702,8 @@ static int64_t zxc_stream_engine_run(FILE* f_in, FILE* f_out, const int n_thread
 
     if (mode == 1 && f_out) {
         uint8_t h[ZXC_FILE_HEADER_SIZE];
-        zxc_write_file_header(h, ZXC_FILE_HEADER_SIZE, runtime_chunk_sz, checksum_enabled);
+        zxc_write_file_header(h, ZXC_FILE_HEADER_SIZE, runtime_chunk_sz, checksum_enabled,
+                              ctx.checksum_algo);
         if (UNLIKELY(fwrite(h, 1, ZXC_FILE_HEADER_SIZE, f_out) != ZXC_FILE_HEADER_SIZE))
             ctx.io_error = 1;
 
@@ -925,6 +932,8 @@ int64_t zxc_stream_compress(FILE* f_in, FILE* f_out, const zxc_compress_opts_t* 
 
     const int n_threads = opts ? opts->n_threads : 0;
     const int checksum_enabled = opts ? opts->checksum_enabled : 0;
+    const int checksum_algo =
+        (opts && opts->checksum_algo) ? opts->checksum_algo : ZXC_CHECKSUM_RAPIDHASH;
     const int seekable = opts ? opts->seekable : 0;
     const int level = (opts && opts->level > 0) ? opts->level : ZXC_LEVEL_DEFAULT;
     const size_t block_size =
@@ -935,7 +944,7 @@ int64_t zxc_stream_compress(FILE* f_in, FILE* f_out, const zxc_compress_opts_t* 
     if (UNLIKELY(!zxc_validate_block_size(block_size))) return ZXC_ERROR_BAD_BLOCK_SIZE;
 
     return zxc_stream_engine_run(f_in, f_out, n_threads, 1, level, block_size, checksum_enabled,
-                                 seekable, zxc_compress_chunk_wrapper, cb, ud);
+                                 checksum_algo, seekable, zxc_compress_chunk_wrapper, cb, ud);
 }
 
 int64_t zxc_stream_decompress(FILE* f_in, FILE* f_out, const zxc_decompress_opts_t* opts) {

--- a/src/lib/zxc_driver.c
+++ b/src/lib/zxc_driver.c
@@ -934,7 +934,7 @@ int64_t zxc_stream_compress(FILE* f_in, FILE* f_out, const zxc_compress_opts_t* 
     const int n_threads = opts ? opts->n_threads : 0;
     const int checksum_enabled = opts ? opts->checksum_enabled : 0;
     const int checksum_algo =
-        (opts && opts->checksum_algo) ? opts->checksum_algo : ZXC_CHECKSUM_RAPIDHASH;
+        (opts && opts->checksum_algo) ? opts->checksum_algo : ZXC_CHECKSUM_ALGO_RAPIDHASH;
     const int seekable = opts ? opts->seekable : 0;
     const int level = (opts && opts->level > 0) ? opts->level : ZXC_LEVEL_DEFAULT;
     const size_t block_size =

--- a/src/lib/zxc_driver.c
+++ b/src/lib/zxc_driver.c
@@ -702,9 +702,10 @@ static int64_t zxc_stream_engine_run(FILE* f_in, FILE* f_out, const int n_thread
 
     if (mode == 1 && f_out) {
         uint8_t h[ZXC_FILE_HEADER_SIZE];
-        zxc_write_file_header(h, ZXC_FILE_HEADER_SIZE, runtime_chunk_sz, checksum_enabled,
-                              ctx.checksum_algo);
-        if (UNLIKELY(fwrite(h, 1, ZXC_FILE_HEADER_SIZE, f_out) != ZXC_FILE_HEADER_SIZE))
+        const int hdr_rc = zxc_write_file_header(h, ZXC_FILE_HEADER_SIZE, runtime_chunk_sz,
+                                                 checksum_enabled, ctx.checksum_algo);
+        if (UNLIKELY(hdr_rc < 0 ||
+                     fwrite(h, 1, ZXC_FILE_HEADER_SIZE, f_out) != ZXC_FILE_HEADER_SIZE))
             ctx.io_error = 1;
 
         w_args.total_bytes = ZXC_FILE_HEADER_SIZE;

--- a/src/lib/zxc_driver.c
+++ b/src/lib/zxc_driver.c
@@ -551,8 +551,8 @@ static void* zxc_async_writer(void* arg) {
  */
 static int64_t zxc_stream_engine_run(FILE* f_in, FILE* f_out, const int n_threads, const int mode,
                                      const int level, const size_t block_size,
-                                     const int checksum_enabled, const int checksum_algo, const int seekable,
-                                     zxc_chunk_processor_t func,
+                                     const int checksum_enabled, const int checksum_algo,
+                                     const int seekable, zxc_chunk_processor_t func,
                                      zxc_progress_callback_t progress_cb, void* user_data) {
     zxc_stream_ctx_t ctx;
     ZXC_MEMSET(&ctx, 0, sizeof(ctx));
@@ -955,7 +955,7 @@ int64_t zxc_stream_decompress(FILE* f_in, FILE* f_out, const zxc_decompress_opts
     zxc_progress_callback_t cb = opts ? opts->progress_cb : NULL;
     void* ud = opts ? opts->user_data : NULL;
 
-    return zxc_stream_engine_run(f_in, f_out, n_threads, 0, 0, 0, checksum_enabled, 0,
+    return zxc_stream_engine_run(f_in, f_out, n_threads, 0, 0, 0, checksum_enabled, 0, 0,
                                  (zxc_chunk_processor_t)zxc_decompress_chunk_wrapper, cb, ud);
 }
 

--- a/src/lib/zxc_internal.h
+++ b/src/lib/zxc_internal.h
@@ -335,10 +335,6 @@ extern "C" {
 /** @brief Number of sections in a GHI block. */
 #define ZXC_GHI_SECTIONS 3
 
-/** @brief Checksum algorithm id for rapidhash (default). Alias for @ref
- * ZXC_CHECKSUM_ALGO_RAPIDHASH. */
-#define ZXC_CHECKSUM_RAPIDHASH ((uint8_t)ZXC_CHECKSUM_ALGO_RAPIDHASH)
-
 /** @brief Size of the global checksum appended after EOF block (4 bytes). */
 #define ZXC_GLOBAL_CHECKSUM_SIZE 4
 /** @brief File footer size: original_size(8) + global_checksum(4). */
@@ -1028,7 +1024,7 @@ void zxc_aligned_free(void* ptr);
  * @brief Calculates a 32-bit hash for a given input buffer.
  * @param[in] input Pointer to the data buffer.
  * @param[in] len Length of the data in bytes.
- * @param[in] hash_method Checksum algorithm identifier (e.g., ZXC_CHECKSUM_RAPIDHASH).
+ * @param[in] hash_method Checksum algorithm identifier (e.g., ZXC_CHECKSUM_ALGO_RAPIDHASH).
  * @return The calculated 32-bit hash value.
  */
 static ZXC_ALWAYS_INLINE uint32_t zxc_checksum(const void* RESTRICT input, const size_t len,

--- a/src/lib/zxc_seekable.c
+++ b/src/lib/zxc_seekable.c
@@ -199,6 +199,7 @@ struct zxc_seekable_s {
      * fits in 21 bits. */
     uint32_t block_size;
     int file_has_checksums;
+    int checksum_algo;
 
     /* Reusable decompression context (single-threaded path only) */
     zxc_cctx_t dctx;
@@ -225,7 +226,9 @@ static zxc_seekable* zxc_seekable_parse(const uint8_t* data, const size_t data_s
     /* Step 1: validate file header => block_size */
     size_t block_size_sz = 0;
     int file_has_chk = 0;
-    if (UNLIKELY(zxc_read_file_header(data, data_size, &block_size_sz, &file_has_chk) != ZXC_OK))
+    int chk_algo = 0;
+    if (UNLIKELY(zxc_read_file_header(data, data_size, &block_size_sz, &file_has_chk, &chk_algo) !=
+                 ZXC_OK))
         return NULL;
     const uint32_t block_size = (uint32_t)block_size_sz;
     if (UNLIKELY(block_size == 0)) return NULL;  // LCOV_EXCL_LINE
@@ -268,6 +271,7 @@ static zxc_seekable* zxc_seekable_parse(const uint8_t* data, const size_t data_s
     s->num_blocks = num_blocks;
     s->block_size = block_size;
     s->file_has_checksums = file_has_chk;
+    s->checksum_algo = chk_algo;
     s->src = data;
     s->src_size = (uint64_t)data_size;
 
@@ -402,7 +406,9 @@ zxc_seekable* zxc_seekable_open_file(FILE* f) {
 
     size_t bs_sz = 0;
     int fhc = 0;
-    if (UNLIKELY(zxc_read_file_header(header, ZXC_FILE_HEADER_SIZE, &bs_sz, &fhc) != ZXC_OK)) {
+    int chk_algo = 0;
+    if (UNLIKELY(zxc_read_file_header(header, ZXC_FILE_HEADER_SIZE, &bs_sz, &fhc, &chk_algo) !=
+                 ZXC_OK)) {
         fseeko(f, saved_pos, SEEK_SET);
         return NULL;
     }
@@ -482,6 +488,7 @@ zxc_seekable* zxc_seekable_open_file(FILE* f) {
     s->num_blocks = num_blocks;
     s->block_size = bs;
     s->file_has_checksums = fhc;
+    s->checksum_algo = chk_algo;
 
     s->comp_sizes = (uint32_t*)calloc(num_blocks, sizeof(uint32_t));
     s->comp_offsets = (uint64_t*)calloc((size_t)num_blocks + 1, sizeof(uint64_t));
@@ -590,7 +597,8 @@ int64_t zxc_seekable_decompress_range(zxc_seekable* s, void* dst, const size_t d
     /* Initialize decompression context on first use */
     if (!s->dctx_initialized) {
         // LCOV_EXCL_START
-        if (UNLIKELY(zxc_cctx_init(&s->dctx, (size_t)s->block_size, 0, 0, 0) != ZXC_OK))
+        if (UNLIKELY(zxc_cctx_init(&s->dctx, (size_t)s->block_size, 0, 0, 0, s->checksum_algo) !=
+                     ZXC_OK))
             return ZXC_ERROR_MEMORY;
         // LCOV_EXCL_STOP
         s->dctx_initialized = 1;
@@ -719,7 +727,8 @@ static void* zxc_seek_mt_worker(void* arg) {
     /* Thread-local decompression context (mode=0 for decompress-only) */
     zxc_cctx_t dctx;
     // LCOV_EXCL_START
-    if (UNLIKELY(zxc_cctx_init(&dctx, (size_t)s->block_size, 0, 0, 0) != ZXC_OK)) {
+    if (UNLIKELY(zxc_cctx_init(&dctx, (size_t)s->block_size, 0, 0, 0, s->checksum_algo) !=
+                 ZXC_OK)) {
         job->result = ZXC_ERROR_MEMORY;
         return NULL;
     }

--- a/tests/test.c
+++ b/tests/test.c
@@ -1117,7 +1117,7 @@ int test_legacy_header() {
 
     size_t block_size = 0;
     int has_checksum = -1;
-    int rc = zxc_read_file_header(hdr, sizeof(hdr), &block_size, &has_checksum);
+    int rc = zxc_read_file_header(hdr, sizeof(hdr), &block_size, &has_checksum, NULL);
 
     if (rc != ZXC_OK) {
         printf("  [FAIL] zxc_read_file_header returned %d (%s)\n", rc, zxc_error_name(rc));
@@ -1141,7 +1141,7 @@ int test_legacy_header() {
     hdr[14] = (uint8_t)(crc & 0xFF);
     hdr[15] = (uint8_t)(crc >> 8);
 
-    rc = zxc_read_file_header(hdr, sizeof(hdr), &block_size, &has_checksum);
+    rc = zxc_read_file_header(hdr, sizeof(hdr), &block_size, &has_checksum, NULL);
     if (rc != ZXC_ERROR_BAD_BLOCK_SIZE) {
         printf("  [FAIL] invalid code 99: expected %d, got %d\n", ZXC_ERROR_BAD_BLOCK_SIZE, rc);
         return 0;

--- a/tests/test.c
+++ b/tests/test.c
@@ -1152,6 +1152,108 @@ int test_legacy_header() {
     return 1;
 }
 
+int test_checksum_algo_validation() {
+    printf("=== TEST: Checksum Algorithm Validation ===\n");
+
+    /* ---- zxc_read_file_header: reject unsupported algo when checksum set ---- */
+
+    /* Build a valid header with HAS_CHECKSUM + a fake algo_id = 3. */
+    uint8_t hdr[ZXC_FILE_HEADER_SIZE];
+    memset(hdr, 0, sizeof(hdr));
+    hdr[0] = 0xF5;
+    hdr[1] = 0x2E;
+    hdr[2] = 0xB0;
+    hdr[3] = 0x9C; /* magic */
+    hdr[4] = ZXC_FILE_FORMAT_VERSION;
+    hdr[5] = 18; /* log2(256 KB) */
+    hdr[6] = ZXC_FILE_FLAG_HAS_CHECKSUM | 0x03; /* checksum enabled, algo = 3 (unsupported) */
+    /* CRC16 */
+    hdr[14] = 0;
+    hdr[15] = 0;
+    uint16_t crc = zxc_hash16(hdr);
+    hdr[14] = (uint8_t)(crc & 0xFF);
+    hdr[15] = (uint8_t)(crc >> 8);
+
+    size_t block_size = 0;
+    int has_checksum = -1;
+    int algo = -1;
+    int rc = zxc_read_file_header(hdr, sizeof(hdr), &block_size, &has_checksum, &algo);
+    if (rc != ZXC_ERROR_BAD_HEADER) {
+        printf("  [FAIL] read_file_header unsupported algo: expected %d, got %d\n",
+               ZXC_ERROR_BAD_HEADER, rc);
+        return 0;
+    }
+    printf("  [PASS] zxc_read_file_header rejects unsupported checksum algo\n");
+
+    /* Same header but with checksum flag cleared -> algo bits are ignored, should pass. */
+    hdr[6] = 0x03; /* no HAS_CHECKSUM flag, algo bits still set */
+    hdr[14] = 0;
+    hdr[15] = 0;
+    crc = zxc_hash16(hdr);
+    hdr[14] = (uint8_t)(crc & 0xFF);
+    hdr[15] = (uint8_t)(crc >> 8);
+
+    rc = zxc_read_file_header(hdr, sizeof(hdr), &block_size, &has_checksum, &algo);
+    if (rc != ZXC_OK) {
+        printf("  [FAIL] read_file_header no-checksum with algo bits: expected %d, got %d\n",
+               ZXC_OK, rc);
+        return 0;
+    }
+    printf("  [PASS] zxc_read_file_header accepts algo bits when checksum disabled\n");
+
+    /* Valid header: HAS_CHECKSUM + RapidHash (0) -> should succeed. */
+    hdr[6] = ZXC_FILE_FLAG_HAS_CHECKSUM | ZXC_CHECKSUM_ALGO_RAPIDHASH;
+    hdr[14] = 0;
+    hdr[15] = 0;
+    crc = zxc_hash16(hdr);
+    hdr[14] = (uint8_t)(crc & 0xFF);
+    hdr[15] = (uint8_t)(crc >> 8);
+
+    rc = zxc_read_file_header(hdr, sizeof(hdr), &block_size, &has_checksum, &algo);
+    if (rc != ZXC_OK) {
+        printf("  [FAIL] read_file_header RapidHash: expected %d, got %d\n", ZXC_OK, rc);
+        return 0;
+    }
+    if (has_checksum != 1 || algo != ZXC_CHECKSUM_ALGO_RAPIDHASH) {
+        printf("  [FAIL] read_file_header RapidHash: has_checksum=%d, algo=%d\n",
+               has_checksum, algo);
+        return 0;
+    }
+    printf("  [PASS] zxc_read_file_header accepts RapidHash with checksum enabled\n");
+
+    /* ---- zxc_write_file_header: reject unsupported algo when checksum set ---- */
+
+    uint8_t buf[ZXC_FILE_HEADER_SIZE];
+    rc = zxc_write_file_header(buf, sizeof(buf), 256 * 1024, 1, 7);
+    if (rc != ZXC_ERROR_BAD_HEADER) {
+        printf("  [FAIL] write_file_header unsupported algo: expected %d, got %d\n",
+               ZXC_ERROR_BAD_HEADER, rc);
+        return 0;
+    }
+    printf("  [PASS] zxc_write_file_header rejects unsupported checksum algo\n");
+
+    /* Checksums disabled -> unsupported algo is accepted (ignored). */
+    rc = zxc_write_file_header(buf, sizeof(buf), 256 * 1024, 0, 7);
+    if (rc < 0) {
+        printf("  [FAIL] write_file_header no-checksum with bad algo: expected success, got %d\n",
+               rc);
+        return 0;
+    }
+    printf("  [PASS] zxc_write_file_header accepts any algo when checksum disabled\n");
+
+    /* Valid: checksums enabled + RapidHash -> should succeed. */
+    rc = zxc_write_file_header(buf, sizeof(buf), 256 * 1024, 1, ZXC_CHECKSUM_ALGO_RAPIDHASH);
+    if (rc != ZXC_FILE_HEADER_SIZE) {
+        printf("  [FAIL] write_file_header RapidHash: expected %d, got %d\n",
+               ZXC_FILE_HEADER_SIZE, rc);
+        return 0;
+    }
+    printf("  [PASS] zxc_write_file_header succeeds with RapidHash\n");
+
+    printf("PASS\n\n");
+    return 1;
+}
+
 int test_buffer_error_codes() {
     printf("=== TEST: Unit - Buffer API Error Codes ===\n");
 
@@ -3625,6 +3727,7 @@ int main() {
     if (!test_get_decompressed_size()) total_failures++;
     if (!test_error_name()) total_failures++;
     if (!test_legacy_header()) total_failures++;
+    if (!test_checksum_algo_validation()) total_failures++;
     if (!test_buffer_error_codes()) total_failures++;
     if (!test_stream_get_decompressed_size_errors()) total_failures++;
     if (!test_stream_engine_errors()) total_failures++;


### PR DESCRIPTION
Introduces the infrastructure for specifying and storing a checksum algorithm within ZXC file headers and operational contexts.

This change updates various APIs and internal structures, including:
- `zxc_cctx_t` and stream options contexts to hold the selected algorithm.
- File header read/write functions to encode and decode the checksum algorithm ID.
- Compression and decompression routines to use the context's configured algorithm for checksum calculations.
- High-level `compress`/`decompress`, streaming, and seekable APIs to manage the algorithm selection.

While the framework now supports configurable algorithms, ZXC currently enforces RapidHash (ID 0) as the only supported checksum algorithm. Attempts to write files with other algorithm IDs will be rejected, and decompression will fail if a file header specifies an unsupported algorithm.

Also includes a fix for a missing seekable argument in the streaming decompression call.