### PR TITLE
Updates Node.js and Rust wrapper CI & scope heavy workflows to source paths

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -6,9 +6,14 @@ on:
     branches: [ main ]
     paths:
       - 'src/**'
+      - 'include/**'
       - '.github/workflows/benchmark.yml'
   pull_request:
     branches: [ main ]
+    paths:
+      - 'src/**'
+      - 'include/**'
+      - '.github/workflows/benchmark.yml'
 
 permissions:
   contents: read

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -7,13 +7,11 @@ on:
     paths:
       - 'src/**'
       - 'include/**'
-      - '.github/workflows/benchmark.yml'
   pull_request:
     branches: [ main ]
     paths:
       - 'src/**'
       - 'include/**'
-      - '.github/workflows/benchmark.yml'
 
 permissions:
   contents: read

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -4,8 +4,16 @@ on:
   workflow_dispatch:
   push:
     branches: [ main ]
+    paths:
+      - 'src/**'
+      - 'include/**'
+      - 'tests/**'
   pull_request:
     branches: [ main ]
+    paths:
+      - 'src/**'
+      - 'include/**'
+      - 'tests/**'
 
 jobs:
   coverage:

--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -22,7 +22,6 @@ on:
       - 'include/**'
       - 'tests/fuzz_*.c'
       - '.clusterfuzzlite/**'
-      - '.github/workflows/fuzzing.yml'
   schedule:
     - cron: '0 1 * * 1'
 

--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -17,6 +17,12 @@ on:
         default: '3600'
   pull_request:
     branches: [ main ]
+    paths:
+      - 'src/**'
+      - 'include/**'
+      - 'tests/fuzz_*.c'
+      - '.clusterfuzzlite/**'
+      - '.github/workflows/fuzzing.yml'
   schedule:
     - cron: '0 1 * * 1'
 

--- a/.github/workflows/wrapper-nodejs-publish.yml
+++ b/.github/workflows/wrapper-nodejs-publish.yml
@@ -79,13 +79,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, ubuntu-24.04-arm, macos-26, macos-26-intel, windows-latest, windows-11-arm]
-        node: ["18", "20", "22"]
-        exclude:
-          # Node.js 18 and 20 don't have official Windows ARM64 builds
-          - os: windows-11-arm
-            node: "18"
-          - os: windows-11-arm
-            node: "20"
+        node: ["22", "24"]
     defaults:
       run:
         working-directory: ./wrappers/nodejs

--- a/.github/workflows/wrapper-rust-publish.yml
+++ b/.github/workflows/wrapper-rust-publish.yml
@@ -51,6 +51,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: stable
+          cache-workspaces: "wrappers/rust -> target"
 
       - name: Run Tests
         run: cargo test --workspace
@@ -72,6 +73,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: stable
+          cache-workspaces: "wrappers/rust -> target"
 
       - name: Verify Version Matches Release Tag
         run: |

--- a/.github/workflows/wrapper-rust-publish.yml
+++ b/.github/workflows/wrapper-rust-publish.yml
@@ -88,10 +88,13 @@ jobs:
           
           echo "Version matches: $RELEASE_VERSION"
 
+      - name: Authenticate with crates.io
+        run: cargo login ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
       - name: Publish zxc-compress-sys (FFI bindings)
         run: |
           cd zxc-sys
-          cargo publish --token ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          cargo publish
         continue-on-error: false
 
       # Wait for zxc-compress-sys to be available on crates.io before publishing zxc-compress
@@ -101,7 +104,7 @@ jobs:
       - name: Publish zxc-compress (safe wrapper)
         run: |
           cd zxc
-          cargo publish --token ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          cargo publish
         continue-on-error: false
 
       - name: Summary


### PR DESCRIPTION
### Modernize wrapper publish workflows

Updates and optimizes the continuous integration workflows for both Node.js and Rust wrappers.

*   **Node.js Wrapper CI:** Updates the Node.js matrix to include versions 22 and 24, dropping support for versions 18 and 20 to align with current LTS releases.
*   **Rust Wrapper CI:**
    *   Caches Rust build artifacts (target directory) to significantly reduce build times in subsequent runs.
    *   Centralizes authentication with `crates.io` using a `cargo login` step, which simplifies the publishing commands.

### Path-filter expensive workflows

Several jobs were running on every PR even when only docs/workflows changed.
Added `paths:` filters so they only fire when the inputs they actually exercise are touched:

- **`benchmark.yml`** — runs only when `src/**` or `include/**` change (`push` filter aligned to add `include/**`).
- **`fuzzing.yml`** — runs only when `src/**`, `include/**`, `tests/fuzz_*.c`,  or `.clusterfuzzlite/**` change.
- **`coverage.yml`** — runs only when `src/**`, `include/**`, or `tests/**`  change.
