### PR TITLE
Integrates seekable API fuzzer

### DIFF
--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -6,8 +6,6 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder:v1
 
-RUN apt-get update && apt-get install -y make cmake
-
 COPY . $SRC/zxc
 WORKDIR $SRC/zxc
 

--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -6,7 +6,7 @@
 #  This source code is licensed under the BSD-style license found in the
 #  LICENSE file in the root directory of this source tree.
 
-AVAILABLE_FUZZERS="decompress roundtrip"
+AVAILABLE_FUZZERS="decompress roundtrip seekable"
 
 LIB_SOURCES="src/lib/zxc_common.c src/lib/zxc_compress.c src/lib/zxc_decompress.c src/lib/zxc_driver.c src/lib/zxc_dispatch.c src/lib/zxc_seekable.c"
 

--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -35,7 +35,7 @@ jobs:
       fail-fast: false
       matrix:
         sanitizer: [address, undefined]
-        fuzzer: [decompress, roundtrip]
+        fuzzer: [decompress, roundtrip, seekable]
 
     steps:
     - name: Checkout Repository
@@ -116,6 +116,7 @@ jobs:
             corpus
           echo "roundtrip inputs: $(find corpus/corpus/zxc_fuzzer_roundtrip -type f | wc -l)"
           echo "decompress inputs: $(find corpus/corpus/zxc_fuzzer_decompress -type f | wc -l)"
+          echo "seekable inputs: $(find corpus/corpus/zxc_fuzzer_seekable -type f 2>/dev/null | wc -l)"
 
       - name: Build Coverage Harnesses
         run: |
@@ -131,27 +132,37 @@ jobs:
           clang $CFLAGS $INCLUDES $DEFS $SOURCES tests/fuzz_decompress.c \
             -fsanitize=fuzzer -lm -lpthread -o build-cov/fuzz_decompress
 
+          clang $CFLAGS $INCLUDES $DEFS $SOURCES tests/fuzz_seekable.c \
+            -fsanitize=fuzzer -lm -lpthread -o build-cov/fuzz_seekable
+
       - name: Replay Corpora
         run: |
           LLVM_PROFILE_FILE="build-cov/roundtrip.profraw" \
             build-cov/fuzz_roundtrip corpus/corpus/zxc_fuzzer_roundtrip/ -runs=0 2>&1 | tail -1
           LLVM_PROFILE_FILE="build-cov/decompress.profraw" \
             build-cov/fuzz_decompress corpus/corpus/zxc_fuzzer_decompress/ -runs=0 2>&1 | tail -1
+          if [ -d corpus/corpus/zxc_fuzzer_seekable ]; then
+            LLVM_PROFILE_FILE="build-cov/seekable.profraw" \
+              build-cov/fuzz_seekable corpus/corpus/zxc_fuzzer_seekable/ -runs=0 2>&1 | tail -1
+          fi
 
       - name: Generate Coverage Report
         run: |
           llvm-profdata merge \
             build-cov/roundtrip.profraw build-cov/decompress.profraw \
+            $([ -f build-cov/seekable.profraw ] && echo build-cov/seekable.profraw) \
             -o build-cov/fuzz.profdata
 
           echo "=== COVERAGE SUMMARY ==="
           llvm-cov report \
             build-cov/fuzz_roundtrip -object build-cov/fuzz_decompress \
+            $([ -f build-cov/fuzz_seekable ] && echo "-object build-cov/fuzz_seekable") \
             -instr-profile=build-cov/fuzz.profdata \
             --ignore-filename-regex='(vendors/|tests/|fuzz_|zxc_driver)'
 
           llvm-cov show \
             build-cov/fuzz_roundtrip -object build-cov/fuzz_decompress \
+            $([ -f build-cov/fuzz_seekable ] && echo "-object build-cov/fuzz_seekable") \
             -instr-profile=build-cov/fuzz.profdata \
             --ignore-filename-regex='(vendors/|tests/|fuzz_|zxc_driver)' \
             --format=html -output-dir=build-cov/coverage_html

