### PR TITLE
Feat: Add WHATWG TransformStream adapters and `detectZxc` utility

### DIFF
--- a/wrappers/wasm/test.mjs
+++ b/wrappers/wasm/test.mjs
@@ -347,13 +347,16 @@ async function main() {
             start(c) { c.enqueue(truncated); c.close(); }
         }).pipeThrough(zxc.createDecompressTransformStream());
 
-        let caught = null;
+        let didThrow = false;
+        let errorCode;
         try {
             for await (const _ of truncSource) { /* drain */ }
         } catch (e) {
-            caught = e;
+            didThrow = true;
+            errorCode = e?.code;
         }
-        assert(caught && caught.code === 'ZXC_TRUNCATED', 'truncated frame errors with code ZXC_TRUNCATED');
+        assert(didThrow, 'truncated frame throws an error');
+        assert(errorCode === 'ZXC_TRUNCATED', 'truncated frame error code is ZXC_TRUNCATED');
     }
 
     // --- Summary ---

--- a/wrappers/wasm/test.mjs
+++ b/wrappers/wasm/test.mjs
@@ -284,6 +284,78 @@ async function main() {
         assert(arraysEqual(data, decoded), 'pstream roundtrip byte-exact match');
     }
 
+    // --- 9. WHATWG TransformStream adapters -------------------------------
+    console.log('\n9. WHATWG TransformStream adapters + detectZxc');
+    {
+        const { default: createZXC, detectZxc } = await import('./zxc_wasm.js');
+        const zxc = await createZXC({}, ZXCModule);
+
+        // detectZxc: works without WASM init too (pure JS), but check both
+        // call sites as they share the same implementation.
+        assert(detectZxc === zxc.detectZxc, 'detectZxc exported at module + API level');
+        assert(!detectZxc(null), 'detectZxc(null) === false');
+        assert(!detectZxc(new Uint8Array([0xF5, 0x2E, 0xB0])), 'detectZxc rejects 3-byte input');
+        assert(!detectZxc(new Uint8Array(4)), 'detectZxc rejects zero buffer');
+
+        // Build a frame with the buffer API and sniff it.
+        const frame = zxc.compress(new Uint8Array([1, 2, 3, 4, 5]));
+        assert(detectZxc(frame), 'detectZxc accepts compress() output');
+        assert(detectZxc(frame.buffer), 'detectZxc accepts ArrayBuffer');
+
+        // TransformStream roundtrip via pipeThrough().
+        const data = new Uint8Array(64 * 1024);
+        for (let i = 0; i < data.length; i++) data[i] = (i ^ 0x5A) & 0xFF;
+
+        const sourceCompressed = new ReadableStream({
+            start(c) { c.enqueue(data); c.close(); }
+        }).pipeThrough(zxc.createCompressTransformStream());
+
+        const compressedChunks = [];
+        let cTotal = 0;
+        for await (const c of sourceCompressed) {
+            compressedChunks.push(c);
+            cTotal += c.length;
+        }
+        const compressed = new Uint8Array(cTotal);
+        {
+            let off = 0;
+            for (const c of compressedChunks) { compressed.set(c, off); off += c.length; }
+        }
+        assert(detectZxc(compressed), 'TransformStream output is a valid ZXC frame');
+
+        const sourceDecompressed = new ReadableStream({
+            start(c) { c.enqueue(compressed); c.close(); }
+        }).pipeThrough(zxc.createDecompressTransformStream());
+
+        const outChunks = [];
+        let dTotal = 0;
+        for await (const c of sourceDecompressed) {
+            outChunks.push(c);
+            dTotal += c.length;
+        }
+        const decoded = new Uint8Array(dTotal);
+        {
+            let off = 0;
+            for (const c of outChunks) { decoded.set(c, off); off += c.length; }
+        }
+        assert(decoded.length === data.length, `TransformStream decoded ${decoded.length} bytes (expected ${data.length})`);
+        assert(arraysEqual(data, decoded), 'TransformStream roundtrip byte-exact match');
+
+        // Truncated frame must error the decode stream.
+        const truncated = compressed.subarray(0, Math.floor(compressed.length / 2));
+        const truncSource = new ReadableStream({
+            start(c) { c.enqueue(truncated); c.close(); }
+        }).pipeThrough(zxc.createDecompressTransformStream());
+
+        let caught = null;
+        try {
+            for await (const _ of truncSource) { /* drain */ }
+        } catch (e) {
+            caught = e;
+        }
+        assert(caught && caught.code === 'ZXC_TRUNCATED', 'truncated frame errors with code ZXC_TRUNCATED');
+    }
+
     // --- Summary ---
     console.log(`\n${'='.repeat(40)}`);
     console.log(`Results: ${passed} passed, ${failed} failed`);

--- a/wrappers/wasm/zxc_wasm.js
+++ b/wrappers/wasm/zxc_wasm.js
@@ -3,13 +3,6 @@
  *
  * High-level JavaScript API for ZXC compression/decompression via WASM.
  *
