### PR TITLE
feat: Add Node.js stream.Transform adapters and zxc frame detection

### DIFF
--- a/wrappers/nodejs/lib/index.d.ts
+++ b/wrappers/nodejs/lib/index.d.ts
@@ -155,3 +155,33 @@ export class DStream {
     /** Suggested output chunk size in bytes. */
     outSize(): number;
 }
+
+// ---------- stream.Transform adapters ----------
+
+import { Transform, TransformOptions } from 'node:stream';
+
+/** Returns true if `buf` starts with the ZXC file magic word. */
+export function detectZxc(buf: Buffer | Uint8Array): boolean;
+
+export interface CompressStreamOptions extends TransformOptions, CStreamOptions {}
+export interface DecompressStreamOptions extends TransformOptions, DStreamOptions {}
+
+/**
+ * `stream.Transform` that compresses bytes through a ZXC frame. Designed to
+ * be piped between any Node Readable/Writable (fs, http, tar-stream, OCI
+ * registry clients, etc.). Mirrors `zlib.createGzip()` ergonomics.
+ */
+export class CompressStream extends Transform {
+    constructor(options?: CompressStreamOptions);
+}
+
+/**
+ * `stream.Transform` that decompresses a ZXC frame. Emits `'error'` with
+ * `code === 'ZXC_TRUNCATED'` if the input ends before the footer.
+ */
+export class DecompressStream extends Transform {
+    constructor(options?: DecompressStreamOptions);
+}
+
+export function createCompressStream(options?: CompressStreamOptions): CompressStream;
+export function createDecompressStream(options?: DecompressStreamOptions): DecompressStream;

--- a/wrappers/nodejs/lib/index.js
+++ b/wrappers/nodejs/lib/index.js
@@ -7,6 +7,7 @@
 
 'use strict';
 
+const { Transform } = require('node:stream');
 const native = require('../build/Release/zxc_nodejs.node');
 
 // Re-export compression level constants
@@ -190,6 +191,163 @@ const CStream = native.CStream;
  */
 const DStream = native.DStream;
 
