### PR TITLE
ci: Generates SBOM for GitHub releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -171,83 +171,33 @@ jobs:
 
   sbom:
     name: Generate SBOM
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Sanitize ref name
         id: ref
         run: echo "slug=${GITHUB_REF_NAME//\//-}" >> "$GITHUB_OUTPUT"
 
-      - name: Generate SBOM (SPDX 2.3)
+      - name: Render SBOM from template
         shell: bash
         env:
           SBOM_FILE: zxc-${{ steps.ref.outputs.slug }}-sbom.spdx.json
-          VERSION: ${{ github.ref_name }}
-          REPO: ${{ github.repository }}
-          SHA: ${{ github.sha }}
+          VERSION: ${{ steps.ref.outputs.slug }}
+          COMMIT: ${{ github.sha }}
         run: |
-          jq -n \
-            --arg version "$VERSION" \
-            --arg repo "$REPO" \
-            --arg sha "$SHA" \
-            --arg created "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
-            '{
-              spdxVersion: "SPDX-2.3",
-              dataLicense: "CC0-1.0",
-              SPDXID: "SPDXRef-DOCUMENT",
-              name: "zxc",
-              documentNamespace: ("https://github.com/" + $repo + "/sbom/" + $version + "-" + $sha),
-              creationInfo: {
-                created: $created,
-                creators: ["Tool: zxc-build-workflow"]
-              },
-              packages: [
-                {
-                  name: "zxc",
-                  SPDXID: "SPDXRef-Package-zxc",
-                  versionInfo: $version,
-                  supplier: "Person: Bertrand Lebonnois",
-                  originator: "Person: Bertrand Lebonnois",
-                  downloadLocation: ("https://github.com/" + $repo),
-                  filesAnalyzed: false,
-                  licenseConcluded: "BSD-3-Clause",
-                  licenseDeclared: "BSD-3-Clause",
-                  copyrightText: "NOASSERTION",
-                  externalRefs: [{
-                    referenceCategory: "PACKAGE-MANAGER",
-                    referenceType: "purl",
-                    referenceLocator: ("pkg:github/" + $repo + "@" + $version)
-                  }]
-                },
-                {
-                  name: "rapidhash",
-                  SPDXID: "SPDXRef-Package-rapidhash",
-                  versionInfo: "V3",
-                  supplier: "Person: Nicolas De Carli",
-                  originator: "Person: Nicolas De Carli",
-                  downloadLocation: "https://github.com/Nicoshev/rapidhash",
-                  filesAnalyzed: false,
-                  sourceInfo: "Vendored single-header at src/lib/vendors/rapidhash.h",
-                  licenseConcluded: "MIT",
-                  licenseDeclared: "MIT",
-                  copyrightText: "Copyright (C) 2025 Nicolas De Carli",
-                  externalRefs: [{
-                    referenceCategory: "PACKAGE-MANAGER",
-                    referenceType: "purl",
-                    referenceLocator: "pkg:github/Nicoshev/rapidhash@V3"
-                  }]
-                }
-              ],
-              relationships: [
-                { spdxElementId: "SPDXRef-DOCUMENT",    relationshipType: "DESCRIBES",   relatedSpdxElement: "SPDXRef-Package-zxc" },
-                { spdxElementId: "SPDXRef-Package-zxc", relationshipType: "STATIC_LINK", relatedSpdxElement: "SPDXRef-Package-rapidhash" }
-              ]
-            }' > "$SBOM_FILE"
+          CREATED="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          sed \
+            -e "s|@VERSION@|${VERSION}|g" \
+            -e "s|@COMMIT@|${COMMIT}|g" \
+            -e "s|@CREATED@|${CREATED}|g" \
+            SBOM.spdx.json.in > "$SBOM_FILE"
+          # Validate JSON syntax
+          jq empty "$SBOM_FILE"
 
       - name: Upload SBOM artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: sbom
           path: zxc-${{ steps.ref.outputs.slug }}-sbom.spdx.json

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -180,13 +180,66 @@ jobs:
         id: ref
         run: echo "slug=${GITHUB_REF_NAME//\//-}" >> "$GITHUB_OUTPUT"
 
