### PR TITLE
Increases default block size to 512 KB

### DIFF
--- a/.github/workflows/multiarch.yml
+++ b/.github/workflows/multiarch.yml
@@ -230,7 +230,7 @@ jobs:
       - name: Install cross-compiler
         run: |
           apt-get update
-          apt-get install -y cmake build-essential ninja-build ${{ matrix.cross_pkg }} qemu-user
+          apt-get install -y cmake build-essential ${{ matrix.cross_pkg }} qemu-user
 
       - name: Configure, Build & Test (Static & Shared)
         shell: bash
@@ -300,7 +300,7 @@ jobs:
       - name: Install cross-compiler
         run: |
           apt-get update
-          apt-get install -y cmake build-essential ninja-build ${{ matrix.cross_pkg }} qemu-user
+          apt-get install -y cmake build-essential ${{ matrix.cross_pkg }} qemu-user
 
       - name: Configure, Build & Test (Static & Shared)
         shell: bash

--- a/.github/workflows/multicomp.yml
+++ b/.github/workflows/multicomp.yml
@@ -130,12 +130,12 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Ubuntu 22.04 ships GCC 9, 10, 11, 12 in universe
-          - { os: ubuntu-22.04, version: 9 }
+          # Ubuntu 22.04 preinstalls GCC 10, 11, 12; GCC 9 lives in universe.
+          - { os: ubuntu-22.04, version: 9, needs_install: true }
           - { os: ubuntu-22.04, version: 10 }
           - { os: ubuntu-22.04, version: 11 }
           - { os: ubuntu-22.04, version: 12 }
-          # Ubuntu 24.04 ships GCC 12, 13, 14
+          # Ubuntu 24.04 preinstalls GCC 12, 13, 14.
           - { os: ubuntu-latest, version: 13 }
           - { os: ubuntu-latest, version: 14 }
 
@@ -144,6 +144,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install GCC ${{ matrix.version }}
+        if: matrix.needs_install
         run: |
           sudo apt-get update
           sudo apt-get install -y gcc-${{ matrix.version }} g++-${{ matrix.version }}
@@ -264,7 +265,7 @@ jobs:
       - name: Install cross-compiler & QEMU
         run: |
           sudo apt-get update
-          sudo apt-get install -y cmake build-essential ${{ matrix.cross_pkg }} qemu-user
+          sudo apt-get install -y ${{ matrix.cross_pkg }} qemu-user
 
       - name: Configure, Build & Test (Static & Shared)
         shell: bash

--- a/README.md
+++ b/README.md
@@ -374,27 +374,27 @@ cmake --build build --parallel
 
 ## Block Size Tuning
 
-The default block size is **256 KB**, a conservative choice that balances compression quality, memory usage, and random-access granularity. For **bulk/archival workloads** where maximum throughput matters, **512 KB blocks** are recommended.
+The default block size is **512 KB**, tuned for bulk/archival workloads where ratio and decompression throughput matter most. For **memory-constrained or streaming use cases**, **256 KB blocks** halve the per-context memory footprint at a small cost in ratio and decompression speed.
 
 **Why larger blocks help:** Each block starts with a cold hash table, so the LZ match-finder has no history and produces more literals until the table warms up. Doubling the block size halves the number of cold-start penalties, improving both ratio and decompression speed.
 
-| Block Size | Memory (per context) | Ratio (level -3) | Decompression gain vs 256 KB |
-|:----------:|:--------------------:|:-----------------:|:----------------------------:|
-| 256 KB *(default)* | ~1.7 MB | 46.36% | — |
-| 512 KB | ~3.3 MB | 45.81% *(−0.55 pp)* | +1% to +8% depending on CPU |
+| Block Size | Memory (per context) | Ratio (level -3) | Decompression vs 256 KB |
+|:----------:|:--------------------:|:-----------------:|:-----------------------:|
+| 256 KB             | ~1.7 MB | 46.36% | — |
+| 512 KB *(default)* | ~3.3 MB | 45.81% *(−0.55 pp)* | +1% to +8% depending on CPU |
 
 ```bash
-# CLI
-zxc -B 512K -5 input_file output_file
+# CLI — fall back to 256 KB blocks (e.g. embedded / streaming)
+zxc -B 256K -5 input_file output_file
 
 # API
 zxc_compress_opts_t opts = {
     .level      = ZXC_LEVEL_COMPACT,
-    .block_size = 512 * 1024,
+    .block_size = 256 * 1024,
 };
 ```
 
