### PR TITLE
Updates CI for Go ARM64 and Node.js 22

### DIFF
--- a/.github/workflows/multicomp.yml
+++ b/.github/workflows/multicomp.yml
@@ -25,8 +25,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Ubuntu 22.04 ships Clang 13, 14, 15 — only 12 needs LLVM APT
-          - { os: ubuntu-22.04, version: 12, needs_llvm_apt: true,  llvm_distro: jammy }
+          # Ubuntu 22.04 ships Clang 13, 14, 15 — Clang 12 is in standard repos
+          - { os: ubuntu-22.04, version: 12, needs_install: true,  needs_llvm_apt: false, llvm_distro: "" }
           - { os: ubuntu-22.04, version: 13, needs_llvm_apt: false, llvm_distro: "" }
           - { os: ubuntu-22.04, version: 14, needs_llvm_apt: false, llvm_distro: "" }
           - { os: ubuntu-22.04, version: 15, needs_llvm_apt: false, llvm_distro: "" }
@@ -40,6 +40,12 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v6
+
+      - name: Install Clang ${{ matrix.version }} (standard repos)
+        if: matrix.needs_install && !matrix.needs_llvm_apt
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang-${{ matrix.version }}
 
       - name: Install Clang ${{ matrix.version }} (LLVM APT)
         if: matrix.needs_llvm_apt

--- a/.github/workflows/multicomp.yml
+++ b/.github/workflows/multicomp.yml
@@ -19,23 +19,33 @@ jobs:
   # Clang 12–20 on Ubuntu
   # ===========================================================================
   clang:
-    name: "Clang ${{ matrix.version }} (Ubuntu 22.04)"
-    runs-on: ubuntu-22.04
+    name: "Clang ${{ matrix.version }} (${{ matrix.os }})"
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        version: [12, 13, 14, 15, 16, 17, 18, 19, 20]
+        include:
+          # Ubuntu 22.04 ships Clang 13, 14, 15 — only 12 needs LLVM APT
+          - { os: ubuntu-22.04, version: 12, needs_llvm_apt: true,  llvm_distro: jammy }
+          - { os: ubuntu-22.04, version: 13, needs_llvm_apt: false, llvm_distro: "" }
+          - { os: ubuntu-22.04, version: 14, needs_llvm_apt: false, llvm_distro: "" }
+          - { os: ubuntu-22.04, version: 15, needs_llvm_apt: false, llvm_distro: "" }
+          # Ubuntu 24.04 ships Clang 16, 17, 18 — 19/20 need LLVM APT
+          - { os: ubuntu-latest, version: 16, needs_llvm_apt: false, llvm_distro: "" }
+          - { os: ubuntu-latest, version: 17, needs_llvm_apt: false, llvm_distro: "" }
+          - { os: ubuntu-latest, version: 18, needs_llvm_apt: false, llvm_distro: "" }
+          - { os: ubuntu-latest, version: 19, needs_llvm_apt: true,  llvm_distro: noble }
+          - { os: ubuntu-latest, version: 20, needs_llvm_apt: true,  llvm_distro: noble }
 
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v6
 
-      - name: Install Clang ${{ matrix.version }}
+      - name: Install Clang ${{ matrix.version }} (LLVM APT)
+        if: matrix.needs_llvm_apt
         run: |
-          if [ ${{ matrix.version }} -ge 15 ]; then
-            wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc
-            echo "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-${{ matrix.version }} main" | sudo tee /etc/apt/sources.list.d/llvm.list
-          fi
+          wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc
+          echo "deb http://apt.llvm.org/${{ matrix.llvm_distro }}/ llvm-toolchain-${{ matrix.llvm_distro }}-${{ matrix.version }} main" | sudo tee /etc/apt/sources.list.d/llvm.list
           sudo apt-get update
           sudo apt-get install -y clang-${{ matrix.version }}
 

--- a/.github/workflows/multicomp.yml
+++ b/.github/workflows/multicomp.yml
@@ -107,19 +107,28 @@ jobs:
   # ===========================================================================
   # GCC 9–14 on Ubuntu
   # ===========================================================================
-  gcc-jammy:
-    name: "GCC ${{ matrix.version }} (Ubuntu 22.04)"
-    runs-on: ubuntu-22.04
+  gcc:
+    name: "GCC ${{ matrix.version }} (${{ matrix.os }})"
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        version: [9, 10, 11, 12, 13]
+        include:
+          # Ubuntu 22.04 ships GCC 10, 11, 12 — only GCC 9 needs PPA
+          - { os: ubuntu-22.04, version: 9,  needs_ppa: true }
+          - { os: ubuntu-22.04, version: 10, needs_ppa: false }
+          - { os: ubuntu-22.04, version: 11, needs_ppa: false }
+          - { os: ubuntu-22.04, version: 12, needs_ppa: false }
+          # Ubuntu 24.04 ships GCC 12, 13, 14
+          - { os: ubuntu-latest, version: 13, needs_ppa: false }
+          - { os: ubuntu-latest, version: 14, needs_ppa: false }
 
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v6
 