--- a/tests/fuzz_decompress.c
+++ b/tests/fuzz_decompress.c
@@ -12,7 +12,7 @@
 #include "../include/zxc_buffer.h"
 
 int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
-    static uint8_t out_buf[1048576]; /* 1 MB max for fuzzer */
+    static uint8_t out_buf[4 << 20]; /* 4 MiB */
     size_t out_capacity = sizeof(out_buf);
 
     uint64_t expected_size = zxc_get_decompressed_size(data, size);

--- a/tests/fuzz_roundtrip.c
+++ b/tests/fuzz_roundtrip.c
@@ -13,13 +13,19 @@
 
 #include "../include/zxc_buffer.h"
 
+#define FUZZ_ROUNDTRIP_MAX_INPUT (4 << 20) /* 4 MiB */
+
 int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
     static void* comp_buf = NULL;
     static size_t comp_cap = 0;
     static void* decomp_buf = NULL;
     static size_t decomp_cap = 0;
 
-    const size_t bound = zxc_compress_bound(size);
+    if (size > FUZZ_ROUNDTRIP_MAX_INPUT) return 0;
+
+    const uint64_t bound64 = zxc_compress_bound(size);
+    if (bound64 == 0 || bound64 > SIZE_MAX) return 0;
+    const size_t bound = (size_t)bound64;
     if (bound > comp_cap) {
         void* new_buf = realloc(comp_buf, bound);
         if (!new_buf) return 0;

--- a/tests/fuzz_seekable.c
+++ b/tests/fuzz_seekable.c
@@ -23,6 +23,8 @@
 #include "../include/zxc_buffer.h"
 #include "../include/zxc_seekable.h"
 
+#define FUZZ_SEEKABLE_MAX_INPUT (4 << 20) /* 4 MiB */
+
 int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
     if (size < 2) return 0;
 
@@ -33,14 +35,26 @@ int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
     data += 2;
     size -= 2;
 
-    if (size == 0) return 0;
+    if (size == 0 || size > FUZZ_SEEKABLE_MAX_INPUT) return 0;
+
+    /* Persistent buffers - reused across iterations to reduce allocator pressure */
+    static uint8_t* comp_buf = NULL;
+    static size_t comp_cap = 0;
+    static uint8_t* decomp_buf = NULL;
+    static size_t decomp_cap = 0;
 
     /* ------------------------------------------------------------------ */
     /* Phase 1: Compress with seekable=1                                   */
     /* ------------------------------------------------------------------ */
-    const size_t bound = zxc_compress_bound(size);
-    uint8_t* comp_buf = (uint8_t*)malloc(bound);
-    if (!comp_buf) return 0;
+    const uint64_t bound64 = zxc_compress_bound(size);
+    if (bound64 == 0 || bound64 > SIZE_MAX) return 0;
+    const size_t bound = (size_t)bound64;
+    if (bound > comp_cap) {
+        void* new_buf = realloc(comp_buf, bound);
+        if (!new_buf) return 0;
+        comp_buf = (uint8_t*)new_buf;
+        comp_cap = bound;
+    }
 
     zxc_compress_opts_t copts = {
         .level = level,
@@ -84,11 +98,14 @@ int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
     /* ------------------------------------------------------------------ */
     /* Phase 4: Full decompression via seekable range                       */
     /* ------------------------------------------------------------------ */
-    uint8_t* decomp_buf = (uint8_t*)malloc(size);
-    if (!decomp_buf) {
-        zxc_seekable_free(s);
-        free(comp_buf);
-        return 0;
+    if (size > decomp_cap) {
+        void* new_buf = realloc(decomp_buf, size);
+        if (!new_buf) {
+            zxc_seekable_free(s);
+            return 0;
+        }
+        decomp_buf = (uint8_t*)new_buf;
+        decomp_cap = size;
     }
 
     int64_t dec_result;
@@ -128,9 +145,8 @@ int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
     assert(zxc_seekable_get_decompressed_size(NULL) == 0);
 
     /* ------------------------------------------------------------------ */
-    /* Cleanup                                                              */
+    /* Cleanup (comp_buf and decomp_buf are static, not freed)              */
     /* ------------------------------------------------------------------ */
-    free(decomp_buf);
     zxc_seekable_free(s);
 
     /* ------------------------------------------------------------------ */
@@ -150,6 +166,6 @@ int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
         zxc_seekable_free(s2);
     }
 
-    free(comp_buf);
+
     return 0;
 }

--- a/tests/fuzz_seekable.c
+++ b/tests/fuzz_seekable.c
@@ -28,6 +28,10 @@
 int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
     if (size < 2) return 0;
 
+    /* Save original input for phase 7 (raw parser fuzzing) */
+    const uint8_t* const raw_data = data;
+    const size_t raw_size = size;
+
     /* Use first byte as level, second as flags */
     const int level = (data[0] % 5) + 1;
     const int use_checksum = data[1] & 1;
@@ -44,7 +48,7 @@ int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
     static size_t decomp_cap = 0;
 
     /* ------------------------------------------------------------------ */
-    /* Phase 1: Compress with seekable=1                                   */
+    /* Phase 1: Compress with seekable=1                                  */
     /* ------------------------------------------------------------------ */
     const uint64_t bound64 = zxc_compress_bound(size);
     if (bound64 == 0 || bound64 > SIZE_MAX) return 0;
@@ -62,22 +66,16 @@ int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
         .seekable = 1,
     };
     const int64_t csize = zxc_compress(data, size, comp_buf, bound, &copts);