+// =============================================================================
+// stream.Transform adapters over the push streaming API
+// =============================================================================
+//
+// Mirror of the wrappers shipped by the Go, Rust and Python bindings: turns a
+// CStream / DStream pair into a Node.js `stream.Transform` so ZXC can be
+// piped through any code that expects standard Node streams (tar-stream,
+// node-tar, OCI registry clients, HTTP request/response, etc.).
+
+// Magic word identifying a ZXC file frame: little-endian 0x9CB02EF5.
+const ZXC_MAGIC_LE = Buffer.from([0xF5, 0x2E, 0xB0, 0x9C]);
+
+/**
+ * Returns true if `buf` starts with the ZXC file magic word.
+ *
+ * Useful for content-type sniffing in containers / object stores that need
+ * to dispatch on media type (e.g. OCI). Cheap and side-effect free; does
+ * not validate the rest of the header or the footer.
+ *
+ * @param {Buffer|Uint8Array} buf
+ * @returns {boolean}
+ */
+function detectZxc(buf) {
+    if (!buf || buf.length < 4) return false;
+    return buf[0] === 0xF5 && buf[1] === 0x2E && buf[2] === 0xB0 && buf[3] === 0x9C;
+}
+
+/**
+ * A Node.js `stream.Transform` that compresses bytes through a ZXC frame.
+ *
+ * @example
+ *   const fs = require('node:fs');
+ *   const { pipeline } = require('node:stream/promises');
+ *   await pipeline(
+ *     fs.createReadStream('input.bin'),
+ *     zxc.createCompressStream({ level: zxc.LEVEL_DEFAULT }),
+ *     fs.createWriteStream('output.zxc'),
+ *   );
+ */
+class CompressStream extends Transform {
+    constructor(options = {}) {
+        const { level, checksum, blockSize, ...transformOpts } = options;
+        super(transformOpts);
+        this._cs = new CStream({
+            ...(level !== undefined ? { level } : {}),
+            ...(checksum !== undefined ? { checksum } : {}),
+            ...(blockSize !== undefined ? { blockSize } : {}),
+        });
+    }
+
+    _transform(chunk, encoding, callback) {
+        try {
+            const buf = Buffer.isBuffer(chunk)
+                ? chunk
+                : Buffer.from(chunk, typeof encoding === 'string' ? encoding : 'utf8');
+            const out = this._cs.compress(buf);
+            if (out.length > 0) this.push(out);
+            callback();
+        } catch (err) {
+            callback(err);
+        }
+    }
+
+    _flush(callback) {
+        try {
+            const tail = this._cs.end();
+            if (tail.length > 0) this.push(tail);
+            this._cs.close();
+            callback();
+        } catch (err) {
+            callback(err);
+        }
+    }
+
+    _destroy(err, callback) {
+        try { this._cs.close(); } catch (_) { /* idempotent */ }
+        callback(err);
+    }
+}
+
+/**
+ * A Node.js `stream.Transform` that decompresses a ZXC frame.
+ *
+ * Emits `'error'` with code `'ZXC_TRUNCATED'` if the input ends before the
+ * footer is reached.
+ *
+ * @example
+ *   const fs = require('node:fs');
+ *   const { pipeline } = require('node:stream/promises');
+ *   await pipeline(
+ *     fs.createReadStream('input.zxc'),
+ *     zxc.createDecompressStream(),
+ *     fs.createWriteStream('output.bin'),
+ *   );
+ */
+class DecompressStream extends Transform {
+    constructor(options = {}) {
+        const { checksum, ...transformOpts } = options;
+        super(transformOpts);
+        this._ds = new DStream({
+            ...(checksum !== undefined ? { checksum } : {}),
+        });
+    }
+
+    _transform(chunk, encoding, callback) {
+        try {
+            const buf = Buffer.isBuffer(chunk)
+                ? chunk
+                : Buffer.from(chunk, typeof encoding === 'string' ? encoding : 'utf8');
+            const out = this._ds.decompress(buf);
+            if (out.length > 0) this.push(out);
+            callback();
+        } catch (err) {
+            callback(err);
+        }
+    }
+
+    _flush(callback) {
+        try {
+            if (!this._ds.finished()) {
+                const err = new Error('zxc: input drained before footer (truncated frame)');
+                err.code = 'ZXC_TRUNCATED';
+                this._ds.close();
+                callback(err);
+                return;
+            }
+            this._ds.close();
+            callback();
+        } catch (err) {
+            callback(err);
+        }
+    }
+
+    _destroy(err, callback) {
+        try { this._ds.close(); } catch (_) { /* idempotent */ }
+        callback(err);
+    }
+}
+
+/**
+ * Factory matching the `zlib.createGzip()` convention.
+ * @param {object} [options]
+ * @returns {CompressStream}
+ */
+function createCompressStream(options) {
+    return new CompressStream(options);
+}
+
+/**
+ * Factory matching the `zlib.createGunzip()` convention.
+ * @param {object} [options]
+ * @returns {DecompressStream}
+ */
+function createDecompressStream(options) {
+    return new DecompressStream(options);
+}
+
 module.exports = {
     // Functions
     compress,
@@ -200,6 +358,13 @@ module.exports = {
     // Push streaming classes
     CStream,
     DStream,
+
+    // stream.Transform adapters
+    CompressStream,
+    DecompressStream,
+    createCompressStream,
+    createDecompressStream,
+    detectZxc,
 
     // Library info helpers
     minLevel,

--- a/wrappers/nodejs/lib/index.js
+++ b/wrappers/nodejs/lib/index.js
@@ -194,14 +194,7 @@ const DStream = native.DStream;
 // =============================================================================
 // stream.Transform adapters over the push streaming API
 // =============================================================================
-//
-// Mirror of the wrappers shipped by the Go, Rust and Python bindings: turns a
-// CStream / DStream pair into a Node.js `stream.Transform` so ZXC can be
-// piped through any code that expects standard Node streams (tar-stream,
-// node-tar, OCI registry clients, HTTP request/response, etc.).
 
-// Magic word identifying a ZXC file frame: little-endian 0x9CB02EF5.
-const ZXC_MAGIC_LE = Buffer.from([0xF5, 0x2E, 0xB0, 0x9C]);
 
 /**
  * Returns true if `buf` starts with the ZXC file magic word.
@@ -210,6 +203,8 @@ const ZXC_MAGIC_LE = Buffer.from([0xF5, 0x2E, 0xB0, 0x9C]);
  * to dispatch on media type (e.g. OCI). Cheap and side-effect free; does
  * not validate the rest of the header or the footer.
  *
+ * Magic word identifying a ZXC file frame: little-endian 0x9CB02EF5.
+ * 
  * @param {Buffer|Uint8Array} buf
  * @returns {boolean}
  */

--- a/wrappers/nodejs/test/zxc.streams.test.js
+++ b/wrappers/nodejs/test/zxc.streams.test.js
@@ -1,0 +1,136 @@
+/*
+ * ZXC - High-performance lossless compression
+ *
+ * Copyright (c) 2025-2026 Bertrand Lebonnois and contributors.
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Tests for the stream.Transform adapters and detectZxc helper.
+ */
+
+'use strict';
+
+const { Readable, PassThrough } = require('node:stream');
+const { pipeline } = require('node:stream/promises');
+const zxc = require('../lib/index');
+
+async function gather(stream) {
+    const chunks = [];
+    for await (const c of stream) chunks.push(c);
+    return Buffer.concat(chunks);
+}
+
+async function roundtripPipeline(data, opts = {}) {
+    const compressed = await gather(
+        Readable.from([data]).pipe(zxc.createCompressStream(opts)),
+    );
+    const decompressed = await gather(
+        Readable.from([compressed]).pipe(zxc.createDecompressStream(opts)),
+    );
+    return decompressed;
+}
+
+describe('CompressStream / DecompressStream roundtrip', () => {
+    test('small buffer', async () => {
+        const data = Buffer.from('Hello stream.Transform bridge over ZXC!');
+        const got = await roundtripPipeline(data);
+        expect(Buffer.compare(got, data)).toBe(0);
+    });
+
+    test('large 2 MB buffer', async () => {
+        const data = Buffer.alloc(2 * 1024 * 1024);
+        for (let i = 0; i < data.length; i++) data[i] = (i * 13) % 251;
+        const got = await roundtripPipeline(data);
+        expect(got.length).toBe(data.length);
+        expect(Buffer.compare(got, data)).toBe(0);
+    });
+
+    test('many small chunks fed sequentially', async () => {
+        const want = Buffer.alloc(64 * 1024);
+        for (let i = 0; i < want.length; i++) want[i] = (i ^ 0x5A) & 0xFF;
+
+        // Feed 257-byte chunks to exercise buffering boundaries.
+        const chunks = [];
+        for (let i = 0; i < want.length; i += 257) {
+            chunks.push(want.subarray(i, Math.min(i + 257, want.length)));
+        }
+        const compressed = await gather(
+            Readable.from(chunks).pipe(zxc.createCompressStream()),
+        );
+        const got = await gather(
+            Readable.from([compressed]).pipe(zxc.createDecompressStream()),
+        );
+        expect(Buffer.compare(got, want)).toBe(0);
+    });
+
+    test('with checksum option', async () => {
+        const data = Buffer.alloc(32 * 1024);
+        for (let i = 0; i < data.length; i++) data[i] = i & 0xFF;
+        const got = await roundtripPipeline(data, { checksum: true });
+        expect(Buffer.compare(got, data)).toBe(0);
+    });
+
+    test('via pipeline()', async () => {
+        const data = Buffer.from('pipeline integration smoke test'.repeat(100));
+        const intermediate = new PassThrough();
+        const finalSink = new PassThrough();
+        const collected = gather(finalSink);
+
+        await pipeline(
+            Readable.from([data]),
+            zxc.createCompressStream(),
+            intermediate,
+            zxc.createDecompressStream(),
+            finalSink,
+        );
+
+        expect(Buffer.compare(await collected, data)).toBe(0);
+    });
+});
+
+describe('DecompressStream error paths', () => {
+    test('truncated frame emits ZXC_TRUNCATED', async () => {
+        const data = Buffer.alloc(32 * 1024, 0x41);
+        const compressed = await gather(
+            Readable.from([data]).pipe(zxc.createCompressStream()),
+        );
+        const truncated = compressed.subarray(0, Math.floor(compressed.length / 2));
+
+        await expect(
+            gather(Readable.from([truncated]).pipe(zxc.createDecompressStream())),
+        ).rejects.toMatchObject({ code: 'ZXC_TRUNCATED' });
+    });
+});
+
+describe('detectZxc', () => {
+    test('detects a frame produced by compress()', () => {
+        const frame = zxc.compress(Buffer.from('sniff me'));
+        expect(zxc.detectZxc(frame)).toBe(true);
+    });
+
+    test('detects a frame produced by CompressStream', async () => {
+        const frame = await gather(
+            Readable.from([Buffer.from('hi')]).pipe(zxc.createCompressStream()),
+        );
+        expect(zxc.detectZxc(frame)).toBe(true);
+    });
+
+    test.each([
+        ['empty', Buffer.alloc(0)],
+        ['too short', Buffer.from([0xF5, 0x2E, 0xB0])],
+        ['zeros', Buffer.alloc(4)],
+        ['random text', Buffer.from('not a zxc frame at all')],
+    ])('rejects %s', (_name, buf) => {
+        expect(zxc.detectZxc(buf)).toBe(false);
+    });
+
+    test('accepts Uint8Array', () => {
+        const frame = zxc.compress(Buffer.from('x'));
+        const u8 = new Uint8Array(frame);
+        expect(zxc.detectZxc(u8)).toBe(true);
+    });
+
+    test('returns false for null/undefined', () => {
+        expect(zxc.detectZxc(null)).toBe(false);
+        expect(zxc.detectZxc(undefined)).toBe(false);
+    });
+});


### PR DESCRIPTION
These new `CompressStream` and `DecompressStream` classes provide an idiomatic Node.js streaming interface (mirroring `zlib`'s ergonomics) by adapting the underlying CStream/DStream native bindings. This enables seamless integration of zxc into standard Node.js stream pipelines.

Additionally, `detectZxc` offers a cheap and side-effect-free way to identify zxc frames, useful for content-type sniffing.