-      - name: Generate SBOM (SPDX)
-        uses: anchore/sbom-action@v0
+      - name: Install Syft
+        uses: anchore/sbom-action/download-syft@v0
+
+      - name: Generate and augment SBOM
+        shell: bash
+        env:
+          SBOM_FILE: zxc-${{ steps.ref.outputs.slug }}-sbom.spdx.json
+          VERSION: ${{ github.ref_name }}
+          REPO: ${{ github.repository }}
+        run: |
+          syft scan dir:src/ -o spdx-json="$SBOM_FILE"
+          jq --arg version "$VERSION" --arg repo "$REPO" '
+            .name = "zxc" |
+            .packages += [
+              {
+                name: "zxc",
+                SPDXID: "SPDXRef-Package-zxc",
+                versionInfo: $version,
+                supplier: ("Organization: " + ($repo | split("/")[0])),
+                downloadLocation: ("https://github.com/" + $repo),
+                filesAnalyzed: false,
+                licenseConcluded: "BSD-3-Clause",
+                licenseDeclared: "BSD-3-Clause",
+                copyrightText: "NOASSERTION",
+                externalRefs: [{
+                  referenceCategory: "PACKAGE-MANAGER",
+                  referenceType: "purl",
+                  referenceLocator: ("pkg:github/" + $repo + "@" + $version)
+                }]
+              },
+              {
+                name: "rapidhash",
+                SPDXID: "SPDXRef-Package-rapidhash",
+                versionInfo: "V3",
+                supplier: "Person: Nicolas De Carli",
+                originator: "Person: Nicolas De Carli",
+                downloadLocation: "https://github.com/Nicoshev/rapidhash",
+                filesAnalyzed: false,
+                sourceInfo: "Vendored single-header at src/lib/vendors/rapidhash.h",
+                licenseConcluded: "MIT",
+                licenseDeclared: "MIT",
+                copyrightText: "Copyright (C) 2025 Nicolas De Carli",
+                externalRefs: [{
+                  referenceCategory: "PACKAGE-MANAGER",
+                  referenceType: "purl",
+                  referenceLocator: "pkg:github/Nicoshev/rapidhash@V3"
+                }]
+              }
+            ] |
+            .relationships = ((.relationships // []) + [
+              { spdxElementId: "SPDXRef-DOCUMENT",     relationshipType: "DESCRIBES",   relatedSpdxElement: "SPDXRef-Package-zxc" },
+              { spdxElementId: "SPDXRef-Package-zxc",  relationshipType: "STATIC_LINK", relatedSpdxElement: "SPDXRef-Package-rapidhash" }
+            ])
+          ' "$SBOM_FILE" > "$SBOM_FILE.tmp" && mv "$SBOM_FILE.tmp" "$SBOM_FILE"
+
+      - name: Upload SBOM artifact
+        uses: actions/upload-artifact@v7
         with:
-          path: .
-          format: spdx-json
-          artifact-name: zxc-${{ steps.ref.outputs.slug }}-sbom.spdx.json
-          upload-release-assets: false
+          name: sbom
+          path: zxc-${{ steps.ref.outputs.slug }}-sbom.spdx.json
 
   release:
     name: Create GitHub Release

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -180,60 +180,71 @@ jobs:
         id: ref
         run: echo "slug=${GITHUB_REF_NAME//\//-}" >> "$GITHUB_OUTPUT"
 
-      - name: Install Syft
-        uses: anchore/sbom-action/download-syft@v0
-
-      - name: Generate and augment SBOM
+      - name: Generate SBOM (SPDX 2.3)
         shell: bash
         env:
           SBOM_FILE: zxc-${{ steps.ref.outputs.slug }}-sbom.spdx.json
           VERSION: ${{ github.ref_name }}
           REPO: ${{ github.repository }}
+          SHA: ${{ github.sha }}
         run: |