-**Guideline:** Use 256 KB (default) for streaming, embedded, or memory-constrained environments. Use 512 KB for bulk compression pipelines, CI/CD asset packaging, and high-throughput servers.
+**Guideline:** Stick with 512 KB (default) for bulk compression pipelines, CI/CD asset packaging, and high-throughput servers. Use 256 KB (`-B 256K`) for streaming, embedded, or memory-constrained environments.
 
 ---
 
@@ -458,7 +458,7 @@ uint64_t bound = zxc_compress_bound(src_size);
 zxc_compress_opts_t c_opts = {
     .level            = ZXC_LEVEL_DEFAULT,
     .checksum_enabled = 1,
-    /* .block_size = 0 -> 256 KB default */
+    /* .block_size = 0 -> 512 KB default */
 };
 int64_t compressed_size = zxc_compress(src, src_size, dst, bound, &c_opts);
 
@@ -476,7 +476,7 @@ zxc_compress_opts_t c_opts = {
     .n_threads        = 0,               // 0 = auto
     .level            = ZXC_LEVEL_DEFAULT,
     .checksum_enabled = 1,
-    /* .block_size = 0 -> 256 KB default */
+    /* .block_size = 0 -> 512 KB default */
 };
 int64_t bytes_written = zxc_stream_compress(f_in, f_out, &c_opts);
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -141,7 +141,7 @@ Defined in `zxc_constants.h`:
 #define ZXC_BLOCK_SIZE_MAX_LOG2  21              // exponent for maximum
 #define ZXC_BLOCK_SIZE_MIN       (1U << 12)      // 4 KB
 #define ZXC_BLOCK_SIZE_MAX       (1U << 21)      // 2 MB
-#define ZXC_BLOCK_SIZE_DEFAULT   (256 * 1024)    // 256 KB
+#define ZXC_BLOCK_SIZE_DEFAULT   (512 * 1024)    // 512 KB
 ```
 
 Block size must be a power of two within `[ZXC_BLOCK_SIZE_MIN, ZXC_BLOCK_SIZE_MAX]`.
@@ -201,7 +201,7 @@ All public functions that can fail return negative `zxc_error_t` values on error
 typedef struct {
     int    n_threads;         // Worker thread count (0 = auto-detect).
     int    level;             // Compression level 1–6 (0 = default).
-    size_t block_size;        // Block size in bytes (0 = 256 KB default).
+    size_t block_size;        // Block size in bytes (0 = 512 KB default).
     int    checksum_enabled;  // 1 = enable checksums, 0 = disable.
     int    seekable;          // 1 = append seek table for random access.
     zxc_progress_callback_t progress_cb;  // Optional callback (NULL to disable).

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -43,7 +43,7 @@ int main(void) {
     zxc_compress_opts_t c_opts = {
         .level            = ZXC_LEVEL_DEFAULT,
         .checksum_enabled = 1,
-        /* .block_size = 0  ->  256 KB default */
+        /* .block_size = 0  ->  512 KB default */
     };
     int64_t compressed_size = zxc_compress(
         original,            // Source buffer
@@ -142,12 +142,12 @@ int main(int argc, char* argv[]) {
         return 1;
     }
 
-    // 0 threads = auto-detect CPU cores; 0 block_size = 256 KB default
+    // 0 threads = auto-detect CPU cores; 0 block_size = 512 KB default
     zxc_compress_opts_t c_opts = {
         .n_threads        = 0,
         .level            = ZXC_LEVEL_DEFAULT,
         .checksum_enabled = 1,
-        /* .block_size = 0  ->  256 KB */
+        /* .block_size = 0  ->  512 KB */
     };
     int64_t compressed_bytes = zxc_stream_compress(f_in, f_out, &c_opts);
 

--- a/docs/FORMAT.md
+++ b/docs/FORMAT.md
@@ -572,7 +572,7 @@ Generated archive size: **58 bytes**.
 ### 13.1 Full hexdump
 
 ```text
