### PR TITLE
Simplifies checksum selection and standardizes on RapidHash

### DIFF
--- a/include/zxc_constants.h
+++ b/include/zxc_constants.h
@@ -89,21 +89,4 @@ typedef enum {
 
 /** @} */ /* end of levels */
 
-/**
- * @defgroup checksum_algo Checksum Algorithm
- * @brief Identifies the hash function used for block and global checksums.
- *
- * The algorithm ID is stored in bits 0-3 of the File Header Flags byte,
- * allowing up to 16 distinct algorithms.  Pass one of these values as
- * @c checksum_algo in @ref zxc_compress_opts_t.
- *
- * At decompression time the algorithm is always read from the file header,
- * so no selection is required in @ref zxc_decompress_opts_t.
- * @{
- */
-typedef enum {
-    ZXC_CHECKSUM_ALGO_RAPIDHASH = 0, /**< RapidHash v3 (default, zero-init value). */
-} zxc_checksum_algo_t;
-/** @} */ /* end of checksum_algo */
-
 #endif  // ZXC_CONSTANTS_H

--- a/src/lib/zxc_internal.h
+++ b/src/lib/zxc_internal.h
@@ -335,9 +335,8 @@ extern "C" {
 /** @brief Number of sections in a GHI block. */
 #define ZXC_GHI_SECTIONS 3
 
-/** @brief Checksum algorithm id for rapidhash (default). Alias for @ref
- * ZXC_CHECKSUM_ALGO_RAPIDHASH. */
-#define ZXC_CHECKSUM_RAPIDHASH ((uint8_t)ZXC_CHECKSUM_ALGO_RAPIDHASH)
+/** @brief Checksum algorithm id for RapidHash (default, sole implementation). */
+#define ZXC_CHECKSUM_RAPIDHASH 0
 
 /** @brief Size of the global checksum appended after EOF block (4 bytes). */
 #define ZXC_GLOBAL_CHECKSUM_SIZE 4


### PR DESCRIPTION
* Removes the `zxc_checksum_algo_t` enum from the public API.
* Hardcodes RapidHash as the sole checksum implementation and moves the algorithm ID definition to an internal constant.