-      - name: Install GCC ${{ matrix.version }}
+      - name: Install GCC ${{ matrix.version }} (PPA)
+        if: matrix.needs_ppa
         run: |
           sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
           sudo apt-get update
@@ -141,45 +150,7 @@ jobs:
                   -DCMAKE_CXX_COMPILER=g++-${{ matrix.version }} \
                   -DCMAKE_C_STANDARD=17 \
                   -DZXC_NATIVE_ARCH=OFF \
-                  -DBUILD_SHARED_LIBS=$SHARED_FLAG
-
-              cmake --build $BUILD_DIR --config Release --parallel
-
-              echo "Running Tests for $LIB_TYPE..."
-              ctest --test-dir $BUILD_DIR -C Release --output-on-failure
-
-              echo ">>> Completed Build: $LIB_TYPE"
-              echo ""
-          done
-
-  # ===========================================================================
-  # GCC 14 on Ubuntu 24.04
-  # ===========================================================================
-  gcc-latest:
-    name: "GCC 14 (Ubuntu 24.04)"
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v6
-
-
-      - name: Configure, Build & Test (Static & Shared)
-        shell: bash
-        run: |
-          for LIB_TYPE in "STATIC" "SHARED"; do
-              echo ">>> Starting Build: GCC 14 – $LIB_TYPE"
-              BUILD_DIR="build_${LIB_TYPE}"
-
-              SHARED_FLAG="OFF"
-              if [ "$LIB_TYPE" == "SHARED" ]; then SHARED_FLAG="ON"; fi
-
-              cmake -S . -B $BUILD_DIR \
-                  -DCMAKE_BUILD_TYPE=Release \
-                  -DCMAKE_C_COMPILER=gcc-14 \
-                  -DCMAKE_CXX_COMPILER=g++-14 \
-                  -DCMAKE_C_STANDARD=17 \
-                  -DZXC_NATIVE_ARCH=OFF \
+                  -DZXC_ENABLE_LTO=OFF \
                   -DBUILD_SHARED_LIBS=$SHARED_FLAG
 
               cmake --build $BUILD_DIR --config Release --parallel

--- a/.github/workflows/wrapper-go-test.yml
+++ b/.github/workflows/wrapper-go-test.yml
@@ -39,6 +39,17 @@ jobs:
           sudo xcode-select -s /Applications/Xcode_26.4.app
           clang --version
 
+      - name: Install llvm-mingw (Windows ARM64)
+        if: matrix.os == 'windows-11-arm'
+        shell: pwsh
+        run: |
+          $LLVM_MINGW_URL = "https://github.com/mstorsjo/llvm-mingw/releases/download/20260407/llvm-mingw-20260407-ucrt-aarch64.zip"
+          Invoke-WebRequest -Uri $LLVM_MINGW_URL -OutFile llvm-mingw.zip
+          Expand-Archive llvm-mingw.zip -DestinationPath C:\llvm-mingw
+          $MINGW_BIN = "C:\llvm-mingw\llvm-mingw-20260407-ucrt-aarch64\bin"
+          echo "$MINGW_BIN" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          echo "CC=aarch64-w64-mingw32-gcc" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
       - name: Set up Go
         uses: actions/setup-go@v6
         with:

--- a/.github/workflows/wrapper-go-test.yml
+++ b/.github/workflows/wrapper-go-test.yml
@@ -20,6 +20,7 @@ jobs:
           - os: ubuntu-24.04-arm
           - os: macos-26
           - os: windows-latest
+          - os: windows-11-arm
 
     steps:
       - name: Checkout Repository

--- a/.github/workflows/wrapper-wasm.yml
+++ b/.github/workflows/wrapper-wasm.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Run Tests
         run: BUILD_DIR=build-wasm node wrappers/wasm/test.mjs

--- a/.github/workflows/wrapper-wasm.yml
+++ b/.github/workflows/wrapper-wasm.yml
@@ -6,10 +6,10 @@
 name: WASM Build
 
 on:
+  workflow_dispatch:
+  release:
+    types: [ published ]
   push:
-    workflow_dispatch:
-    release:
-      types: [ published ]
     branches: [ main ]
     paths:
       - 'src/**'


### PR DESCRIPTION
Expands the Go wrapper test matrix to include Windows ARM64, enhancing CI coverage for diverse platforms.

Upgrades the Node.js version to 22 for WASM wrapper tests, ensuring continued compatibility and leveraging the latest runtime features.