-    if (csize < 0) {
-        free(comp_buf);
-        return 0;
-    }
+    if (csize < 0) return 0;
 
     /* ------------------------------------------------------------------ */
     /* Phase 2: Open seekable handle                                       */
     /* ------------------------------------------------------------------ */
     zxc_seekable* s = zxc_seekable_open(comp_buf, (size_t)csize);
-    if (!s) {
-        free(comp_buf);
-        return 0;
-    }
+    if (!s) return 0;
 
     /* ------------------------------------------------------------------ */
-    /* Phase 3: Exercise metadata getters                                   */
+    /* Phase 3: Exercise metadata getters                                 */
     /* ------------------------------------------------------------------ */
     const uint32_t num_blocks = zxc_seekable_get_num_blocks(s);
     const uint64_t total_decomp = zxc_seekable_get_decompressed_size(s);
@@ -96,7 +94,7 @@ int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
     assert(zxc_seekable_get_block_decomp_size(s, num_blocks) == 0);
 
     /* ------------------------------------------------------------------ */
-    /* Phase 4: Full decompression via seekable range                       */
+    /* Phase 4: Full decompression via seekable range                     */
     /* ------------------------------------------------------------------ */
     if (size > decomp_cap) {
         void* new_buf = realloc(decomp_buf, size);
@@ -118,7 +116,7 @@ int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
     assert(memcmp(data, decomp_buf, size) == 0);
 
     /* ------------------------------------------------------------------ */
-    /* Phase 5: Partial range decompression (sub-block extraction)          */
+    /* Phase 5: Partial range decompression (sub-block extraction)        */
     /* ------------------------------------------------------------------ */
     if (size >= 4) {
         /* Extract a range from the middle */
@@ -130,7 +128,7 @@ int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
     }
 
     /* ------------------------------------------------------------------ */
-    /* Phase 6: Edge cases                                                  */
+    /* Phase 6: Edge cases                                                */
     /* ------------------------------------------------------------------ */
     /* Zero-length read */
     dec_result = zxc_seekable_decompress_range(s, decomp_buf, size, 0, 0);
@@ -145,18 +143,18 @@ int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
     assert(zxc_seekable_get_decompressed_size(NULL) == 0);
 
     /* ------------------------------------------------------------------ */
-    /* Cleanup (comp_buf and decomp_buf are static, not freed)              */
+    /* Cleanup                                                            */
     /* ------------------------------------------------------------------ */
     zxc_seekable_free(s);
 
     /* ------------------------------------------------------------------ */
     /* Phase 7: Fuzz the parser with raw data (malformed seekable archives) */
     /* ------------------------------------------------------------------ */
-    zxc_seekable* s2 = zxc_seekable_open(data, size);
+    zxc_seekable* s2 = zxc_seekable_open(raw_data, raw_size);
     if (s2) {
         /* If it parsed, try a read - should not crash */
         const uint64_t td = zxc_seekable_get_decompressed_size(s2);
-        if (td > 0 && td <= 1048576) {
+        if (td > 0 && td <= FUZZ_SEEKABLE_MAX_INPUT) {
             uint8_t* tmp = (uint8_t*)malloc((size_t)td);
             if (tmp) {
                 zxc_seekable_decompress_range(s2, tmp, (size_t)td, 0, (size_t)td);

--- a/tests/fuzz_seekable.c
+++ b/tests/fuzz_seekable.c
@@ -1,0 +1,155 @@
+/*
+ * ZXC - High-performance lossless compression
+ *
+ * Copyright (c) 2025-2026 Bertrand Lebonnois and contributors.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/**
+ * @file fuzz_seekable.c
+ * @brief Fuzzer for the seekable random-access decompression API.
+ *
+ * Strategy: compress fuzzed input with seekable=1, then exercise the full
+ * seekable read path (open, metadata getters, single-threaded decompress,
+ * multi-threaded decompress) and verify data integrity.
+ */
+
+#include <assert.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "../include/zxc_buffer.h"
+#include "../include/zxc_seekable.h"
+
+int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
+    if (size < 2) return 0;
+
+    /* Use first byte as level, second as flags */
+    const int level = (data[0] % 5) + 1;
+    const int use_checksum = data[1] & 1;
+    const int use_mt = data[1] & 2;
+    data += 2;
+    size -= 2;
+
+    if (size == 0) return 0;
+
+    /* ------------------------------------------------------------------ */
+    /* Phase 1: Compress with seekable=1                                   */
+    /* ------------------------------------------------------------------ */
+    const size_t bound = zxc_compress_bound(size);
+    uint8_t* comp_buf = (uint8_t*)malloc(bound);
+    if (!comp_buf) return 0;
+
+    zxc_compress_opts_t copts = {
+        .level = level,
+        .checksum_enabled = use_checksum,
+        .seekable = 1,
+    };
+    const int64_t csize = zxc_compress(data, size, comp_buf, bound, &copts);
+    if (csize < 0) {
+        free(comp_buf);
+        return 0;
+    }
+
+    /* ------------------------------------------------------------------ */
+    /* Phase 2: Open seekable handle                                       */
+    /* ------------------------------------------------------------------ */
+    zxc_seekable* s = zxc_seekable_open(comp_buf, (size_t)csize);
+    if (!s) {
+        free(comp_buf);
+        return 0;
+    }
+
+    /* ------------------------------------------------------------------ */
+    /* Phase 3: Exercise metadata getters                                   */
+    /* ------------------------------------------------------------------ */
+    const uint32_t num_blocks = zxc_seekable_get_num_blocks(s);
+    const uint64_t total_decomp = zxc_seekable_get_decompressed_size(s);
+    assert(total_decomp == size);
+
+    for (uint32_t i = 0; i < num_blocks; i++) {
+        const uint32_t csz = zxc_seekable_get_block_comp_size(s, i);
+        const uint32_t dsz = zxc_seekable_get_block_decomp_size(s, i);
+        assert(csz > 0);
+        assert(dsz > 0);
+        (void)csz;
+        (void)dsz;
+    }
+    /* Out-of-range access should return 0 */
+    assert(zxc_seekable_get_block_comp_size(s, num_blocks) == 0);
+    assert(zxc_seekable_get_block_decomp_size(s, num_blocks) == 0);
+
+    /* ------------------------------------------------------------------ */
+    /* Phase 4: Full decompression via seekable range                       */
+    /* ------------------------------------------------------------------ */
+    uint8_t* decomp_buf = (uint8_t*)malloc(size);
+    if (!decomp_buf) {
+        zxc_seekable_free(s);
+        free(comp_buf);
+        return 0;
+    }
+
+    int64_t dec_result;
+    if (use_mt && size > 4096) {
+        dec_result = zxc_seekable_decompress_range_mt(s, decomp_buf, size, 0, size, 2);
+    } else {
+        dec_result = zxc_seekable_decompress_range(s, decomp_buf, size, 0, size);
+    }
+    assert(dec_result == (int64_t)size);
+    assert(memcmp(data, decomp_buf, size) == 0);
+
+    /* ------------------------------------------------------------------ */
+    /* Phase 5: Partial range decompression (sub-block extraction)          */
+    /* ------------------------------------------------------------------ */
+    if (size >= 4) {
+        /* Extract a range from the middle */
+        const size_t off = size / 4;
+        const size_t len = size / 2;
+        dec_result = zxc_seekable_decompress_range(s, decomp_buf, len, off, len);
+        assert(dec_result == (int64_t)len);
+        assert(memcmp(data + off, decomp_buf, len) == 0);
+    }
+
+    /* ------------------------------------------------------------------ */
+    /* Phase 6: Edge cases                                                  */
+    /* ------------------------------------------------------------------ */
+    /* Zero-length read */
+    dec_result = zxc_seekable_decompress_range(s, decomp_buf, size, 0, 0);
+    assert(dec_result == 0);
+
+    /* Out-of-bounds read */
+    dec_result = zxc_seekable_decompress_range(s, decomp_buf, size, total_decomp, 1);
+    assert(dec_result < 0);
+
+    /* NULL handle */
+    assert(zxc_seekable_get_num_blocks(NULL) == 0);
+    assert(zxc_seekable_get_decompressed_size(NULL) == 0);
+
+    /* ------------------------------------------------------------------ */
+    /* Cleanup                                                              */
+    /* ------------------------------------------------------------------ */
+    free(decomp_buf);
+    zxc_seekable_free(s);
+
+    /* ------------------------------------------------------------------ */
+    /* Phase 7: Fuzz the parser with raw data (malformed seekable archives) */
+    /* ------------------------------------------------------------------ */
+    zxc_seekable* s2 = zxc_seekable_open(data, size);
+    if (s2) {
+        /* If it parsed, try a read - should not crash */
+        const uint64_t td = zxc_seekable_get_decompressed_size(s2);
+        if (td > 0 && td <= 1048576) {
+            uint8_t* tmp = (uint8_t*)malloc((size_t)td);
+            if (tmp) {
+                zxc_seekable_decompress_range(s2, tmp, (size_t)td, 0, (size_t)td);
+                free(tmp);
+            }
+        }
+        zxc_seekable_free(s2);
+    }
+
+    free(comp_buf);
+    return 0;
+}


### PR DESCRIPTION
Adds a new fuzzer for the seekable random-access decompression API. This fuzzer enhances code robustness by:
- Compressing fuzzed input with seekable mode enabled.
- Exercising metadata getters and various decompression scenarios (full, partial, multi-threaded).
- Validating data integrity and handling edge cases, including malformed inputs.

Updates the CI workflows and ClusterFuzzLite configuration to build, run, and collect coverage for the `seekable` fuzzer. Also removes redundant `make` and `cmake` installations from the ClusterFuzzLite Dockerfile for a more efficient build environment.