-00000000: F5 2E B0 9C 05 12 80 00 00 00 00 00 00 00 9E 53
+00000000: F5 2E B0 9C 05 13 80 00 00 00 00 00 00 00 B8 90
 00000010: 00 00 00 0A 00 00 00 69 48 65 6C 6C 6F 20 5A 58
 00000020: 43 0A 90 BB A1 75 FF 00 00 00 00 00 00 02 0A 00
 00000030: 00 00 00 00 00 00 90 BB A1 75
@@ -583,15 +583,15 @@ Generated archive size: **58 bytes**.
 #### A) File Header (offset `0x00`, 16 bytes)
 
 ```text
-F5 2E B0 9C | 05 | 12 | 80 | 00 00 00 00 00 00 00 | 9E 53
+F5 2E B0 9C | 05 | 13 | 80 | 00 00 00 00 00 00 00 | B8 90
 ```
 
 - `F5 2E B0 9C` -> magic word (LE) = `0x9CB02EF5`.
 - `05` -> format version 5.
-- `12` -> chunk-size code 18 (exponent encoding: `2^18 = 262144` bytes, i.e. 256 KiB).
+- `13` -> chunk-size code 19 (exponent encoding: `2^19 = 524288` bytes, i.e. 512 KiB, the default).
 - `80` -> checksum enabled (`HAS_CHECKSUM=1`, algo id 0).
 - next 7 bytes are reserved zeros.
-- `9E 53` -> header CRC16.
+- `B8 90` -> header CRC16.
 
 #### B) Data Block #0 (RAW)
 