-          syft scan dir:src/ -o spdx-json="$SBOM_FILE"
-          jq --arg version "$VERSION" --arg repo "$REPO" '
-            .name = "zxc" |
-            .packages += [
-              {
-                name: "zxc",
-                SPDXID: "SPDXRef-Package-zxc",
-                versionInfo: $version,
-                supplier: ("Organization: " + ($repo | split("/")[0])),
-                downloadLocation: ("https://github.com/" + $repo),
-                filesAnalyzed: false,
-                licenseConcluded: "BSD-3-Clause",
-                licenseDeclared: "BSD-3-Clause",
-                copyrightText: "NOASSERTION",
-                externalRefs: [{
-                  referenceCategory: "PACKAGE-MANAGER",
-                  referenceType: "purl",
-                  referenceLocator: ("pkg:github/" + $repo + "@" + $version)
-                }]
+          jq -n \
+            --arg version "$VERSION" \
+            --arg repo "$REPO" \
+            --arg sha "$SHA" \
+            --arg created "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            '{
+              spdxVersion: "SPDX-2.3",
+              dataLicense: "CC0-1.0",
+              SPDXID: "SPDXRef-DOCUMENT",
+              name: "zxc",
+              documentNamespace: ("https://github.com/" + $repo + "/sbom/" + $version + "-" + $sha),
+              creationInfo: {
+                created: $created,
+                creators: ["Tool: zxc-build-workflow"]
               },
-              {
-                name: "rapidhash",
-                SPDXID: "SPDXRef-Package-rapidhash",
-                versionInfo: "V3",
-                supplier: "Person: Nicolas De Carli",
-                originator: "Person: Nicolas De Carli",
-                downloadLocation: "https://github.com/Nicoshev/rapidhash",
-                filesAnalyzed: false,
-                sourceInfo: "Vendored single-header at src/lib/vendors/rapidhash.h",
-                licenseConcluded: "MIT",
-                licenseDeclared: "MIT",
-                copyrightText: "Copyright (C) 2025 Nicolas De Carli",
-                externalRefs: [{
-                  referenceCategory: "PACKAGE-MANAGER",
-                  referenceType: "purl",
-                  referenceLocator: "pkg:github/Nicoshev/rapidhash@V3"
-                }]
-              }
-            ] |
-            .relationships = ((.relationships // []) + [
-              { spdxElementId: "SPDXRef-DOCUMENT",     relationshipType: "DESCRIBES",   relatedSpdxElement: "SPDXRef-Package-zxc" },
-              { spdxElementId: "SPDXRef-Package-zxc",  relationshipType: "STATIC_LINK", relatedSpdxElement: "SPDXRef-Package-rapidhash" }
-            ])
-          ' "$SBOM_FILE" > "$SBOM_FILE.tmp" && mv "$SBOM_FILE.tmp" "$SBOM_FILE"
+              packages: [
+                {
+                  name: "zxc",
+                  SPDXID: "SPDXRef-Package-zxc",
+                  versionInfo: $version,
+                  supplier: "Person: Bertrand Lebonnois",
+                  originator: "Person: Bertrand Lebonnois",
+                  downloadLocation: ("https://github.com/" + $repo),
+                  filesAnalyzed: false,
+                  licenseConcluded: "BSD-3-Clause",
+                  licenseDeclared: "BSD-3-Clause",
+                  copyrightText: "NOASSERTION",
+                  externalRefs: [{
+                    referenceCategory: "PACKAGE-MANAGER",
+                    referenceType: "purl",
+                    referenceLocator: ("pkg:github/" + $repo + "@" + $version)
+                  }]
+                },
+                {
+                  name: "rapidhash",
+                  SPDXID: "SPDXRef-Package-rapidhash",
+                  versionInfo: "V3",
+                  supplier: "Person: Nicolas De Carli",
+                  originator: "Person: Nicolas De Carli",
+                  downloadLocation: "https://github.com/Nicoshev/rapidhash",
+                  filesAnalyzed: false,
+                  sourceInfo: "Vendored single-header at src/lib/vendors/rapidhash.h",
+                  licenseConcluded: "MIT",
+                  licenseDeclared: "MIT",
+                  copyrightText: "Copyright (C) 2025 Nicolas De Carli",
+                  externalRefs: [{
+                    referenceCategory: "PACKAGE-MANAGER",
+                    referenceType: "purl",
+                    referenceLocator: "pkg:github/Nicoshev/rapidhash@V3"
+                  }]
+                }
+              ],
+              relationships: [
+                { spdxElementId: "SPDXRef-DOCUMENT",    relationshipType: "DESCRIBES",   relatedSpdxElement: "SPDXRef-Package-zxc" },
+                { spdxElementId: "SPDXRef-Package-zxc", relationshipType: "STATIC_LINK", relatedSpdxElement: "SPDXRef-Package-rapidhash" }
+              ]
+            }' > "$SBOM_FILE"
 
       - name: Upload SBOM artifact
         uses: actions/upload-artifact@v7

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -169,9 +169,28 @@ jobs:
           name: zxc-${{ matrix.platform }}
           path: ${{ env.ARCHIVE }}
 
