### PR TITLE
Adds LEVEL_DENSITY support to wrappers

### DIFF
--- a/wrappers/nodejs/lib/index.d.ts
+++ b/wrappers/nodejs/lib/index.d.ts
@@ -15,6 +15,8 @@ export const LEVEL_DEFAULT: number;
 export const LEVEL_BALANCED: number;
 /** High density. Best for storage/firmware/assets. */
 export const LEVEL_COMPACT: number;
+/** Maximum density: Huffman-coded literals on top of COMPACT. */
+export const LEVEL_DENSITY: number;
 
 /** Memory allocation failure. */
 export const ERROR_MEMORY: number;
@@ -46,7 +48,7 @@ export const ERROR_BAD_BLOCK_TYPE: number;
 export const ERROR_BAD_BLOCK_SIZE: number;
 
 export interface CompressOptions {
-    /** Compression level (1-5). Defaults to LEVEL_DEFAULT. */
+    /** Compression level (1-6). Defaults to LEVEL_DEFAULT. */
     level?: number;
     /** Enable checksum verification. Defaults to false. */
     checksum?: boolean;
@@ -91,7 +93,7 @@ export function errorName(code: number): string;
 /** Returns the minimum supported compression level (currently 1). */
 export function minLevel(): number;
 
-/** Returns the maximum supported compression level (currently 5). */
+/** Returns the maximum supported compression level (currently 6). */
 export function maxLevel(): number;
 
 /** Returns the default compression level (currently 3). */
@@ -104,7 +106,7 @@ export function defaultLevel(): number;
 export function libraryVersion(): string;
 
 export interface CStreamOptions {
-    /** Compression level (1-5). Defaults to LEVEL_DEFAULT. */
+    /** Compression level (1-6). Defaults to LEVEL_DEFAULT. */
     level?: number;
     /** Enable per-block and global checksums. Defaults to false. */
     checksum?: boolean;

--- a/wrappers/nodejs/lib/index.js
+++ b/wrappers/nodejs/lib/index.js
@@ -16,6 +16,7 @@ const LEVEL_FAST     = native.LEVEL_FAST;
 const LEVEL_DEFAULT  = native.LEVEL_DEFAULT;
 const LEVEL_BALANCED = native.LEVEL_BALANCED;
 const LEVEL_COMPACT  = native.LEVEL_COMPACT;
+const LEVEL_DENSITY  = native.LEVEL_DENSITY;
 
 // Re-export error constants
 const ERROR_MEMORY         = native.ERROR_MEMORY;
@@ -42,7 +43,7 @@ function minLevel() {
 }
 
 /**
- * Returns the maximum supported compression level (currently 5).
+ * Returns the maximum supported compression level (currently 6).
  * @returns {number}
  */
 function maxLevel() {
@@ -98,7 +99,7 @@ function compressBound(inputSize) {
  *
  * @param {Buffer} data - Buffer to compress.
  * @param {object} [options] - Compression options.
- * @param {number} [options.level=LEVEL_DEFAULT] - Compression level (1-5).
+ * @param {number} [options.level=LEVEL_DEFAULT] - Compression level (1-6).
  * @param {boolean} [options.checksum=false] - Enable checksum verification.
  * @param {boolean} [options.seekable=false] - Enable seek table for random-access decompression.
  * @returns {Buffer} Compressed data.
@@ -373,6 +374,7 @@ module.exports = {
     LEVEL_DEFAULT,
     LEVEL_BALANCED,
     LEVEL_COMPACT,
+    LEVEL_DENSITY,
 
     // Error handling
     errorName,

--- a/wrappers/nodejs/src/zxc_addon.cc
+++ b/wrappers/nodejs/src/zxc_addon.cc
@@ -492,6 +492,7 @@ static Napi::Object Init(Napi::Env env, Napi::Object exports) {
     exports.Set("LEVEL_DEFAULT", Napi::Number::New(env, ZXC_LEVEL_DEFAULT));
     exports.Set("LEVEL_BALANCED", Napi::Number::New(env, ZXC_LEVEL_BALANCED));
     exports.Set("LEVEL_COMPACT", Napi::Number::New(env, ZXC_LEVEL_COMPACT));
+    exports.Set("LEVEL_DENSITY", Napi::Number::New(env, ZXC_LEVEL_DENSITY));
 
     // Error constants
     exports.Set("ERROR_MEMORY", Napi::Number::New(env, ZXC_ERROR_MEMORY));

--- a/wrappers/nodejs/test/zxc.test.js
+++ b/wrappers/nodejs/test/zxc.test.js
@@ -23,7 +23,7 @@ describe('compress/decompress roundtrip', () => {
 
     for (const { name, data } of testCases) {
         test(`roundtrip: ${name}`, () => {
-            for (let level = zxc.LEVEL_FASTEST; level <= zxc.LEVEL_COMPACT; level++) {
+            for (let level = zxc.LEVEL_FASTEST; level <= zxc.LEVEL_DENSITY; level++) {
                 const compressed = zxc.compress(data, { level });
                 const size = zxc.getDecompressedSize(compressed);
                 const decompressed = zxc.decompress(compressed, { size });
@@ -121,6 +121,7 @@ describe('constants', () => {
         expect(zxc.LEVEL_DEFAULT).toBe(3);
         expect(zxc.LEVEL_BALANCED).toBe(4);
         expect(zxc.LEVEL_COMPACT).toBe(5);
+        expect(zxc.LEVEL_DENSITY).toBe(6);
     });
 });
 

--- a/wrappers/python/src/zxc/__init__.py
+++ b/wrappers/python/src/zxc/__init__.py
@@ -34,6 +34,7 @@ from ._zxc import (
     LEVEL_DEFAULT,
     LEVEL_BALANCED,
     LEVEL_COMPACT,
+    LEVEL_DENSITY,
     ERROR_MEMORY,
     ERROR_DST_TOO_SMALL,
     ERROR_SRC_TOO_SMALL,
@@ -84,6 +85,7 @@ __all__ = [
     "LEVEL_DEFAULT",
     "LEVEL_BALANCED",
     "LEVEL_COMPACT",
+    "LEVEL_DENSITY",
 
     # Error Constants
     "ERROR_MEMORY",

--- a/wrappers/python/src/zxc/_zxc.c
+++ b/wrappers/python/src/zxc/_zxc.c
@@ -164,6 +164,7 @@ PyMODINIT_FUNC PyInit__zxc(void) {
     PyModule_AddIntConstant(m, "LEVEL_DEFAULT", ZXC_LEVEL_DEFAULT);
     PyModule_AddIntConstant(m, "LEVEL_BALANCED", ZXC_LEVEL_BALANCED);
     PyModule_AddIntConstant(m, "LEVEL_COMPACT", ZXC_LEVEL_COMPACT);
+    PyModule_AddIntConstant(m, "LEVEL_DENSITY", ZXC_LEVEL_DENSITY);
 
     /* Error Enums */
     PyModule_AddIntConstant(m, "ERROR_MEMORY", ZXC_ERROR_MEMORY);

--- a/wrappers/python/tests/test_buffer.py
+++ b/wrappers/python/tests/test_buffer.py
@@ -54,13 +54,12 @@ def test_compress_corruption(data, corrupt_func, exc):
 )
 
 def test_compress_roundtrip(data):
-    # test all compression levels
-    levels_cnt = zxc.LEVEL_COMPACT 
-    for level in range(levels_cnt + 1):
+    # test all compression levels (1..LEVEL_DENSITY)
+    for level in range(zxc.LEVEL_FASTEST, zxc.LEVEL_DENSITY + 1):
         compressed = zxc.compress(data, level)
-    
+
         out_size = zxc.get_decompressed_size(compressed)
-        decompressed = zxc.decompress(compressed, out_size) 
+        decompressed = zxc.decompress(compressed, out_size)
         assert len(data) == len(decompressed)
         assert data == decompressed
     

--- a/wrappers/python/tests/test_stream.py
+++ b/wrappers/python/tests/test_stream.py
@@ -107,8 +107,7 @@ def test_stream_roundtrip(tmp_path, data):
 
     src_file_path.write_bytes(data)
 
-    levels_cnt = zxc.LEVEL_COMPACT 
-    for level in range(levels_cnt + 1):
+    for level in range(zxc.LEVEL_FASTEST, zxc.LEVEL_DENSITY + 1):
         with open(src_file_path, "rb") as src, \
             open(compressed_file_path, "wb") as compressed:
             zxc.stream_compress(src, compressed, level=level)

--- a/wrappers/rust/zxc-sys/src/lib.rs
+++ b/wrappers/rust/zxc-sys/src/lib.rs
@@ -155,7 +155,7 @@ pub const ZXC_ERROR_BAD_BLOCK_SIZE: i32 = -14;
 pub struct zxc_compress_opts_t {
     /// Worker thread count (0 = auto-detect CPU cores).
     pub n_threads: c_int,
-    /// Compression level 1-5 (0 = default).
+    /// Compression level 1-6 (0 = default).
     pub level: c_int,
     /// Block size in bytes (0 = default 256 KB). Must be power of 2, 4 KB – 2 MB.
     pub block_size: usize,
@@ -463,7 +463,7 @@ unsafe extern "C" {
     /// * `f_in` - Input file stream
     /// * `f_out` - Output file stream  
     /// * `n_threads` - Number of worker threads (0 = auto-detect CPU cores)
-    /// * `level` - Compression level (1-5)
+    /// * `level` - Compression level (1-6)
     /// * `checksum_enabled` - If non-zero, enables checksum verification
     ///
     /// # Returns
@@ -986,6 +986,7 @@ mod tests {
             ZXC_LEVEL_DEFAULT,
             ZXC_LEVEL_BALANCED,
             ZXC_LEVEL_COMPACT,
+            ZXC_LEVEL_DENSITY,
         ] {
             unsafe {
                 let bound = zxc_compress_bound(input.len()) as usize;

--- a/wrappers/wasm/test.mjs
+++ b/wrappers/wasm/test.mjs
@@ -73,7 +73,7 @@ async function main() {
     const version = _version_string();
     assert(typeof version === 'string' && version.length > 0, `Version: ${version}`);
     assert(_min_level() === 1, `Min level: ${_min_level()}`);
-    assert(_max_level() === 5, `Max level: ${_max_level()}`);
+    assert(_max_level() === 6, `Max level: ${_max_level()}`);
     assert(_default_level() === 3, `Default level: ${_default_level()}`);
 
     // --- 3. Compress bound ---
@@ -130,7 +130,7 @@ async function main() {
         }
         const bound = _compress_bound(input.length);
 
-        for (let level = 1; level <= 5; level++) {
+        for (let level = 1; level <= 6; level++) {
             const srcPtr = Module._malloc(input.length);
             const dstPtr = Module._malloc(bound);
             Module.HEAPU8.set(input, srcPtr);

--- a/wrappers/wasm/zxc_wasm.js
+++ b/wrappers/wasm/zxc_wasm.js
@@ -149,7 +149,7 @@ export default async function createZXC(moduleOverrides, factory) {
      *
      * @param {Uint8Array} data - Input data to compress.
      * @param {object} [opts] - Options.
-     * @param {number} [opts.level=3] - Compression level (1-5).
+     * @param {number} [opts.level=3] - Compression level (1-6).
      * @param {boolean} [opts.checksum=false] - Enable checksums.
      * @param {boolean} [opts.seekable=false] - Append seek table for random-access.
      * @returns {Uint8Array} Compressed data.


### PR DESCRIPTION
Introduces `LEVEL_DENSITY` (compression level 6) across Node.js, Python, Rust, and WebAssembly wrappers. This new level provides maximum density compression, utilizing Huffman-coded literals on top of the `COMPACT` level.

- Exposes the `LEVEL_DENSITY` constant in all affected wrappers.
- Updates documentation and type definitions to reflect the expanded compression level range (1-6).
- Enhances test suites in Node.js, Python, and WebAssembly to validate roundtrip compression/decompression using the new `LEVEL_DENSITY`.