@@ -672,7 +672,7 @@ Generated archive size: **70 bytes** (12 bytes larger than the non-seekable vari
 #### Full hexdump
 
 ```text
-00000000: F5 2E B0 9C 05 12 80 00 00 00 00 00 00 00 9E 53
+00000000: F5 2E B0 9C 05 13 80 00 00 00 00 00 00 00 B8 90
 00000010: 00 00 00 0A 00 00 00 69 48 65 6C 6C 6F 20 5A 58
 00000020: 43 0A 90 BB A1 75 FF 00 00 00 00 00 00 02 FE 00
 00000030: 00 04 00 00 00 D2 16 00 00 00 0A 00 00 00 00 00

--- a/docs/FORMAT.md
+++ b/docs/FORMAT.md
@@ -57,8 +57,8 @@ Offset  Size  Field
 - **Format Version** (`u8`): currently `5`.
 - **Chunk Size Code** (`u8`):
   - If the value is in the range `[12, 21]`, it is an **exponent**: `block_size = 2^code`.
-    - `12` = 4 KB, `13` = 8 KB, ..., `18` = 256 KB (default), ..., `21` = 2 MB.
-  - The legacy value `64` (from older encoders) is accepted and maps to 256 KB (default).
+    - `12` = 4 KB, `13` = 8 KB, ..., `19` = 512 KB (default), ..., `21` = 2 MB.
+  - The legacy value `64` (from older encoders) is accepted and maps to 256 KB.
   - All other values are rejected (`ZXC_ERROR_BAD_BLOCK_SIZE`).
   - Valid block sizes are powers of 2 in the range **4 KB – 2 MB**.
 - **Flags** (`u8`):

--- a/docs/WHITEPAPER.md
+++ b/docs/WHITEPAPER.md
@@ -35,7 +35,7 @@ ZXC utilizes a hybrid approach combining LZ77 (Lempel-Ziv) dictionary matching w
 
 ### 4.1 LZ77 Engine
 The heart of ZXC is a heavily optimized LZ77 engine that adapts its behavior based on the requested compression level:
-*   **Hash Chain & Collision Resolution**: Uses a fast hash table with chaining to find matches in the history window (configurable sliding window, power-of-2 from 4 KB to 2 MB, default 256 KB).
+*   **Hash Chain & Collision Resolution**: Uses a fast hash table with chaining to find matches in the history window (configurable sliding window, power-of-2 from 4 KB to 2 MB, default 512 KB).
 *   **Lazy Matching**: Implements a "lookahead" strategy to find better matches at the cost of slight encoding speed, significantly improving decompression density.
 
 ### 4.2 Specialized SIMD Acceleration & Hardware Hashing
@@ -105,7 +105,7 @@ The file begins with a **16-byte** header that identifies the format and specifi
 * **Version (1 byte)**: Current version is `5`.
 * **Chunk Size Code (1 byte)**: Defines the processing block size using **exponent encoding**:
   - If the value is in `[12, 21]`: block size = `2^value` bytes (4 KB to 2 MB).
-    - `12` = 4 KB, `13` = 8 KB, `14` = 16 KB, `15` = 32 KB, `16` = 64 KB, `17` = 128 KB, `18` = 256 KB (default), `19` = 512 KB, `20` = 1 MB, `21` = 2 MB.
+    - `12` = 4 KB, `13` = 8 KB, `14` = 16 KB, `15` = 32 KB, `16` = 64 KB, `17` = 128 KB, `18` = 256 KB, `19` = 512 KB (default), `20` = 1 MB, `21` = 2 MB.
   - Legacy value `64` is accepted for backward compatibility (maps to 256 KB).
   - Block sizes must be powers of 2.
 * **Flags (1 byte)**: Global configuration flags.
@@ -477,7 +477,7 @@ ZXC supports **O(1)** random-access decompression without decoding the entire st
 ZXC leverages a threaded **Producer-Consumer** model to saturate modern multi-core CPUs.
 
 ### 6.1 Asynchronous Compression Pipeline
-1.  **Block Splitting (Main Thread)**: The input file is read and sliced into fixed-size chunks (configurable, default 256 KB, power of 2 from 4 KB to 2 MB).
+1.  **Block Splitting (Main Thread)**: The input file is read and sliced into fixed-size chunks (configurable, default 512 KB, power of 2 from 4 KB to 2 MB).
 2.  **Ring Buffer Submission**: Chunks are placed into a lock-free ring buffer.
 3.  **Parallel Compression (Worker Threads)**:
     *   Workers pull chunks from the queue.
@@ -496,7 +496,7 @@ ZXC leverages a threaded **Producer-Consumer** model to saturate modern multi-co
 ## 7. Performance Analysis (Benchmarks)
 
 **Methodology:**
-Benchmarks were conducted using `lzbench` (by inikep) with the **default block size of 256 KB**, checksums disabled, single-threaded execution, on the standard Silesia Corpus ([silesia.tar](https://github.com/DataCompression/corpus-collection/tree/main/Silesia-Corpus), 202 MB).
+Benchmarks were conducted using `lzbench` (by inikep) with a **block size of 256 KB**, checksums disabled, single-threaded execution, on the standard Silesia Corpus ([silesia.tar](https://github.com/DataCompression/corpus-collection/tree/main/Silesia-Corpus), 202 MB).
 * **Target 1 (Client):** Apple M2 / macOS 26 (Clang 21)
 * **Target 2 (Cloud):** Google Axion / Linux (GCC 14)
 * **Target 3 (Build):** AMD EPYC 9B45 / Linux (GCC 14)
@@ -707,7 +707,7 @@ Benchmarks were conducted using lzbench 2.2.1 (from @inikep), compiled with GCC 
 
 ### 7.5 Block Size Impact: 256 KB vs 512 KB
 
-All benchmarks in sections 7.1–7.4 use the **default block size of 256 KB**. This section evaluates the performance impact of increasing the block size to **512 KB**, measured on three architectures using lzbench 2.2.1 under identical conditions.
+All benchmarks in sections 7.1–7.4 use a **block size of 256 KB** (the previous default; the current default is 512 KB). This section evaluates the performance impact of increasing the block size from **256 KB** to **512 KB (current default)**, measured on three architectures using lzbench 2.2.1 under identical conditions.
 
 **Why block size matters:** Each block starts with a cold hash table, so the LZ77 match-finder has no history and produces more literals until the table warms up. Doubling the block size halves the number of cold-start penalties (~809 blocks to ~405 blocks on the Silesia corpus), improving both compression ratio and decompression throughput.
 
@@ -717,7 +717,7 @@ All benchmarks in sections 7.1–7.4 use the **default block size of 256 KB**. T
 
 Benchmarked using lzbench 2.2.1, compiled with Clang 21.0.0 using *MOREFLAGS="-march=native"* on macOS Tahoe 26.4 (Build 25E246). Apple M2 processor (ARM64, P-core frequency 3.5 GHz).
 
-**Block Size: 256 KB (default)**
+**Block Size: 256 KB**
 
 | Compressor name         | Compression| Decompress.| Compr. size | Ratio |
 | ---------------         | -----------| -----------| ----------- | ----- |
@@ -727,7 +727,7 @@ Benchmarked using lzbench 2.2.1, compiled with Clang 21.0.0 using *MOREFLAGS="-m
 | **zxc 0.10.0 -4**       |   176 MB/s |  **6636 MB/s** |    91429653 | **43.14** |
 | **zxc 0.10.0 -5**       |   104 MB/s |  **6181 MB/s** |    86196446 | **40.67** |
 
-**Block Size: 512 KB**
+**Block Size: 512 KB (default)**
 
 | Compressor name         | Compression| Decompress.| Compr. size | Ratio |
 | ---------------         | -----------| -----------| ----------- | ----- |
@@ -753,7 +753,7 @@ Benchmarked using lzbench 2.2.1, compiled with Clang 21.0.0 using *MOREFLAGS="-m
 
 Benchmarked using lzbench 2.2.1, compiled with GCC 14.3.0 using *MOREFLAGS="-march=native"* on Linux Debian 12. Google Neoverse-V2 processor (ARM64, 2.6 GHz).
 
-**Block Size: 256 KB (default)**
+**Block Size: 256 KB**
 
 | Compressor name         | Compression| Decompress.| Compr. size | Ratio |
 | ---------------         | -----------| -----------| ----------- | ----- |
@@ -763,7 +763,7 @@ Benchmarked using lzbench 2.2.1, compiled with GCC 14.3.0 using *MOREFLAGS="-mar
 | **zxc 0.10.0 -4**       |   170 MB/s |  **5038 MB/s** |    91429653 | **43.14** |
 | **zxc 0.10.0 -5**       |   100 MB/s |  **4676 MB/s** |    86196446 | **40.67** |
 
-**Block Size: 512 KB**
+**Block Size: 512 KB (default)**
 
 | Compressor name         | Compression| Decompress.| Compr. size | Ratio |
 | ---------------         | -----------| -----------| ----------- | ----- |
@@ -789,7 +789,7 @@ Benchmarked using lzbench 2.2.1, compiled with GCC 14.3.0 using *MOREFLAGS="-mar
 
 Benchmarked using lzbench 2.2.1, compiled with GCC 14.3.0 using *MOREFLAGS="-march=native"* on Linux Ubuntu 24.04. AMD EPYC 9B45 processor (x86_64, 2.1 GHz).
 
-**Block Size: 256 KB (default)**
+**Block Size: 256 KB**
 
 | Compressor name         | Compression| Decompress.| Compr. size | Ratio |
 | ---------------         | -----------| -----------| ----------- | ----- |
@@ -799,7 +799,7 @@ Benchmarked using lzbench 2.2.1, compiled with GCC 14.3.0 using *MOREFLAGS="-mar
 | **zxc 0.10.0 -4**       |   169 MB/s |  **5660 MB/s** |    91429653 | **43.14** |
 | **zxc 0.10.0 -5**       |   100 MB/s |  **5316 MB/s** |    86196446 | **40.67** |
 
-**Block Size: 512 KB**
+**Block Size: 512 KB (default)**
 
 | Compressor name         | Compression| Decompress.| Compr. size | Ratio |
 | ---------------         | -----------| -----------| ----------- | ----- |
@@ -825,7 +825,7 @@ Benchmarked using lzbench 2.2.1, compiled with GCC 14.3.0 using *MOREFLAGS="-mar
 
 Benchmarked using lzbench 2.2.1, compiled with GCC 14.2.0 using *MOREFLAGS="-march=native"* on Linux Ubuntu 24.04. AMD EPYC 7763 64-Core processor (x86_64, 2.45 GHz).
 
-**Block Size: 256 KB (default)**
+**Block Size: 256 KB**
 
 | Compressor name         | Compression| Decompress.| Compr. size | Ratio | Filename |
 | ---------------         | -----------| -----------| ----------- | ----- | -------- |
@@ -844,7 +844,7 @@ Benchmarked using lzbench 2.2.1, compiled with GCC 14.2.0 using *MOREFLAGS="-mar
 | zstd 1.5.7 -1           |   409 MB/s |  1221 MB/s |    73193704 | 34.53 | 1 files|
 | zlib 1.3.1 -1           |  98.5 MB/s |   328 MB/s |    77259029 | 36.45 | 1 files|
 
-**Block Size: 512 KB**
+**Block Size: 512 KB (default)**
 
 | Compressor name         | Compression| Decompress.| Compr. size | Ratio |
 | ---------------         | -----------| -----------| ----------- | ----- |
@@ -882,15 +882,15 @@ Benchmarked using lzbench 2.2.1, compiled with GCC 14.2.0 using *MOREFLAGS="-mar
 
 | Block Size | Context Memory | Δ vs 256 KB |
 |:----------:|:--------------:|:-----------:|
-| 256 KB *(default)* | ~1.7 MB  | —           |
-| 512 KB             | ~3.3 MB  | +92%        |
+| 256 KB             | ~1.7 MB  | —           |
+| 512 KB *(default)* | ~3.3 MB  | +92%        |
 
-> **Guideline:** Use 256 KB (default) for streaming, embedded, or memory-constrained environments. Use 512 KB (`-B 512K`) for bulk compression pipelines and high-throughput servers where memory is not a constraint.
+> **Guideline:** Use 512 KB (default) for bulk compression pipelines and high-throughput servers, where the better ratio and decompression throughput outweigh the extra ~1.6 MB of context memory. Use 256 KB (`-B 256K`) for streaming, embedded, or memory-constrained environments.
 
 
 ## 8. Compression Ratio Benchmarks
 
-To evaluate compression effectiveness across diverse data distributions, the compressed size is reported as a percentage of the original input for each corpus. All measurements were performed using lzbench 2.2.1 (inikep), compiled with GCC 13.3.0 and *MOREFLAGS="-march=native"* on Linux 64-bit Ubuntu 24.04. The reference platform is an AMD EPYC 7763 (x86_64). ZXC was configured with its default block size of 256KB. Lower values indicate superior compression density.
+To evaluate compression effectiveness across diverse data distributions, the compressed size is reported as a percentage of the original input for each corpus. All measurements were performed using lzbench 2.2.1 (inikep), compiled with GCC 13.3.0 and *MOREFLAGS="-march=native"* on Linux 64-bit Ubuntu 24.04. The reference platform is an AMD EPYC 7763 (x86_64). ZXC was configured with a block size of 256 KB. Lower values indicate superior compression density.
 
 | Corpus | zxc 0.9.0 -1 | zxc 0.9.0 -2 | zxc 0.9.0 -3 | zxc 0.9.0 -4 | zxc 0.9.0 -5 | lz4 1.10.0 | lz4 1.10.0 --fast -17 | lz4hc 1.10.0 -12 | zstd 1.5.7 -1 | zstd 1.5.7 --fast --1 | Source |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |

--- a/include/zxc_constants.h
+++ b/include/zxc_constants.h
@@ -56,8 +56,8 @@
 #define ZXC_BLOCK_SIZE_MIN_LOG2 12
 /** @brief log2(ZXC_BLOCK_SIZE_MAX) - exponent code for maximum block size. */
 #define ZXC_BLOCK_SIZE_MAX_LOG2 21
-/** @brief Default block size (256 KB). */
-#define ZXC_BLOCK_SIZE_DEFAULT (256 * 1024)
+/** @brief Default block size (512 KB). */
+#define ZXC_BLOCK_SIZE_DEFAULT (512 * 1024)
 /** @brief Minimum allowed block size (4 KB = 2^12). */
 #define ZXC_BLOCK_SIZE_MIN (1U << ZXC_BLOCK_SIZE_MIN_LOG2)
 /** @brief Maximum allowed block size (2 MB = 2^21). */

--- a/include/zxc_pstream.h
+++ b/include/zxc_pstream.h
@@ -200,7 +200,7 @@ ZXC_EXPORT int64_t zxc_cstream_end(zxc_cstream* cs, zxc_outbuf_t* out);
 /**
  * @brief Suggested input chunk size for best throughput.
  *
- * Equal to the configured block size (default 256 KB).  The caller may
+ * Equal to the configured block size (default 512 KB).  The caller may
  * supply any input chunk; this is purely a performance hint.
  *
  * @param[in] cs  Compression stream.

--- a/wrappers/nodejs/lib/index.d.ts
+++ b/wrappers/nodejs/lib/index.d.ts
@@ -110,7 +110,7 @@ export interface CStreamOptions {
     level?: number;
     /** Enable per-block and global checksums. Defaults to false. */
     checksum?: boolean;
-    /** Block size in bytes (0 = default 256 KB). Power of 2, 4 KB – 2 MB. */
+    /** Block size in bytes (0 = default 512 KB). Power of 2, 4 KB – 2 MB. */
     blockSize?: number;
 }
 

--- a/wrappers/nodejs/test/zxc.test.js
+++ b/wrappers/nodejs/test/zxc.test.js
@@ -214,8 +214,8 @@ describe('pstream roundtrip', () => {
         expect(pstreamRoundtrip(data, { checksum: true }).equals(data)).toBe(true);
     });
 
-    test('multi-block (>256 KB)', () => {
-        const data = Buffer.alloc(512 * 1024);
+    test('multi-block (>512 KB)', () => {
+        const data = Buffer.alloc(1536 * 1024);
         for (let i = 0; i < data.length; i++) data[i] = (i * 7) % 256;
         expect(pstreamRoundtrip(data).equals(data)).toBe(true);
     });

--- a/wrappers/python/tests/test_pstream.py
+++ b/wrappers/python/tests/test_pstream.py
@@ -43,8 +43,8 @@ def test_pstream_with_checksum():
 
 
 def test_pstream_multi_block():
-    # Larger than one default block (256 KB) to force multiple blocks.
-    data = bytes(((i * 7) % 256 for i in range(512 * 1024)))
+    # Larger than one default block (512 KB) to force multiple blocks.
+    data = bytes(((i * 7) % 256 for i in range(1536 * 1024)))
     assert _roundtrip(data) == data
 
 

--- a/wrappers/rust/zxc-sys/src/lib.rs
+++ b/wrappers/rust/zxc-sys/src/lib.rs
@@ -157,7 +157,7 @@ pub struct zxc_compress_opts_t {
     pub n_threads: c_int,
     /// Compression level 1-6 (0 = default).
     pub level: c_int,
-    /// Block size in bytes (0 = default 256 KB). Must be power of 2, 4 KB – 2 MB.
+    /// Block size in bytes (0 = default 512 KB). Must be power of 2, 4 KB – 2 MB.
     pub block_size: usize,
     /// 1 to enable per-block and global checksums, 0 to disable.
     pub checksum_enabled: c_int,

--- a/wrappers/rust/zxc/src/pstream.rs
+++ b/wrappers/rust/zxc/src/pstream.rs
@@ -353,8 +353,8 @@ mod tests {
 
     #[test]
     fn pstream_multi_block() {
-        // Larger than one default block (256 KB) to force multiple blocks.
-        let data: Vec<u8> = (0..512 * 1024).map(|i| ((i * 7) % 256) as u8).collect();
+        // Larger than one default block (512 KB) to force multiple blocks.
+        let data: Vec<u8> = (0..1536 * 1024).map(|i| ((i * 7) % 256) as u8).collect();
         let out = pstream_roundtrip(&data, None, None);
         assert_eq!(out, data);
     }


### PR DESCRIPTION
Elevates the default compression block size from 256 KB to 512 KB. This change aims to improve both compression ratio and decompression throughput, particularly for bulk and archival workloads.

The larger block size reduces the frequency of "cold-start penalties" where the LZ match-finder's hash table is initially empty. This results in better overall compression density and faster decompression.

**Key changes include:**
*   Updates the `ZXC_BLOCK_SIZE_DEFAULT` constant.
*   Adjusts documentation across the README, API, examples, format specification, and whitepaper to reflect the new default and provide updated performance guidelines.
*   Modifies code comments in the core library and language wrappers (Node.js, Python, Rust) to refer to the 512 KB default.
*   Updates multi-block test cases in wrappers to accommodate the increased default block size.

While 512 KB is now the recommended default for most use cases, especially those prioritizing performance, users can explicitly set the block size to 256 KB (e.g., `zxc -B 256K`) for memory-constrained, streaming, or embedded environments, where the lower memory footprint might be beneficial.