### PR TITLE
Abstracts memory and sorting for portability

### DIFF
--- a/src/lib/zxc_common.c
+++ b/src/lib/zxc_common.c
@@ -52,7 +52,7 @@ void zxc_aligned_free(void* ptr) {
 #if defined(_WIN32)
     _aligned_free(ptr);
 #else
-    ZXC_FREE(ptr);
+    free(ptr);
 #endif
 }
 
@@ -112,7 +112,7 @@ int zxc_cctx_init(zxc_cctx_t* RESTRICT ctx, const size_t chunk_size, const int m
     const size_t off_lit = total_size;
     total_size += ZXC_ALIGN_CL(sz_lit);
 
-    uint8_t* const mem = (uint8_t*)zxc_aligned_malloc(total_size, ZXC_CACHE_LINE_SIZE);
+    uint8_t* const mem = (uint8_t*)ZXC_ALIGNED_MALLOC(total_size, ZXC_CACHE_LINE_SIZE);
     if (UNLIKELY(!mem)) return ZXC_ERROR_MEMORY;
 
     ctx->memory_block = mem;
@@ -143,7 +143,7 @@ int zxc_cctx_init(zxc_cctx_t* RESTRICT ctx, const size_t chunk_size, const int m
  */
 void zxc_cctx_free(zxc_cctx_t* ctx) {
     if (ctx->memory_block) {
-        zxc_aligned_free(ctx->memory_block);
+        ZXC_ALIGNED_FREE(ctx->memory_block);
         ctx->memory_block = NULL;
     }
 
@@ -158,7 +158,7 @@ void zxc_cctx_free(zxc_cctx_t* ctx) {
     }
 
     if (ctx->opt_scratch) {
-        zxc_aligned_free(ctx->opt_scratch);
+        ZXC_ALIGNED_FREE(ctx->opt_scratch);
         ctx->opt_scratch = NULL;
     }
 

--- a/src/lib/zxc_common.c
+++ b/src/lib/zxc_common.c
@@ -52,7 +52,7 @@ void zxc_aligned_free(void* ptr) {
 #if defined(_WIN32)
     _aligned_free(ptr);
 #else
-    free(ptr);
+    ZXC_FREE(ptr);
 #endif
 }
 
@@ -148,12 +148,12 @@ void zxc_cctx_free(zxc_cctx_t* ctx) {
     }
 
     if (ctx->lit_buffer) {
-        free(ctx->lit_buffer);
+        ZXC_FREE(ctx->lit_buffer);
         ctx->lit_buffer = NULL;
     }
 
     if (ctx->work_buf) {
-        free(ctx->work_buf);
+        ZXC_FREE(ctx->work_buf);
         ctx->work_buf = NULL;
     }
 

--- a/src/lib/zxc_compress.c
+++ b/src/lib/zxc_compress.c
@@ -939,8 +939,8 @@ static int zxc_lz77_optimal_parse_glo(zxc_cctx_t* RESTRICT ctx, const uint8_t* R
         (dp_needed > ZXC_HUF_BUILD_SCRATCH_SIZE) ? dp_needed : ZXC_HUF_BUILD_SCRATCH_SIZE;
 
     if (UNLIKELY(ctx->opt_scratch_cap < needed)) {
-        if (ctx->opt_scratch) zxc_aligned_free(ctx->opt_scratch);
-        ctx->opt_scratch = (uint8_t*)zxc_aligned_malloc(needed, ZXC_CACHE_LINE_SIZE);
+        if (ctx->opt_scratch) ZXC_ALIGNED_FREE(ctx->opt_scratch);
+        ctx->opt_scratch = (uint8_t*)ZXC_ALIGNED_MALLOC(needed, ZXC_CACHE_LINE_SIZE);
         if (UNLIKELY(!ctx->opt_scratch)) {
             ctx->opt_scratch_cap = 0;
             return ZXC_ERROR_MEMORY;

--- a/src/lib/zxc_decompress.c
+++ b/src/lib/zxc_decompress.c
@@ -635,9 +635,9 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
                 return ZXC_ERROR_DST_TOO_SMALL;
             const size_t alloc_size = required_size + ZXC_PAD_SIZE;
             if (UNLIKELY(ctx->lit_buffer_cap < alloc_size)) {
-                uint8_t* new_buf = (uint8_t*)realloc(ctx->lit_buffer, alloc_size);
+                uint8_t* new_buf = (uint8_t*)ZXC_REALLOC(ctx->lit_buffer, alloc_size);
                 if (UNLIKELY(!new_buf)) {
-                    free(ctx->lit_buffer);
+                    ZXC_FREE(ctx->lit_buffer);
                     ctx->lit_buffer = NULL;
                     ctx->lit_buffer_cap = 0;
                     return ZXC_ERROR_MEMORY;
@@ -660,9 +660,9 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
             const size_t alloc_size = required_size + ZXC_PAD_SIZE;
 
             if (UNLIKELY(ctx->lit_buffer_cap < alloc_size)) {
-                uint8_t* new_buf = (uint8_t*)realloc(ctx->lit_buffer, alloc_size);
+                uint8_t* new_buf = (uint8_t*)ZXC_REALLOC(ctx->lit_buffer, alloc_size);
                 if (UNLIKELY(!new_buf)) {
-                    free(ctx->lit_buffer);
+                    ZXC_FREE(ctx->lit_buffer);
                     ctx->lit_buffer = NULL;
                     ctx->lit_buffer_cap = 0;
                     return ZXC_ERROR_MEMORY;

--- a/src/lib/zxc_dispatch.c
+++ b/src/lib/zxc_dispatch.c
@@ -513,7 +513,7 @@ int64_t zxc_compress(const void* RESTRICT src, const size_t src_size, void* REST
             return ZXC_ERROR_BAD_BLOCK_SIZE;
         }
         seek_cap = (uint32_t)(block_count + 2);
-        seek_comp = (uint32_t*)malloc(seek_cap * sizeof(uint32_t));
+        seek_comp = (uint32_t*)ZXC_MALLOC(seek_cap * sizeof(uint32_t));
         // LCOV_EXCL_START
         if (UNLIKELY(!seek_comp)) {
             zxc_cctx_free(&ctx);
@@ -529,7 +529,7 @@ int64_t zxc_compress(const void* RESTRICT src, const size_t src_size, void* REST
 
         const int res = zxc_compress_chunk_wrapper(&ctx, ip + pos, chunk_len, op, rem_cap);
         if (UNLIKELY(res < 0)) {
-            free(seek_comp);
+            ZXC_FREE(seek_comp);
             zxc_cctx_free(&ctx);
             return res;
         }
@@ -548,9 +548,9 @@ int64_t zxc_compress(const void* RESTRICT src, const size_t src_size, void* REST
             // LCOV_EXCL_START
             if (UNLIKELY(seek_count >= seek_cap)) {
                 seek_cap = seek_cap * 2;
-                uint32_t* nc = (uint32_t*)realloc(seek_comp, seek_cap * sizeof(uint32_t));
+                uint32_t* nc = (uint32_t*)ZXC_REALLOC(seek_comp, seek_cap * sizeof(uint32_t));
                 if (UNLIKELY(!nc)) {
-                    free(seek_comp);
+                    ZXC_FREE(seek_comp);
                     zxc_cctx_free(&ctx);
                     return ZXC_ERROR_MEMORY;
                 }
@@ -574,7 +574,7 @@ int64_t zxc_compress(const void* RESTRICT src, const size_t src_size, void* REST
     const int eof_val = zxc_write_block_header(op, rem_cap, &eof_bh);
     // LCOV_EXCL_START
     if (UNLIKELY(eof_val < 0)) {
-        free(seek_comp);
+        ZXC_FREE(seek_comp);
         return eof_val;
     }
     // LCOV_EXCL_STOP
@@ -584,11 +584,11 @@ int64_t zxc_compress(const void* RESTRICT src, const size_t src_size, void* REST
     if (seekable && seek_count > 0) {
         const size_t st_cap = (size_t)(op_end - op);
         const int64_t st_val = zxc_write_seek_table(op, st_cap, seek_comp, seek_count);
-        free(seek_comp);
+        ZXC_FREE(seek_comp);
         if (UNLIKELY(st_val < 0)) return (int64_t)st_val;  // LCOV_EXCL_LINE
         op += st_val;
     } else {
-        free(seek_comp);
+        ZXC_FREE(seek_comp);
     }
 
     if (UNLIKELY((size_t)(op_end - op) < ZXC_FILE_FOOTER_SIZE))
@@ -646,8 +646,8 @@ int64_t zxc_decompress(const void* RESTRICT src, const size_t src_size, void* RE
     // Decode into a padded scratch buffer, then memcpy the exact result out.
     const size_t work_sz = runtime_chunk_size + ZXC_PAD_SIZE;
     if (ctx.work_buf_cap < work_sz) {
-        free(ctx.work_buf);
-        ctx.work_buf = (uint8_t*)malloc(work_sz);
+        ZXC_FREE(ctx.work_buf);
+        ctx.work_buf = (uint8_t*)ZXC_MALLOC(work_sz);
         // LCOV_EXCL_START
         if (UNLIKELY(!ctx.work_buf)) {
             zxc_cctx_free(&ctx);
@@ -779,7 +779,7 @@ struct zxc_cctx_s {
 };
 
 zxc_cctx* zxc_create_cctx(const zxc_compress_opts_t* opts) {
-    zxc_cctx* const cctx = (zxc_cctx*)calloc(1, sizeof(zxc_cctx));
+    zxc_cctx* const cctx = (zxc_cctx*)ZXC_CALLOC(1, sizeof(zxc_cctx));
     if (UNLIKELY(!cctx)) return NULL;  // LCOV_EXCL_LINE
 
     /* Resolve and store sticky defaults. */
@@ -793,7 +793,7 @@ zxc_cctx* zxc_create_cctx(const zxc_compress_opts_t* opts) {
         if (UNLIKELY(!zxc_validate_block_size(cctx->stored_block_size) ||
                      zxc_cctx_init(&cctx->inner, cctx->stored_block_size, 1, cctx->stored_level,
                                    cctx->stored_checksum) != ZXC_OK)) {
-            free(cctx);
+            ZXC_FREE(cctx);
             return NULL;
         }
         // LCOV_EXCL_STOP
@@ -807,7 +807,7 @@ zxc_cctx* zxc_create_cctx(const zxc_compress_opts_t* opts) {
 void zxc_free_cctx(zxc_cctx* cctx) {
     if (UNLIKELY(!cctx)) return;
     if (cctx->initialized) zxc_cctx_free(&cctx->inner);
-    free(cctx);
+    ZXC_FREE(cctx);
 }
 
 int64_t zxc_compress_cctx(zxc_cctx* cctx, const void* RESTRICT src, const size_t src_size,
@@ -907,14 +907,14 @@ struct zxc_dctx_s {
 };
 
 zxc_dctx* zxc_create_dctx(void) {
-    zxc_dctx* const dctx = (zxc_dctx*)calloc(1, sizeof(zxc_dctx));
+    zxc_dctx* const dctx = (zxc_dctx*)ZXC_CALLOC(1, sizeof(zxc_dctx));
     return dctx;
 }
 
 void zxc_free_dctx(zxc_dctx* dctx) {
     if (UNLIKELY(!dctx)) return;
     if (dctx->initialized) zxc_cctx_free(&dctx->inner);
-    free(dctx);
+    ZXC_FREE(dctx);
 }
 
 int64_t zxc_decompress_dctx(zxc_dctx* dctx, const void* RESTRICT src, const size_t src_size,
@@ -963,8 +963,8 @@ int64_t zxc_decompress_dctx(zxc_dctx* dctx, const void* RESTRICT src, const size
     /* Ensure scratch buffer is large enough. */
     const size_t work_sz = runtime_chunk_size + ZXC_PAD_SIZE;
     if (UNLIKELY(ctx->work_buf_cap < work_sz)) {
-        free(ctx->work_buf);
-        ctx->work_buf = (uint8_t*)malloc(work_sz);
+        ZXC_FREE(ctx->work_buf);
+        ctx->work_buf = (uint8_t*)ZXC_MALLOC(work_sz);
         if (UNLIKELY(!ctx->work_buf)) return ZXC_ERROR_MEMORY;  // LCOV_EXCL_LINE
         ctx->work_buf_cap = work_sz;
     }
@@ -1099,8 +1099,8 @@ int64_t zxc_decompress_block(zxc_dctx* dctx, const void* RESTRICT src, const siz
     /* Ensure scratch buffer for safe-path wild copies. */
     const size_t work_sz = block_size + ZXC_PAD_SIZE;
     if (ctx->work_buf_cap < work_sz) {
-        free(ctx->work_buf);
-        ctx->work_buf = (uint8_t*)malloc(work_sz);
+        ZXC_FREE(ctx->work_buf);
+        ctx->work_buf = (uint8_t*)ZXC_MALLOC(work_sz);
         if (UNLIKELY(!ctx->work_buf)) return ZXC_ERROR_MEMORY;  // LCOV_EXCL_LINE
         ctx->work_buf_cap = work_sz;
     }

--- a/src/lib/zxc_driver.c
+++ b/src/lib/zxc_driver.c
@@ -74,7 +74,7 @@ static unsigned __stdcall zxc_win_thread_entry(void* p) {
     zxc_win_thread_arg_t* a = (zxc_win_thread_arg_t*)p;
     void* (*f)(void*) = a->func;
     void* arg = a->arg;
-    free(a);
+    ZXC_FREE(a);
     f(arg);
     return 0;
 }
@@ -82,13 +82,13 @@ static unsigned __stdcall zxc_win_thread_entry(void* p) {
 static int pthread_create(pthread_t* thread, const void* attr, void* (*start_routine)(void*),
                           void* arg) {
     (void)attr;
-    zxc_win_thread_arg_t* wrapper = malloc(sizeof(zxc_win_thread_arg_t));
+    zxc_win_thread_arg_t* wrapper = ZXC_MALLOC(sizeof(zxc_win_thread_arg_t));
     if (UNLIKELY(!wrapper)) return ZXC_ERROR_MEMORY;
     wrapper->func = start_routine;
     wrapper->arg = arg;
     uintptr_t handle = _beginthreadex(NULL, 0, zxc_win_thread_entry, wrapper, 0, NULL);
     if (UNLIKELY(handle == 0)) {
-        free(wrapper);
+        ZXC_FREE(wrapper);
         return ZXC_ERROR_MEMORY;
     }
     *thread = (HANDLE)handle;
@@ -475,7 +475,7 @@ static void* zxc_async_writer(void* arg) {
             if (UNLIKELY(args->seek_count >= args->seek_cap)) {
                 args->seek_cap = args->seek_cap * 2;
                 uint32_t* nc =
-                    (uint32_t*)realloc(args->seek_comp, args->seek_cap * sizeof(uint32_t));
+                    (uint32_t*)ZXC_REALLOC(args->seek_comp, args->seek_cap * sizeof(uint32_t));
                 // LCOV_EXCL_START
                 if (UNLIKELY(!nc)) {
                     pthread_mutex_lock(&ctx->lock);
@@ -645,7 +645,7 @@ static int64_t zxc_stream_engine_run(FILE* f_in, FILE* f_out, const int n_thread
     pthread_cond_init(&ctx.cond_worker, NULL);
     pthread_cond_init(&ctx.cond_writer, NULL);
 
-    pthread_t* const workers = malloc((size_t)num_workers * sizeof(pthread_t));
+    pthread_t* const workers = ZXC_MALLOC((size_t)num_workers * sizeof(pthread_t));
     if (UNLIKELY(!workers)) {
         // LCOV_EXCL_START
         zxc_aligned_free(mem_block);
@@ -663,7 +663,7 @@ static int64_t zxc_stream_engine_run(FILE* f_in, FILE* f_out, const int n_thread
         pthread_cond_destroy(&ctx.cond_worker);
         pthread_cond_destroy(&ctx.cond_reader);
         pthread_mutex_destroy(&ctx.lock);
-        free(workers);
+        ZXC_FREE(workers);
         zxc_aligned_free(mem_block);
         return ZXC_ERROR_MEMORY;
         // LCOV_EXCL_STOP
@@ -674,7 +674,7 @@ static int64_t zxc_stream_engine_run(FILE* f_in, FILE* f_out, const int n_thread
     /* Seekable: allocate initial block-size tracking array */
     if (mode == 1 && seekable) {
         w_args.seek_cap = 64;
-        w_args.seek_comp = (uint32_t*)malloc(w_args.seek_cap * sizeof(uint32_t));
+        w_args.seek_comp = (uint32_t*)ZXC_MALLOC(w_args.seek_cap * sizeof(uint32_t));
         // LCOV_EXCL_START
         if (UNLIKELY(!w_args.seek_comp)) {
             pthread_mutex_lock(&ctx.lock);
@@ -686,7 +686,7 @@ static int64_t zxc_stream_engine_run(FILE* f_in, FILE* f_out, const int n_thread
             pthread_cond_destroy(&ctx.cond_worker);
             pthread_cond_destroy(&ctx.cond_reader);
             pthread_mutex_destroy(&ctx.lock);
-            free(workers);
+            ZXC_FREE(workers);
             zxc_aligned_free(mem_block);
             return ZXC_ERROR_MEMORY;
         }
@@ -713,7 +713,7 @@ static int64_t zxc_stream_engine_run(FILE* f_in, FILE* f_out, const int n_thread
         pthread_cond_destroy(&ctx.cond_worker);
         pthread_cond_destroy(&ctx.cond_reader);
         pthread_mutex_destroy(&ctx.lock);
-        free(workers);
+        ZXC_FREE(workers);
         zxc_aligned_free(mem_block);
         return ZXC_ERROR_MEMORY;
         // LCOV_EXCL_STOP
@@ -841,14 +841,14 @@ static int64_t zxc_stream_engine_run(FILE* f_in, FILE* f_out, const int n_thread
         /* Seekable: write SEK block between EOF and footer */
         if (!ctx.io_error && w_args.seek_comp && w_args.seek_count > 0) {
             const size_t st_size = zxc_seek_table_size(w_args.seek_count);
-            uint8_t* const st_buf = (uint8_t*)malloc(st_size);
+            uint8_t* const st_buf = (uint8_t*)ZXC_MALLOC(st_size);
             if (st_buf) {
                 const int64_t st_val =
                     zxc_write_seek_table(st_buf, st_size, w_args.seek_comp, w_args.seek_count);
                 if (st_val > 0 && f_out &&
                     fwrite(st_buf, 1, (size_t)st_val, f_out) == (size_t)st_val)
                     w_args.total_bytes += st_val;
-                free(st_buf);
+                ZXC_FREE(st_buf);
             }
         }
 
@@ -910,8 +910,8 @@ static int64_t zxc_stream_engine_run(FILE* f_in, FILE* f_out, const int n_thread
         }
     }
 
-    free(w_args.seek_comp);
-    free(workers);
+    ZXC_FREE(w_args.seek_comp);
+    ZXC_FREE(workers);
     zxc_aligned_free(mem_block);
 
     if (UNLIKELY(ctx.io_error)) return ZXC_ERROR_IO;

--- a/src/lib/zxc_driver.c
+++ b/src/lib/zxc_driver.c
@@ -610,10 +610,10 @@ static int64_t zxc_stream_engine_run(FILE* f_in, FILE* f_out, const int n_thread
 
     const size_t per_job_sz = sizeof(zxc_stream_job_t) + sizeof(int) + alloc_in + alloc_out;
     const size_t alloc_size = ctx.ring_size * per_job_sz;
-    uint8_t* const mem_block = zxc_aligned_malloc(alloc_size, ZXC_CACHE_LINE_SIZE);
+    uint8_t* const mem_block = ZXC_ALIGNED_MALLOC(alloc_size, ZXC_CACHE_LINE_SIZE);
     if (UNLIKELY(!mem_block || per_job_sz > SIZE_MAX / ctx.ring_size)) {
         // LCOV_EXCL_START
-        zxc_aligned_free(mem_block);
+        ZXC_ALIGNED_FREE(mem_block);
         return ZXC_ERROR_MEMORY;
         // LCOV_EXCL_STOP
     }
@@ -648,7 +648,7 @@ static int64_t zxc_stream_engine_run(FILE* f_in, FILE* f_out, const int n_thread
     pthread_t* const workers = ZXC_MALLOC((size_t)num_workers * sizeof(pthread_t));
     if (UNLIKELY(!workers)) {
         // LCOV_EXCL_START
-        zxc_aligned_free(mem_block);
+        ZXC_ALIGNED_FREE(mem_block);
         return ZXC_ERROR_MEMORY;
         // LCOV_EXCL_STOP
     }
@@ -664,7 +664,7 @@ static int64_t zxc_stream_engine_run(FILE* f_in, FILE* f_out, const int n_thread
         pthread_cond_destroy(&ctx.cond_reader);
         pthread_mutex_destroy(&ctx.lock);
         ZXC_FREE(workers);
-        zxc_aligned_free(mem_block);
+        ZXC_ALIGNED_FREE(mem_block);
         return ZXC_ERROR_MEMORY;
         // LCOV_EXCL_STOP
     }
@@ -687,7 +687,7 @@ static int64_t zxc_stream_engine_run(FILE* f_in, FILE* f_out, const int n_thread
             pthread_cond_destroy(&ctx.cond_reader);
             pthread_mutex_destroy(&ctx.lock);
             ZXC_FREE(workers);
-            zxc_aligned_free(mem_block);
+            ZXC_ALIGNED_FREE(mem_block);
             return ZXC_ERROR_MEMORY;
         }
         // LCOV_EXCL_STOP
@@ -714,7 +714,7 @@ static int64_t zxc_stream_engine_run(FILE* f_in, FILE* f_out, const int n_thread
         pthread_cond_destroy(&ctx.cond_reader);
         pthread_mutex_destroy(&ctx.lock);
         ZXC_FREE(workers);
-        zxc_aligned_free(mem_block);
+        ZXC_ALIGNED_FREE(mem_block);
         return ZXC_ERROR_MEMORY;
         // LCOV_EXCL_STOP
     }
@@ -912,7 +912,7 @@ static int64_t zxc_stream_engine_run(FILE* f_in, FILE* f_out, const int n_thread
 
     ZXC_FREE(w_args.seek_comp);
     ZXC_FREE(workers);
-    zxc_aligned_free(mem_block);
+    ZXC_ALIGNED_FREE(mem_block);
 
     if (UNLIKELY(ctx.io_error)) return ZXC_ERROR_IO;
 

--- a/src/lib/zxc_huffman.c
+++ b/src/lib/zxc_huffman.c
@@ -159,15 +159,15 @@ int zxc_huf_build_code_lengths(const uint32_t* RESTRICT freq, uint8_t* RESTRICT 
         p = (uint8_t*)(((uintptr_t)p + 7u) & ~(uintptr_t)7u);
         stack = (frame_t*)p;
     } else {
-        owned_items = (pm_item_t*)malloc((size_t)ZXC_HUF_MAX_CODE_LEN * (size_t)max_per_level *
-                                         sizeof(pm_item_t));
-        owned_counts = (int*)calloc((size_t)ZXC_HUF_MAX_CODE_LEN, sizeof(int));
-        owned_stack = (frame_t*)malloc((size_t)ZXC_HUF_MAX_CODE_LEN * (size_t)max_per_level *
-                                       sizeof(frame_t));
+        owned_items = (pm_item_t*)ZXC_MALLOC((size_t)ZXC_HUF_MAX_CODE_LEN * (size_t)max_per_level *
+                                             sizeof(pm_item_t));
+        owned_counts = (int*)ZXC_CALLOC((size_t)ZXC_HUF_MAX_CODE_LEN, sizeof(int));
+        owned_stack = (frame_t*)ZXC_MALLOC((size_t)ZXC_HUF_MAX_CODE_LEN * (size_t)max_per_level *
+                                           sizeof(frame_t));
         if (UNLIKELY(!owned_items || !owned_counts || !owned_stack)) {
-            free(owned_items);
-            free(owned_counts);
-            free(owned_stack);
+            ZXC_FREE(owned_items);
+            ZXC_FREE(owned_counts);
+            ZXC_FREE(owned_stack);
             return ZXC_ERROR_MEMORY;
         }
         items = owned_items;
@@ -245,9 +245,9 @@ int zxc_huf_build_code_lengths(const uint32_t* RESTRICT freq, uint8_t* RESTRICT 
     }
 
     if (owned_items) {
-        free(owned_items);
-        free(owned_counts);
-        free(owned_stack);
+        ZXC_FREE(owned_items);
+        ZXC_FREE(owned_counts);
+        ZXC_FREE(owned_stack);
     }
 #undef ITEM
     return ZXC_OK;

--- a/src/lib/zxc_huffman.c
+++ b/src/lib/zxc_huffman.c
@@ -36,9 +36,6 @@
 #define zxc_huf_decode_section ZXC_CAT(zxc_huf_decode_section, ZXC_FUNCTION_SUFFIX)
 #endif
 
-#include <stdlib.h>
-#include <string.h>
-
 #include "../../include/zxc_error.h"
 #include "zxc_internal.h"
 
@@ -135,7 +132,7 @@ int zxc_huf_build_code_lengths(const uint32_t* RESTRICT freq, uint8_t* RESTRICT 
         return ZXC_OK;
     }
 
-    qsort(leaves, (size_t)n, sizeof(pm_leaf_t), pm_leaf_cmp);
+    ZXC_QSORT(leaves, (size_t)n, sizeof(pm_leaf_t), pm_leaf_cmp);
 
     /* n <= 256 <= 2^ZXC_HUF_MAX_CODE_LEN, so length-limit is always feasible. */
     const int max_per_level = 2 * n;

--- a/src/lib/zxc_internal.h
+++ b/src/lib/zxc_internal.h
@@ -264,6 +264,39 @@ extern "C" {
 /** @} */
 
 /**
+ * @name Aligned Allocator Abstraction
+ * @brief Macros around the cache-line-aligned allocator used for compression
+ * workspace and per-context scratch buffers.
+ *
+ * The default expansion calls the internal helpers @ref zxc_aligned_malloc /
+ * @ref zxc_aligned_free, which wrap `_aligned_malloc`/`_aligned_free` on
+ * Windows and `posix_memalign`/`free` on POSIX. The malloc/free pair is
+ * opaque — if you override one, you **must** override the other (a pointer
+ * returned by an override must not be freed by the default, and vice versa).
+ *
+ * Example kernel-side override:
+ * @code
+ * // kmalloc returns memory aligned to ARCH_KMALLOC_MINALIGN (>= cache line
+ * // on most modern archs). For stricter alignment, use kmem_cache_* with
+ * // SLAB_HWCACHE_ALIGN and a per-context cache.
+ * -DZXC_ALIGNED_MALLOC(s,a)=kmalloc(s, GFP_KERNEL)
+ * -DZXC_ALIGNED_FREE(p)=kfree(p)
+ * @endcode
+ *
+ * @note Both call sites pass `ZXC_CACHE_LINE_SIZE` as alignment. The kernel
+ * override may ignore the @c align argument if its allocator guarantees a
+ * sufficient natural alignment.
+ * @{
+ */
+#ifndef ZXC_ALIGNED_MALLOC
+#define ZXC_ALIGNED_MALLOC(size, alignment) zxc_aligned_malloc(size, alignment)
+#endif
+#ifndef ZXC_ALIGNED_FREE
+#define ZXC_ALIGNED_FREE(ptr) zxc_aligned_free(ptr)
+#endif
+/** @} */
+
+/**
  * @name Endianness Detection
  * @brief Compile-time detection of host byte order.
  *

--- a/src/lib/zxc_internal.h
+++ b/src/lib/zxc_internal.h
@@ -26,7 +26,6 @@
 #ifndef ZXC_INTERNAL_H
 #define ZXC_INTERNAL_H
 
-#include <assert.h>
 #include <inttypes.h>
 #include <limits.h>
 #include <stdint.h>

--- a/src/lib/zxc_internal.h
+++ b/src/lib/zxc_internal.h
@@ -233,6 +233,38 @@ extern "C" {
 /** @} */ /* end of Compiler Abstractions */
 
 /**
+ * @name Heap Allocator Abstraction
+ * @brief Macros around the libc allocators so non-libc targets (Linux kernel,
+ * embedded freestanding builds, custom arenas) can override them via `-D`
+ * flags **before** including any zxc header.
+ *
+ * Example kernel-side override:
+ * @code
+ * -DZXC_MALLOC(n)=kmalloc(n, GFP_KERNEL)
+ * -DZXC_CALLOC(n, s)=kcalloc(n, s, GFP_KERNEL)
+ * -DZXC_REALLOC(p, n)=krealloc(p, n, GFP_KERNEL)
+ * -DZXC_FREE(p)=kfree(p)
+ * @endcode
+ *
+ * @note Aligned allocations still go through @ref zxc_aligned_malloc /
+ * @ref zxc_aligned_free, which are platform-specific and not covered here.
+ * @{
+ */
+#ifndef ZXC_MALLOC
+#define ZXC_MALLOC(size) malloc(size)
+#endif
+#ifndef ZXC_CALLOC
+#define ZXC_CALLOC(nmemb, size) calloc(nmemb, size)
+#endif
+#ifndef ZXC_REALLOC
+#define ZXC_REALLOC(ptr, size) realloc(ptr, size)
+#endif
+#ifndef ZXC_FREE
+#define ZXC_FREE(ptr) free(ptr)
+#endif
+/** @} */
+
+/**
  * @name Endianness Detection
  * @brief Compile-time detection of host byte order.
  *

--- a/src/lib/zxc_internal.h
+++ b/src/lib/zxc_internal.h
@@ -26,10 +26,8 @@
 #ifndef ZXC_INTERNAL_H
 #define ZXC_INTERNAL_H
 
-#include <inttypes.h>
 #include <limits.h>
 #include <stdint.h>
-#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -261,6 +259,9 @@ extern "C" {
 #ifndef ZXC_FREE
 #define ZXC_FREE(ptr) free(ptr)
 #endif
+#ifndef ZXC_QSORT
+#define ZXC_QSORT(base, nmemb, size, cmp) qsort(base, nmemb, size, cmp)
+#endif
 /** @} */
 
 /**
@@ -270,22 +271,8 @@ extern "C" {
  *
  * The default expansion calls the internal helpers @ref zxc_aligned_malloc /
  * @ref zxc_aligned_free, which wrap `_aligned_malloc`/`_aligned_free` on
- * Windows and `posix_memalign`/`free` on POSIX. The malloc/free pair is
- * opaque — if you override one, you **must** override the other (a pointer
- * returned by an override must not be freed by the default, and vice versa).
+ * Windows and `posix_memalign`/`free` on POSIX.
  *
- * Example kernel-side override:
- * @code
- * // kmalloc returns memory aligned to ARCH_KMALLOC_MINALIGN (>= cache line
- * // on most modern archs). For stricter alignment, use kmem_cache_* with
- * // SLAB_HWCACHE_ALIGN and a per-context cache.
- * -DZXC_ALIGNED_MALLOC(s,a)=kmalloc(s, GFP_KERNEL)
- * -DZXC_ALIGNED_FREE(p)=kfree(p)
- * @endcode
- *
- * @note Both call sites pass `ZXC_CACHE_LINE_SIZE` as alignment. The kernel
- * override may ignore the @c align argument if its allocator guarantees a
- * sufficient natural alignment.
  * @{
  */
 #ifndef ZXC_ALIGNED_MALLOC

--- a/src/lib/zxc_pstream.c
+++ b/src/lib/zxc_pstream.c
@@ -180,7 +180,7 @@ static int cs_compress_one_block(zxc_cstream* cs) {
     // LCOV_EXCL_START
     if (UNLIKELY(bound == 0 || bound > SIZE_MAX)) return ZXC_ERROR_OVERFLOW;
     if (UNLIKELY(bound > cs->pending_cap)) {
-        uint8_t* nb = (uint8_t*)realloc(cs->pending, (size_t)bound);
+        uint8_t* nb = (uint8_t*)ZXC_REALLOC(cs->pending, (size_t)bound);
         if (UNLIKELY(!nb)) return ZXC_ERROR_MEMORY;
         cs->pending = nb;
         cs->pending_cap = (size_t)bound;
@@ -244,7 +244,7 @@ static int cs_drain_pending(zxc_cstream* cs, zxc_outbuf_t* out) {
  *         failure / invalid option values.
  */
 zxc_cstream* zxc_cstream_create(const zxc_compress_opts_t* opts) {
-    zxc_cstream* cs = (zxc_cstream*)calloc(1, sizeof(*cs));
+    zxc_cstream* cs = (zxc_cstream*)ZXC_CALLOC(1, sizeof(*cs));
     if (UNLIKELY(!cs)) return NULL;  // LCOV_EXCL_LINE
 
     if (opts) cs->opts = *opts;
@@ -260,25 +260,25 @@ zxc_cstream* zxc_cstream_create(const zxc_compress_opts_t* opts) {
     cs->cctx = zxc_create_cctx(&cs->opts);
     // LCOV_EXCL_START
     if (UNLIKELY(!cs->cctx)) {
-        free(cs);
+        ZXC_FREE(cs);
         return NULL;
     }
-    cs->in_block = (uint8_t*)malloc(cs->block_size);
+    cs->in_block = (uint8_t*)ZXC_MALLOC(cs->block_size);
     if (UNLIKELY(!cs->in_block)) {
         zxc_free_cctx(cs->cctx);
-        free(cs);
+        ZXC_FREE(cs);
         return NULL;
     }
     // LCOV_EXCL_STOP
     /* Pre-size pending so the file header path never needs realloc. */
     cs->pending_cap =
         ZXC_FILE_HEADER_SIZE > ZXC_FILE_FOOTER_SIZE ? ZXC_FILE_HEADER_SIZE : ZXC_FILE_FOOTER_SIZE;
-    cs->pending = (uint8_t*)malloc(cs->pending_cap);
+    cs->pending = (uint8_t*)ZXC_MALLOC(cs->pending_cap);
     // LCOV_EXCL_START
     if (UNLIKELY(!cs->pending)) {
-        free(cs->in_block);
+        ZXC_FREE(cs->in_block);
         zxc_free_cctx(cs->cctx);
-        free(cs);
+        ZXC_FREE(cs);
         return NULL;
     }
     // LCOV_EXCL_STOP
@@ -313,7 +313,7 @@ static int cs_stage_file_header(zxc_cstream* cs) {
 static int cs_stage_eof(zxc_cstream* cs) {
     // LCOV_EXCL_START
     if (UNLIKELY(ZXC_BLOCK_HEADER_SIZE > cs->pending_cap)) {
-        uint8_t* nb = (uint8_t*)realloc(cs->pending, ZXC_BLOCK_HEADER_SIZE);
+        uint8_t* nb = (uint8_t*)ZXC_REALLOC(cs->pending, ZXC_BLOCK_HEADER_SIZE);
         if (UNLIKELY(!nb)) return ZXC_ERROR_MEMORY;
         cs->pending = nb;
         cs->pending_cap = ZXC_BLOCK_HEADER_SIZE;
@@ -345,7 +345,7 @@ static int cs_stage_eof(zxc_cstream* cs) {
 static int cs_stage_footer(zxc_cstream* cs) {
     // LCOV_EXCL_START
     if (UNLIKELY(ZXC_FILE_FOOTER_SIZE > cs->pending_cap)) {
-        uint8_t* nb = (uint8_t*)realloc(cs->pending, ZXC_FILE_FOOTER_SIZE);
+        uint8_t* nb = (uint8_t*)ZXC_REALLOC(cs->pending, ZXC_FILE_FOOTER_SIZE);
         if (UNLIKELY(!nb)) return ZXC_ERROR_MEMORY;
         cs->pending = nb;
         cs->pending_cap = ZXC_FILE_FOOTER_SIZE;
@@ -368,10 +368,10 @@ static int cs_stage_footer(zxc_cstream* cs) {
  */
 void zxc_cstream_free(zxc_cstream* cs) {
     if (!cs) return;
-    free(cs->pending);
-    free(cs->in_block);
+    ZXC_FREE(cs->pending);
+    ZXC_FREE(cs->in_block);
     zxc_free_cctx(cs->cctx);
-    free(cs);
+    ZXC_FREE(cs);
 }
 
 /**
@@ -794,7 +794,7 @@ static int ds_pull_payload(zxc_dstream* ds, zxc_inbuf_t* in) {
  * @return New stream owned by the caller, or @c NULL on allocation failure.
  */
 zxc_dstream* zxc_dstream_create(const zxc_decompress_opts_t* opts) {
-    zxc_dstream* ds = (zxc_dstream*)calloc(1, sizeof(*ds));
+    zxc_dstream* ds = (zxc_dstream*)ZXC_CALLOC(1, sizeof(*ds));
     if (UNLIKELY(!ds)) return NULL;  // LCOV_EXCL_LINE
     if (opts) ds->opts = *opts;
     ds->opts.n_threads = 0;
@@ -814,10 +814,10 @@ zxc_dstream* zxc_dstream_create(const zxc_decompress_opts_t* opts) {
  */
 void zxc_dstream_free(zxc_dstream* ds) {
     if (!ds) return;
-    free(ds->payload);
-    free(ds->decoded);
+    ZXC_FREE(ds->payload);
+    ZXC_FREE(ds->decoded);
     if (ds->inner_initialized) zxc_cctx_free(&ds->inner);
-    free(ds);
+    ZXC_FREE(ds);
 }
 
 /**
@@ -916,14 +916,14 @@ static int ds_handle_need_file_header(zxc_dstream* ds, zxc_inbuf_t* in) {
     if (UNLIKELY(pb == 0 || pb > SIZE_MAX)) return ds_set_error(ds, ZXC_ERROR_OVERFLOW);
     // LCOV_EXCL_STOP
     ds->payload_cap = (size_t)pb;
-    ds->payload = (uint8_t*)malloc(ds->payload_cap);
+    ds->payload = (uint8_t*)ZXC_MALLOC(ds->payload_cap);
 
     /* Decoded buffer is sized for the wild-copy fast path: block_size +
      * ZXC_PAD_SIZE; same pattern as the buffer API uses internally.  Real
      * decoded payload lives in [0..decoded_size); the trailing PAD bytes
      * hold wild-copy overflow we never emit. */
     ds->decoded_cap = ds->block_size + ZXC_PAD_SIZE;
-    ds->decoded = (uint8_t*)malloc(ds->decoded_cap);
+    ds->decoded = (uint8_t*)ZXC_MALLOC(ds->decoded_cap);
     // LCOV_EXCL_START
     if (UNLIKELY(!ds->payload || !ds->decoded)) return ds_set_error(ds, ZXC_ERROR_MEMORY);
 
@@ -984,7 +984,7 @@ static int ds_handle_need_block_header(zxc_dstream* ds, zxc_inbuf_t* in) {
     // LCOV_EXCL_START
     if (UNLIKELY(ds->payload_need > ds->payload_cap)) {
         /* grow */
-        uint8_t* nb = (uint8_t*)realloc(ds->payload, ds->payload_need);
+        uint8_t* nb = (uint8_t*)ZXC_REALLOC(ds->payload, ds->payload_need);
         if (UNLIKELY(!nb)) return ds_set_error(ds, ZXC_ERROR_MEMORY);
         ds->payload = nb;
         ds->payload_cap = ds->payload_need;

--- a/src/lib/zxc_pstream.c
+++ b/src/lib/zxc_pstream.c
@@ -24,9 +24,6 @@
 
 #include "../../include/zxc_pstream.h"
 
-#include <stdlib.h>
-#include <string.h>
-
 #include "../../include/zxc_buffer.h"
 #include "../../include/zxc_constants.h"
 #include "../../include/zxc_error.h"

--- a/src/lib/zxc_seekable.c
+++ b/src/lib/zxc_seekable.c
@@ -623,24 +623,30 @@ int64_t zxc_seekable_decompress_range(zxc_seekable* s, void* dst, const size_t d
         /* Read compressed block data */
         const int read_res = zxc_seek_read_block(s, bi, read_buf, max_comp + ZXC_PAD_SIZE);
         if (UNLIKELY(read_res < 0)) {
+            // LCOV_EXCL_START
             ZXC_FREE(read_buf);
             return read_res;
+            // LCOV_EXCL_STOP
         }
 
         /* Decompress the block */
         const int dec_res = zxc_decompress_chunk_wrapper(&s->dctx, read_buf, (size_t)read_res,
                                                          s->dctx.work_buf, work_sz);
         if (UNLIKELY(dec_res < 0)) {
+            // LCOV_EXCL_START
             ZXC_FREE(read_buf);
             return dec_res;
+            // LCOV_EXCL_STOP
         }
 
         /* Calculate which portion of this block's decompressed data we need */
         const uint64_t blk_decomp_start = zxc_seek_decomp_offset(s->block_size, bi);
         const size_t skip = (offset > blk_decomp_start) ? (size_t)(offset - blk_decomp_start) : 0;
         if (UNLIKELY((size_t)dec_res < skip)) {
+            // LCOV_EXCL_START
             ZXC_FREE(read_buf);
             return ZXC_ERROR_CORRUPT_DATA;
+            // LCOV_EXCL_STOP
         }
         const size_t avail = (size_t)dec_res - skip;
         const size_t copy = (avail < remaining) ? avail : remaining;
@@ -821,8 +827,10 @@ int64_t zxc_seekable_decompress_range_mt(zxc_seekable* s, void* dst, const size_
         const size_t skip = (offset > blk_decomp_start) ? (size_t)(offset - blk_decomp_start) : 0;
         const size_t blk_decomp_sz = zxc_seek_decomp_size(s->block_size, s->total_decomp, bi);
         if (UNLIKELY(blk_decomp_sz < skip)) {
+            // LCOV_EXCL_START
             ZXC_FREE(jobs);
             return ZXC_ERROR_CORRUPT_DATA;
+            // LCOV_EXCL_STOP
         }
         const size_t avail = blk_decomp_sz - skip;
         const size_t copy = (avail < remaining) ? avail : remaining;

--- a/src/lib/zxc_seekable.c
+++ b/src/lib/zxc_seekable.c
@@ -60,19 +60,19 @@ static unsigned __stdcall zxc_seek_thread_entry(void* p) {
     zxc_seek_thread_arg_t* a = (zxc_seek_thread_arg_t*)p;
     void* (*f)(void*) = a->func;
     void* arg = a->arg;
-    free(a);
+    ZXC_FREE(a);
     f(arg);
     return 0;
 }
 
 static int zxc_seek_thread_create(zxc_thread_t* t, void* (*fn)(void*), void* arg) {
-    zxc_seek_thread_arg_t* wrapper = malloc(sizeof(zxc_seek_thread_arg_t));
+    zxc_seek_thread_arg_t* wrapper = ZXC_MALLOC(sizeof(zxc_seek_thread_arg_t));
     if (UNLIKELY(!wrapper)) return ZXC_ERROR_MEMORY;
     wrapper->func = fn;
     wrapper->arg = arg;
     uintptr_t handle = _beginthreadex(NULL, 0, zxc_seek_thread_entry, wrapper, 0, NULL);
     if (UNLIKELY(handle == 0)) {
-        free(wrapper);
+        ZXC_FREE(wrapper);
         return ZXC_ERROR_MEMORY;
     }
     *t = (HANDLE)handle;
@@ -259,7 +259,7 @@ static zxc_seekable* zxc_seekable_parse(const uint8_t* data, const size_t data_s
     if (UNLIKELY(bh.comp_size != (uint32_t)entries_total)) return NULL;
 
     /* Step 5: allocate handle and parse entries */
-    zxc_seekable* const s = (zxc_seekable*)calloc(1, sizeof(zxc_seekable));
+    zxc_seekable* const s = (zxc_seekable*)ZXC_CALLOC(1, sizeof(zxc_seekable));
     // LCOV_EXCL_START
     if (UNLIKELY(!s)) return NULL;
     // LCOV_EXCL_STOP
@@ -271,8 +271,8 @@ static zxc_seekable* zxc_seekable_parse(const uint8_t* data, const size_t data_s
     s->src_size = (uint64_t)data_size;
 
     /* Allocate arrays */
-    s->comp_sizes = (uint32_t*)calloc(num_blocks, sizeof(uint32_t));
-    s->comp_offsets = (uint64_t*)calloc((size_t)num_blocks + 1, sizeof(uint64_t));
+    s->comp_sizes = (uint32_t*)ZXC_CALLOC(num_blocks, sizeof(uint32_t));
+    s->comp_offsets = (uint64_t*)ZXC_CALLOC((size_t)num_blocks + 1, sizeof(uint64_t));
     // LCOV_EXCL_START
     if (UNLIKELY(!s->comp_sizes || !s->comp_offsets)) {
         zxc_seekable_free(s);
@@ -361,7 +361,7 @@ zxc_seekable* zxc_seekable_open_file(FILE* f) {
      * The seek table parsing needs the file header. */
     if ((size_t)file_size <= 64 * 1024 * 1024) {
         /* File <= 64 MB: read it all into memory */
-        uint8_t* const full = (uint8_t*)malloc((size_t)file_size);
+        uint8_t* const full = (uint8_t*)ZXC_MALLOC((size_t)file_size);
         // LCOV_EXCL_START
         if (UNLIKELY(!full)) {
             fseeko(f, saved_pos, SEEK_SET);
@@ -369,7 +369,7 @@ zxc_seekable* zxc_seekable_open_file(FILE* f) {
         }
         if (UNLIKELY(fseeko(f, 0, SEEK_SET) != 0 ||
                      fread(full, 1, (size_t)file_size, f) != (size_t)file_size)) {
-            free(full);
+            ZXC_FREE(full);
             fseeko(f, saved_pos, SEEK_SET);
             return NULL;
         }
@@ -386,7 +386,7 @@ zxc_seekable* zxc_seekable_open_file(FILE* f) {
             s->fd = fileno(f);
 #endif
         }
-        free(full);
+        ZXC_FREE(full);
         return s;
     }
 
@@ -439,7 +439,7 @@ zxc_seekable* zxc_seekable_open_file(FILE* f) {
 
     /* Read the full seek block */
     const size_t seek_block_total = ZXC_BLOCK_HEADER_SIZE + (size_t)entries_total_64;
-    uint8_t* const seek_buf = (uint8_t*)malloc(seek_block_total);
+    uint8_t* const seek_buf = (uint8_t*)ZXC_MALLOC(seek_block_total);
     if (UNLIKELY(!seek_buf)) {
         fseeko(f, saved_pos, SEEK_SET);
         return NULL;
@@ -449,7 +449,7 @@ zxc_seekable* zxc_seekable_open_file(FILE* f) {
         file_size - (long long)ZXC_FILE_FOOTER_SIZE - (long long)seek_block_total;
     if (UNLIKELY(seek_offset < 0 || fseeko(f, seek_offset, SEEK_SET) != 0 ||
                  fread(seek_buf, 1, seek_block_total, f) != seek_block_total)) {
-        free(seek_buf);
+        ZXC_FREE(seek_buf);
         fseeko(f, saved_pos, SEEK_SET);
         return NULL;
     }
@@ -459,14 +459,14 @@ zxc_seekable* zxc_seekable_open_file(FILE* f) {
     zxc_block_header_t bh;
     if (UNLIKELY(zxc_read_block_header(seek_buf, seek_block_total, &bh) != ZXC_OK) ||
         bh.block_type != ZXC_BLOCK_SEK || bh.comp_size != (uint32_t)entries_total_64) {
-        free(seek_buf);
+        ZXC_FREE(seek_buf);
         return NULL;
     }
 
     /* Build seekable handle */
-    zxc_seekable* const s = (zxc_seekable*)calloc(1, sizeof(zxc_seekable));
+    zxc_seekable* const s = (zxc_seekable*)ZXC_CALLOC(1, sizeof(zxc_seekable));
     if (UNLIKELY(!s)) {
-        free(seek_buf);
+        ZXC_FREE(seek_buf);
         return NULL;
     }
 
@@ -482,10 +482,10 @@ zxc_seekable* zxc_seekable_open_file(FILE* f) {
     s->block_size = bs;
     s->file_has_checksums = fhc;
 
-    s->comp_sizes = (uint32_t*)calloc(num_blocks, sizeof(uint32_t));
-    s->comp_offsets = (uint64_t*)calloc((size_t)num_blocks + 1, sizeof(uint64_t));
+    s->comp_sizes = (uint32_t*)ZXC_CALLOC(num_blocks, sizeof(uint32_t));
+    s->comp_offsets = (uint64_t*)ZXC_CALLOC((size_t)num_blocks + 1, sizeof(uint64_t));
     if (UNLIKELY(!s->comp_sizes || !s->comp_offsets)) {
-        free(seek_buf);
+        ZXC_FREE(seek_buf);
         zxc_seekable_free(s);
         return NULL;
     }
@@ -499,7 +499,7 @@ zxc_seekable* zxc_seekable_open_file(FILE* f) {
 
         /* Reject entries larger than the entire file */
         if (UNLIKELY(s->comp_sizes[i] > (uint64_t)file_size)) {
-            free(seek_buf);
+            ZXC_FREE(seek_buf);
             zxc_seekable_free(s);
             return NULL;
         }
@@ -508,7 +508,7 @@ zxc_seekable* zxc_seekable_open_file(FILE* f) {
     }
     s->comp_offsets[num_blocks] = comp_acc;
 
-    free(seek_buf);
+    ZXC_FREE(seek_buf);
     return s;
     // LCOV_EXCL_STOP
 }
@@ -598,8 +598,8 @@ int64_t zxc_seekable_decompress_range(zxc_seekable* s, void* dst, const size_t d
     /* Ensure work buffer is large enough */
     const size_t work_sz = (size_t)s->block_size + ZXC_PAD_SIZE;
     if (s->dctx.work_buf_cap < work_sz) {
-        free(s->dctx.work_buf);
-        s->dctx.work_buf = (uint8_t*)malloc(work_sz);
+        ZXC_FREE(s->dctx.work_buf);
+        s->dctx.work_buf = (uint8_t*)ZXC_MALLOC(work_sz);
         if (UNLIKELY(!s->dctx.work_buf)) return ZXC_ERROR_MEMORY;  // LCOV_EXCL_LINE
         s->dctx.work_buf_cap = work_sz;
     }
@@ -616,14 +616,14 @@ int64_t zxc_seekable_decompress_range(zxc_seekable* s, void* dst, const size_t d
     for (uint32_t bi = blk_start; bi <= blk_end; bi++) {
         if (s->comp_sizes[bi] > max_comp) max_comp = s->comp_sizes[bi];
     }
-    uint8_t* const read_buf = (uint8_t*)malloc(max_comp + ZXC_PAD_SIZE);
+    uint8_t* const read_buf = (uint8_t*)ZXC_MALLOC(max_comp + ZXC_PAD_SIZE);
     if (UNLIKELY(!read_buf)) return ZXC_ERROR_MEMORY;  // LCOV_EXCL_LINE
 
     for (uint32_t bi = blk_start; bi <= blk_end; bi++) {
         /* Read compressed block data */
         const int read_res = zxc_seek_read_block(s, bi, read_buf, max_comp + ZXC_PAD_SIZE);
         if (UNLIKELY(read_res < 0)) {
-            free(read_buf);
+            ZXC_FREE(read_buf);
             return read_res;
         }
 
@@ -631,7 +631,7 @@ int64_t zxc_seekable_decompress_range(zxc_seekable* s, void* dst, const size_t d
         const int dec_res = zxc_decompress_chunk_wrapper(&s->dctx, read_buf, (size_t)read_res,
                                                          s->dctx.work_buf, work_sz);
         if (UNLIKELY(dec_res < 0)) {
-            free(read_buf);
+            ZXC_FREE(read_buf);
             return dec_res;
         }
 
@@ -639,7 +639,7 @@ int64_t zxc_seekable_decompress_range(zxc_seekable* s, void* dst, const size_t d
         const uint64_t blk_decomp_start = zxc_seek_decomp_offset(s->block_size, bi);
         const size_t skip = (offset > blk_decomp_start) ? (size_t)(offset - blk_decomp_start) : 0;
         if (UNLIKELY((size_t)dec_res < skip)) {
-            free(read_buf);
+            ZXC_FREE(read_buf);
             return ZXC_ERROR_CORRUPT_DATA;
         }
         const size_t avail = (size_t)dec_res - skip;
@@ -650,7 +650,7 @@ int64_t zxc_seekable_decompress_range(zxc_seekable* s, void* dst, const size_t d
         remaining -= copy;
     }
 
-    free(read_buf);
+    ZXC_FREE(read_buf);
     return (int64_t)len;
 }
 
@@ -726,7 +726,7 @@ static void* zxc_seek_mt_worker(void* arg) {
 
     /* Allocate work buffer for decompressed output */
     const size_t work_sz = (size_t)s->block_size + ZXC_PAD_SIZE;
-    dctx.work_buf = (uint8_t*)malloc(work_sz);
+    dctx.work_buf = (uint8_t*)ZXC_MALLOC(work_sz);
     // LCOV_EXCL_START
     if (UNLIKELY(!dctx.work_buf)) {
         zxc_cctx_free(&dctx);
@@ -738,7 +738,7 @@ static void* zxc_seek_mt_worker(void* arg) {
 
     /* Read compressed block */
     const uint32_t csz = s->comp_sizes[bi];
-    uint8_t* const read_buf = (uint8_t*)malloc(csz + ZXC_PAD_SIZE);
+    uint8_t* const read_buf = (uint8_t*)ZXC_MALLOC(csz + ZXC_PAD_SIZE);
     // LCOV_EXCL_START
     if (UNLIKELY(!read_buf)) {
         zxc_cctx_free(&dctx);
@@ -750,7 +750,7 @@ static void* zxc_seek_mt_worker(void* arg) {
     const int read_res = zxc_seek_read_block_mt(s, bi, read_buf, csz + ZXC_PAD_SIZE);
     // LCOV_EXCL_START
     if (UNLIKELY(read_res < 0)) {
-        free(read_buf);
+        ZXC_FREE(read_buf);
         zxc_cctx_free(&dctx);
         job->result = read_res;
         return NULL;
@@ -760,7 +760,7 @@ static void* zxc_seek_mt_worker(void* arg) {
     /* Decompress */
     const int dec_res =
         zxc_decompress_chunk_wrapper(&dctx, read_buf, (size_t)read_res, dctx.work_buf, work_sz);
-    free(read_buf);
+    ZXC_FREE(read_buf);
 
     // LCOV_EXCL_START
     if (UNLIKELY(dec_res < 0)) {
@@ -808,7 +808,8 @@ int64_t zxc_seekable_decompress_range_mt(zxc_seekable* s, void* dst, const size_
     if (n_threads > ZXC_MAX_THREADS) n_threads = ZXC_MAX_THREADS;
 
     /* Allocate job descriptors */
-    zxc_seek_mt_job_t* const jobs = (zxc_seek_mt_job_t*)calloc(num_jobs, sizeof(zxc_seek_mt_job_t));
+    zxc_seek_mt_job_t* const jobs =
+        (zxc_seek_mt_job_t*)ZXC_CALLOC(num_jobs, sizeof(zxc_seek_mt_job_t));
     if (UNLIKELY(!jobs)) return ZXC_ERROR_MEMORY;  // LCOV_EXCL_LINE
 
     /* Plan jobs: compute skip, copy_len, and dst pointer for each block */
@@ -820,7 +821,7 @@ int64_t zxc_seekable_decompress_range_mt(zxc_seekable* s, void* dst, const size_
         const size_t skip = (offset > blk_decomp_start) ? (size_t)(offset - blk_decomp_start) : 0;
         const size_t blk_decomp_sz = zxc_seek_decomp_size(s->block_size, s->total_decomp, bi);
         if (UNLIKELY(blk_decomp_sz < skip)) {
-            free(jobs);
+            ZXC_FREE(jobs);
             return ZXC_ERROR_CORRUPT_DATA;
         }
         const size_t avail = blk_decomp_sz - skip;
@@ -838,10 +839,11 @@ int64_t zxc_seekable_decompress_range_mt(zxc_seekable* s, void* dst, const size_
     }
 
     /* Launch worker threads (fork phase) */
-    zxc_thread_t* const threads = (zxc_thread_t*)malloc((size_t)n_threads * sizeof(zxc_thread_t));
+    zxc_thread_t* const threads =
+        (zxc_thread_t*)ZXC_MALLOC((size_t)n_threads * sizeof(zxc_thread_t));
     // LCOV_EXCL_START
     if (UNLIKELY(!threads)) {
-        free(jobs);
+        ZXC_FREE(jobs);
         return ZXC_ERROR_MEMORY;
     }
     // LCOV_EXCL_STOP
@@ -881,7 +883,7 @@ int64_t zxc_seekable_decompress_range_mt(zxc_seekable* s, void* dst, const size_
         job_idx += (uint32_t)launched;
     }
 
-    free(threads);
+    ZXC_FREE(threads);
 
     /* Check for errors */
     int64_t result = (int64_t)len;
@@ -894,14 +896,14 @@ int64_t zxc_seekable_decompress_range_mt(zxc_seekable* s, void* dst, const size_
         }
     }
 
-    free(jobs);
+    ZXC_FREE(jobs);
     return result;
 }
 
 void zxc_seekable_free(zxc_seekable* s) {
     if (!s) return;
     if (s->dctx_initialized) zxc_cctx_free(&s->dctx);
-    free(s->comp_sizes);
-    free(s->comp_offsets);
-    free(s);
+    ZXC_FREE(s->comp_sizes);
+    ZXC_FREE(s->comp_offsets);
+    ZXC_FREE(s);
 }


### PR DESCRIPTION
Abstracts standard library functions related to memory management and sorting into configurable macros. This provides:

*   **Customizable memory allocation**: Replaces direct calls to `malloc`, `calloc`, `realloc`, `free`, `zxc_aligned_malloc`, and `zxc_aligned_free` with `ZXC_MALLOC`, `ZXC_CALLOC`, `ZXC_REALLOC`, `ZXC_FREE`, `ZXC_ALIGNED_MALLOC`, and `ZXC_ALIGNED_FREE` macros. Users can override these macros to integrate with specific memory allocators.
*   **Customizable sorting**: Replaces `qsort` with a `ZXC_QSORT` macro, allowing for custom sorting implementations.
*   **Reduced standard library dependencies**: Removes unnecessary inclusions of `assert.h`, `inttypes.h`, and `stdio.h`, further aiding portability.

This enhancement enables Zxc to be used in environments that do not link against the standard C library, such as Linux kernel modules or embedded applications.