+  sbom:
+    name: Generate SBOM
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v6
+
+      - name: Sanitize ref name
+        id: ref
+        run: echo "slug=${GITHUB_REF_NAME//\//-}" >> "$GITHUB_OUTPUT"
+
+      - name: Generate SBOM (SPDX)
+        uses: anchore/sbom-action@v0
+        with:
+          path: .
+          format: spdx-json
+          artifact-name: zxc-${{ steps.ref.outputs.slug }}-sbom.spdx.json
+          upload-release-assets: false
+
   release:
     name: Create GitHub Release
-    needs: build-and-test
+    needs: [build-and-test, sbom]
     runs-on: ubuntu-slim
     if: startsWith(github.ref, 'refs/tags/')
     permissions:
@@ -194,5 +213,6 @@ jobs:
           files: |
             release/*.tar.gz
             release/*.zip
+            release/*.spdx.json
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/SBOM.spdx.json.in
+++ b/SBOM.spdx.json.in
@@ -1,0 +1,58 @@
+{
+  "spdxVersion": "SPDX-2.3",
+  "dataLicense": "CC0-1.0",
+  "SPDXID": "SPDXRef-DOCUMENT",
+  "name": "zxc",
+  "documentNamespace": "https://github.com/hellobertrand/zxc/sbom/@VERSION@-@COMMIT@",
+  "creationInfo": {
+    "created": "@CREATED@",
+    "creators": ["Tool: zxc-build-workflow"]
+  },
+  "packages": [
+    {
+      "name": "zxc",
+      "SPDXID": "SPDXRef-Package-zxc",
+      "versionInfo": "@VERSION@",
+      "supplier": "Person: Bertrand Lebonnois",
+      "originator": "Person: Bertrand Lebonnois",
+      "downloadLocation": "https://github.com/hellobertrand/zxc",
+      "filesAnalyzed": false,
+      "licenseConcluded": "BSD-3-Clause",
+      "licenseDeclared": "BSD-3-Clause",
+      "copyrightText": "NOASSERTION",
+      "primaryPackagePurpose": "APPLICATION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:github/hellobertrand/zxc@@VERSION@"
+        }
+      ]
+    },
+    {
+      "name": "rapidhash",
+      "SPDXID": "SPDXRef-Package-rapidhash",
+      "versionInfo": "V3",
+      "supplier": "Person: Nicolas De Carli",
+      "originator": "Person: Nicolas De Carli",
+      "downloadLocation": "https://github.com/Nicoshev/rapidhash",
+      "filesAnalyzed": false,
+      "sourceInfo": "Vendored single-header at src/lib/vendors/rapidhash.h",
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "Copyright (C) 2025 Nicolas De Carli",
+      "primaryPackagePurpose": "SOURCE",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:github/Nicoshev/rapidhash@V3"
+        }
+      ]
+    }
+  ],
+  "relationships": [
+    { "spdxElementId": "SPDXRef-DOCUMENT",    "relationshipType": "DESCRIBES",   "relatedSpdxElement": "SPDXRef-Package-zxc" },
+    { "spdxElementId": "SPDXRef-Package-zxc", "relationshipType": "STATIC_LINK", "relatedSpdxElement": "SPDXRef-Package-rapidhash" }
+  ]
+}


### PR DESCRIPTION
Adds a new CI workflow job to generate a Software Bill of Materials (SBOM) for the project.

- Generates an SPDX 2.3 compliant SBOM using a predefined template.
- Populates the SBOM with dynamic information such as version, commit hash, and creation timestamp.
- Validates the generated SBOM for correct JSON syntax.
- Uploads the SBOM as a build artifact.
- Integrates the SBOM into GitHub releases by making the release job dependent on its generation and including it as a release asset.

This enhancement improves supply chain security and transparency by providing a standardized manifest of software components.