- * @example
- * import createZXC from './zxc_wasm.js';
- * const zxc = await createZXC();
- *
- * const compressed = zxc.compress(inputUint8Array, { level: 3 });
- * const decompressed = zxc.decompress(compressed);
- *
  * Copyright (c) 2025-2026 Bertrand Lebonnois and contributors.
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/wrappers/wasm/zxc_wasm.js
+++ b/wrappers/wasm/zxc_wasm.js
@@ -15,6 +15,24 @@
  */
 
 /**
+ * Returns true if `buf` starts with the ZXC file magic word
+ * (little-endian 0x9CB02EF5).
+ *
+ * Side-effect free, synchronous, does not require WASM initialisation —
+ * suitable for content-type sniffing in fetch/Service Worker pipelines and
+ * for OCI media-type negotiation.
+ *
+ * @param {Uint8Array | ArrayBuffer | null | undefined} buf
+ * @returns {boolean}
+ */
+export function detectZxc(buf) {
+    if (!buf) return false;
+    const view = buf instanceof ArrayBuffer ? new Uint8Array(buf) : buf;
+    if (!view || view.length < 4) return false;
+    return view[0] === 0xF5 && view[1] === 0x2E && view[2] === 0xB0 && view[3] === 0x9C;
+}
+
+/**
  * Initialise the ZXC WASM module and return an ergonomic API object.
  *
  * @param {object} [moduleOverrides] - Optional Emscripten module overrides
@@ -510,6 +528,95 @@ export default async function createZXC(moduleOverrides, factory) {
         };
     }
 
+    // --- WHATWG TransformStream adapters -------------------------------------
+    //
+    // Mirror of the wrappers shipped by the Go, Rust, Python and Node bindings:
+    // turn a CStream / DStream pair into a `TransformStream` so ZXC can be
+    // wired into fetch pipelines, Service Workers, Deno, Bun, Node ≥18 — any
+    // host that exposes the Streams API. Useful for OCI use cases such as
+    // streaming a compressed layer through `fetch().body.pipeThrough(...)`.
+
+    /**
+     * Returns a WHATWG TransformStream that compresses bytes through a ZXC
+     * frame. Pipe a ReadableStream<Uint8Array> through it to produce a
+     * compressed ReadableStream<Uint8Array>.
+     *
+     * @param {object} [opts]
+     * @param {number} [opts.level]
+     * @param {boolean} [opts.checksum]
+     * @returns {TransformStream<Uint8Array, Uint8Array>}
+     */
+    function createCompressTransformStream(opts) {
+        let cs;
+        return new TransformStream({
+            start() {
+                cs = createCStream(opts);
+            },
+            transform(chunk, controller) {
+                try {
+                    const out = cs.compress(chunk);
+                    if (out.length > 0) controller.enqueue(out);
+                } catch (e) {
+                    controller.error(e);
+                    try { cs.free(); } catch (_) { /* idempotent */ }
+                }
+            },
+            flush(controller) {
+                try {
+                    const tail = cs.end();
+                    if (tail.length > 0) controller.enqueue(tail);
+                } catch (e) {
+                    controller.error(e);
+                } finally {
+                    try { cs.free(); } catch (_) { /* idempotent */ }
+                }
+            },
+        });
+    }
+
+    /**
+     * Returns a WHATWG TransformStream that decompresses a ZXC frame.
+     *
+     * Errors the stream with a `'ZXC_TRUNCATED'`-tagged Error if the input
+     * ends before the footer is reached.
+     *
+     * @param {object} [opts]
+     * @param {boolean} [opts.checksum]
+     * @returns {TransformStream<Uint8Array, Uint8Array>}
+     */
+    function createDecompressTransformStream(opts) {
+        let ds;
+        return new TransformStream({
+            start() {
+                ds = createDStream(opts);
+            },
+            transform(chunk, controller) {
+                try {
+                    const out = ds.decompress(chunk);
+                    if (out.length > 0) controller.enqueue(out);
+                } catch (e) {
+                    controller.error(e);
+                    try { ds.free(); } catch (_) { /* idempotent */ }
+                }
+            },
+            flush(controller) {
+                try {
+                    if (!ds.finished()) {
+                        const err = new Error(
+                            'ZXC: input drained before footer (truncated frame)');
+                        err.code = 'ZXC_TRUNCATED';
+                        controller.error(err);
+                        return;
+                    }
+                } catch (e) {
+                    controller.error(e);
+                } finally {
+                    try { ds.free(); } catch (_) { /* idempotent */ }
+                }
+            },
+        });
+    }
+
     // --- Exposed API object --------------------------------------------------
     return Object.freeze({
         compress,
@@ -520,6 +627,9 @@ export default async function createZXC(moduleOverrides, factory) {
         createDecompressContext,
         createCStream,
         createDStream,
+        createCompressTransformStream,
+        createDecompressTransformStream,
+        detectZxc,
 
         /** Library version string (e.g. "0.10.0"). */
         version: _version_string(),


### PR DESCRIPTION
Integrates zxc compression and decompression with the WHATWG Streams API via `TransformStream`, enabling use in modern JavaScript streaming pipelines (e.g., `fetch().body.pipeThrough()`). This enhances compatibility for web, Deno, Bun, and Node.js environments, and facilitates use cases like OCI layer streaming.

Additionally, introduces a pure JavaScript `detectZxc` function for lightweight content sniffing, which operates without WASM module initialization.
