### PR TITLE
Adds Windows ARM64 Build and Refines CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,6 +44,11 @@ jobs:
             artifact_name: zxc.exe
             asset_name: zxc-windows-x64
             cmake_flags: "-DZXC_NATIVE_ARCH=OFF"
+          - name: Windows ARM64
+            os: windows-11-arm
+            artifact_name: zxc.exe
+            asset_name: zxc-windows-arm64
+            cmake_flags: "-DZXC_NATIVE_ARCH=OFF"
 
 
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -105,7 +105,7 @@ jobs:
           cmake --install build --prefix release_staging --config Release
           
           # Strip binary on Unix-like systems only (installed to bin/)
-          if [[ "${{ matrix.os }}" != "windows-latest" ]]; then
+          if [[ "${{ runner.os }}" != "Windows" ]]; then
             strip release_staging/bin/${{ matrix.artifact_name }}
           fi
           
@@ -115,7 +115,7 @@ jobs:
           
           # Create archive
           cd release_staging
-          if [[ "${{ matrix.os }}" == "windows-latest" ]]; then
+          if [[ "${{ runner.os }}" == "Windows" ]]; then
             7z a ../${{ matrix.asset_name }}.zip *
           else
             tar -czvf ../${{ matrix.asset_name }}.tar.gz *

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,12 +43,12 @@ jobs:
             os: windows-latest
             artifact_name: zxc.exe
             asset_name: zxc-windows-x64
-            cmake_flags: "-DZXC_NATIVE_ARCH=OFF"
+            cmake_flags: "-A x64 -DZXC_NATIVE_ARCH=OFF"
           - name: Windows ARM64
             os: windows-11-arm
             artifact_name: zxc.exe
             asset_name: zxc-windows-arm64
-            cmake_flags: "-DZXC_NATIVE_ARCH=OFF"
+            cmake_flags: "-A ARM64 -DZXC_NATIVE_ARCH=OFF"
 
 
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,7 @@ jobs:
           - name: Windows x64
             os: windows-latest
             artifact_name: zxc.exe
-            asset_name: zxc-windows-x64.exe
+            asset_name: zxc-windows-x64
             cmake_flags: "-DZXC_NATIVE_ARCH=OFF"
 
 

--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ Benchmarks were conducted using lzbench 2.2.1 (from @inikep), compiled with GCC 
 
     **Windows:**
     *   `zxc-windows-x64.zip` (Runtime dispatch for AVX2/AVX512).
+    *   `zxc-windows-arm64.zip` (NEON optimizations included).
 
 3.  Extract and install:
     ```bash


### PR DESCRIPTION
Adds a new build target for Windows ARM64, expanding cross-platform support. This change also improves the robustness of the CI workflow's conditional logic for Windows operating systems.

-   Introduces a dedicated CI job to build and package `zxc` for Windows ARM64, including NEON optimizations.
-   Updates the `README.md` to reflect the availability of the new `zxc-windows-arm64.zip` release artifact.
-   Generalizes Windows OS checks within the build workflow to use `runner.os == 'Windows'`, making the pipeline more flexible for various Windows environments.
-   Standardizes Windows release asset naming by removing the `.exe` extension from `asset_name` in the workflow configuration.