### PR TITLE
ci: Add automated ABI stability check workflow

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -46,6 +46,11 @@ Performs static analysis using Cppcheck and Clang Static Analyzer. Runs memory l
 
 Runs CodeQL security analysis to detect potential security vulnerabilities and coding errors in the C/C++ codebase.
 
+### abi-check.yml - ABI Stability Check
+**Triggers:** Pull requests (lib/header changes), push to main, manual dispatch
+
+Builds `libzxc.so` with debug info, generates an ABI XML via [`abidw`](https://sourceware.org/libabigail/), and compares it against the committed baseline at [`docs/abi/libzxc-linux-x86_64.abi.xml`](../../docs/abi/libzxc-linux-x86_64.abi.xml) using `abidiff --no-added-syms`. Adding new symbols passes (MINOR bump); removing or changing existing symbols fails (MAJOR bump required + regenerate baseline). Run with `mode=regenerate` to produce a fresh baseline as a downloadable artifact.
+
 ### scorecard.yml - OSSF Scorecard
 **Triggers:** Push to main, scheduled (weekly), manual dispatch
 

--- a/.github/workflows/abi-check.yml
+++ b/.github/workflows/abi-check.yml
@@ -1,0 +1,135 @@
+name: ABI Check
+
+on:
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: 'check = diff against baseline; regenerate = produce a new baseline as artifact'
+        required: true
+        default: 'check'
+        type: choice
+        options:
+          - check
+          - regenerate
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'src/lib/**'
+      - 'include/**'
+      - 'CMakeLists.txt'
+      - 'docs/abi/**'
+      - '.github/workflows/abi-check.yml'
+  push:
+    branches: [ main ]
+    paths:
+      - 'src/lib/**'
+      - 'include/**'
+      - 'CMakeLists.txt'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: abi-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  abi:
+    name: Compare ABI vs baseline
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install abigail-tools
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq abigail-tools
+          abidiff --version
+
+      - name: Build libzxc.so (with debug info)
+        run: |
+          cmake -S . -B build \
+            -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+            -DBUILD_SHARED_LIBS=ON \
+            -DZXC_BUILD_CLI=OFF \
+            -DZXC_BUILD_TESTS=OFF \
+            -DZXC_NATIVE_ARCH=OFF
+          cmake --build build --parallel
+
+      - name: Locate libzxc.so
+        id: lib
+        run: |
+          LIB=$(find build -maxdepth 3 -name 'libzxc.so*' -not -type l | head -1)
+          if [ -z "$LIB" ]; then
+            echo "::error::libzxc.so not found in build/"
+            find build -name 'libzxc*'
+            exit 1
+          fi
+          echo "Using $LIB"
+          echo "path=$LIB" >> "$GITHUB_OUTPUT"
+
+      - name: Generate current ABI XML
+        run: |
+          abidw --headers-dir include "${{ steps.lib.outputs.path }}" \
+                --out-file build/current.abi.xml
+          echo "=== Symbols summary ==="
+          grep -c '<elf-symbol' build/current.abi.xml || true
+
+      # ---- regenerate mode: publish artifact, do not diff ----
+      - name: Upload regenerated baseline
+        if: github.event_name == 'workflow_dispatch' && inputs.mode == 'regenerate'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: abi-baseline-linux-x86_64
+          path: build/current.abi.xml
+          retention-days: 30
+
+      - name: Regenerate summary
+        if: github.event_name == 'workflow_dispatch' && inputs.mode == 'regenerate'
+        run: |
+          {
+            echo "## ABI baseline regenerated"
+            echo
+            echo "Download the **abi-baseline-linux-x86_64** artifact above and commit it as:"
+            echo
+            echo '```'
+            echo 'docs/abi/libzxc-linux-x86_64.abi.xml'
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      # ---- check mode (PR / push / manual): diff against committed baseline ----
+      - name: Diff against committed baseline
+        if: github.event_name != 'workflow_dispatch' || inputs.mode != 'regenerate'
+        run: |
+          BASELINE=docs/abi/libzxc-linux-x86_64.abi.xml
+          if [ ! -f "$BASELINE" ]; then
+            echo "::error::Baseline $BASELINE not found. Run this workflow with mode=regenerate first, then commit the artifact."
+            exit 1
+          fi
+
+          # --no-added-syms: adding symbols is allowed (MINOR bump);
+          # removals/changes are reported as ABI breaks (MAJOR bump required).
+          set +e
+          abidiff --no-added-syms "$BASELINE" build/current.abi.xml | tee abi-report.txt
+          STATUS=$?
+          set -e
+
+          {
+            echo "## ABI diff vs baseline"
+            echo
+            echo '```'
+            cat abi-report.txt
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          # abidiff exit codes:
+          #   0           = compatible
+          #   bit 2 (4)   = ABI incompatible change  -> fail
+          #   bit 3 (8)   = ABI compatible change    -> pass (we report it)
+          if [ $((STATUS & 4)) -ne 0 ]; then
+            echo "::error::ABI break detected — bump SOVERSION and regenerate the baseline."
+            exit 1
+          fi
+          exit 0

--- a/docs/abi/libzxc-linux-x86_64.abi.xml
+++ b/docs/abi/libzxc-linux-x86_64.abi.xml
@@ -1,0 +1,1471 @@
+<abi-corpus version='2.2' path='build/libzxc.so.0.11.0' architecture='elf-amd-x86_64' soname='libzxc.so.4'>
+  <elf-needed>
+    <dependency name='libc.so.6'/>
+  </elf-needed>
+  <elf-function-symbols>
+    <elf-symbol name='zxc_compress' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zxc_compress_block' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zxc_compress_block_bound' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zxc_compress_bound' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zxc_compress_cctx' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zxc_create_cctx' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zxc_create_dctx' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zxc_cstream_compress' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zxc_cstream_create' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zxc_cstream_end' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zxc_cstream_free' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zxc_cstream_in_size' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zxc_cstream_out_size' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zxc_decompress' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zxc_decompress_block' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zxc_decompress_block_bound' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zxc_decompress_block_safe' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zxc_decompress_dctx' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zxc_default_level' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zxc_dstream_create' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zxc_dstream_decompress' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zxc_dstream_finished' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zxc_dstream_free' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zxc_dstream_in_size' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zxc_dstream_out_size' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zxc_error_name' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zxc_estimate_cctx_size' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zxc_free_cctx' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zxc_free_dctx' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zxc_get_decompressed_size' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zxc_max_level' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zxc_min_level' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zxc_seek_table_size' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zxc_seekable_decompress_range' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zxc_seekable_decompress_range_mt' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zxc_seekable_free' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zxc_seekable_get_block_comp_size' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zxc_seekable_get_block_decomp_size' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zxc_seekable_get_decompressed_size' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zxc_seekable_get_num_blocks' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zxc_seekable_open' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zxc_seekable_open_file' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zxc_stream_compress' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zxc_stream_decompress' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zxc_stream_get_decompressed_size' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zxc_version_string' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zxc_write_seek_table' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+  </elf-function-symbols>
+  <abi-instr address-size='64' path='/src/src/lib/zxc_common.c' comp-dir-path='/src/build' language='LANG_C11'>
+    <pointer-type-def type-id='type-id-1' size-in-bits='64' id='type-id-2'/>
+    <function-decl name='free' filepath='/usr/include/stdlib.h' line='687' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-1'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+    <function-decl name='posix_memalign' filepath='/usr/lib/gcc/x86_64-linux-gnu/13/include/mm_malloc.h' line='32' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-2'/>
+      <parameter type-id='type-id-4'/>
+      <parameter type-id='type-id-4'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='/src/src/lib/zxc_compress.c' comp-dir-path='/src/build' language='LANG_C11'>
+    <class-decl name='zxc_gnr_header_t' size-in-bits='96' is-struct='yes' naming-typedef-id='type-id-6' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='794' column='1' id='type-id-7'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='n_sequences' type-id='type-id-8' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='795' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='n_literals' type-id='type-id-8' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='796' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='enc_lit' type-id='type-id-9' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='797' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='72'>
+        <var-decl name='enc_litlen' type-id='type-id-9' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='798' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='80'>
+        <var-decl name='enc_mlen' type-id='type-id-9' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='799' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='88'>
+        <var-decl name='enc_off' type-id='type-id-9' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='800' column='1'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='zxc_num_header_t' size-in-bits='128' is-struct='yes' naming-typedef-id='type-id-10' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='825' column='1' id='type-id-11'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='n_values' type-id='type-id-12' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='826' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='frame_size' type-id='type-id-13' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='827' column='1'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='zxc_section_desc_t' size-in-bits='64' is-struct='yes' naming-typedef-id='type-id-14' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='810' column='1' id='type-id-15'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='sizes' type-id='type-id-12' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='811' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='zxc_gnr_header_t' type-id='type-id-7' filepath='/src/src/lib/zxc_internal.h' line='801' column='1' id='type-id-6'/>
+    <typedef-decl name='zxc_num_header_t' type-id='type-id-11' filepath='/src/src/lib/zxc_internal.h' line='828' column='1' id='type-id-10'/>
+    <typedef-decl name='zxc_section_desc_t' type-id='type-id-15' filepath='/src/src/lib/zxc_internal.h' line='812' column='1' id='type-id-14'/>
+    <qualified-type-def type-id='type-id-6' const='yes' id='type-id-16'/>
+    <pointer-type-def type-id='type-id-16' size-in-bits='64' id='type-id-17'/>
+    <qualified-type-def type-id='type-id-17' restrict='yes' id='type-id-18'/>
+    <qualified-type-def type-id='type-id-10' const='yes' id='type-id-19'/>
+    <pointer-type-def type-id='type-id-19' size-in-bits='64' id='type-id-20'/>
+    <qualified-type-def type-id='type-id-20' restrict='yes' id='type-id-21'/>
+    <qualified-type-def type-id='type-id-14' const='yes' id='type-id-22'/>
+    <pointer-type-def type-id='type-id-22' size-in-bits='64' id='type-id-23'/>
+    <qualified-type-def type-id='type-id-1' restrict='yes' id='type-id-24'/>
+    <qualified-type-def type-id='type-id-1' restrict='yes' id='type-id-25'/>
+    <qualified-type-def type-id='type-id-1' restrict='yes' id='type-id-26'/>
+    <function-decl name='zxc_aligned_malloc' filepath='/src/src/lib/zxc_internal.h' line='1199' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-27'/>
+      <parameter type-id='type-id-27'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zxc_aligned_free' filepath='/src/src/lib/zxc_internal.h' line='1211' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-1'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+    <function-decl name='zxc_bitpack_stream_32' filepath='/src/src/lib/zxc_internal.h' line='1371' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-28'/>
+      <parameter type-id='type-id-27'/>
+      <parameter type-id='type-id-29'/>
+      <parameter type-id='type-id-27'/>
+      <parameter type-id='type-id-30'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='zxc_write_num_header' filepath='/src/src/lib/zxc_internal.h' line='1385' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-29'/>
+      <parameter type-id='type-id-27'/>
+      <parameter type-id='type-id-21'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='zxc_write_glo_header_and_desc' filepath='/src/src/lib/zxc_internal.h' line='1415' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-29'/>
+      <parameter type-id='type-id-27'/>
+      <parameter type-id='type-id-18'/>
+      <parameter type-id='type-id-23'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='zxc_write_ghi_header_and_desc' filepath='/src/src/lib/zxc_internal.h' line='1446' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-29'/>
+      <parameter type-id='type-id-27'/>
+      <parameter type-id='type-id-18'/>
+      <parameter type-id='type-id-23'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='zxc_huf_build_code_lengths_avx2' filepath='/src/src/lib/zxc_internal.h' line='1492' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-28'/>
+      <parameter type-id='type-id-29'/>
+      <parameter type-id='type-id-25'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='zxc_huf_build_code_lengths_avx512' filepath='/src/src/lib/zxc_internal.h' line='1492' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-28'/>
+      <parameter type-id='type-id-29'/>
+      <parameter type-id='type-id-26'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='zxc_huf_build_code_lengths_default' filepath='/src/src/lib/zxc_internal.h' line='1492' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-28'/>
+      <parameter type-id='type-id-29'/>
+      <parameter type-id='type-id-24'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='zxc_huf_encode_section_avx2' filepath='/src/src/lib/zxc_internal.h' line='1509' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-31'/>
+      <parameter type-id='type-id-27'/>
+      <parameter type-id='type-id-31'/>
+      <parameter type-id='type-id-29'/>
+      <parameter type-id='type-id-27'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='zxc_huf_encode_section_avx512' filepath='/src/src/lib/zxc_internal.h' line='1509' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-31'/>
+      <parameter type-id='type-id-27'/>
+      <parameter type-id='type-id-31'/>
+      <parameter type-id='type-id-29'/>
+      <parameter type-id='type-id-27'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='zxc_huf_encode_section_default' filepath='/src/src/lib/zxc_internal.h' line='1509' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-31'/>
+      <parameter type-id='type-id-27'/>
+      <parameter type-id='type-id-31'/>
+      <parameter type-id='type-id-29'/>
+      <parameter type-id='type-id-27'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='zxc_write_block_header' filepath='/src/src/lib/zxc_internal.h' line='1739' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-29'/>
+      <parameter type-id='type-id-27'/>
+      <parameter type-id='type-id-32'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='/src/src/lib/zxc_decompress.c' comp-dir-path='/src/build' language='LANG_C11'>
+    <pointer-type-def type-id='type-id-6' size-in-bits='64' id='type-id-33'/>
+    <qualified-type-def type-id='type-id-33' restrict='yes' id='type-id-34'/>
+    <pointer-type-def type-id='type-id-10' size-in-bits='64' id='type-id-35'/>
+    <qualified-type-def type-id='type-id-35' restrict='yes' id='type-id-36'/>
+    <pointer-type-def type-id='type-id-14' size-in-bits='64' id='type-id-37'/>
+    <function-decl name='zxc_read_num_header' filepath='/src/src/lib/zxc_internal.h' line='1399' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-31'/>
+      <parameter type-id='type-id-27'/>
+      <parameter type-id='type-id-36'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='zxc_read_glo_header_and_desc' filepath='/src/src/lib/zxc_internal.h' line='1432' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-31'/>
+      <parameter type-id='type-id-27'/>
+      <parameter type-id='type-id-34'/>
+      <parameter type-id='type-id-37'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='zxc_read_ghi_header_and_desc' filepath='/src/src/lib/zxc_internal.h' line='1464' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-31'/>
+      <parameter type-id='type-id-27'/>
+      <parameter type-id='type-id-34'/>
+      <parameter type-id='type-id-37'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='zxc_huf_decode_section_avx2' filepath='/src/src/lib/zxc_internal.h' line='1524' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-31'/>
+      <parameter type-id='type-id-27'/>
+      <parameter type-id='type-id-29'/>
+      <parameter type-id='type-id-27'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='zxc_huf_decode_section_avx512' filepath='/src/src/lib/zxc_internal.h' line='1524' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-31'/>
+      <parameter type-id='type-id-27'/>
+      <parameter type-id='type-id-29'/>
+      <parameter type-id='type-id-27'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='zxc_huf_decode_section_default' filepath='/src/src/lib/zxc_internal.h' line='1524' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-31'/>
+      <parameter type-id='type-id-27'/>
+      <parameter type-id='type-id-29'/>
+      <parameter type-id='type-id-27'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='realloc' filepath='/usr/include/stdlib.h' line='683' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-1'/>
+      <parameter type-id='type-id-4'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='/src/src/lib/zxc_dispatch.c' comp-dir-path='/src/build' language='LANG_C11'>
+    <qualified-type-def type-id='type-id-38' restrict='yes' id='type-id-28'/>
+    <function-decl name='zxc_write_seek_table' filepath='/src/src/lib/../../include/zxc_seekable.h' line='200' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-39'/>
+      <parameter type-id='type-id-27'/>
+      <parameter type-id='type-id-38'/>
+      <parameter type-id='type-id-40'/>
+      <return type-id='type-id-41'/>
+    </function-decl>
+    <function-decl name='zxc_decompress_chunk_wrapper_default' filepath='/src/src/lib/zxc_dispatch.c' line='47' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-42'/>
+      <parameter type-id='type-id-31'/>
+      <parameter type-id='type-id-27'/>
+      <parameter type-id='type-id-29'/>
+      <parameter type-id='type-id-27'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='zxc_decompress_chunk_wrapper_safe_default' filepath='/src/src/lib/zxc_dispatch.c' line='50' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-42'/>
+      <parameter type-id='type-id-31'/>
+      <parameter type-id='type-id-27'/>
+      <parameter type-id='type-id-29'/>
+      <parameter type-id='type-id-27'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='zxc_decompress_chunk_wrapper_avx2' filepath='/src/src/lib/zxc_dispatch.c' line='56' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-42'/>
+      <parameter type-id='type-id-31'/>
+      <parameter type-id='type-id-27'/>
+      <parameter type-id='type-id-29'/>
+      <parameter type-id='type-id-27'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='zxc_decompress_chunk_wrapper_avx512' filepath='/src/src/lib/zxc_dispatch.c' line='59' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-42'/>
+      <parameter type-id='type-id-31'/>
+      <parameter type-id='type-id-27'/>
+      <parameter type-id='type-id-29'/>
+      <parameter type-id='type-id-27'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='zxc_decompress_chunk_wrapper_safe_avx2' filepath='/src/src/lib/zxc_dispatch.c' line='62' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-42'/>
+      <parameter type-id='type-id-31'/>
+      <parameter type-id='type-id-27'/>
+      <parameter type-id='type-id-29'/>
+      <parameter type-id='type-id-27'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='zxc_decompress_chunk_wrapper_safe_avx512' filepath='/src/src/lib/zxc_dispatch.c' line='65' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-42'/>
+      <parameter type-id='type-id-31'/>
+      <parameter type-id='type-id-27'/>
+      <parameter type-id='type-id-29'/>
+      <parameter type-id='type-id-27'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='zxc_compress_chunk_wrapper_default' filepath='/src/src/lib/zxc_dispatch.c' line='79' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-42'/>
+      <parameter type-id='type-id-31'/>
+      <parameter type-id='type-id-27'/>
+      <parameter type-id='type-id-29'/>
+      <parameter type-id='type-id-27'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='zxc_compress_chunk_wrapper_avx2' filepath='/src/src/lib/zxc_dispatch.c' line='96' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-42'/>
+      <parameter type-id='type-id-31'/>
+      <parameter type-id='type-id-27'/>
+      <parameter type-id='type-id-29'/>
+      <parameter type-id='type-id-27'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='zxc_compress_chunk_wrapper_avx512' filepath='/src/src/lib/zxc_dispatch.c' line='99' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-42'/>
+      <parameter type-id='type-id-31'/>
+      <parameter type-id='type-id-27'/>
+      <parameter type-id='type-id-29'/>
+      <parameter type-id='type-id-27'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='zxc_cctx_init' filepath='/src/src/lib/zxc_internal.h' line='1606' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-43'/>
+      <parameter type-id='type-id-27'/>
+      <parameter type-id='type-id-44'/>
+      <parameter type-id='type-id-44'/>
+      <parameter type-id='type-id-44'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='zxc_cctx_free' filepath='/src/src/lib/zxc_internal.h' line='1617' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-43'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+    <function-decl name='zxc_write_file_header' filepath='/src/src/lib/zxc_internal.h' line='1702' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-29'/>
+      <parameter type-id='type-id-27'/>
+      <parameter type-id='type-id-27'/>
+      <parameter type-id='type-id-44'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='zxc_read_file_header' filepath='/src/src/lib/zxc_internal.h' line='1722' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-31'/>
+      <parameter type-id='type-id-27'/>
+      <parameter type-id='type-id-45'/>
+      <parameter type-id='type-id-46'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='zxc_read_block_header' filepath='/src/src/lib/zxc_internal.h' line='1756' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-31'/>
+      <parameter type-id='type-id-27'/>
+      <parameter type-id='type-id-47'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='zxc_write_file_footer' filepath='/src/src/lib/zxc_internal.h' line='1775' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-29'/>
+      <parameter type-id='type-id-27'/>
+      <parameter type-id='type-id-48'/>
+      <parameter type-id='type-id-40'/>
+      <parameter type-id='type-id-44'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='malloc' filepath='/usr/include/stdlib.h' line='672' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-4'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='calloc' filepath='/usr/include/stdlib.h' line='675' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-4'/>
+      <parameter type-id='type-id-4'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='/src/src/lib/zxc_driver.c' comp-dir-path='/src/build' language='LANG_C11'>
+    <array-type-def dimensions='1' type-id='type-id-49' size-in-bits='320' id='type-id-50'>
+      <subrange length='40' lower-bound='0' upper-bound='39' type-id='type-id-51' id='type-id-52'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-49' size-in-bits='384' id='type-id-53'>
+      <subrange length='48' lower-bound='0' upper-bound='47' type-id='type-id-51' id='type-id-54'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-49' size-in-bits='32' id='type-id-55'>
+      <subrange length='4' lower-bound='0' upper-bound='3' type-id='type-id-51' id='type-id-56'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-49' size-in-bits='448' id='type-id-57'>
+      <subrange length='56' lower-bound='0' upper-bound='55' type-id='type-id-51' id='type-id-58'/>
+    </array-type-def>
+    <type-decl name='long long int' size-in-bits='64' id='type-id-59'/>
+    <type-decl name='short int' size-in-bits='16' id='type-id-60'/>
+    <class-decl name='__pthread_cond_s' size-in-bits='384' is-struct='yes' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='94' column='1' id='type-id-61'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__wseq' type-id='type-id-62' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='96' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='__g1_start' type-id='type-id-62' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='97' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='__g_refs' type-id='type-id-63' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='98' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='__g_size' type-id='type-id-63' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='99' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='__g1_orig_size' type-id='type-id-64' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='100' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='288'>
+        <var-decl name='__wrefs' type-id='type-id-64' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='101' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='__g_signals' type-id='type-id-63' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='102' column='1'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__pthread_internal_list' size-in-bits='128' is-struct='yes' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='51' column='1' id='type-id-65'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__prev' type-id='type-id-66' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='53' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='__next' type-id='type-id-66' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='54' column='1'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__pthread_mutex_s' size-in-bits='320' is-struct='yes' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/struct_mutex.h' line='22' column='1' id='type-id-67'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__lock' type-id='type-id-5' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/struct_mutex.h' line='24' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='__count' type-id='type-id-64' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/struct_mutex.h' line='25' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='__owner' type-id='type-id-5' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/struct_mutex.h' line='26' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='__nusers' type-id='type-id-64' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/struct_mutex.h' line='28' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='__kind' type-id='type-id-5' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/struct_mutex.h' line='32' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='160'>
+        <var-decl name='__spins' type-id='type-id-60' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/struct_mutex.h' line='34' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='176'>
+        <var-decl name='__elision' type-id='type-id-60' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/struct_mutex.h' line='35' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='__list' type-id='type-id-68' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/struct_mutex.h' line='36' column='1'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__anonymous_struct__' size-in-bits='64' is-struct='yes' is-anonymous='yes' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/atomic_wide_counter.h' line='28' column='1' id='type-id-69'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__low' type-id='type-id-64' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/atomic_wide_counter.h' line='30' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='__high' type-id='type-id-64' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/atomic_wide_counter.h' line='31' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='__atomic_wide_counter' type-id='type-id-70' filepath='/usr/include/x86_64-linux-gnu/bits/atomic_wide_counter.h' line='33' column='1' id='type-id-62'/>
+    <typedef-decl name='__pthread_list_t' type-id='type-id-65' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='55' column='1' id='type-id-68'/>
+    <typedef-decl name='pthread_attr_t' type-id='type-id-71' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='62' column='1' id='type-id-72'/>
+    <typedef-decl name='pthread_cond_t' type-id='type-id-73' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='80' column='1' id='type-id-74'/>
+    <typedef-decl name='pthread_condattr_t' type-id='type-id-75' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='45' column='1' id='type-id-76'/>
+    <typedef-decl name='pthread_mutex_t' type-id='type-id-77' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='72' column='1' id='type-id-78'/>
+    <typedef-decl name='pthread_mutexattr_t' type-id='type-id-79' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='36' column='1' id='type-id-80'/>
+    <typedef-decl name='pthread_t' type-id='type-id-51' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='27' column='1' id='type-id-81'/>
+    <union-decl name='__atomic_wide_counter' size-in-bits='64' naming-typedef-id='type-id-62' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/atomic_wide_counter.h' line='25' column='1' id='type-id-70'>
+      <data-member access='public'>
+        <var-decl name='__value64' type-id='type-id-82' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/atomic_wide_counter.h' line='27' column='1'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='__value32' type-id='type-id-69' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/atomic_wide_counter.h' line='32' column='1'/>
+      </data-member>
+    </union-decl>
+    <union-decl name='pthread_attr_t' size-in-bits='448' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='56' column='1' id='type-id-71'>
+      <data-member access='public'>
+        <var-decl name='__size' type-id='type-id-57' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='58' column='1'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='__align' type-id='type-id-83' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='59' column='1'/>
+      </data-member>
+    </union-decl>
+    <union-decl name='pthread_cond_t' size-in-bits='384' naming-typedef-id='type-id-74' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='75' column='1' id='type-id-73'>
+      <data-member access='public'>
+        <var-decl name='__data' type-id='type-id-61' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='77' column='1'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='__size' type-id='type-id-53' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='78' column='1'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='__align' type-id='type-id-59' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='79' column='1'/>
+      </data-member>
+    </union-decl>
+    <union-decl name='pthread_condattr_t' size-in-bits='32' naming-typedef-id='type-id-76' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='41' column='1' id='type-id-75'>
+      <data-member access='public'>
+        <var-decl name='__size' type-id='type-id-55' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='43' column='1'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='__align' type-id='type-id-5' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='44' column='1'/>
+      </data-member>
+    </union-decl>
+    <union-decl name='pthread_mutex_t' size-in-bits='320' naming-typedef-id='type-id-78' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='67' column='1' id='type-id-77'>
+      <data-member access='public'>
+        <var-decl name='__data' type-id='type-id-67' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='69' column='1'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='__size' type-id='type-id-50' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='70' column='1'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='__align' type-id='type-id-83' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='71' column='1'/>
+      </data-member>
+    </union-decl>
+    <union-decl name='pthread_mutexattr_t' size-in-bits='32' naming-typedef-id='type-id-80' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='32' column='1' id='type-id-79'>
+      <data-member access='public'>
+        <var-decl name='__size' type-id='type-id-55' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='34' column='1'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='__align' type-id='type-id-5' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='35' column='1'/>
+      </data-member>
+    </union-decl>
+    <array-type-def dimensions='1' type-id='type-id-64' size-in-bits='64' id='type-id-63'>
+      <subrange length='2' lower-bound='0' upper-bound='1' type-id='type-id-51' id='type-id-84'/>
+    </array-type-def>
+    <type-decl name='unsigned long long int' size-in-bits='64' id='type-id-82'/>
+    <qualified-type-def type-id='type-id-85' restrict='yes' id='type-id-86'/>
+    <pointer-type-def type-id='type-id-65' size-in-bits='64' id='type-id-66'/>
+    <qualified-type-def type-id='type-id-72' const='yes' id='type-id-87'/>
+    <pointer-type-def type-id='type-id-87' size-in-bits='64' id='type-id-88'/>
+    <qualified-type-def type-id='type-id-88' restrict='yes' id='type-id-89'/>
+    <qualified-type-def type-id='type-id-76' const='yes' id='type-id-90'/>
+    <pointer-type-def type-id='type-id-90' size-in-bits='64' id='type-id-91'/>
+    <qualified-type-def type-id='type-id-91' restrict='yes' id='type-id-92'/>
+    <qualified-type-def type-id='type-id-80' const='yes' id='type-id-93'/>
+    <pointer-type-def type-id='type-id-93' size-in-bits='64' id='type-id-94'/>
+    <qualified-type-def type-id='type-id-95' restrict='yes' id='type-id-31'/>
+    <qualified-type-def type-id='type-id-96' const='yes' id='type-id-97'/>
+    <pointer-type-def type-id='type-id-97' size-in-bits='64' id='type-id-32'/>
+    <pointer-type-def type-id='type-id-5' size-in-bits='64' id='type-id-46'/>
+    <pointer-type-def type-id='type-id-74' size-in-bits='64' id='type-id-98'/>
+    <qualified-type-def type-id='type-id-98' restrict='yes' id='type-id-99'/>
+    <pointer-type-def type-id='type-id-78' size-in-bits='64' id='type-id-100'/>
+    <qualified-type-def type-id='type-id-100' restrict='yes' id='type-id-101'/>
+    <pointer-type-def type-id='type-id-81' size-in-bits='64' id='type-id-102'/>
+    <qualified-type-def type-id='type-id-102' restrict='yes' id='type-id-103'/>
+    <pointer-type-def type-id='type-id-4' size-in-bits='64' id='type-id-45'/>
+    <qualified-type-def type-id='type-id-39' restrict='yes' id='type-id-29'/>
+    <pointer-type-def type-id='type-id-104' size-in-bits='64' id='type-id-105'/>
+    <pointer-type-def type-id='type-id-96' size-in-bits='64' id='type-id-47'/>
+    <pointer-type-def type-id='type-id-106' size-in-bits='64' id='type-id-43'/>
+    <qualified-type-def type-id='type-id-43' restrict='yes' id='type-id-42'/>
+    <qualified-type-def type-id='type-id-1' restrict='yes' id='type-id-107'/>
+    <qualified-type-def type-id='type-id-1' restrict='yes' id='type-id-108'/>
+    <function-decl name='zxc_compress_bound' filepath='/src/src/lib/../../include/zxc_buffer.h' line='114' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-27'/>
+      <return type-id='type-id-12'/>
+    </function-decl>
+    <function-decl name='zxc_seek_table_size' filepath='/src/src/lib/../../include/zxc_seekable.h' line='209' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-40'/>
+      <return type-id='type-id-4'/>
+    </function-decl>
+    <function-decl name='zxc_decompress_chunk_wrapper' filepath='/src/src/lib/zxc_internal.h' line='1639' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-42'/>
+      <parameter type-id='type-id-31'/>
+      <parameter type-id='type-id-27'/>
+      <parameter type-id='type-id-29'/>
+      <parameter type-id='type-id-27'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='zxc_compress_chunk_wrapper' filepath='/src/src/lib/zxc_internal.h' line='1661' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-42'/>
+      <parameter type-id='type-id-31'/>
+      <parameter type-id='type-id-27'/>
+      <parameter type-id='type-id-29'/>
+      <parameter type-id='type-id-27'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='pthread_create' filepath='/usr/include/pthread.h' line='202' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-103'/>
+      <parameter type-id='type-id-89'/>
+      <parameter type-id='type-id-105'/>
+      <parameter type-id='type-id-107'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='pthread_join' filepath='/usr/include/pthread.h' line='219' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-81'/>
+      <parameter type-id='type-id-2'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='pthread_mutex_init' filepath='/usr/include/pthread.h' line='781' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-100'/>
+      <parameter type-id='type-id-94'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='pthread_mutex_destroy' filepath='/usr/include/pthread.h' line='786' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-100'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='pthread_mutex_lock' filepath='/usr/include/pthread.h' line='794' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-100'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='pthread_mutex_unlock' filepath='/usr/include/pthread.h' line='835' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-100'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='pthread_cond_init' filepath='/usr/include/pthread.h' line='1112' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-99'/>
+      <parameter type-id='type-id-92'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='pthread_cond_destroy' filepath='/usr/include/pthread.h' line='1117' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-98'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='pthread_cond_signal' filepath='/usr/include/pthread.h' line='1121' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-98'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='pthread_cond_broadcast' filepath='/usr/include/pthread.h' line='1125' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-98'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='pthread_cond_wait' filepath='/usr/include/pthread.h' line='1133' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-99'/>
+      <parameter type-id='type-id-101'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='fwrite' filepath='/usr/include/stdio.h' line='745' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-108'/>
+      <parameter type-id='type-id-4'/>
+      <parameter type-id='type-id-4'/>
+      <parameter type-id='type-id-86'/>
+      <return type-id='type-id-4'/>
+    </function-decl>
+    <function-decl name='sysconf' filepath='/usr/include/unistd.h' line='640' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-5'/>
+      <return type-id='type-id-83'/>
+    </function-decl>
+    <function-decl name='__fread_chk' filepath='/usr/include/x86_64-linux-gnu/bits/stdio2-decl.h' line='122' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-107'/>
+      <parameter type-id='type-id-4'/>
+      <parameter type-id='type-id-4'/>
+      <parameter type-id='type-id-4'/>
+      <parameter type-id='type-id-86'/>
+      <return type-id='type-id-4'/>
+    </function-decl>
+    <function-type size-in-bits='64' id='type-id-104'>
+      <parameter type-id='type-id-1'/>
+      <return type-id='type-id-1'/>
+    </function-type>
+  </abi-instr>
+  <abi-instr address-size='64' path='/src/src/lib/zxc_huffman.c' comp-dir-path='/src/build' language='LANG_C11'>
+    <typedef-decl name='__compar_fn_t' type-id='type-id-109' filepath='/usr/include/stdlib.h' line='948' column='1' id='type-id-110'/>
+    <pointer-type-def type-id='type-id-111' size-in-bits='64' id='type-id-109'/>
+    <function-decl name='qsort' filepath='/usr/include/stdlib.h' line='970' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-1'/>
+      <parameter type-id='type-id-4'/>
+      <parameter type-id='type-id-4'/>
+      <parameter type-id='type-id-110'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+    <function-type size-in-bits='64' id='type-id-111'>
+      <parameter type-id='type-id-1'/>
+      <parameter type-id='type-id-1'/>
+      <return type-id='type-id-5'/>
+    </function-type>
+  </abi-instr>
+  <abi-instr address-size='64' path='/src/src/lib/zxc_pstream.c' comp-dir-path='/src/build' language='LANG_C11'>
+    <function-decl name='zxc_compress_block_bound' filepath='/src/src/lib/../../include/zxc_buffer.h' line='218' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-4'/>
+      <return type-id='type-id-12'/>
+    </function-decl>
+    <function-decl name='zxc_compress_block' filepath='/src/src/lib/../../include/zxc_buffer.h' line='258' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-112'/>
+      <parameter type-id='type-id-1'/>
+      <parameter type-id='type-id-4'/>
+      <parameter type-id='type-id-1'/>
+      <parameter type-id='type-id-4'/>
+      <parameter type-id='type-id-113'/>
+      <return type-id='type-id-41'/>
+    </function-decl>
+    <function-decl name='zxc_create_cctx' filepath='/src/src/lib/../../include/zxc_buffer.h' line='364' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-113'/>
+      <return type-id='type-id-112'/>
+    </function-decl>
+    <function-decl name='zxc_free_cctx' filepath='/src/src/lib/../../include/zxc_buffer.h' line='373' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-112'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='/src/src/lib/zxc_seekable.c' comp-dir-path='/src/build' language='LANG_C11'>
+    <typedef-decl name='__ssize_t' type-id='type-id-83' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='194' column='1' id='type-id-114'/>
+    <typedef-decl name='ssize_t' type-id='type-id-114' filepath='/usr/include/stdio.h' line='78' column='1' id='type-id-115'/>
+    <qualified-type-def type-id='type-id-1' restrict='yes' id='type-id-116'/>
+    <function-decl name='fileno' filepath='/usr/include/stdio.h' line='883' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-85'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='__pread64_chk' filepath='/usr/include/x86_64-linux-gnu/bits/unistd-decl.h' line='42' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-5'/>
+      <parameter type-id='type-id-1'/>
+      <parameter type-id='type-id-4'/>
+      <parameter type-id='type-id-117'/>
+      <parameter type-id='type-id-4'/>
+      <return type-id='type-id-115'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='&lt;artificial&gt;-c' comp-dir-path='/src/build' language='LANG_C11'>
+    <type-decl name='char' size-in-bits='8' id='type-id-49'/>
+    <array-type-def dimensions='1' type-id='type-id-49' size-in-bits='8' id='type-id-118'>
+      <subrange length='1' lower-bound='0' upper-bound='0' type-id='type-id-51' id='type-id-119'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-49' size-in-bits='160' id='type-id-120'>
+      <subrange length='20' lower-bound='0' upper-bound='19' type-id='type-id-51' id='type-id-121'/>
+    </array-type-def>
+    <enum-decl name='cstream_state_t' naming-typedef-id='type-id-122' filepath='/src/src/lib/zxc_pstream.c' line='69' column='1' id='type-id-123'>
+      <underlying-type type-id='type-id-124'/>
+      <enumerator name='CS_INIT' value='0'/>
+      <enumerator name='CS_DRAIN_HEADER' value='1'/>
+      <enumerator name='CS_ACCUMULATE' value='2'/>
+      <enumerator name='CS_DRAIN_BLOCK' value='3'/>
+      <enumerator name='CS_DRAIN_LAST' value='4'/>
+      <enumerator name='CS_DRAIN_EOF' value='5'/>
+      <enumerator name='CS_DRAIN_FOOTER' value='6'/>
+      <enumerator name='CS_DONE' value='7'/>
+      <enumerator name='CS_ERRORED' value='8'/>
+    </enum-decl>
+    <enum-decl name='dstream_state_t' naming-typedef-id='type-id-125' filepath='/src/src/lib/zxc_pstream.c' line='608' column='1' id='type-id-126'>
+      <underlying-type type-id='type-id-124'/>
+      <enumerator name='DS_NEED_FILE_HEADER' value='0'/>
+      <enumerator name='DS_NEED_BLOCK_HEADER' value='1'/>
+      <enumerator name='DS_NEED_BLOCK_PAYLOAD' value='2'/>
+      <enumerator name='DS_DECODE_BLOCK' value='3'/>
+      <enumerator name='DS_EMIT_DECODED' value='4'/>
+      <enumerator name='DS_PEEK_TAIL' value='5'/>
+      <enumerator name='DS_DRAIN_SEK_PAYLOAD' value='6'/>
+      <enumerator name='DS_NEED_FOOTER_FULL' value='7'/>
+      <enumerator name='DS_NEED_FOOTER_REST' value='8'/>
+      <enumerator name='DS_VALIDATE_FOOTER' value='9'/>
+      <enumerator name='DS_DONE' value='10'/>
+      <enumerator name='DS_ERRORED' value='11'/>
+    </enum-decl>
+    <type-decl name='int' size-in-bits='32' id='type-id-5'/>
+    <type-decl name='long int' size-in-bits='64' id='type-id-83'/>
+    <type-decl name='signed char' size-in-bits='8' id='type-id-127'/>
+    <class-decl name='_IO_FILE' size-in-bits='1728' is-struct='yes' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='49' column='1' id='type-id-128'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='_flags' type-id='type-id-5' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='51' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='_IO_read_ptr' type-id='type-id-129' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='54' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='_IO_read_end' type-id='type-id-129' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='55' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='_IO_read_base' type-id='type-id-129' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='56' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='_IO_write_base' type-id='type-id-129' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='57' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='_IO_write_ptr' type-id='type-id-129' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='58' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='_IO_write_end' type-id='type-id-129' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='59' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='_IO_buf_base' type-id='type-id-129' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='60' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='_IO_buf_end' type-id='type-id-129' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='61' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='576'>
+        <var-decl name='_IO_save_base' type-id='type-id-129' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='64' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='640'>
+        <var-decl name='_IO_backup_base' type-id='type-id-129' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='65' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='704'>
+        <var-decl name='_IO_save_end' type-id='type-id-129' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='66' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='768'>
+        <var-decl name='_markers' type-id='type-id-130' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='68' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='832'>
+        <var-decl name='_chain' type-id='type-id-131' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='70' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='896'>
+        <var-decl name='_fileno' type-id='type-id-5' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='72' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='928'>
+        <var-decl name='_flags2' type-id='type-id-5' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='73' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='960'>
+        <var-decl name='_old_offset' type-id='type-id-132' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='74' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1024'>
+        <var-decl name='_cur_column' type-id='type-id-133' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='77' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1040'>
+        <var-decl name='_vtable_offset' type-id='type-id-127' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='78' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1048'>
+        <var-decl name='_shortbuf' type-id='type-id-118' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='79' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1088'>
+        <var-decl name='_lock' type-id='type-id-134' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='81' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1152'>
+        <var-decl name='_offset' type-id='type-id-117' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='89' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1216'>
+        <var-decl name='_codecvt' type-id='type-id-135' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='91' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1280'>
+        <var-decl name='_wide_data' type-id='type-id-136' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='92' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1344'>
+        <var-decl name='_freeres_list' type-id='type-id-131' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='93' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1408'>
+        <var-decl name='_freeres_buf' type-id='type-id-1' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='94' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1472'>
+        <var-decl name='__pad5' type-id='type-id-4' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='95' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1536'>
+        <var-decl name='_mode' type-id='type-id-5' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='96' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1568'>
+        <var-decl name='_unused2' type-id='type-id-120' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='98' column='1'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='zxc_block_header_t' size-in-bits='64' is-struct='yes' naming-typedef-id='type-id-96' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='1680' column='1' id='type-id-137'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='block_type' type-id='type-id-9' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='1681' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='8'>
+        <var-decl name='block_flags' type-id='type-id-9' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='1682' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='16'>
+        <var-decl name='reserved' type-id='type-id-9' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='1683' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='24'>
+        <var-decl name='header_crc' type-id='type-id-9' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='1684' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='comp_size' type-id='type-id-8' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='1685' column='1'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='zxc_cctx_s' size-in-bits='1536' is-struct='yes' visibility='default' filepath='/src/src/lib/zxc_dispatch.c' line='771' column='1' id='type-id-138'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='inner' type-id='type-id-106' visibility='default' filepath='/src/src/lib/zxc_dispatch.c' line='772' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1280'>
+        <var-decl name='initialized' type-id='type-id-5' visibility='default' filepath='/src/src/lib/zxc_dispatch.c' line='773' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1344'>
+        <var-decl name='last_block_size' type-id='type-id-4' visibility='default' filepath='/src/src/lib/zxc_dispatch.c' line='774' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1408'>
+        <var-decl name='stored_level' type-id='type-id-5' visibility='default' filepath='/src/src/lib/zxc_dispatch.c' line='776' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1440'>
+        <var-decl name='stored_checksum' type-id='type-id-5' visibility='default' filepath='/src/src/lib/zxc_dispatch.c' line='777' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1472'>
+        <var-decl name='stored_block_size' type-id='type-id-4' visibility='default' filepath='/src/src/lib/zxc_dispatch.c' line='778' column='1'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='zxc_cctx_t' size-in-bits='1280' is-struct='yes' naming-typedef-id='type-id-106' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='1555' column='1' id='type-id-139'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='hash_table' type-id='type-id-140' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='1558' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='hash_tags' type-id='type-id-39' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='1559' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='chain_table' type-id='type-id-141' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='1560' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='memory_block' type-id='type-id-1' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='1561' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='epoch' type-id='type-id-8' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='1562' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='buf_sequences' type-id='type-id-140' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='1565' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='buf_tokens' type-id='type-id-39' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='1566' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='buf_offsets' type-id='type-id-141' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='1567' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='buf_extras' type-id='type-id-39' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='1568' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='576'>
+        <var-decl name='literals' type-id='type-id-39' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='1569' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='640'>
+        <var-decl name='lit_buffer' type-id='type-id-39' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='1572' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='704'>
+        <var-decl name='lit_buffer_cap' type-id='type-id-4' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='1573' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='768'>
+        <var-decl name='work_buf' type-id='type-id-39' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='1574' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='832'>
+        <var-decl name='work_buf_cap' type-id='type-id-4' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='1575' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='896'>
+        <var-decl name='opt_scratch' type-id='type-id-39' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='1576' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='960'>
+        <var-decl name='opt_scratch_cap' type-id='type-id-4' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='1580' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1024'>
+        <var-decl name='checksum_enabled' type-id='type-id-5' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='1581' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1056'>
+        <var-decl name='compression_level' type-id='type-id-5' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='1582' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1088'>
+        <var-decl name='chunk_size' type-id='type-id-4' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='1585' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1152'>
+        <var-decl name='offset_bits' type-id='type-id-8' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='1586' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1184'>
+        <var-decl name='offset_mask' type-id='type-id-8' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='1587' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1216'>
+        <var-decl name='max_epoch' type-id='type-id-8' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='1588' column='1'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='zxc_compress_opts_t' size-in-bits='320' is-struct='yes' naming-typedef-id='type-id-142' visibility='default' filepath='/src/src/lib/../../include/zxc_opts.h' line='59' column='1' id='type-id-143'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='n_threads' type-id='type-id-5' visibility='default' filepath='/src/src/lib/../../include/zxc_opts.h' line='60' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='level' type-id='type-id-5' visibility='default' filepath='/src/src/lib/../../include/zxc_opts.h' line='61' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='block_size' type-id='type-id-4' visibility='default' filepath='/src/src/lib/../../include/zxc_opts.h' line='62' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='checksum_enabled' type-id='type-id-5' visibility='default' filepath='/src/src/lib/../../include/zxc_opts.h' line='64' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='160'>
+        <var-decl name='seekable' type-id='type-id-5' visibility='default' filepath='/src/src/lib/../../include/zxc_opts.h' line='65' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='progress_cb' type-id='type-id-144' visibility='default' filepath='/src/src/lib/../../include/zxc_opts.h' line='66' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='user_data' type-id='type-id-1' visibility='default' filepath='/src/src/lib/../../include/zxc_opts.h' line='67' column='1'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='zxc_cstream_s' size-in-bits='1024' is-struct='yes' visibility='default' filepath='/src/src/lib/zxc_pstream.c' line='123' column='1' id='type-id-145'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='opts' type-id='type-id-142' visibility='default' filepath='/src/src/lib/zxc_pstream.c' line='124' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='cctx' type-id='type-id-112' visibility='default' filepath='/src/src/lib/zxc_pstream.c' line='125' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='block_size' type-id='type-id-4' visibility='default' filepath='/src/src/lib/zxc_pstream.c' line='126' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='in_block' type-id='type-id-39' visibility='default' filepath='/src/src/lib/zxc_pstream.c' line='128' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='in_used' type-id='type-id-4' visibility='default' filepath='/src/src/lib/zxc_pstream.c' line='129' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='576'>
+        <var-decl name='pending' type-id='type-id-39' visibility='default' filepath='/src/src/lib/zxc_pstream.c' line='131' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='640'>
+        <var-decl name='pending_cap' type-id='type-id-4' visibility='default' filepath='/src/src/lib/zxc_pstream.c' line='132' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='704'>
+        <var-decl name='pending_len' type-id='type-id-4' visibility='default' filepath='/src/src/lib/zxc_pstream.c' line='133' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='768'>
+        <var-decl name='pending_pos' type-id='type-id-4' visibility='default' filepath='/src/src/lib/zxc_pstream.c' line='134' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='832'>
+        <var-decl name='total_in' type-id='type-id-12' visibility='default' filepath='/src/src/lib/zxc_pstream.c' line='136' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='896'>
+        <var-decl name='global_hash' type-id='type-id-8' visibility='default' filepath='/src/src/lib/zxc_pstream.c' line='137' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='928'>
+        <var-decl name='state' type-id='type-id-122' visibility='default' filepath='/src/src/lib/zxc_pstream.c' line='139' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='960'>
+        <var-decl name='error_code' type-id='type-id-5' visibility='default' filepath='/src/src/lib/zxc_pstream.c' line='140' column='1'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='zxc_dctx_s' size-in-bits='1408' is-struct='yes' visibility='default' filepath='/src/src/lib/zxc_dispatch.c' line='903' column='1' id='type-id-146'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='inner' type-id='type-id-106' visibility='default' filepath='/src/src/lib/zxc_dispatch.c' line='904' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1280'>
+        <var-decl name='last_block_size' type-id='type-id-4' visibility='default' filepath='/src/src/lib/zxc_dispatch.c' line='905' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1344'>
+        <var-decl name='initialized' type-id='type-id-5' visibility='default' filepath='/src/src/lib/zxc_dispatch.c' line='906' column='1'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='zxc_decompress_opts_t' size-in-bits='192' is-struct='yes' naming-typedef-id='type-id-147' visibility='default' filepath='/src/src/lib/../../include/zxc_opts.h' line='80' column='1' id='type-id-148'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='n_threads' type-id='type-id-5' visibility='default' filepath='/src/src/lib/../../include/zxc_opts.h' line='81' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='checksum_enabled' type-id='type-id-5' visibility='default' filepath='/src/src/lib/../../include/zxc_opts.h' line='82' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='progress_cb' type-id='type-id-144' visibility='default' filepath='/src/src/lib/../../include/zxc_opts.h' line='83' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='user_data' type-id='type-id-1' visibility='default' filepath='/src/src/lib/../../include/zxc_opts.h' line='84' column='1'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='zxc_dstream_s' size-in-bits='2880' is-struct='yes' visibility='default' filepath='/src/src/lib/zxc_pstream.c' line='686' column='1' id='type-id-149'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='opts' type-id='type-id-147' visibility='default' filepath='/src/src/lib/zxc_pstream.c' line='687' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='inner' type-id='type-id-106' visibility='default' filepath='/src/src/lib/zxc_pstream.c' line='688' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1472'>
+        <var-decl name='inner_initialized' type-id='type-id-5' visibility='default' filepath='/src/src/lib/zxc_pstream.c' line='689' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1536'>
+        <var-decl name='block_size' type-id='type-id-4' visibility='default' filepath='/src/src/lib/zxc_pstream.c' line='690' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1600'>
+        <var-decl name='file_has_checksum' type-id='type-id-5' visibility='default' filepath='/src/src/lib/zxc_pstream.c' line='691' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1632'>
+        <var-decl name='scratch' type-id='type-id-150' visibility='default' filepath='/src/src/lib/zxc_pstream.c' line='693' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1920'>
+        <var-decl name='scratch_used' type-id='type-id-4' visibility='default' filepath='/src/src/lib/zxc_pstream.c' line='694' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1984'>
+        <var-decl name='scratch_need' type-id='type-id-4' visibility='default' filepath='/src/src/lib/zxc_pstream.c' line='695' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2048'>
+        <var-decl name='payload' type-id='type-id-39' visibility='default' filepath='/src/src/lib/zxc_pstream.c' line='697' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2112'>
+        <var-decl name='payload_cap' type-id='type-id-4' visibility='default' filepath='/src/src/lib/zxc_pstream.c' line='698' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2176'>
+        <var-decl name='payload_used' type-id='type-id-4' visibility='default' filepath='/src/src/lib/zxc_pstream.c' line='699' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2240'>
+        <var-decl name='payload_need' type-id='type-id-4' visibility='default' filepath='/src/src/lib/zxc_pstream.c' line='700' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2304'>
+        <var-decl name='decoded' type-id='type-id-39' visibility='default' filepath='/src/src/lib/zxc_pstream.c' line='702' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2368'>
+        <var-decl name='decoded_cap' type-id='type-id-4' visibility='default' filepath='/src/src/lib/zxc_pstream.c' line='703' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2432'>
+        <var-decl name='decoded_size' type-id='type-id-4' visibility='default' filepath='/src/src/lib/zxc_pstream.c' line='704' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2496'>
+        <var-decl name='decoded_pos' type-id='type-id-4' visibility='default' filepath='/src/src/lib/zxc_pstream.c' line='705' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2560'>
+        <var-decl name='cur_bh' type-id='type-id-96' visibility='default' filepath='/src/src/lib/zxc_pstream.c' line='707' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2624'>
+        <var-decl name='sek_remaining' type-id='type-id-4' visibility='default' filepath='/src/src/lib/zxc_pstream.c' line='708' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2688'>
+        <var-decl name='total_out' type-id='type-id-12' visibility='default' filepath='/src/src/lib/zxc_pstream.c' line='710' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2752'>
+        <var-decl name='global_hash' type-id='type-id-8' visibility='default' filepath='/src/src/lib/zxc_pstream.c' line='711' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2784'>
+        <var-decl name='state' type-id='type-id-125' visibility='default' filepath='/src/src/lib/zxc_pstream.c' line='713' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2816'>
+        <var-decl name='error_code' type-id='type-id-5' visibility='default' filepath='/src/src/lib/zxc_pstream.c' line='714' column='1'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='zxc_inbuf_t' size-in-bits='192' is-struct='yes' naming-typedef-id='type-id-151' visibility='default' filepath='/src/src/lib/../../include/zxc_pstream.h' line='88' column='1' id='type-id-152'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='src' type-id='type-id-1' visibility='default' filepath='/src/src/lib/../../include/zxc_pstream.h' line='89' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='size' type-id='type-id-4' visibility='default' filepath='/src/src/lib/../../include/zxc_pstream.h' line='90' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='pos' type-id='type-id-4' visibility='default' filepath='/src/src/lib/../../include/zxc_pstream.h' line='91' column='1'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='zxc_outbuf_t' size-in-bits='192' is-struct='yes' naming-typedef-id='type-id-153' visibility='default' filepath='/src/src/lib/../../include/zxc_pstream.h' line='102' column='1' id='type-id-154'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='dst' type-id='type-id-1' visibility='default' filepath='/src/src/lib/../../include/zxc_pstream.h' line='103' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='size' type-id='type-id-4' visibility='default' filepath='/src/src/lib/../../include/zxc_pstream.h' line='104' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='pos' type-id='type-id-4' visibility='default' filepath='/src/src/lib/../../include/zxc_pstream.h' line='105' column='1'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='zxc_seekable_s' size-in-bits='1856' is-struct='yes' visibility='default' filepath='/src/src/lib/zxc_seekable.c' line='178' column='1' id='type-id-155'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='src' type-id='type-id-95' visibility='default' filepath='/src/src/lib/zxc_seekable.c' line='180' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='src_size' type-id='type-id-12' visibility='default' filepath='/src/src/lib/zxc_seekable.c' line='181' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='file' type-id='type-id-85' visibility='default' filepath='/src/src/lib/zxc_seekable.c' line='182' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='fd' type-id='type-id-5' visibility='default' filepath='/src/src/lib/zxc_seekable.c' line='188' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='224'>
+        <var-decl name='num_blocks' type-id='type-id-8' visibility='default' filepath='/src/src/lib/zxc_seekable.c' line='192' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='comp_sizes' type-id='type-id-140' visibility='default' filepath='/src/src/lib/zxc_seekable.c' line='193' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='comp_offsets' type-id='type-id-156' visibility='default' filepath='/src/src/lib/zxc_seekable.c' line='194' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='total_decomp' type-id='type-id-12' visibility='default' filepath='/src/src/lib/zxc_seekable.c' line='195' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='block_size' type-id='type-id-8' visibility='default' filepath='/src/src/lib/zxc_seekable.c' line='199' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='480'>
+        <var-decl name='file_has_checksums' type-id='type-id-5' visibility='default' filepath='/src/src/lib/zxc_seekable.c' line='200' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='dctx' type-id='type-id-106' visibility='default' filepath='/src/src/lib/zxc_seekable.c' line='203' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1792'>
+        <var-decl name='dctx_initialized' type-id='type-id-5' visibility='default' filepath='/src/src/lib/zxc_seekable.c' line='204' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='FILE' type-id='type-id-128' filepath='/usr/include/x86_64-linux-gnu/bits/types/FILE.h' line='7' column='1' id='type-id-157'/>
+    <typedef-decl name='_IO_lock_t' type-id='type-id-3' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='43' column='1' id='type-id-158'/>
+    <typedef-decl name='__int64_t' type-id='type-id-83' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='44' column='1' id='type-id-159'/>
+    <typedef-decl name='__off64_t' type-id='type-id-83' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='153' column='1' id='type-id-117'/>
+    <typedef-decl name='__off_t' type-id='type-id-83' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='152' column='1' id='type-id-132'/>
+    <typedef-decl name='__uint16_t' type-id='type-id-133' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='40' column='1' id='type-id-160'/>
+    <typedef-decl name='__uint32_t' type-id='type-id-64' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='42' column='1' id='type-id-161'/>
+    <typedef-decl name='__uint64_t' type-id='type-id-51' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='45' column='1' id='type-id-162'/>
+    <typedef-decl name='__uint8_t' type-id='type-id-163' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='38' column='1' id='type-id-164'/>
+    <typedef-decl name='cstream_state_t' type-id='type-id-123' filepath='/src/src/lib/zxc_pstream.c' line='79' column='1' id='type-id-122'/>
+    <typedef-decl name='dstream_state_t' type-id='type-id-126' filepath='/src/src/lib/zxc_pstream.c' line='621' column='1' id='type-id-125'/>
+    <typedef-decl name='int64_t' type-id='type-id-159' filepath='/usr/include/x86_64-linux-gnu/bits/stdint-intn.h' line='27' column='1' id='type-id-41'/>
+    <typedef-decl name='size_t' type-id='type-id-51' filepath='/usr/lib/gcc/x86_64-linux-gnu/13/include/stddef.h' line='214' column='1' id='type-id-4'/>
+    <typedef-decl name='uint16_t' type-id='type-id-160' filepath='/usr/include/x86_64-linux-gnu/bits/stdint-uintn.h' line='25' column='1' id='type-id-13'/>
+    <typedef-decl name='uint32_t' type-id='type-id-161' filepath='/usr/include/x86_64-linux-gnu/bits/stdint-uintn.h' line='26' column='1' id='type-id-8'/>
+    <typedef-decl name='uint64_t' type-id='type-id-162' filepath='/usr/include/x86_64-linux-gnu/bits/stdint-uintn.h' line='27' column='1' id='type-id-12'/>
+    <typedef-decl name='uint8_t' type-id='type-id-164' filepath='/usr/include/x86_64-linux-gnu/bits/stdint-uintn.h' line='24' column='1' id='type-id-9'/>
+    <typedef-decl name='zxc_block_header_t' type-id='type-id-137' filepath='/src/src/lib/zxc_internal.h' line='1686' column='1' id='type-id-96'/>
+    <typedef-decl name='zxc_cctx' type-id='type-id-138' filepath='/src/src/lib/../../include/zxc_buffer.h' line='205' column='1' id='type-id-165'/>
+    <typedef-decl name='zxc_cctx_t' type-id='type-id-139' filepath='/src/src/lib/zxc_internal.h' line='1589' column='1' id='type-id-106'/>
+    <typedef-decl name='zxc_compress_opts_t' type-id='type-id-143' filepath='/src/src/lib/../../include/zxc_opts.h' line='68' column='1' id='type-id-142'/>
+    <typedef-decl name='zxc_cstream' type-id='type-id-145' filepath='/src/src/lib/../../include/zxc_pstream.h' line='109' column='1' id='type-id-166'/>
+    <typedef-decl name='zxc_dctx' type-id='type-id-146' filepath='/src/src/lib/../../include/zxc_buffer.h' line='206' column='1' id='type-id-167'/>
+    <typedef-decl name='zxc_decompress_opts_t' type-id='type-id-148' filepath='/src/src/lib/../../include/zxc_opts.h' line='85' column='1' id='type-id-147'/>
+    <typedef-decl name='zxc_dstream' type-id='type-id-149' filepath='/src/src/lib/../../include/zxc_pstream.h' line='110' column='1' id='type-id-168'/>
+    <typedef-decl name='zxc_inbuf_t' type-id='type-id-152' filepath='/src/src/lib/../../include/zxc_pstream.h' line='92' column='1' id='type-id-151'/>
+    <typedef-decl name='zxc_outbuf_t' type-id='type-id-154' filepath='/src/src/lib/../../include/zxc_pstream.h' line='106' column='1' id='type-id-153'/>
+    <typedef-decl name='zxc_progress_callback_t' type-id='type-id-169' filepath='/src/src/lib/../../include/zxc_opts.h' line='44' column='1' id='type-id-144'/>
+    <typedef-decl name='zxc_seekable' type-id='type-id-155' filepath='/src/src/lib/../../include/zxc_seekable.h' line='65' column='1' id='type-id-170'/>
+    <array-type-def dimensions='1' type-id='type-id-9' size-in-bits='256' id='type-id-150'>
+      <subrange length='32' lower-bound='0' upper-bound='31' type-id='type-id-51' id='type-id-171'/>
+    </array-type-def>
+    <type-decl name='unnamed-enum-underlying-type-32' is-anonymous='yes' size-in-bits='32' alignment-in-bits='32' id='type-id-124'/>
+    <type-decl name='unsigned char' size-in-bits='8' id='type-id-163'/>
+    <type-decl name='unsigned int' size-in-bits='32' id='type-id-64'/>
+    <type-decl name='unsigned long int' size-in-bits='64' id='type-id-51'/>
+    <type-decl name='unsigned short int' size-in-bits='16' id='type-id-133'/>
+    <pointer-type-def type-id='type-id-157' size-in-bits='64' id='type-id-85'/>
+    <pointer-type-def type-id='type-id-128' size-in-bits='64' id='type-id-131'/>
+    <pointer-type-def type-id='type-id-49' size-in-bits='64' id='type-id-129'/>
+    <qualified-type-def type-id='type-id-49' const='yes' id='type-id-172'/>
+    <pointer-type-def type-id='type-id-172' size-in-bits='64' id='type-id-173'/>
+    <qualified-type-def type-id='type-id-5' const='yes' id='type-id-44'/>
+    <qualified-type-def type-id='type-id-4' const='yes' id='type-id-27'/>
+    <qualified-type-def type-id='type-id-8' const='yes' id='type-id-40'/>
+    <pointer-type-def type-id='type-id-40' size-in-bits='64' id='type-id-38'/>
+    <qualified-type-def type-id='type-id-12' const='yes' id='type-id-48'/>
+    <qualified-type-def type-id='type-id-9' const='yes' id='type-id-30'/>
+    <pointer-type-def type-id='type-id-30' size-in-bits='64' id='type-id-95'/>
+    <qualified-type-def type-id='type-id-142' const='yes' id='type-id-174'/>
+    <pointer-type-def type-id='type-id-174' size-in-bits='64' id='type-id-113'/>
+    <qualified-type-def type-id='type-id-166' const='yes' id='type-id-175'/>
+    <pointer-type-def type-id='type-id-175' size-in-bits='64' id='type-id-176'/>
+    <qualified-type-def type-id='type-id-147' const='yes' id='type-id-177'/>
+    <pointer-type-def type-id='type-id-177' size-in-bits='64' id='type-id-178'/>
+    <qualified-type-def type-id='type-id-168' const='yes' id='type-id-179'/>
+    <pointer-type-def type-id='type-id-179' size-in-bits='64' id='type-id-180'/>
+    <qualified-type-def type-id='type-id-170' const='yes' id='type-id-181'/>
+    <pointer-type-def type-id='type-id-181' size-in-bits='64' id='type-id-182'/>
+    <pointer-type-def type-id='type-id-13' size-in-bits='64' id='type-id-141'/>
+    <pointer-type-def type-id='type-id-8' size-in-bits='64' id='type-id-140'/>
+    <pointer-type-def type-id='type-id-12' size-in-bits='64' id='type-id-156'/>
+    <pointer-type-def type-id='type-id-9' size-in-bits='64' id='type-id-39'/>
+    <pointer-type-def type-id='type-id-183' size-in-bits='64' id='type-id-169'/>
+    <pointer-type-def type-id='type-id-165' size-in-bits='64' id='type-id-112'/>
+    <pointer-type-def type-id='type-id-166' size-in-bits='64' id='type-id-184'/>
+    <pointer-type-def type-id='type-id-167' size-in-bits='64' id='type-id-185'/>
+    <pointer-type-def type-id='type-id-168' size-in-bits='64' id='type-id-186'/>
+    <pointer-type-def type-id='type-id-151' size-in-bits='64' id='type-id-187'/>
+    <pointer-type-def type-id='type-id-153' size-in-bits='64' id='type-id-188'/>
+    <pointer-type-def type-id='type-id-170' size-in-bits='64' id='type-id-189'/>
+    <pointer-type-def type-id='type-id-190' size-in-bits='64' id='type-id-135'/>
+    <pointer-type-def type-id='type-id-158' size-in-bits='64' id='type-id-134'/>
+    <pointer-type-def type-id='type-id-191' size-in-bits='64' id='type-id-130'/>
+    <pointer-type-def type-id='type-id-192' size-in-bits='64' id='type-id-136'/>
+    <class-decl name='_IO_codecvt' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-190'/>
+    <class-decl name='_IO_marker' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-191'/>
+    <class-decl name='_IO_wide_data' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-192'/>
+    <qualified-type-def type-id='type-id-1' restrict='yes' id='type-id-193'/>
+    <qualified-type-def type-id='type-id-1' restrict='yes' id='type-id-194'/>
+    <function-decl name='zxc_compress_block_bound' mangled-name='zxc_compress_block_bound' filepath='/src/src/lib/zxc_common.c' line='612' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zxc_compress_block_bound'>
+      <parameter type-id='type-id-27' name='input_size' filepath='/src/src/lib/zxc_common.c' line='612' column='1'/>
+      <return type-id='type-id-12'/>
+    </function-decl>
+    <function-decl name='zxc_decompress_block_bound' mangled-name='zxc_decompress_block_bound' filepath='/src/src/lib/zxc_common.c' line='626' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zxc_decompress_block_bound'>
+      <parameter type-id='type-id-27' name='uncompressed_size' filepath='/src/src/lib/zxc_common.c' line='626' column='1'/>
+      <return type-id='type-id-12'/>
+    </function-decl>
+    <function-decl name='zxc_estimate_cctx_size' mangled-name='zxc_estimate_cctx_size' filepath='/src/src/lib/zxc_common.c' line='644' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zxc_estimate_cctx_size'>
+      <parameter type-id='type-id-27' name='src_size' filepath='/src/src/lib/zxc_common.c' line='644' column='1'/>
+      <parameter type-id='type-id-44' name='level' filepath='/src/src/lib/zxc_common.c' line='644' column='1'/>
+      <return type-id='type-id-12'/>
+    </function-decl>
+    <function-decl name='zxc_error_name' mangled-name='zxc_error_name' filepath='/src/src/lib/zxc_common.c' line='694' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zxc_error_name'>
+      <parameter type-id='type-id-44' name='code' filepath='/src/src/lib/zxc_common.c' line='694' column='1'/>
+      <return type-id='type-id-173'/>
+    </function-decl>
+    <function-decl name='zxc_min_level' mangled-name='zxc_min_level' filepath='/src/src/lib/zxc_common.c' line='744' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zxc_min_level'>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='zxc_max_level' mangled-name='zxc_max_level' filepath='/src/src/lib/zxc_common.c' line='751' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zxc_max_level'>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='zxc_default_level' mangled-name='zxc_default_level' filepath='/src/src/lib/zxc_common.c' line='758' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zxc_default_level'>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='zxc_version_string' mangled-name='zxc_version_string' filepath='/src/src/lib/zxc_common.c' line='766' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zxc_version_string'>
+      <return type-id='type-id-173'/>
+    </function-decl>
+    <function-decl name='zxc_compress' mangled-name='zxc_compress' filepath='/src/src/lib/zxc_dispatch.c' line='471' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zxc_compress'>
+      <parameter type-id='type-id-193' name='src' filepath='/src/src/lib/zxc_dispatch.c' line='471' column='1'/>
+      <parameter type-id='type-id-27' name='src_size' filepath='/src/src/lib/zxc_dispatch.c' line='471' column='1'/>
+      <parameter type-id='type-id-194' name='dst' filepath='/src/src/lib/zxc_dispatch.c' line='471' column='1'/>
+      <parameter type-id='type-id-27' name='dst_capacity' filepath='/src/src/lib/zxc_dispatch.c' line='472' column='1'/>
+      <parameter type-id='type-id-113' name='opts' filepath='/src/src/lib/zxc_dispatch.c' line='472' column='1'/>
+      <return type-id='type-id-41'/>
+    </function-decl>
+    <function-decl name='zxc_decompress' mangled-name='zxc_decompress' filepath='/src/src/lib/zxc_dispatch.c' line='620' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zxc_decompress'>
+      <parameter type-id='type-id-193' name='src' filepath='/src/src/lib/zxc_dispatch.c' line='620' column='1'/>
+      <parameter type-id='type-id-27' name='src_size' filepath='/src/src/lib/zxc_dispatch.c' line='620' column='1'/>
+      <parameter type-id='type-id-194' name='dst' filepath='/src/src/lib/zxc_dispatch.c' line='620' column='1'/>
+      <parameter type-id='type-id-27' name='dst_capacity' filepath='/src/src/lib/zxc_dispatch.c' line='621' column='1'/>
+      <parameter type-id='type-id-178' name='opts' filepath='/src/src/lib/zxc_dispatch.c' line='621' column='1'/>
+      <return type-id='type-id-41'/>
+    </function-decl>
+    <function-decl name='zxc_get_decompressed_size' mangled-name='zxc_get_decompressed_size' filepath='/src/src/lib/zxc_dispatch.c' line='749' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zxc_get_decompressed_size'>
+      <parameter type-id='type-id-1' name='src' filepath='/src/src/lib/zxc_dispatch.c' line='749' column='1'/>
+      <parameter type-id='type-id-27' name='src_size' filepath='/src/src/lib/zxc_dispatch.c' line='749' column='1'/>
+      <return type-id='type-id-12'/>
+    </function-decl>
+    <function-decl name='zxc_compress_cctx' mangled-name='zxc_compress_cctx' filepath='/src/src/lib/zxc_dispatch.c' line='813' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zxc_compress_cctx'>
+      <parameter type-id='type-id-112' name='cctx' filepath='/src/src/lib/zxc_dispatch.c' line='813' column='1'/>
+      <parameter type-id='type-id-193' name='src' filepath='/src/src/lib/zxc_dispatch.c' line='813' column='1'/>
+      <parameter type-id='type-id-27' name='src_size' filepath='/src/src/lib/zxc_dispatch.c' line='813' column='1'/>
+      <parameter type-id='type-id-194' name='dst' filepath='/src/src/lib/zxc_dispatch.c' line='814' column='1'/>
+      <parameter type-id='type-id-27' name='dst_capacity' filepath='/src/src/lib/zxc_dispatch.c' line='814' column='1'/>
+      <parameter type-id='type-id-113' name='opts' filepath='/src/src/lib/zxc_dispatch.c' line='815' column='1'/>
+      <return type-id='type-id-41'/>
+    </function-decl>
+    <function-decl name='zxc_create_dctx' mangled-name='zxc_create_dctx' filepath='/src/src/lib/zxc_dispatch.c' line='909' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zxc_create_dctx'>
+      <return type-id='type-id-185'/>
+    </function-decl>
+    <function-decl name='zxc_free_dctx' mangled-name='zxc_free_dctx' filepath='/src/src/lib/zxc_dispatch.c' line='914' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zxc_free_dctx'>
+      <parameter type-id='type-id-185' name='dctx' filepath='/src/src/lib/zxc_dispatch.c' line='914' column='1'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+    <function-decl name='zxc_decompress_dctx' mangled-name='zxc_decompress_dctx' filepath='/src/src/lib/zxc_dispatch.c' line='920' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zxc_decompress_dctx'>
+      <parameter type-id='type-id-185' name='dctx' filepath='/src/src/lib/zxc_dispatch.c' line='920' column='1'/>
+      <parameter type-id='type-id-193' name='src' filepath='/src/src/lib/zxc_dispatch.c' line='920' column='1'/>
+      <parameter type-id='type-id-27' name='src_size' filepath='/src/src/lib/zxc_dispatch.c' line='920' column='1'/>
+      <parameter type-id='type-id-194' name='dst' filepath='/src/src/lib/zxc_dispatch.c' line='921' column='1'/>
+      <parameter type-id='type-id-27' name='dst_capacity' filepath='/src/src/lib/zxc_dispatch.c' line='921' column='1'/>
+      <parameter type-id='type-id-178' name='opts' filepath='/src/src/lib/zxc_dispatch.c' line='922' column='1'/>
+      <return type-id='type-id-41'/>
+    </function-decl>
+    <function-decl name='zxc_compress_block' mangled-name='zxc_compress_block' filepath='/src/src/lib/zxc_dispatch.c' line='1026' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zxc_compress_block'>
+      <parameter type-id='type-id-112' name='cctx' filepath='/src/src/lib/zxc_dispatch.c' line='1026' column='1'/>
+      <parameter type-id='type-id-193' name='src' filepath='/src/src/lib/zxc_dispatch.c' line='1026' column='1'/>
+      <parameter type-id='type-id-27' name='src_size' filepath='/src/src/lib/zxc_dispatch.c' line='1026' column='1'/>
+      <parameter type-id='type-id-194' name='dst' filepath='/src/src/lib/zxc_dispatch.c' line='1027' column='1'/>
+      <parameter type-id='type-id-27' name='dst_capacity' filepath='/src/src/lib/zxc_dispatch.c' line='1027' column='1'/>
+      <parameter type-id='type-id-113' name='opts' filepath='/src/src/lib/zxc_dispatch.c' line='1028' column='1'/>
+      <return type-id='type-id-41'/>
+    </function-decl>
+    <function-decl name='zxc_decompress_block' mangled-name='zxc_decompress_block' filepath='/src/src/lib/zxc_dispatch.c' line='1072' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zxc_decompress_block'>
+      <parameter type-id='type-id-185' name='dctx' filepath='/src/src/lib/zxc_dispatch.c' line='1072' column='1'/>
+      <parameter type-id='type-id-193' name='src' filepath='/src/src/lib/zxc_dispatch.c' line='1072' column='1'/>
+      <parameter type-id='type-id-27' name='src_size' filepath='/src/src/lib/zxc_dispatch.c' line='1072' column='1'/>
+      <parameter type-id='type-id-194' name='dst' filepath='/src/src/lib/zxc_dispatch.c' line='1073' column='1'/>
+      <parameter type-id='type-id-27' name='dst_capacity' filepath='/src/src/lib/zxc_dispatch.c' line='1073' column='1'/>
+      <parameter type-id='type-id-178' name='opts' filepath='/src/src/lib/zxc_dispatch.c' line='1074' column='1'/>
+      <return type-id='type-id-41'/>
+    </function-decl>
+    <function-decl name='zxc_decompress_block_safe' mangled-name='zxc_decompress_block_safe' filepath='/src/src/lib/zxc_dispatch.c' line='1133' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zxc_decompress_block_safe'>
+      <parameter type-id='type-id-185' name='dctx' filepath='/src/src/lib/zxc_dispatch.c' line='1133' column='1'/>
+      <parameter type-id='type-id-193' name='src' filepath='/src/src/lib/zxc_dispatch.c' line='1133' column='1'/>
+      <parameter type-id='type-id-27' name='src_size' filepath='/src/src/lib/zxc_dispatch.c' line='1133' column='1'/>
+      <parameter type-id='type-id-194' name='dst' filepath='/src/src/lib/zxc_dispatch.c' line='1134' column='1'/>
+      <parameter type-id='type-id-27' name='dst_capacity' filepath='/src/src/lib/zxc_dispatch.c' line='1134' column='1'/>
+      <parameter type-id='type-id-178' name='opts' filepath='/src/src/lib/zxc_dispatch.c' line='1135' column='1'/>
+      <return type-id='type-id-41'/>
+    </function-decl>
+    <function-decl name='zxc_stream_compress' mangled-name='zxc_stream_compress' filepath='/src/src/lib/zxc_driver.c' line='922' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zxc_stream_compress'>
+      <parameter type-id='type-id-85' name='f_in' filepath='/src/src/lib/zxc_driver.c' line='922' column='1'/>
+      <parameter type-id='type-id-85' name='f_out' filepath='/src/src/lib/zxc_driver.c' line='922' column='1'/>
+      <parameter type-id='type-id-113' name='opts' filepath='/src/src/lib/zxc_driver.c' line='922' column='1'/>
+      <return type-id='type-id-41'/>
+    </function-decl>
+    <function-decl name='zxc_stream_decompress' mangled-name='zxc_stream_decompress' filepath='/src/src/lib/zxc_driver.c' line='940' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zxc_stream_decompress'>
+      <parameter type-id='type-id-85' name='f_in' filepath='/src/src/lib/zxc_driver.c' line='940' column='1'/>
+      <parameter type-id='type-id-85' name='f_out' filepath='/src/src/lib/zxc_driver.c' line='940' column='1'/>
+      <parameter type-id='type-id-178' name='opts' filepath='/src/src/lib/zxc_driver.c' line='940' column='1'/>
+      <return type-id='type-id-41'/>
+    </function-decl>
+    <function-decl name='zxc_stream_get_decompressed_size' mangled-name='zxc_stream_get_decompressed_size' filepath='/src/src/lib/zxc_driver.c' line='952' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zxc_stream_get_decompressed_size'>
+      <parameter type-id='type-id-85' name='f_in' filepath='/src/src/lib/zxc_driver.c' line='952' column='1'/>
+      <return type-id='type-id-41'/>
+    </function-decl>
+    <function-decl name='zxc_cstream_create' mangled-name='zxc_cstream_create' filepath='/src/src/lib/zxc_pstream.c' line='243' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zxc_cstream_create'>
+      <parameter type-id='type-id-113' name='opts' filepath='/src/src/lib/zxc_pstream.c' line='243' column='1'/>
+      <return type-id='type-id-184'/>
+    </function-decl>
+    <function-decl name='zxc_cstream_free' mangled-name='zxc_cstream_free' filepath='/src/src/lib/zxc_pstream.c' line='366' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zxc_cstream_free'>
+      <parameter type-id='type-id-184' name='cs' filepath='/src/src/lib/zxc_pstream.c' line='366' column='1'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+    <function-decl name='zxc_cstream_in_size' mangled-name='zxc_cstream_in_size' filepath='/src/src/lib/zxc_pstream.c' line='380' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zxc_cstream_in_size'>
+      <parameter type-id='type-id-176' name='cs' filepath='/src/src/lib/zxc_pstream.c' line='380' column='1'/>
+      <return type-id='type-id-4'/>
+    </function-decl>
+    <function-decl name='zxc_cstream_out_size' mangled-name='zxc_cstream_out_size' filepath='/src/src/lib/zxc_pstream.c' line='392' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zxc_cstream_out_size'>
+      <parameter type-id='type-id-176' name='cs' filepath='/src/src/lib/zxc_pstream.c' line='392' column='1'/>
+      <return type-id='type-id-4'/>
+    </function-decl>
+    <function-decl name='zxc_cstream_compress' mangled-name='zxc_cstream_compress' filepath='/src/src/lib/zxc_pstream.c' line='418' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zxc_cstream_compress'>
+      <parameter type-id='type-id-184' name='cs' filepath='/src/src/lib/zxc_pstream.c' line='418' column='1'/>
+      <parameter type-id='type-id-188' name='out' filepath='/src/src/lib/zxc_pstream.c' line='418' column='1'/>
+      <parameter type-id='type-id-187' name='in' filepath='/src/src/lib/zxc_pstream.c' line='418' column='1'/>
+      <return type-id='type-id-41'/>
+    </function-decl>
+    <function-decl name='zxc_cstream_end' mangled-name='zxc_cstream_end' filepath='/src/src/lib/zxc_pstream.c' line='493' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zxc_cstream_end'>
+      <parameter type-id='type-id-184' name='cs' filepath='/src/src/lib/zxc_pstream.c' line='493' column='1'/>
+      <parameter type-id='type-id-188' name='out' filepath='/src/src/lib/zxc_pstream.c' line='493' column='1'/>
+      <return type-id='type-id-41'/>
+    </function-decl>
+    <function-decl name='zxc_dstream_create' mangled-name='zxc_dstream_create' filepath='/src/src/lib/zxc_pstream.c' line='793' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zxc_dstream_create'>
+      <parameter type-id='type-id-178' name='opts' filepath='/src/src/lib/zxc_pstream.c' line='793' column='1'/>
+      <return type-id='type-id-186'/>
+    </function-decl>
+    <function-decl name='zxc_dstream_free' mangled-name='zxc_dstream_free' filepath='/src/src/lib/zxc_pstream.c' line='812' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zxc_dstream_free'>
+      <parameter type-id='type-id-186' name='ds' filepath='/src/src/lib/zxc_pstream.c' line='812' column='1'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+    <function-decl name='zxc_dstream_finished' mangled-name='zxc_dstream_finished' filepath='/src/src/lib/zxc_pstream.c' line='826' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zxc_dstream_finished'>
+      <parameter type-id='type-id-180' name='ds' filepath='/src/src/lib/zxc_pstream.c' line='826' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='zxc_dstream_in_size' mangled-name='zxc_dstream_in_size' filepath='/src/src/lib/zxc_pstream.c' line='838' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zxc_dstream_in_size'>
+      <parameter type-id='type-id-180' name='ds' filepath='/src/src/lib/zxc_pstream.c' line='838' column='1'/>
+      <return type-id='type-id-4'/>
+    </function-decl>
+    <function-decl name='zxc_dstream_out_size' mangled-name='zxc_dstream_out_size' filepath='/src/src/lib/zxc_pstream.c' line='854' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zxc_dstream_out_size'>
+      <parameter type-id='type-id-180' name='ds' filepath='/src/src/lib/zxc_pstream.c' line='854' column='1'/>
+      <return type-id='type-id-4'/>
+    </function-decl>
+    <function-decl name='zxc_dstream_decompress' mangled-name='zxc_dstream_decompress' filepath='/src/src/lib/zxc_pstream.c' line='1019' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zxc_dstream_decompress'>
+      <parameter type-id='type-id-186' name='ds' filepath='/src/src/lib/zxc_pstream.c' line='1019' column='1'/>
+      <parameter type-id='type-id-188' name='out' filepath='/src/src/lib/zxc_pstream.c' line='1019' column='1'/>
+      <parameter type-id='type-id-187' name='in' filepath='/src/src/lib/zxc_pstream.c' line='1019' column='1'/>
+      <return type-id='type-id-41'/>
+    </function-decl>
+    <function-decl name='zxc_seekable_open' mangled-name='zxc_seekable_open' filepath='/src/src/lib/zxc_seekable.c' line='334' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zxc_seekable_open'>
+      <parameter type-id='type-id-1' name='src' filepath='/src/src/lib/zxc_seekable.c' line='334' column='1'/>
+      <parameter type-id='type-id-27' name='src_size' filepath='/src/src/lib/zxc_seekable.c' line='334' column='1'/>
+      <return type-id='type-id-189'/>
+    </function-decl>
+    <function-decl name='zxc_seekable_open_file' mangled-name='zxc_seekable_open_file' filepath='/src/src/lib/zxc_seekable.c' line='339' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zxc_seekable_open_file'>
+      <parameter type-id='type-id-85' name='f' filepath='/src/src/lib/zxc_seekable.c' line='339' column='1'/>
+      <return type-id='type-id-189'/>
+    </function-decl>
+    <function-decl name='zxc_seekable_get_num_blocks' mangled-name='zxc_seekable_get_num_blocks' filepath='/src/src/lib/zxc_seekable.c' line='516' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zxc_seekable_get_num_blocks'>
+      <parameter type-id='type-id-182' name='s' filepath='/src/src/lib/zxc_seekable.c' line='516' column='1'/>
+      <return type-id='type-id-8'/>
+    </function-decl>
+    <function-decl name='zxc_seekable_get_decompressed_size' mangled-name='zxc_seekable_get_decompressed_size' filepath='/src/src/lib/zxc_seekable.c' line='518' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zxc_seekable_get_decompressed_size'>
+      <parameter type-id='type-id-182' name='s' filepath='/src/src/lib/zxc_seekable.c' line='518' column='1'/>
+      <return type-id='type-id-12'/>
+    </function-decl>
+    <function-decl name='zxc_seekable_get_block_comp_size' mangled-name='zxc_seekable_get_block_comp_size' filepath='/src/src/lib/zxc_seekable.c' line='522' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zxc_seekable_get_block_comp_size'>
+      <parameter type-id='type-id-182' name='s' filepath='/src/src/lib/zxc_seekable.c' line='522' column='1'/>
+      <parameter type-id='type-id-40' name='block_idx' filepath='/src/src/lib/zxc_seekable.c' line='522' column='1'/>
+      <return type-id='type-id-8'/>
+    </function-decl>
+    <function-decl name='zxc_seekable_get_block_decomp_size' mangled-name='zxc_seekable_get_block_decomp_size' filepath='/src/src/lib/zxc_seekable.c' line='527' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zxc_seekable_get_block_decomp_size'>
+      <parameter type-id='type-id-182' name='s' filepath='/src/src/lib/zxc_seekable.c' line='527' column='1'/>
+      <parameter type-id='type-id-40' name='block_idx' filepath='/src/src/lib/zxc_seekable.c' line='527' column='1'/>
+      <return type-id='type-id-8'/>
+    </function-decl>
+    <function-decl name='zxc_seekable_decompress_range' mangled-name='zxc_seekable_decompress_range' filepath='/src/src/lib/zxc_seekable.c' line='582' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zxc_seekable_decompress_range'>
+      <parameter type-id='type-id-189' name='s' filepath='/src/src/lib/zxc_seekable.c' line='582' column='1'/>
+      <parameter type-id='type-id-1' name='dst' filepath='/src/src/lib/zxc_seekable.c' line='582' column='1'/>
+      <parameter type-id='type-id-27' name='dst_capacity' filepath='/src/src/lib/zxc_seekable.c' line='582' column='1'/>
+      <parameter type-id='type-id-48' name='offset' filepath='/src/src/lib/zxc_seekable.c' line='583' column='1'/>
+      <parameter type-id='type-id-27' name='len' filepath='/src/src/lib/zxc_seekable.c' line='583' column='1'/>
+      <return type-id='type-id-41'/>
+    </function-decl>
+    <function-decl name='zxc_seekable_decompress_range_mt' mangled-name='zxc_seekable_decompress_range_mt' filepath='/src/src/lib/zxc_seekable.c' line='792' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zxc_seekable_decompress_range_mt'>
+      <parameter type-id='type-id-189' name='s' filepath='/src/src/lib/zxc_seekable.c' line='792' column='1'/>
+      <parameter type-id='type-id-1' name='dst' filepath='/src/src/lib/zxc_seekable.c' line='792' column='1'/>
+      <parameter type-id='type-id-27' name='dst_capacity' filepath='/src/src/lib/zxc_seekable.c' line='792' column='1'/>
+      <parameter type-id='type-id-48' name='offset' filepath='/src/src/lib/zxc_seekable.c' line='793' column='1'/>
+      <parameter type-id='type-id-27' name='len' filepath='/src/src/lib/zxc_seekable.c' line='793' column='1'/>
+      <parameter type-id='type-id-5' name='n_threads' filepath='/src/src/lib/zxc_seekable.c' line='793' column='1'/>
+      <return type-id='type-id-41'/>
+    </function-decl>
+    <function-decl name='zxc_seekable_free' mangled-name='zxc_seekable_free' filepath='/src/src/lib/zxc_seekable.c' line='911' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zxc_seekable_free'>
+      <parameter type-id='type-id-189' name='s' filepath='/src/src/lib/zxc_seekable.c' line='911' column='1'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+    <type-decl name='void' id='type-id-3'/>
+    <pointer-type-def type-id='type-id-3' id='type-id-1'/>
+    <function-type size-in-bits='64' id='type-id-183'>
+      <parameter type-id='type-id-12'/>
+      <parameter type-id='type-id-12'/>
+      <parameter type-id='type-id-1'/>
+      <return type-id='type-id-3'/>
+    </function-type>
+  </abi-instr>
+</abi-corpus>


### PR DESCRIPTION
This workflow uses `abidw` to generate an ABI representation of `libzxc.so` and `abidiff` to compare it against a committed baseline. It prevents accidental ABI breaks by detecting incompatible changes to the library's public interface.

The check mode runs on pull requests and pushes to `main`, failing if existing symbols are removed or modified. Adding new symbols is allowed, aligning with a MINOR version bump.

A manual `regenerate` mode is provided to create a new baseline artifact, which can be committed when an intentional ABI-breaking change (MAJOR version bump) occurs.
