### PR TITLE
fix: Harden decompressor buffer bounds checks

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -12,7 +12,7 @@ permissions: read-all
 jobs:
   analysis:
     name: Scorecard analysis
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     timeout-minutes: 10
 
     permissions:

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -12,7 +12,7 @@ permissions: read-all
 jobs:
   analysis:
     name: Scorecard analysis
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-latest
     timeout-minutes: 10
 
     permissions:

--- a/docs/API.md
+++ b/docs/API.md
@@ -428,7 +428,12 @@ ZXC_EXPORT int64_t zxc_compress_block(
 Compresses a single block using a reusable context.  
 Only `level`, `block_size`, and `checksum_enabled` fields of `opts` are used.
 
+`src_size` must be in `[1, ZXC_BLOCK_SIZE_MAX]` (2 MiB). For larger payloads,
+use the frame API (`zxc_compress`) or streaming API (`zxc_cstream_*`), which
+chunk transparently into format-conformant blocks.
+
 **Returns**: compressed block size (> 0) on success, or negative `zxc_error_t`.
+Returns `ZXC_ERROR_BAD_BLOCK_SIZE` if `src_size > ZXC_BLOCK_SIZE_MAX`.
 
 ### `zxc_decompress_block`
 
@@ -445,10 +450,14 @@ ZXC_EXPORT int64_t zxc_decompress_block(
 
 Decompresses a single block produced by `zxc_compress_block()`.
 `dst_capacity` should be at least
-`zxc_decompress_block_bound(uncompressed_size)` to enable the fast path.
+`zxc_decompress_block_bound(uncompressed_size)` to enable the fast path, and
+**must not exceed** `ZXC_BLOCK_SIZE_MAX + ZXC_DECOMPRESS_TAIL_PAD`. For payloads
+produced by the frame or streaming APIs, use `zxc_decompress` instead.
 Only `checksum_enabled` is used.
 
 **Returns**: decompressed size (> 0) on success, or negative `zxc_error_t`.
+Returns `ZXC_ERROR_BAD_BLOCK_SIZE` if `dst_capacity` exceeds the per-block
+limit.
 
 ### `zxc_decompress_block_safe`
 
@@ -472,6 +481,11 @@ Output is **bit-identical** to `zxc_decompress_block()`. NUM and RAW blocks
 transparently forward to the fast path; only GLO/GHI blocks use the
 strict-tail decoder, which is slightly slower than the wild-copy fast path
 (see the performance table in `EXAMPLES.md`).
+
+Strict-tail variant: `dst_capacity` is the exact uncompressed size with no
+tail-pad margin, so the upper limit is `ZXC_BLOCK_SIZE_MAX` (not
+`MAX+TAIL_PAD` as for `zxc_decompress_block`). Returns
+`ZXC_ERROR_BAD_BLOCK_SIZE` if `dst_capacity > ZXC_BLOCK_SIZE_MAX`.
 
 Only `checksum_enabled` is used.
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -391,7 +391,10 @@ Returns the maximum compressed size for a single block.
 Unlike `zxc_compress_bound()`, this does **not** include file header,
 EOF block, or footer overhead.
 
-**Returns**: upper bound in bytes, or `0` on overflow.
+`input_size` must be in `[0, ZXC_BLOCK_SIZE_MAX]` (the Block API limit).
+
+**Returns**: upper bound in bytes, or `0` if `input_size > ZXC_BLOCK_SIZE_MAX`
+or would overflow the computation.
 
 ### `zxc_decompress_block_bound`
 
@@ -409,8 +412,10 @@ Use this helper to size destination buffers for the fast path. For callers
 that genuinely cannot oversize their output buffer, use
 `zxc_decompress_block_safe()` instead.
 
-**Returns**: minimum `dst_capacity` in bytes, or `0` if `uncompressed_size`
-would overflow.
+`uncompressed_size` must be in `[0, ZXC_BLOCK_SIZE_MAX]` (the Block API limit).
+
+**Returns**: minimum `dst_capacity` in bytes, or `0` if
+`uncompressed_size > ZXC_BLOCK_SIZE_MAX` or would overflow the computation.
 
 ### `zxc_compress_block`
 

--- a/docs/FORMAT.md
+++ b/docs/FORMAT.md
@@ -382,17 +382,34 @@ The **Seek Table** block is an optional block appended between the EOF block and
 
 ZXC extras use a prefix-length varint.
 
-Length is encoded in unary form in the high bits of first byte:
+The length is encoded in unary form in the high bits of the first byte: the
+number of leading `1` bits, followed by a terminating `0`, indicates how
+many additional payload bytes follow. The scheme generalizes to N bytes
+(`11110xxx` = 5, `111110xx` = 6, ...), but the current ZXC spec caps the
+encoding at 3 bytes because no legitimate value exceeds 21 bits (see below).
 
-- `0xxxxxxx` -> 1 byte total
-- `10xxxxxx` -> 2 bytes total
-- `110xxxxx` -> 3 bytes total
-- `1110xxxx` -> 4 bytes total
-- `11110xxx` -> 5 bytes total
+Encodings used:
 
-Payload bits from following bytes are concatenated little-endian style (low bits first).
+- `0xxxxxxx` -> 1 byte total (7 bits payload, value < 128)
+- `10xxxxxx` -> 2 bytes total (14 bits, value < 16384)
+- `110xxxxx` -> 3 bytes total (21 bits, value < 2 MiB)
 
-Used by GLO/GHI to carry LL/ML overflows beyond token/sequence inline limits.
+Payload bits from the following bytes are concatenated little-endian style
+(low bits first). Used by GLO/GHI to carry LL/ML overflows beyond
+token/sequence inline limits.
+
+**Value bound**: a varint encodes `(LL - MASK)` or `(ML - MASK)`.
+Since LL/ML are bounded by `ZXC_BLOCK_SIZE_MAX = 2 MiB` (2^21), every
+legitimate varint value is strictly less than 2^21 and therefore fits in
+**at most 3 bytes**.
+
+Any prefix indicating a length >= 4 bytes (first byte `>= 0xE0`) is out of
+spec for this format version: encoders must never emit such a varint, and
+conforming decoders reject it as corrupt input. This caps the varint
+surface to the format-defined block size limit and neutralizes
+integer-overflow attacks in downstream bounds arithmetic. A future version
+of the format that raises `ZXC_BLOCK_SIZE_MAX` would also extend the
+accepted prefix lengths.
 
 ---
 

--- a/docs/WHITEPAPER.md
+++ b/docs/WHITEPAPER.md
@@ -68,13 +68,30 @@ ZXC uses a **Prefix Varint** encoding for overflow values. Unlike standard VByte
 
 **Encoding Scheme:**
 
+The prefix-length encoding generalizes to **N bytes** by construction: the
+number of leading `1` bits in the first byte (followed by a terminating
+`0`) determines how many additional payload bytes follow. An N-byte varint
+carries `7*N` payload bits (`8 - N` bits in the first byte plus 8 bits per
+following byte). ZXC caps the format at 3 bytes because no legitimate
+value exceeds 21 bits (see below); longer prefixes (`1110xxxx`, `11110xxx`,
+...) are reserved for a future format version that would raise
+`ZXC_BLOCK_SIZE_MAX`.
+
+Encodings used:
+
 | Prefix (Binary) | Total Bytes | Data Bits (1st Byte) | Total Data Bits | Range (Value < X) |
 |-----------------|-------------|----------------------|-----------------|-------------------|
 | `0xxxxxxx`      | 1           | 7                    | 7               | 128               |
 | `10xxxxxx`      | 2           | 6                    | 14 (6+8)        | 16,384            |
-| `110xxxxx`      | 3           | 5                    | 21 (5+8+8)      | 2,097,152         |
-| `1110xxxx`      | 4           | 4                    | 28 (4+8+8+8)    | 268,435,456       |
-| `11110xxx`      | 5           | 3                    | 35 (3+8+8+8+8)  | 34,359,738,368    |
+| `110xxxxx`      | 3           | 5                    | 21 (5+8+8)      | 2,097,152 (2 MiB) |
+
+A varint encodes `(LL - MASK)` or `(ML - MASK)`, both bounded by
+`ZXC_BLOCK_SIZE_MAX = 2 MiB`. **All legitimate ZXC varints fit in at
+most 3 bytes.** Any prefix indicating a length >= 4 bytes (first byte
+`>= 0xE0`) is out of spec for v1: encoders must never emit such a varint,
+and conforming decoders reject it as corrupt input. This caps the varint
+surface to the format-defined block size limit and neutralizes
+integer-overflow attacks in downstream bounds arithmetic.
 
 **Example**: Encoding value `300` (binary: `100101100`):
 ```text

--- a/include/zxc_buffer.h
+++ b/include/zxc_buffer.h
@@ -242,9 +242,15 @@ ZXC_EXPORT uint64_t zxc_decompress_block_bound(const size_t uncompressed_size);
  * Output format: @c block_header(8B) + payload + optional @c checksum(4B).
  * The output can be decompressed with zxc_decompress_block().
  *
+ * The Block API processes a single format-conformant block at a time:
+ * @p src_size must not exceed @ref ZXC_BLOCK_SIZE_MAX (2 MiB). For larger
+ * payloads, use the frame API (zxc_compress) or the streaming API
+ * (zxc_cstream_*), both of which chunk transparently into compliant blocks.
+ *
  * @param[in,out] cctx         Reusable compression context.
  * @param[in]     src          Source data.
- * @param[in]     src_size     Source data size in bytes.
+ * @param[in]     src_size     Source data size in bytes
+ *                             (must be in [1, @ref ZXC_BLOCK_SIZE_MAX]).
  * @param[out]    dst          Destination buffer.
  * @param[in]     dst_capacity Capacity of the destination buffer
  *                             (use zxc_compress_block_bound() to size).
@@ -254,6 +260,8 @@ ZXC_EXPORT uint64_t zxc_decompress_block_bound(const size_t uncompressed_size);
  *
  * @return Compressed block size in bytes (> 0) on success,
  *         or a negative @ref zxc_error_t code on failure.
+ *         Returns @ref ZXC_ERROR_BAD_BLOCK_SIZE if
+ *         @p src_size > @ref ZXC_BLOCK_SIZE_MAX.
  */
 ZXC_EXPORT int64_t zxc_compress_block(zxc_cctx* cctx, const void* src, size_t src_size, void* dst,
                                       size_t dst_capacity, const zxc_compress_opts_t* opts);
@@ -261,17 +269,27 @@ ZXC_EXPORT int64_t zxc_compress_block(zxc_cctx* cctx, const void* src, size_t sr
 /**
  * @brief Decompresses a single block produced by zxc_compress_block().
  *
+ * The Block API decompresses a single format-conformant block at a time:
+ * @p dst_capacity must not exceed @ref ZXC_BLOCK_SIZE_MAX +
+ * @ref ZXC_DECOMPRESS_TAIL_PAD (the size returned by
+ * zxc_decompress_block_bound() for the maximum block size). For payloads
+ * produced by the frame or streaming APIs, use zxc_decompress instead.
+ *
  * @param[in,out] dctx         Reusable decompression context.
  * @param[in]     src          Compressed block data.
  * @param[in]     src_size     Compressed data size in bytes.
  * @param[out]    dst          Destination buffer for decompressed data.
  * @param[in]     dst_capacity Capacity of the destination buffer (must be
- *                             at least the original uncompressed size).
+ *                             at least the original uncompressed size,
+ *                             and at most @ref ZXC_BLOCK_SIZE_MAX +
+ *                             @ref ZXC_DECOMPRESS_TAIL_PAD).
  * @param[in]     opts         Decompression options (NULL for defaults).
  *                             Only @c checksum_enabled is used.
  *
  * @return Decompressed size in bytes (> 0) on success,
  *         or a negative @ref zxc_error_t code on failure.
+ *         Returns @ref ZXC_ERROR_BAD_BLOCK_SIZE if @p dst_capacity exceeds
+ *         the per-block limit.
  */
 ZXC_EXPORT int64_t zxc_decompress_block(zxc_dctx* dctx, const void* src, size_t src_size, void* dst,
                                         size_t dst_capacity, const zxc_decompress_opts_t* opts);
@@ -291,17 +309,24 @@ ZXC_EXPORT int64_t zxc_decompress_block(zxc_dctx* dctx, const void* src, size_t 
  * NUM and RAW blocks transparently forward to zxc_decompress_block(); only
  * GLO/GHI use the strict-tail decoder path.
  *
+ * Strict-tail variant: @p dst_capacity is the exact uncompressed size with
+ * no tail-pad margin, so the upper limit is @ref ZXC_BLOCK_SIZE_MAX (not
+ * @c MAX+TAIL_PAD as for zxc_decompress_block).
+ *
  * @param[in,out] dctx         Reusable decompression context.
  * @param[in]     src          Compressed block data.
  * @param[in]     src_size     Compressed data size in bytes.
  * @param[out]    dst          Destination buffer for decompressed data.
  * @param[in]     dst_capacity Capacity of the destination buffer (may equal
- *                             the original uncompressed size exactly).
+ *                             the original uncompressed size exactly,
+ *                             must be <= @ref ZXC_BLOCK_SIZE_MAX).
  * @param[in]     opts         Decompression options (NULL for defaults).
  *                             Only @c checksum_enabled is used.
  *
  * @return Decompressed size in bytes (> 0) on success,
  *         or a negative @ref zxc_error_t code on failure.
+ *         Returns @ref ZXC_ERROR_BAD_BLOCK_SIZE if
+ *         @p dst_capacity > @ref ZXC_BLOCK_SIZE_MAX.
  */
 ZXC_EXPORT int64_t zxc_decompress_block_safe(zxc_dctx* dctx, const void* src, const size_t src_size,
                                              void* dst, const size_t dst_capacity,

--- a/include/zxc_buffer.h
+++ b/include/zxc_buffer.h
@@ -212,8 +212,11 @@ typedef struct zxc_dctx_s zxc_dctx;
  * EOF block, or footer overhead.  Use this to size the destination
  * buffer for zxc_compress_block().
  *
- * @param[in] input_size Size of the uncompressed block in bytes.
- * @return Upper bound on compressed block size, or 0 on overflow.
+ * @param[in] input_size Size of the uncompressed block in bytes
+ *                       (must be <= @ref ZXC_BLOCK_SIZE_MAX).
+ * @return Upper bound on compressed block size, or 0 if @p input_size is
+ *         out of range for the Block API
+ *         (@p input_size > @ref ZXC_BLOCK_SIZE_MAX) or would overflow.
  */
 ZXC_EXPORT uint64_t zxc_compress_block_bound(size_t input_size);
 
@@ -230,9 +233,11 @@ ZXC_EXPORT uint64_t zxc_compress_block_bound(size_t input_size);
  * guaranteed to enable the fastest decode path without aliasing or
  * overrun checks tripping.
  *
- * @param[in] uncompressed_size Original uncompressed block size in bytes.
- * @return Minimum @c dst_capacity to pass to zxc_decompress_block(),
- *         or 0 if @p uncompressed_size would overflow.
+ * @param[in] uncompressed_size Original uncompressed block size in bytes
+ *                              (must be <= @ref ZXC_BLOCK_SIZE_MAX).
+ * @return Minimum @c dst_capacity to pass to zxc_decompress_block(), or 0 if
+ *         @p uncompressed_size is out of range for the Block API
+ *         (@p uncompressed_size > @ref ZXC_BLOCK_SIZE_MAX) or would overflow.
  */
 ZXC_EXPORT uint64_t zxc_decompress_block_bound(const size_t uncompressed_size);
 

--- a/include/zxc_buffer.h
+++ b/include/zxc_buffer.h
@@ -322,9 +322,11 @@ ZXC_EXPORT int64_t zxc_decompress_block(zxc_dctx* dctx, const void* src, size_t 
  * @param[in]     src          Compressed block data.
  * @param[in]     src_size     Compressed data size in bytes.
  * @param[out]    dst          Destination buffer for decompressed data.
- * @param[in]     dst_capacity Capacity of the destination buffer (may equal
- *                             the original uncompressed size exactly,
- *                             must be <= @ref ZXC_BLOCK_SIZE_MAX).
+ * @param[in]     dst_capacity Capacity of the destination buffer (must be
+ *                             at least the original uncompressed size,
+ *                             and at most @ref ZXC_BLOCK_SIZE_MAX; unlike
+ *                             zxc_decompress_block, no trailing tail-pad
+ *                             margin is required).
  * @param[in]     opts         Decompression options (NULL for defaults).
  *                             Only @c checksum_enabled is used.
  *

--- a/src/lib/zxc_common.c
+++ b/src/lib/zxc_common.c
@@ -685,11 +685,13 @@ int zxc_bitpack_stream_32(const uint32_t* RESTRICT src, const size_t count, uint
  * @return Upper bound on compressed size, or 0 if @p input_size would overflow.
  */
 uint64_t zxc_compress_bound(const size_t input_size) {
-    // Guard UINT64_MAX / SIZE_MAX would overflow.
+    // Guard against uint64 overflow when summing per-block overhead
+    // across very large inputs (input_size approaching SIZE_MAX).
     if (UNLIKELY(input_size > (SIZE_MAX - (SIZE_MAX >> 8)))) return 0;
     uint64_t n = ((uint64_t)input_size + ZXC_BLOCK_SIZE_MIN - 1) / ZXC_BLOCK_SIZE_MIN;
     if (n == 0) n = 1;
-    return ZXC_FILE_HEADER_SIZE + (n * (ZXC_BLOCK_HEADER_SIZE + ZXC_BLOCK_CHECKSUM_SIZE + 64)) +
+    return ZXC_FILE_HEADER_SIZE +
+           (n * (ZXC_BLOCK_HEADER_SIZE + ZXC_BLOCK_CHECKSUM_SIZE + ZXC_BLOCK_FORMAT_OVERHEAD)) +
            (uint64_t)input_size + ZXC_BLOCK_HEADER_SIZE + /* EOF block */
            ZXC_BLOCK_HEADER_SIZE +                        /* SEK block header (seekable) */
            (n * ZXC_SEEK_ENTRY_SIZE) +                    /* SEK entries: 4 bytes per block */
@@ -699,13 +701,23 @@ uint64_t zxc_compress_bound(const size_t input_size) {
 /*
  * @brief Returns the maximum compressed size for a single block (no file framing).
  *
- * @param[in] input_size Uncompressed block size in bytes.
- * @return Upper bound on compressed block size, or 0 on overflow.
+ * @param[in] input_size Uncompressed block size in bytes
+ *                       (must be <= @ref ZXC_BLOCK_SIZE_MAX).
+ * @return Upper bound on compressed block size, or 0 if @p input_size is out
+ *         of range for the Block API (i.e. exceeds ZXC_BLOCK_SIZE_MAX) or if
+ *         the arithmetic would overflow.
  */
 uint64_t zxc_compress_block_bound(const size_t input_size) {
-    if (UNLIKELY(input_size > (SIZE_MAX - (SIZE_MAX >> 8)))) return 0;
-    // Block header + worst-case expansion (64B overhead) + checksum
-    return (uint64_t)ZXC_BLOCK_HEADER_SIZE + (uint64_t)input_size + 64 + ZXC_BLOCK_CHECKSUM_SIZE;
+    // Mirror the Block API contract: src_size must be in [1, ZXC_BLOCK_SIZE_MAX].
+    // Inputs outside this range cause zxc_compress_block to fail
+    // (NULL_INPUT for 0, BAD_BLOCK_SIZE above MAX), so the bound is undefined.
+    // Returning 0 signals "unusable" upfront. The cap also makes the addition
+    // below trivially overflow-free.
+    if (UNLIKELY(input_size == 0 || input_size > ZXC_BLOCK_SIZE_MAX)) return 0;
+    // Outer block header + payload (worst case: incompressible, raw bytes)
+    // + inner format overhead + optional checksum.
+    return (uint64_t)ZXC_BLOCK_HEADER_SIZE + (uint64_t)input_size + ZXC_BLOCK_FORMAT_OVERHEAD +
+           ZXC_BLOCK_CHECKSUM_SIZE;
 }
 
 /*
@@ -715,9 +727,12 @@ uint64_t zxc_compress_block_bound(const size_t input_size) {
  * Sizing the destination to uncompressed_size + ZXC_PAD_SIZE*66 guarantees
  * the fast path is always reachable and that tail bounds checks never
  * spuriously reject the last literals of a valid block.
+ *
+ * Returns 0 if @p uncompressed_size exceeds ZXC_BLOCK_SIZE_MAX (the Block API
+ * limit), or if the arithmetic would overflow.
  */
 uint64_t zxc_decompress_block_bound(const size_t uncompressed_size) {
-    if (UNLIKELY(uncompressed_size > SIZE_MAX - ZXC_DECOMPRESS_TAIL_PAD)) return 0;
+    if (UNLIKELY(uncompressed_size > ZXC_BLOCK_SIZE_MAX)) return 0;
     return (uint64_t)uncompressed_size + ZXC_DECOMPRESS_TAIL_PAD;
 }
 

--- a/src/lib/zxc_compress.c
+++ b/src/lib/zxc_compress.c
@@ -95,6 +95,15 @@ static ZXC_ALWAYS_INLINE uint32_t zxc_mm256_reduce_max_epu32(__m256i v) {
  * @return The number of bytes written to the destination buffer.
  */
 static ZXC_ALWAYS_INLINE size_t zxc_write_varint(uint8_t* RESTRICT dst, const uint32_t val) {
+    // Symmetry with the decoder cap: refuse to emit varints above
+    // ZXC_MAX_VARINT_VALUE since they would be rejected at decode time.
+    // For valid compressor inputs (block_size << 2 GB), this never triggers;
+    // it is a defense-in-depth check against bugs that would produce out-of-range
+    // values upstream. Callers must treat a return of 0 as an encoding error.
+    if (UNLIKELY(val > ZXC_MAX_VARINT_VALUE)) {
+        return 0;
+    }
+
     // 1 byte: 0xxxxxxx (7 bits) = 2^7 = 128
     if (LIKELY(val < (1U << 7))) {
         dst[0] = (uint8_t)val;
@@ -875,15 +884,15 @@ static uint32_t zxc_opt_estimate_lit_bits(const uint8_t* RESTRICT src, const siz
  * @param[out] max_offset_out   Largest biased offset emitted (used by the caller
  *                              to choose 1-byte vs 2-byte offset encoding).
  */
-static void zxc_lz77_optimal_parse_glo(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRICT src,
-                                       const size_t src_sz, uint32_t* RESTRICT hash_table,
-                                       uint8_t* RESTRICT hash_tags, uint16_t* RESTRICT chain_table,
-                                       const uint32_t epoch_mark, const uint32_t offset_mask,
-                                       const int level, uint8_t* RESTRICT literals,
-                                       uint8_t* RESTRICT buf_tokens, uint16_t* RESTRICT buf_offsets,
-                                       uint8_t* RESTRICT buf_extras, uint32_t* RESTRICT seq_c_out,
-                                       size_t* RESTRICT lit_c_out, size_t* RESTRICT extras_sz_out,
-                                       uint16_t* RESTRICT max_offset_out) {
+static int zxc_lz77_optimal_parse_glo(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRICT src,
+                                      const size_t src_sz, uint32_t* RESTRICT hash_table,
+                                      uint8_t* RESTRICT hash_tags, uint16_t* RESTRICT chain_table,
+                                      const uint32_t epoch_mark, const uint32_t offset_mask,
+                                      const int level, uint8_t* RESTRICT literals,
+                                      uint8_t* RESTRICT buf_tokens, uint16_t* RESTRICT buf_offsets,
+                                      uint8_t* RESTRICT buf_extras, uint32_t* RESTRICT seq_c_out,
+                                      size_t* RESTRICT lit_c_out, size_t* RESTRICT extras_sz_out,
+                                      uint16_t* RESTRICT max_offset_out) {
     zxc_lz77_params_t lzp_opt = zxc_get_lz77_params(level);
     lzp_opt.use_lazy = 0;  // guard
 
@@ -896,7 +905,7 @@ static void zxc_lz77_optimal_parse_glo(zxc_cctx_t* RESTRICT ctx, const uint8_t* 
         *seq_c_out = 0;
         *extras_sz_out = 0;
         *max_offset_out = 0;
-        return;
+        return 0;
     }
 
     const size_t mflimit_pos = src_sz - 12;
@@ -1097,10 +1106,16 @@ static void zxc_lz77_optimal_parse_glo(zxc_cctx_t* RESTRICT ctx, const uint8_t* 
             buf_offsets[seq_c] = off_biased;
             if (off_biased > max_offset) max_offset = off_biased;
 
-            if (UNLIKELY(ll >= ZXC_TOKEN_LL_MASK))
-                extras_sz += zxc_write_varint(buf_extras + extras_sz, ll - ZXC_TOKEN_LL_MASK);
-            if (UNLIKELY(ml >= ZXC_TOKEN_ML_MASK))
-                extras_sz += zxc_write_varint(buf_extras + extras_sz, ml - ZXC_TOKEN_ML_MASK);
+            if (UNLIKELY(ll >= ZXC_TOKEN_LL_MASK)) {
+                const size_t n = zxc_write_varint(buf_extras + extras_sz, ll - ZXC_TOKEN_LL_MASK);
+                if (UNLIKELY(n == 0)) return ZXC_ERROR_OVERFLOW;
+                extras_sz += n;
+            }
+            if (UNLIKELY(ml >= ZXC_TOKEN_ML_MASK)) {
+                const size_t n = zxc_write_varint(buf_extras + extras_sz, ml - ZXC_TOKEN_ML_MASK);
+                if (UNLIKELY(n == 0)) return ZXC_ERROR_OVERFLOW;
+                extras_sz += n;
+            }
 
             seq_c++;
             lit_start = pos;
@@ -1118,6 +1133,7 @@ static void zxc_lz77_optimal_parse_glo(zxc_cctx_t* RESTRICT ctx, const uint8_t* 
     *lit_c_out = lit_c;
     *extras_sz_out = extras_sz;
     *max_offset_out = max_offset;
+    return 0;
 }
 
 /**
@@ -1201,9 +1217,10 @@ static int zxc_encode_block_glo(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRIC
     /* Level 6+: price-based optimal parser (fills outputs and skips the
      * lazy loop + last_lits handling below via `goto parse_done`). */
     if (level >= ZXC_LEVEL_DENSITY) {
-        zxc_lz77_optimal_parse_glo(ctx, src, src_sz, hash_table, hash_tags, chain_table, epoch_mark,
-                                   offset_mask, level, literals, buf_tokens, buf_offsets,
-                                   buf_extras, &seq_c, &lit_c, &extras_sz, &max_offset);
+        const int rc = zxc_lz77_optimal_parse_glo(
+            ctx, src, src_sz, hash_table, hash_tags, chain_table, epoch_mark, offset_mask, level,
+            literals, buf_tokens, buf_offsets, buf_extras, &seq_c, &lit_c, &extras_sz, &max_offset);
+        if (UNLIKELY(rc != 0)) return rc;
         goto parse_done;
     }
 
@@ -1250,11 +1267,16 @@ static int zxc_encode_block_glo(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRIC
             if ((off - ZXC_LZ_OFFSET_BIAS) > max_offset)
                 max_offset = (uint16_t)(off - ZXC_LZ_OFFSET_BIAS);
 
-            if (ll >= ZXC_TOKEN_LL_MASK)
-                extras_sz += zxc_write_varint(buf_extras + extras_sz, ll - ZXC_TOKEN_LL_MASK);
-
-            if (ml >= ZXC_TOKEN_ML_MASK)
-                extras_sz += zxc_write_varint(buf_extras + extras_sz, ml - ZXC_TOKEN_ML_MASK);
+            if (ll >= ZXC_TOKEN_LL_MASK) {
+                const size_t n = zxc_write_varint(buf_extras + extras_sz, ll - ZXC_TOKEN_LL_MASK);
+                if (UNLIKELY(n == 0)) return ZXC_ERROR_OVERFLOW;
+                extras_sz += n;
+            }
+            if (ml >= ZXC_TOKEN_ML_MASK) {
+                const size_t n = zxc_write_varint(buf_extras + extras_sz, ml - ZXC_TOKEN_ML_MASK);
+                if (UNLIKELY(n == 0)) return ZXC_ERROR_OVERFLOW;
+                extras_sz += n;
+            }
 
             seq_c++;
 
@@ -1826,10 +1848,16 @@ static int zxc_encode_block_ghi(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRIC
             buf_sequences[seq_c] = seq_val;
             seq_c++;
 
-            if (ll >= ZXC_SEQ_LL_MASK)
-                extras_c += zxc_write_varint(buf_extras + extras_c, ll - ZXC_SEQ_LL_MASK);
-            if (ml >= ZXC_SEQ_ML_MASK)
-                extras_c += zxc_write_varint(buf_extras + extras_c, ml - ZXC_SEQ_ML_MASK);
+            if (ll >= ZXC_SEQ_LL_MASK) {
+                const size_t n = zxc_write_varint(buf_extras + extras_c, ll - ZXC_SEQ_LL_MASK);
+                if (UNLIKELY(n == 0)) return ZXC_ERROR_OVERFLOW;
+                extras_c += n;
+            }
+            if (ml >= ZXC_SEQ_ML_MASK) {
+                const size_t n = zxc_write_varint(buf_extras + extras_c, ml - ZXC_SEQ_ML_MASK);
+                if (UNLIKELY(n == 0)) return ZXC_ERROR_OVERFLOW;
+                extras_c += n;
+            }
 
             ip += m.len;
             anchor = ip;

--- a/src/lib/zxc_compress.c
+++ b/src/lib/zxc_compress.c
@@ -95,11 +95,12 @@ static ZXC_ALWAYS_INLINE uint32_t zxc_mm256_reduce_max_epu32(__m256i v) {
  * @return The number of bytes written to the destination buffer.
  */
 static ZXC_ALWAYS_INLINE size_t zxc_write_varint(uint8_t* RESTRICT dst, const uint32_t val) {
-    // Symmetry with the decoder cap: refuse to emit varints above
-    // ZXC_MAX_VARINT_VALUE since they would be rejected at decode time.
-    // For valid compressor inputs (block_size << 2 GB), this never triggers;
-    // it is a defense-in-depth check against bugs that would produce out-of-range
-    // values upstream. Callers must treat a return of 0 as an encoding error.
+    // Refuse to emit varints above ZXC_MAX_VARINT_VALUE: such values are
+    // out-of-spec (block_size_max is 2^21, the largest legitimate varint is
+    // strictly less) and would be rejected by the decoder. For valid inputs
+    // from the Block API (src_size <= ZXC_BLOCK_SIZE_MAX) this never triggers;
+    // it is a defense-in-depth check. Callers must treat a return of 0 as an
+    // encoding error.
     if (UNLIKELY(val > ZXC_MAX_VARINT_VALUE)) {
         return 0;
     }
@@ -117,30 +118,12 @@ static ZXC_ALWAYS_INLINE size_t zxc_write_varint(uint8_t* RESTRICT dst, const ui
         return 2;
     }
 
-    // 3 bytes: 110xxxxx xxxxxxxx xxxxxxxx (21 bits) = 2^21 = 2097152
-    if (LIKELY(val < (1U << 21))) {
-        dst[0] = (uint8_t)(0xC0 | (val & 0x1F));
-        dst[1] = (uint8_t)(val >> 5);
-        dst[2] = (uint8_t)(val >> 13);
-        return 3;
-    }
-
-    // 4 bytes: 1110xxxx xxxxxxxx xxxxxxxx xxxxxxxx (28 bits) = 2^28 = 268435456
-    if (val < (1U << 28)) {
-        dst[0] = (uint8_t)(0xE0 | (val & 0x0F));
-        dst[1] = (uint8_t)(val >> 4);
-        dst[2] = (uint8_t)(val >> 12);
-        dst[3] = (uint8_t)(val >> 20);
-        return 4;
-    }
-
-    // 5 bytes: 11110xxx xxxxxxxx xxxxxxxx xxxxxxxx xxxxxxxx (32 bits)
-    dst[0] = (uint8_t)(0xF0 | (val & 0x07));
-    dst[1] = (uint8_t)(val >> 3);
-    dst[2] = (uint8_t)(val >> 11);
-    dst[3] = (uint8_t)(val >> 19);
-    dst[4] = (uint8_t)(val >> 27);
-    return 5;
+    // 3 bytes: 110xxxxx xxxxxxxx xxxxxxxx (21 bits) -> max emittable value,
+    // matching ZXC_MAX_VARINT_VALUE = ZXC_BLOCK_SIZE_MAX - 1.
+    dst[0] = (uint8_t)(0xC0 | (val & 0x1F));
+    dst[1] = (uint8_t)(val >> 5);
+    dst[2] = (uint8_t)(val >> 13);
+    return 3;
 }
 
 /**

--- a/src/lib/zxc_decompress.c
+++ b/src/lib/zxc_decompress.c
@@ -809,73 +809,73 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
                 off4 += (uint32_t)((offsets >> 48) & 0xFFFF);
             }
 
-            uint32_t ll1 = (tokens & 0x0F0) >> 4;
-            uint32_t ml1 = (tokens & 0x00F);
+            uint64_t ll1 = (tokens & 0x0F0) >> 4;
+            uint64_t ml1 = (tokens & 0x00F);
             if (UNLIKELY(ll1 == ZXC_TOKEN_LL_MASK)) {
                 ll1 += zxc_read_varint(&e_ptr, e_end);
-                const uint32_t reserve =
+                const uint64_t reserve =
                     ((tokens >> 12) & 0xF) + ((tokens >> 20) & 0xF) + (tokens >> 28);
-                if (UNLIKELY((uint64_t)ll1 + reserve > (uint64_t)(l_end - l_ptr) ||
-                             (uint64_t)ll1 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
+                if (UNLIKELY(ll1 + reserve > (size_t)(l_end - l_ptr) ||
+                             ll1 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
                     goto rollback_safe_4x;
             }
             if (UNLIKELY(ml1 == ZXC_TOKEN_ML_MASK)) {
                 ml1 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY((uint64_t)ll1 + ml1 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE >
-                             (uint64_t)(d_end - d_ptr)))
+                if (UNLIKELY(ll1 + ml1 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE >
+                             (size_t)(d_end - d_ptr)))
                     goto rollback_safe_4x;
             }
             ml1 += ZXC_LZ_MIN_MATCH_LEN;
             DECODE_SEQ_SAFE(ll1, ml1, off1);
 
-            uint32_t ll2 = (tokens & 0x0F000) >> 12;
-            uint32_t ml2 = (tokens & 0x00F00) >> 8;
+            uint64_t ll2 = (tokens & 0x0F000) >> 12;
+            uint64_t ml2 = (tokens & 0x00F00) >> 8;
             if (UNLIKELY(ll2 == ZXC_TOKEN_LL_MASK)) {
                 ll2 += zxc_read_varint(&e_ptr, e_end);
-                const uint32_t reserve = ((tokens >> 20) & 0xF) + (tokens >> 28);
-                if (UNLIKELY((uint64_t)ll2 + reserve > (uint64_t)(l_end - l_ptr) ||
-                             (uint64_t)ll2 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
+                const uint64_t reserve = ((tokens >> 20) & 0xF) + (tokens >> 28);
+                if (UNLIKELY(ll2 + reserve > (size_t)(l_end - l_ptr) ||
+                             ll2 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
                     goto rollback_safe_4x;
             }
             if (UNLIKELY(ml2 == ZXC_TOKEN_ML_MASK)) {
                 ml2 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY((uint64_t)ll2 + ml2 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE >
-                             (uint64_t)(d_end - d_ptr)))
+                if (UNLIKELY(ll2 + ml2 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE >
+                             (size_t)(d_end - d_ptr)))
                     goto rollback_safe_4x;
             }
             ml2 += ZXC_LZ_MIN_MATCH_LEN;
             DECODE_SEQ_SAFE(ll2, ml2, off2);
 
-            uint32_t ll3 = (tokens & 0x0F00000) >> 20;
-            uint32_t ml3 = (tokens & 0x00F0000) >> 16;
+            uint64_t ll3 = (tokens & 0x0F00000) >> 20;
+            uint64_t ml3 = (tokens & 0x00F0000) >> 16;
             if (UNLIKELY(ll3 == ZXC_TOKEN_LL_MASK)) {
                 ll3 += zxc_read_varint(&e_ptr, e_end);
-                const uint32_t reserve = (tokens >> 28);
-                if (UNLIKELY((uint64_t)ll3 + reserve > (uint64_t)(l_end - l_ptr) ||
-                             (uint64_t)ll3 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
+                const uint64_t reserve = (tokens >> 28);
+                if (UNLIKELY(ll3 + reserve > (size_t)(l_end - l_ptr) ||
+                             ll3 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
                     goto rollback_safe_4x;
             }
             if (UNLIKELY(ml3 == ZXC_TOKEN_ML_MASK)) {
                 ml3 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY((uint64_t)ll3 + ml3 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE >
-                             (uint64_t)(d_end - d_ptr)))
+                if (UNLIKELY(ll3 + ml3 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE >
+                             (size_t)(d_end - d_ptr)))
                     goto rollback_safe_4x;
             }
             ml3 += ZXC_LZ_MIN_MATCH_LEN;
             DECODE_SEQ_SAFE(ll3, ml3, off3);
 
-            uint32_t ll4 = (tokens >> 28);
-            uint32_t ml4 = (tokens >> 24) & 0x0F;
+            uint64_t ll4 = (tokens >> 28);
+            uint64_t ml4 = (tokens >> 24) & 0x0F;
             if (UNLIKELY(ll4 == ZXC_TOKEN_LL_MASK)) {
                 ll4 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY((uint64_t)ll4 > (uint64_t)(l_end - l_ptr) ||
-                             (uint64_t)ll4 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
+                if (UNLIKELY(ll4 > (size_t)(l_end - l_ptr) ||
+                             ll4 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
                     goto rollback_safe_4x;
             }
             if (UNLIKELY(ml4 == ZXC_TOKEN_ML_MASK)) {
                 ml4 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY((uint64_t)ll4 + ml4 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE >
-                             (uint64_t)(d_end - d_ptr)))
+                if (UNLIKELY(ll4 + ml4 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE >
+                             (size_t)(d_end - d_ptr)))
                     goto rollback_safe_4x;
             }
             ml4 += ZXC_LZ_MIN_MATCH_LEN;
@@ -919,73 +919,73 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
                 off4 += (uint32_t)((offsets >> 48) & 0xFFFF);
             }
 
-            uint32_t ll1 = (tokens & 0x0F0) >> 4;
-            uint32_t ml1 = (tokens & 0x00F);
+            uint64_t ll1 = (tokens & 0x0F0) >> 4;
+            uint64_t ml1 = (tokens & 0x00F);
             if (UNLIKELY(ll1 == ZXC_TOKEN_LL_MASK)) {
                 ll1 += zxc_read_varint(&e_ptr, e_end);
-                const uint32_t reserve =
+                const uint64_t reserve =
                     ((tokens >> 12) & 0xF) + ((tokens >> 20) & 0xF) + (tokens >> 28);
-                if (UNLIKELY((uint64_t)ll1 + reserve > (uint64_t)(l_end - l_ptr) ||
-                             (uint64_t)ll1 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
+                if (UNLIKELY(ll1 + reserve > (size_t)(l_end - l_ptr) ||
+                             ll1 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
             if (UNLIKELY(ml1 == ZXC_TOKEN_ML_MASK)) {
                 ml1 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY((uint64_t)ll1 + ml1 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE >
-                             (uint64_t)(d_end - d_ptr)))
+                if (UNLIKELY(ll1 + ml1 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE >
+                             (size_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
             ml1 += ZXC_LZ_MIN_MATCH_LEN;
             DECODE_SEQ_SAFE(ll1, ml1, off1);
 
-            uint32_t ll2 = (tokens & 0x0F000) >> 12;
-            uint32_t ml2 = (tokens & 0x00F00) >> 8;
+            uint64_t ll2 = (tokens & 0x0F000) >> 12;
+            uint64_t ml2 = (tokens & 0x00F00) >> 8;
             if (UNLIKELY(ll2 == ZXC_TOKEN_LL_MASK)) {
                 ll2 += zxc_read_varint(&e_ptr, e_end);
-                const uint32_t reserve = ((tokens >> 20) & 0xF) + (tokens >> 28);
-                if (UNLIKELY((uint64_t)ll2 + reserve > (uint64_t)(l_end - l_ptr) ||
-                             (uint64_t)ll2 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
+                const uint64_t reserve = ((tokens >> 20) & 0xF) + (tokens >> 28);
+                if (UNLIKELY(ll2 + reserve > (size_t)(l_end - l_ptr) ||
+                             ll2 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
             if (UNLIKELY(ml2 == ZXC_TOKEN_ML_MASK)) {
                 ml2 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY((uint64_t)ll2 + ml2 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE >
-                             (uint64_t)(d_end - d_ptr)))
+                if (UNLIKELY(ll2 + ml2 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE >
+                             (size_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
             ml2 += ZXC_LZ_MIN_MATCH_LEN;
             DECODE_SEQ_SAFE(ll2, ml2, off2);
 
-            uint32_t ll3 = (tokens & 0x0F00000) >> 20;
-            uint32_t ml3 = (tokens & 0x00F0000) >> 16;
+            uint64_t ll3 = (tokens & 0x0F00000) >> 20;
+            uint64_t ml3 = (tokens & 0x00F0000) >> 16;
             if (UNLIKELY(ll3 == ZXC_TOKEN_LL_MASK)) {
                 ll3 += zxc_read_varint(&e_ptr, e_end);
-                const uint32_t reserve = (tokens >> 28);
-                if (UNLIKELY((uint64_t)ll3 + reserve > (uint64_t)(l_end - l_ptr) ||
-                             (uint64_t)ll3 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
+                const uint64_t reserve = (tokens >> 28);
+                if (UNLIKELY(ll3 + reserve > (size_t)(l_end - l_ptr) ||
+                             ll3 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
             if (UNLIKELY(ml3 == ZXC_TOKEN_ML_MASK)) {
                 ml3 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY((uint64_t)ll3 + ml3 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE >
-                             (uint64_t)(d_end - d_ptr)))
+                if (UNLIKELY(ll3 + ml3 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE >
+                             (size_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
             ml3 += ZXC_LZ_MIN_MATCH_LEN;
             DECODE_SEQ_SAFE(ll3, ml3, off3);
 
-            uint32_t ll4 = (tokens >> 28);
-            uint32_t ml4 = (tokens >> 24) & 0x0F;
+            uint64_t ll4 = (tokens >> 28);
+            uint64_t ml4 = (tokens >> 24) & 0x0F;
             if (UNLIKELY(ll4 == ZXC_TOKEN_LL_MASK)) {
                 ll4 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY((uint64_t)ll4 > (uint64_t)(l_end - l_ptr) ||
-                             (uint64_t)ll4 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
+                if (UNLIKELY(ll4 > (size_t)(l_end - l_ptr) ||
+                             ll4 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
             if (UNLIKELY(ml4 == ZXC_TOKEN_ML_MASK)) {
                 ml4 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY((uint64_t)ll4 + ml4 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE >
-                             (uint64_t)(d_end - d_ptr)))
+                if (UNLIKELY(ll4 + ml4 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE >
+                             (size_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
             ml4 += ZXC_LZ_MIN_MATCH_LEN;
@@ -1024,73 +1024,73 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
                 off4 += (uint32_t)((offsets >> 48) & 0xFFFF);
             }
 
-            uint32_t ll1 = (tokens & 0x0F0) >> 4;
-            uint32_t ml1 = (tokens & 0x00F);
+            uint64_t ll1 = (tokens & 0x0F0) >> 4;
+            uint64_t ml1 = (tokens & 0x00F);
             if (UNLIKELY(ll1 == ZXC_TOKEN_LL_MASK)) {
                 ll1 += zxc_read_varint(&e_ptr, e_end);
-                const uint32_t reserve =
+                const uint64_t reserve =
                     ((tokens >> 12) & 0xF) + ((tokens >> 20) & 0xF) + (tokens >> 28);
-                if (UNLIKELY((uint64_t)ll1 + reserve > (uint64_t)(l_end - l_ptr) ||
-                             (uint64_t)ll1 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
+                if (UNLIKELY(ll1 + reserve > (size_t)(l_end - l_ptr) ||
+                             ll1 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
                     goto rollback_fast_4x;
             }
             if (UNLIKELY(ml1 == ZXC_TOKEN_ML_MASK)) {
                 ml1 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY((uint64_t)ll1 + ml1 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE >
-                             (uint64_t)(d_end - d_ptr)))
+                if (UNLIKELY(ll1 + ml1 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE >
+                             (size_t)(d_end - d_ptr)))
                     goto rollback_fast_4x;
             }
             ml1 += ZXC_LZ_MIN_MATCH_LEN;
             DECODE_SEQ_FAST(ll1, ml1, off1);
 
-            uint32_t ll2 = (tokens & 0x0F000) >> 12;
-            uint32_t ml2 = (tokens & 0x00F00) >> 8;
+            uint64_t ll2 = (tokens & 0x0F000) >> 12;
+            uint64_t ml2 = (tokens & 0x00F00) >> 8;
             if (UNLIKELY(ll2 == ZXC_TOKEN_LL_MASK)) {
                 ll2 += zxc_read_varint(&e_ptr, e_end);
-                const uint32_t reserve = ((tokens >> 20) & 0xF) + (tokens >> 28);
-                if (UNLIKELY((uint64_t)ll2 + reserve > (uint64_t)(l_end - l_ptr) ||
-                             (uint64_t)ll2 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
+                const uint64_t reserve = ((tokens >> 20) & 0xF) + (tokens >> 28);
+                if (UNLIKELY(ll2 + reserve > (size_t)(l_end - l_ptr) ||
+                             ll2 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
                     goto rollback_fast_4x;
             }
             if (UNLIKELY(ml2 == ZXC_TOKEN_ML_MASK)) {
                 ml2 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY((uint64_t)ll2 + ml2 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE >
-                             (uint64_t)(d_end - d_ptr)))
+                if (UNLIKELY(ll2 + ml2 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE >
+                             (size_t)(d_end - d_ptr)))
                     goto rollback_fast_4x;
             }
             ml2 += ZXC_LZ_MIN_MATCH_LEN;
             DECODE_SEQ_FAST(ll2, ml2, off2);
 
-            uint32_t ll3 = (tokens & 0x0F00000) >> 20;
-            uint32_t ml3 = (tokens & 0x00F0000) >> 16;
+            uint64_t ll3 = (tokens & 0x0F00000) >> 20;
+            uint64_t ml3 = (tokens & 0x00F0000) >> 16;
             if (UNLIKELY(ll3 == ZXC_TOKEN_LL_MASK)) {
                 ll3 += zxc_read_varint(&e_ptr, e_end);
-                const uint32_t reserve = (tokens >> 28);
-                if (UNLIKELY((uint64_t)ll3 + reserve > (uint64_t)(l_end - l_ptr) ||
-                             (uint64_t)ll3 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
+                const uint64_t reserve = (tokens >> 28);
+                if (UNLIKELY(ll3 + reserve > (size_t)(l_end - l_ptr) ||
+                             ll3 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
                     goto rollback_fast_4x;
             }
             if (UNLIKELY(ml3 == ZXC_TOKEN_ML_MASK)) {
                 ml3 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY((uint64_t)ll3 + ml3 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE >
-                             (uint64_t)(d_end - d_ptr)))
+                if (UNLIKELY(ll3 + ml3 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE >
+                             (size_t)(d_end - d_ptr)))
                     goto rollback_fast_4x;
             }
             ml3 += ZXC_LZ_MIN_MATCH_LEN;
             DECODE_SEQ_FAST(ll3, ml3, off3);
 
-            uint32_t ll4 = (tokens >> 28);
-            uint32_t ml4 = (tokens >> 24) & 0x0F;
+            uint64_t ll4 = (tokens >> 28);
+            uint64_t ml4 = (tokens >> 24) & 0x0F;
             if (UNLIKELY(ll4 == ZXC_TOKEN_LL_MASK)) {
                 ll4 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY((uint64_t)ll4 > (uint64_t)(l_end - l_ptr) ||
-                             (uint64_t)ll4 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
+                if (UNLIKELY(ll4 > (size_t)(l_end - l_ptr) ||
+                             ll4 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
                     goto rollback_fast_4x;
             }
             if (UNLIKELY(ml4 == ZXC_TOKEN_ML_MASK)) {
                 ml4 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY((uint64_t)ll4 + ml4 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE >
-                             (uint64_t)(d_end - d_ptr)))
+                if (UNLIKELY(ll4 + ml4 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE >
+                             (size_t)(d_end - d_ptr)))
                     goto rollback_fast_4x;
             }
             ml4 += ZXC_LZ_MIN_MATCH_LEN;
@@ -1132,73 +1132,73 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
                 off4 += (uint32_t)((offsets >> 48) & 0xFFFF);
             }
 
-            uint32_t ll1 = (tokens & 0x0F0) >> 4;
-            uint32_t ml1 = (tokens & 0x00F);
+            uint64_t ll1 = (tokens & 0x0F0) >> 4;
+            uint64_t ml1 = (tokens & 0x00F);
             if (UNLIKELY(ll1 == ZXC_TOKEN_LL_MASK)) {
                 ll1 += zxc_read_varint(&e_ptr, e_end);
-                const uint32_t reserve =
+                const uint64_t reserve =
                     ((tokens >> 12) & 0xF) + ((tokens >> 20) & 0xF) + (tokens >> 28);
-                if (UNLIKELY((uint64_t)ll1 + reserve > (uint64_t)(l_end - l_ptr) ||
-                             (uint64_t)ll1 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
+                if (UNLIKELY(ll1 + reserve > (size_t)(l_end - l_ptr) ||
+                             ll1 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
             if (UNLIKELY(ml1 == ZXC_TOKEN_ML_MASK)) {
                 ml1 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY((uint64_t)ll1 + ml1 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE >
-                             (uint64_t)(d_end - d_ptr)))
+                if (UNLIKELY(ll1 + ml1 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE >
+                             (size_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
             ml1 += ZXC_LZ_MIN_MATCH_LEN;
             DECODE_SEQ_FAST(ll1, ml1, off1);
 
-            uint32_t ll2 = (tokens & 0x0F000) >> 12;
-            uint32_t ml2 = (tokens & 0x00F00) >> 8;
+            uint64_t ll2 = (tokens & 0x0F000) >> 12;
+            uint64_t ml2 = (tokens & 0x00F00) >> 8;
             if (UNLIKELY(ll2 == ZXC_TOKEN_LL_MASK)) {
                 ll2 += zxc_read_varint(&e_ptr, e_end);
-                const uint32_t reserve = ((tokens >> 20) & 0xF) + (tokens >> 28);
-                if (UNLIKELY((uint64_t)ll2 + reserve > (uint64_t)(l_end - l_ptr) ||
-                             (uint64_t)ll2 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
+                const uint64_t reserve = ((tokens >> 20) & 0xF) + (tokens >> 28);
+                if (UNLIKELY(ll2 + reserve > (size_t)(l_end - l_ptr) ||
+                             ll2 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
             if (UNLIKELY(ml2 == ZXC_TOKEN_ML_MASK)) {
                 ml2 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY((uint64_t)ll2 + ml2 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE >
-                             (uint64_t)(d_end - d_ptr)))
+                if (UNLIKELY(ll2 + ml2 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE >
+                             (size_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
             ml2 += ZXC_LZ_MIN_MATCH_LEN;
             DECODE_SEQ_FAST(ll2, ml2, off2);
 
-            uint32_t ll3 = (tokens & 0x0F00000) >> 20;
-            uint32_t ml3 = (tokens & 0x00F0000) >> 16;
+            uint64_t ll3 = (tokens & 0x0F00000) >> 20;
+            uint64_t ml3 = (tokens & 0x00F0000) >> 16;
             if (UNLIKELY(ll3 == ZXC_TOKEN_LL_MASK)) {
                 ll3 += zxc_read_varint(&e_ptr, e_end);
-                const uint32_t reserve = (tokens >> 28);
-                if (UNLIKELY((uint64_t)ll3 + reserve > (uint64_t)(l_end - l_ptr) ||
-                             (uint64_t)ll3 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
+                const uint64_t reserve = (tokens >> 28);
+                if (UNLIKELY(ll3 + reserve > (size_t)(l_end - l_ptr) ||
+                             ll3 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
             if (UNLIKELY(ml3 == ZXC_TOKEN_ML_MASK)) {
                 ml3 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY((uint64_t)ll3 + ml3 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE >
-                             (uint64_t)(d_end - d_ptr)))
+                if (UNLIKELY(ll3 + ml3 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE >
+                             (size_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
             ml3 += ZXC_LZ_MIN_MATCH_LEN;
             DECODE_SEQ_FAST(ll3, ml3, off3);
 
-            uint32_t ll4 = (tokens >> 28);
-            uint32_t ml4 = (tokens >> 24) & 0x0F;
+            uint64_t ll4 = (tokens >> 28);
+            uint64_t ml4 = (tokens >> 24) & 0x0F;
             if (UNLIKELY(ll4 == ZXC_TOKEN_LL_MASK)) {
                 ll4 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY((uint64_t)ll4 > (uint64_t)(l_end - l_ptr) ||
-                             (uint64_t)ll4 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
+                if (UNLIKELY(ll4 > (size_t)(l_end - l_ptr) ||
+                             ll4 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
             if (UNLIKELY(ml4 == ZXC_TOKEN_ML_MASK)) {
                 ml4 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY((uint64_t)ll4 + ml4 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE >
-                             (uint64_t)(d_end - d_ptr)))
+                if (UNLIKELY(ll4 + ml4 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE >
+                             (size_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
             ml4 += ZXC_LZ_MIN_MATCH_LEN;
@@ -1219,8 +1219,8 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
         const uint8_t* e_save = e_ptr;
 
         uint8_t token = *t_ptr++;
-        uint32_t ll = token >> ZXC_TOKEN_LIT_BITS;
-        uint32_t ml = token & ZXC_TOKEN_ML_MASK;
+        uint64_t ll = token >> ZXC_TOKEN_LIT_BITS;
+        uint64_t ml = token & ZXC_TOKEN_ML_MASK;
         uint32_t offset = ZXC_LZ_OFFSET_BIAS;
         if (gh.enc_off == 1) {
             offset += *o_ptr++;  // 1-byte offset (biased)
@@ -1242,7 +1242,7 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
         ml += ZXC_LZ_MIN_MATCH_LEN;
 
         // Check bounds before wild copies - if too close to end, fall back to Safe Path
-        if (UNLIKELY((uint64_t)ll + ml + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr))) {
+        if (UNLIKELY(ll + ml + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr))) {
             // Restore pointers and let Safe Path handle this sequence
             t_ptr = t_save;
             o_ptr = o_save;
@@ -1309,8 +1309,8 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
     // --- Safe Path for Remaining Sequences ---
     while (n_seq > 0) {
         uint8_t token = *t_ptr++;
-        uint32_t ll = token >> ZXC_TOKEN_LIT_BITS;
-        uint32_t ml = token & ZXC_TOKEN_ML_MASK;
+        uint64_t ll = token >> ZXC_TOKEN_LIT_BITS;
+        uint64_t ml = token & ZXC_TOKEN_ML_MASK;
         uint32_t offset = ZXC_LZ_OFFSET_BIAS;
         if (gh.enc_off == 1) {
             offset += *o_ptr++;  // 1-byte offset (biased)
@@ -1323,7 +1323,7 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
         if (UNLIKELY(ml == ZXC_TOKEN_ML_MASK)) ml += zxc_read_varint(&e_ptr, e_end);
         ml += ZXC_LZ_MIN_MATCH_LEN;
 
-        if (UNLIKELY((uint64_t)ll + ml > (uint64_t)(d_end - d_ptr) || (size_t)(l_end - l_ptr) < ll))
+        if (UNLIKELY(ll + ml > (size_t)(d_end - d_ptr) || (size_t)(l_end - l_ptr) < ll))
             return ZXC_ERROR_OVERFLOW;
         ZXC_MEMCPY(d_ptr, l_ptr, ll);
         l_ptr += ll;
@@ -1455,72 +1455,72 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(zxc_cctx_t* RESTRICT ctx,
             uint32_t s4 = zxc_le32(seq_ptr + 12);
             seq_ptr += 16;
 
-            uint32_t ll1 = (uint32_t)(s1 >> 24);
+            uint64_t ll1 = (uint32_t)(s1 >> 24);
             if (UNLIKELY(ll1 == ZXC_SEQ_LL_MASK)) {
                 ll1 += zxc_read_varint(&extras_ptr, extras_end);
-                const uint32_t reserve = (s2 >> 24) + (s3 >> 24) + (s4 >> 24);
-                if (UNLIKELY((uint64_t)ll1 + reserve > (uint64_t)(l_end - l_ptr) ||
-                             (uint64_t)ll1 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
+                const uint64_t reserve = (s2 >> 24) + (s3 >> 24) + (s4 >> 24);
+                if (UNLIKELY(ll1 + reserve > (size_t)(l_end - l_ptr) ||
+                             ll1 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
                     goto rollback_safe_4x;
             }
             uint32_t m1b = (uint32_t)((s1 >> 16) & 0xFF);
-            uint32_t ml1 = m1b + ZXC_LZ_MIN_MATCH_LEN;
+            uint64_t ml1 = m1b + ZXC_LZ_MIN_MATCH_LEN;
             if (UNLIKELY(m1b == ZXC_SEQ_ML_MASK)) {
                 ml1 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY((uint64_t)ll1 + ml1 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
+                if (UNLIKELY(ll1 + ml1 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
                     goto rollback_safe_4x;
             }
             uint32_t off1 = (uint32_t)(s1 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
             DECODE_SEQ_SAFE(ll1, ml1, off1);
 
-            uint32_t ll2 = (uint32_t)(s2 >> 24);
+            uint64_t ll2 = (uint32_t)(s2 >> 24);
             if (UNLIKELY(ll2 == ZXC_SEQ_LL_MASK)) {
                 ll2 += zxc_read_varint(&extras_ptr, extras_end);
-                const uint32_t reserve = (s3 >> 24) + (s4 >> 24);
-                if (UNLIKELY((uint64_t)ll2 + reserve > (uint64_t)(l_end - l_ptr) ||
-                             (uint64_t)ll2 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
+                const uint64_t reserve = (s3 >> 24) + (s4 >> 24);
+                if (UNLIKELY(ll2 + reserve > (size_t)(l_end - l_ptr) ||
+                             ll2 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
                     goto rollback_safe_4x;
             }
             uint32_t m2b = (uint32_t)((s2 >> 16) & 0xFF);
-            uint32_t ml2 = m2b + ZXC_LZ_MIN_MATCH_LEN;
+            uint64_t ml2 = m2b + ZXC_LZ_MIN_MATCH_LEN;
             if (UNLIKELY(m2b == ZXC_SEQ_ML_MASK)) {
                 ml2 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY((uint64_t)ll2 + ml2 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
+                if (UNLIKELY(ll2 + ml2 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
                     goto rollback_safe_4x;
             }
             uint32_t off2 = (uint32_t)(s2 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
             DECODE_SEQ_SAFE(ll2, ml2, off2);
 
-            uint32_t ll3 = (uint32_t)(s3 >> 24);
+            uint64_t ll3 = (uint32_t)(s3 >> 24);
             if (UNLIKELY(ll3 == ZXC_SEQ_LL_MASK)) {
                 ll3 += zxc_read_varint(&extras_ptr, extras_end);
-                const uint32_t reserve = (s4 >> 24);
-                if (UNLIKELY((uint64_t)ll3 + reserve > (uint64_t)(l_end - l_ptr) ||
-                             (uint64_t)ll3 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
+                const uint64_t reserve = (s4 >> 24);
+                if (UNLIKELY(ll3 + reserve > (size_t)(l_end - l_ptr) ||
+                             ll3 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
                     goto rollback_safe_4x;
             }
             uint32_t m3b = (uint32_t)((s3 >> 16) & 0xFF);
-            uint32_t ml3 = m3b + ZXC_LZ_MIN_MATCH_LEN;
+            uint64_t ml3 = m3b + ZXC_LZ_MIN_MATCH_LEN;
             if (UNLIKELY(m3b == ZXC_SEQ_ML_MASK)) {
                 ml3 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY((uint64_t)ll3 + ml3 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
+                if (UNLIKELY(ll3 + ml3 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
                     goto rollback_safe_4x;
             }
             uint32_t off3 = (uint32_t)(s3 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
             DECODE_SEQ_SAFE(ll3, ml3, off3);
 
-            uint32_t ll4 = (uint32_t)(s4 >> 24);
+            uint64_t ll4 = (uint32_t)(s4 >> 24);
             if (UNLIKELY(ll4 == ZXC_SEQ_LL_MASK)) {
                 ll4 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY((uint64_t)ll4 > (uint64_t)(l_end - l_ptr) ||
-                             (uint64_t)ll4 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
+                if (UNLIKELY(ll4 > (size_t)(l_end - l_ptr) ||
+                             ll4 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
                     goto rollback_safe_4x;
             }
             uint32_t m4b = (uint32_t)((s4 >> 16) & 0xFF);
-            uint32_t ml4 = m4b + ZXC_LZ_MIN_MATCH_LEN;
+            uint64_t ml4 = m4b + ZXC_LZ_MIN_MATCH_LEN;
             if (UNLIKELY(m4b == ZXC_SEQ_ML_MASK)) {
                 ml4 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY((uint64_t)ll4 + ml4 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
+                if (UNLIKELY(ll4 + ml4 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
                     goto rollback_safe_4x;
             }
             uint32_t off4 = (uint32_t)(s4 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
@@ -1546,72 +1546,72 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(zxc_cctx_t* RESTRICT ctx,
             uint32_t s4 = zxc_le32(seq_ptr + 12);
             seq_ptr += 16;
 
-            uint32_t ll1 = (uint32_t)(s1 >> 24);
+            uint64_t ll1 = (uint32_t)(s1 >> 24);
             if (UNLIKELY(ll1 == ZXC_SEQ_LL_MASK)) {
                 ll1 += zxc_read_varint(&extras_ptr, extras_end);
-                const uint32_t reserve = (s2 >> 24) + (s3 >> 24) + (s4 >> 24);
-                if (UNLIKELY((uint64_t)ll1 + reserve > (uint64_t)(l_end - l_ptr) ||
-                             (uint64_t)ll1 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
+                const uint64_t reserve = (s2 >> 24) + (s3 >> 24) + (s4 >> 24);
+                if (UNLIKELY(ll1 + reserve > (size_t)(l_end - l_ptr) ||
+                             ll1 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
             uint32_t m1b = (uint32_t)((s1 >> 16) & 0xFF);
-            uint32_t ml1 = m1b + ZXC_LZ_MIN_MATCH_LEN;
+            uint64_t ml1 = m1b + ZXC_LZ_MIN_MATCH_LEN;
             if (UNLIKELY(m1b == ZXC_SEQ_ML_MASK)) {
                 ml1 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY((uint64_t)ll1 + ml1 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
+                if (UNLIKELY(ll1 + ml1 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
             uint32_t off1 = (uint32_t)(s1 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
             DECODE_SEQ_SAFE(ll1, ml1, off1);
 
-            uint32_t ll2 = (uint32_t)(s2 >> 24);
+            uint64_t ll2 = (uint32_t)(s2 >> 24);
             if (UNLIKELY(ll2 == ZXC_SEQ_LL_MASK)) {
                 ll2 += zxc_read_varint(&extras_ptr, extras_end);
-                const uint32_t reserve = (s3 >> 24) + (s4 >> 24);
-                if (UNLIKELY((uint64_t)ll2 + reserve > (uint64_t)(l_end - l_ptr) ||
-                             (uint64_t)ll2 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
+                const uint64_t reserve = (s3 >> 24) + (s4 >> 24);
+                if (UNLIKELY(ll2 + reserve > (size_t)(l_end - l_ptr) ||
+                             ll2 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
             uint32_t m2b = (uint32_t)((s2 >> 16) & 0xFF);
-            uint32_t ml2 = m2b + ZXC_LZ_MIN_MATCH_LEN;
+            uint64_t ml2 = m2b + ZXC_LZ_MIN_MATCH_LEN;
             if (UNLIKELY(m2b == ZXC_SEQ_ML_MASK)) {
                 ml2 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY((uint64_t)ll2 + ml2 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
+                if (UNLIKELY(ll2 + ml2 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
             uint32_t off2 = (uint32_t)(s2 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
             DECODE_SEQ_SAFE(ll2, ml2, off2);
 
-            uint32_t ll3 = (uint32_t)(s3 >> 24);
+            uint64_t ll3 = (uint32_t)(s3 >> 24);
             if (UNLIKELY(ll3 == ZXC_SEQ_LL_MASK)) {
                 ll3 += zxc_read_varint(&extras_ptr, extras_end);
-                const uint32_t reserve = (s4 >> 24);
-                if (UNLIKELY((uint64_t)ll3 + reserve > (uint64_t)(l_end - l_ptr) ||
-                             (uint64_t)ll3 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
+                const uint64_t reserve = (s4 >> 24);
+                if (UNLIKELY(ll3 + reserve > (size_t)(l_end - l_ptr) ||
+                             ll3 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
             uint32_t m3b = (uint32_t)((s3 >> 16) & 0xFF);
-            uint32_t ml3 = m3b + ZXC_LZ_MIN_MATCH_LEN;
+            uint64_t ml3 = m3b + ZXC_LZ_MIN_MATCH_LEN;
             if (UNLIKELY(m3b == ZXC_SEQ_ML_MASK)) {
                 ml3 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY((uint64_t)ll3 + ml3 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
+                if (UNLIKELY(ll3 + ml3 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
             uint32_t off3 = (uint32_t)(s3 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
             DECODE_SEQ_SAFE(ll3, ml3, off3);
 
-            uint32_t ll4 = (uint32_t)(s4 >> 24);
+            uint64_t ll4 = (uint32_t)(s4 >> 24);
             if (UNLIKELY(ll4 == ZXC_SEQ_LL_MASK)) {
                 ll4 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY((uint64_t)ll4 > (uint64_t)(l_end - l_ptr) ||
-                             (uint64_t)ll4 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
+                if (UNLIKELY(ll4 > (size_t)(l_end - l_ptr) ||
+                             ll4 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
             uint32_t m4b = (uint32_t)((s4 >> 16) & 0xFF);
-            uint32_t ml4 = m4b + ZXC_LZ_MIN_MATCH_LEN;
+            uint64_t ml4 = m4b + ZXC_LZ_MIN_MATCH_LEN;
             if (UNLIKELY(m4b == ZXC_SEQ_ML_MASK)) {
                 ml4 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY((uint64_t)ll4 + ml4 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
+                if (UNLIKELY(ll4 + ml4 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
             uint32_t off4 = (uint32_t)(s4 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
@@ -1626,19 +1626,19 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(zxc_cctx_t* RESTRICT ctx,
         uint32_t seq = zxc_le32(seq_ptr);
         seq_ptr += 4;
 
-        uint32_t ll = (uint32_t)(seq >> 24);
+        uint64_t ll = (uint32_t)(seq >> 24);
         if (UNLIKELY(ll == ZXC_SEQ_LL_MASK)) ll += zxc_read_varint(&extras_ptr, extras_end);
 
         uint32_t m_bits = (uint32_t)((seq >> 16) & 0xFF);
-        uint32_t ml = m_bits + ZXC_LZ_MIN_MATCH_LEN;
+        uint64_t ml = m_bits + ZXC_LZ_MIN_MATCH_LEN;
         if (UNLIKELY(m_bits == ZXC_SEQ_ML_MASK)) ml += zxc_read_varint(&extras_ptr, extras_end);
 
         uint32_t offset = (uint32_t)(seq & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
 
         // Strict bounds check: sequence must fit, AND wild copies must not overshoot
         // Check both destination (d_ptr) and source literal stream (l_ptr)
-        if (UNLIKELY((uint64_t)ll + ml + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr) ||
-                     (uint64_t)ll + ZXC_PAD_SIZE > (uint64_t)(l_end - l_ptr))) {
+        if (UNLIKELY(ll + ml + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr) ||
+                     ll + ZXC_PAD_SIZE > (size_t)(l_end - l_ptr))) {
             // Fallback to exact copy (slow but safe)
             if (UNLIKELY((size_t)(d_end - d_ptr) < ll || (size_t)(l_end - l_ptr) < ll))
                 return ZXC_ERROR_OVERFLOW;
@@ -1681,72 +1681,72 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(zxc_cctx_t* RESTRICT ctx,
             // Prefetch ahead in literal and extras streams to hide memory latency
             ZXC_PREFETCH_READ(l_ptr + ZXC_CACHE_LINE_SIZE);
 
-            uint32_t ll1 = (uint32_t)(s1 >> 24);
+            uint64_t ll1 = (uint32_t)(s1 >> 24);
             if (UNLIKELY(ll1 == ZXC_SEQ_LL_MASK)) {
                 ll1 += zxc_read_varint(&extras_ptr, extras_end);
-                const uint32_t reserve = (s2 >> 24) + (s3 >> 24) + (s4 >> 24);
-                if (UNLIKELY((uint64_t)ll1 + reserve > (uint64_t)(l_end - l_ptr) ||
-                             (uint64_t)ll1 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
+                const uint64_t reserve = (s2 >> 24) + (s3 >> 24) + (s4 >> 24);
+                if (UNLIKELY(ll1 + reserve > (size_t)(l_end - l_ptr) ||
+                             ll1 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
                     goto rollback_fast_4x;
             }
             uint32_t m1b = (uint32_t)((s1 >> 16) & 0xFF);
-            uint32_t ml1 = m1b + ZXC_LZ_MIN_MATCH_LEN;
+            uint64_t ml1 = m1b + ZXC_LZ_MIN_MATCH_LEN;
             if (UNLIKELY(m1b == ZXC_SEQ_ML_MASK)) {
                 ml1 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY((uint64_t)ll1 + ml1 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
+                if (UNLIKELY(ll1 + ml1 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
                     goto rollback_fast_4x;
             }
             uint32_t off1 = (uint32_t)(s1 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
             DECODE_SEQ_FAST(ll1, ml1, off1);
 
-            uint32_t ll2 = (uint32_t)(s2 >> 24);
+            uint64_t ll2 = (uint32_t)(s2 >> 24);
             if (UNLIKELY(ll2 == ZXC_SEQ_LL_MASK)) {
                 ll2 += zxc_read_varint(&extras_ptr, extras_end);
-                const uint32_t reserve = (s3 >> 24) + (s4 >> 24);
-                if (UNLIKELY((uint64_t)ll2 + reserve > (uint64_t)(l_end - l_ptr) ||
-                             (uint64_t)ll2 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
+                const uint64_t reserve = (s3 >> 24) + (s4 >> 24);
+                if (UNLIKELY(ll2 + reserve > (size_t)(l_end - l_ptr) ||
+                             ll2 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
                     goto rollback_fast_4x;
             }
             uint32_t m2b = (uint32_t)((s2 >> 16) & 0xFF);
-            uint32_t ml2 = m2b + ZXC_LZ_MIN_MATCH_LEN;
+            uint64_t ml2 = m2b + ZXC_LZ_MIN_MATCH_LEN;
             if (UNLIKELY(m2b == ZXC_SEQ_ML_MASK)) {
                 ml2 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY((uint64_t)ll2 + ml2 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
+                if (UNLIKELY(ll2 + ml2 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
                     goto rollback_fast_4x;
             }
             uint32_t off2 = (uint32_t)(s2 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
             DECODE_SEQ_FAST(ll2, ml2, off2);
 
-            uint32_t ll3 = (uint32_t)(s3 >> 24);
+            uint64_t ll3 = (uint32_t)(s3 >> 24);
             if (UNLIKELY(ll3 == ZXC_SEQ_LL_MASK)) {
                 ll3 += zxc_read_varint(&extras_ptr, extras_end);
-                const uint32_t reserve = (s4 >> 24);
-                if (UNLIKELY((uint64_t)ll3 + reserve > (uint64_t)(l_end - l_ptr) ||
-                             (uint64_t)ll3 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
+                const uint64_t reserve = (s4 >> 24);
+                if (UNLIKELY(ll3 + reserve > (size_t)(l_end - l_ptr) ||
+                             ll3 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
                     goto rollback_fast_4x;
             }
             uint32_t m3b = (uint32_t)((s3 >> 16) & 0xFF);
-            uint32_t ml3 = m3b + ZXC_LZ_MIN_MATCH_LEN;
+            uint64_t ml3 = m3b + ZXC_LZ_MIN_MATCH_LEN;
             if (UNLIKELY(m3b == ZXC_SEQ_ML_MASK)) {
                 ml3 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY((uint64_t)ll3 + ml3 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
+                if (UNLIKELY(ll3 + ml3 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
                     goto rollback_fast_4x;
             }
             uint32_t off3 = (uint32_t)(s3 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
             DECODE_SEQ_FAST(ll3, ml3, off3);
 
-            uint32_t ll4 = (uint32_t)(s4 >> 24);
+            uint64_t ll4 = (uint32_t)(s4 >> 24);
             if (UNLIKELY(ll4 == ZXC_SEQ_LL_MASK)) {
                 ll4 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY((uint64_t)ll4 > (uint64_t)(l_end - l_ptr) ||
-                             (uint64_t)ll4 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
+                if (UNLIKELY(ll4 > (size_t)(l_end - l_ptr) ||
+                             ll4 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
                     goto rollback_fast_4x;
             }
             uint32_t m4b = (uint32_t)((s4 >> 16) & 0xFF);
-            uint32_t ml4 = m4b + ZXC_LZ_MIN_MATCH_LEN;
+            uint64_t ml4 = m4b + ZXC_LZ_MIN_MATCH_LEN;
             if (UNLIKELY(m4b == ZXC_SEQ_ML_MASK)) {
                 ml4 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY((uint64_t)ll4 + ml4 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
+                if (UNLIKELY(ll4 + ml4 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
                     goto rollback_fast_4x;
             }
             uint32_t off4 = (uint32_t)(s4 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
@@ -1773,72 +1773,72 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(zxc_cctx_t* RESTRICT ctx,
             // Prefetch ahead in literal and extras streams to hide memory latency
             ZXC_PREFETCH_READ(l_ptr + ZXC_CACHE_LINE_SIZE);
 
-            uint32_t ll1 = (uint32_t)(s1 >> 24);
+            uint64_t ll1 = (uint32_t)(s1 >> 24);
             if (UNLIKELY(ll1 == ZXC_SEQ_LL_MASK)) {
                 ll1 += zxc_read_varint(&extras_ptr, extras_end);
-                const uint32_t reserve = (s2 >> 24) + (s3 >> 24) + (s4 >> 24);
-                if (UNLIKELY((uint64_t)ll1 + reserve > (uint64_t)(l_end - l_ptr) ||
-                             (uint64_t)ll1 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
+                const uint64_t reserve = (s2 >> 24) + (s3 >> 24) + (s4 >> 24);
+                if (UNLIKELY(ll1 + reserve > (size_t)(l_end - l_ptr) ||
+                             ll1 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
             uint32_t m1b = (uint32_t)((s1 >> 16) & 0xFF);
-            uint32_t ml1 = m1b + ZXC_LZ_MIN_MATCH_LEN;
+            uint64_t ml1 = m1b + ZXC_LZ_MIN_MATCH_LEN;
             if (UNLIKELY(m1b == ZXC_SEQ_ML_MASK)) {
                 ml1 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY((uint64_t)ll1 + ml1 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
+                if (UNLIKELY(ll1 + ml1 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
             uint32_t off1 = (uint32_t)(s1 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
             DECODE_SEQ_FAST(ll1, ml1, off1);
 
-            uint32_t ll2 = (uint32_t)(s2 >> 24);
+            uint64_t ll2 = (uint32_t)(s2 >> 24);
             if (UNLIKELY(ll2 == ZXC_SEQ_LL_MASK)) {
                 ll2 += zxc_read_varint(&extras_ptr, extras_end);
-                const uint32_t reserve = (s3 >> 24) + (s4 >> 24);
-                if (UNLIKELY((uint64_t)ll2 + reserve > (uint64_t)(l_end - l_ptr) ||
-                             (uint64_t)ll2 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
+                const uint64_t reserve = (s3 >> 24) + (s4 >> 24);
+                if (UNLIKELY(ll2 + reserve > (size_t)(l_end - l_ptr) ||
+                             ll2 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
             uint32_t m2b = (uint32_t)((s2 >> 16) & 0xFF);
-            uint32_t ml2 = m2b + ZXC_LZ_MIN_MATCH_LEN;
+            uint64_t ml2 = m2b + ZXC_LZ_MIN_MATCH_LEN;
             if (UNLIKELY(m2b == ZXC_SEQ_ML_MASK)) {
                 ml2 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY((uint64_t)ll2 + ml2 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
+                if (UNLIKELY(ll2 + ml2 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
             uint32_t off2 = (uint32_t)(s2 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
             DECODE_SEQ_FAST(ll2, ml2, off2);
 
-            uint32_t ll3 = (uint32_t)(s3 >> 24);
+            uint64_t ll3 = (uint32_t)(s3 >> 24);
             if (UNLIKELY(ll3 == ZXC_SEQ_LL_MASK)) {
                 ll3 += zxc_read_varint(&extras_ptr, extras_end);
-                const uint32_t reserve = (s4 >> 24);
-                if (UNLIKELY((uint64_t)ll3 + reserve > (uint64_t)(l_end - l_ptr) ||
-                             (uint64_t)ll3 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
+                const uint64_t reserve = (s4 >> 24);
+                if (UNLIKELY(ll3 + reserve > (size_t)(l_end - l_ptr) ||
+                             ll3 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
             uint32_t m3b = (uint32_t)((s3 >> 16) & 0xFF);
-            uint32_t ml3 = m3b + ZXC_LZ_MIN_MATCH_LEN;
+            uint64_t ml3 = m3b + ZXC_LZ_MIN_MATCH_LEN;
             if (UNLIKELY(m3b == ZXC_SEQ_ML_MASK)) {
                 ml3 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY((uint64_t)ll3 + ml3 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
+                if (UNLIKELY(ll3 + ml3 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
             uint32_t off3 = (uint32_t)(s3 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
             DECODE_SEQ_FAST(ll3, ml3, off3);
 
-            uint32_t ll4 = (uint32_t)(s4 >> 24);
+            uint64_t ll4 = (uint32_t)(s4 >> 24);
             if (UNLIKELY(ll4 == ZXC_SEQ_LL_MASK)) {
                 ll4 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY((uint64_t)ll4 > (uint64_t)(l_end - l_ptr) ||
-                             (uint64_t)ll4 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
+                if (UNLIKELY(ll4 > (size_t)(l_end - l_ptr) ||
+                             ll4 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
             uint32_t m4b = (uint32_t)((s4 >> 16) & 0xFF);
-            uint32_t ml4 = m4b + ZXC_LZ_MIN_MATCH_LEN;
+            uint64_t ml4 = m4b + ZXC_LZ_MIN_MATCH_LEN;
             if (UNLIKELY(m4b == ZXC_SEQ_ML_MASK)) {
                 ml4 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY((uint64_t)ll4 + ml4 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
+                if (UNLIKELY(ll4 + ml4 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
             uint32_t off4 = (uint32_t)(s4 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
@@ -1857,7 +1857,7 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(zxc_cctx_t* RESTRICT ctx,
         const uint32_t seq = zxc_le32(seq_ptr);
         seq_ptr += 4;
 
-        uint32_t ll = (uint32_t)(seq >> 24);
+        uint64_t ll = (uint32_t)(seq >> 24);
         if (UNLIKELY(ll == ZXC_SEQ_LL_MASK)) {
             ll += zxc_read_varint(&extras_ptr, extras_end);
             if (UNLIKELY((size_t)(l_end - l_ptr) < ll)) {
@@ -1868,11 +1868,11 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(zxc_cctx_t* RESTRICT ctx,
         }
 
         uint32_t m_bits = (uint32_t)((seq >> 16) & 0xFF);
-        uint32_t ml = m_bits + ZXC_LZ_MIN_MATCH_LEN;
+        uint64_t ml = m_bits + ZXC_LZ_MIN_MATCH_LEN;
         if (UNLIKELY(m_bits == ZXC_SEQ_ML_MASK)) ml += zxc_read_varint(&extras_ptr, extras_end);
 
         // Strict bounds checks (including wild copy overrun safety)
-        if (UNLIKELY((uint64_t)ll + ml + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr))) {
+        if (UNLIKELY(ll + ml + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr))) {
             // Restore state and break to Safe Path
             seq_ptr = seq_save;
             extras_ptr = ext_save;
@@ -1941,15 +1941,15 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(zxc_cctx_t* RESTRICT ctx,
         uint32_t seq = zxc_le32(seq_ptr);
         seq_ptr += 4;
 
-        uint32_t ll = (uint32_t)(seq >> 24);
+        uint64_t ll = (uint32_t)(seq >> 24);
         if (UNLIKELY(ll == ZXC_SEQ_LL_MASK)) ll += zxc_read_varint(&extras_ptr, extras_end);
 
         uint32_t m_bits = (uint32_t)((seq >> 16) & 0xFF);
-        uint32_t ml = m_bits + ZXC_LZ_MIN_MATCH_LEN;
+        uint64_t ml = m_bits + ZXC_LZ_MIN_MATCH_LEN;
         if (UNLIKELY(m_bits == ZXC_SEQ_ML_MASK)) ml += zxc_read_varint(&extras_ptr, extras_end);
         uint32_t offset = (uint32_t)(seq & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
 
-        if (UNLIKELY((uint64_t)ll + ml > (uint64_t)(d_end - d_ptr) || (size_t)(l_end - l_ptr) < ll))
+        if (UNLIKELY(ll + ml > (size_t)(d_end - d_ptr) || (size_t)(l_end - l_ptr) < ll))
             return ZXC_ERROR_OVERFLOW;
         ZXC_MEMCPY(d_ptr, l_ptr, ll);
         l_ptr += ll;

--- a/src/lib/zxc_decompress.c
+++ b/src/lib/zxc_decompress.c
@@ -1231,7 +1231,7 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
 
         if (UNLIKELY(ll == ZXC_TOKEN_LL_MASK)) {
             ll += zxc_read_varint(&e_ptr, e_end);
-            if (UNLIKELY(l_ptr + ll > l_end)) {
+            if (UNLIKELY((size_t)(l_end - l_ptr) < ll)) {
                 t_ptr = t_save;
                 o_ptr = o_save;
                 e_ptr = e_save;
@@ -1323,14 +1323,14 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
         if (UNLIKELY(ml == ZXC_TOKEN_ML_MASK)) ml += zxc_read_varint(&e_ptr, e_end);
         ml += ZXC_LZ_MIN_MATCH_LEN;
 
-        if (UNLIKELY((size_t)(d_end - d_ptr) < ll || (size_t)(l_end - l_ptr) < ll))
+        if (UNLIKELY((uint64_t)ll + ml > (uint64_t)(d_end - d_ptr) || (size_t)(l_end - l_ptr) < ll))
             return ZXC_ERROR_OVERFLOW;
         ZXC_MEMCPY(d_ptr, l_ptr, ll);
         l_ptr += ll;
         d_ptr += ll;
 
         const uint8_t* match_src = d_ptr - offset;
-        if (UNLIKELY(match_src < dst || (size_t)(d_end - d_ptr) < ml)) return ZXC_ERROR_BAD_OFFSET;
+        if (UNLIKELY(match_src < dst)) return ZXC_ERROR_BAD_OFFSET;
 
         if (offset < ml) {
             for (size_t i = 0; i < ml; i++) d_ptr[i] = match_src[i];
@@ -1346,7 +1346,7 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
     if (UNLIKELY(l_ptr > l_end)) return ZXC_ERROR_CORRUPT_DATA;
     const size_t remaining_literals = (size_t)(l_end - l_ptr);
     if (remaining_literals > 0) {
-        if (UNLIKELY(d_ptr + remaining_literals > d_end)) return ZXC_ERROR_OVERFLOW;
+        if (UNLIKELY((size_t)(d_end - d_ptr) < remaining_literals)) return ZXC_ERROR_OVERFLOW;
         ZXC_MEMCPY(d_ptr, l_ptr, remaining_literals);
         d_ptr += remaining_literals;
     }
@@ -1640,13 +1640,15 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(zxc_cctx_t* RESTRICT ctx,
         if (UNLIKELY((uint64_t)ll + ml + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr) ||
                      (uint64_t)ll + ZXC_PAD_SIZE > (uint64_t)(l_end - l_ptr))) {
             // Fallback to exact copy (slow but safe)
-            if (UNLIKELY(d_ptr + ll > d_end || l_ptr + ll > l_end)) return ZXC_ERROR_OVERFLOW;
+            if (UNLIKELY((size_t)(d_end - d_ptr) < ll || (size_t)(l_end - l_ptr) < ll))
+                return ZXC_ERROR_OVERFLOW;
             ZXC_MEMCPY(d_ptr, l_ptr, ll);
             l_ptr += ll;
             d_ptr += ll;
             written += ll;
 
-            if (UNLIKELY(offset > written || d_ptr + ml > d_end)) return ZXC_ERROR_BAD_OFFSET;
+            if (UNLIKELY(offset > written || (size_t)(d_end - d_ptr) < ml))
+                return ZXC_ERROR_BAD_OFFSET;
             const uint8_t* match_src = d_ptr - offset;
 
             if (offset < ml) {
@@ -1858,7 +1860,7 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(zxc_cctx_t* RESTRICT ctx,
         uint32_t ll = (uint32_t)(seq >> 24);
         if (UNLIKELY(ll == ZXC_SEQ_LL_MASK)) {
             ll += zxc_read_varint(&extras_ptr, extras_end);
-            if (UNLIKELY(l_ptr + ll > l_end)) {
+            if (UNLIKELY((size_t)(l_end - l_ptr) < ll)) {
                 seq_ptr = seq_save;
                 extras_ptr = ext_save;
                 break;
@@ -1947,14 +1949,14 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(zxc_cctx_t* RESTRICT ctx,
         if (UNLIKELY(m_bits == ZXC_SEQ_ML_MASK)) ml += zxc_read_varint(&extras_ptr, extras_end);
         uint32_t offset = (uint32_t)(seq & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
 
-        if (UNLIKELY((size_t)(d_end - d_ptr) < ll || (size_t)(l_end - l_ptr) < ll))
+        if (UNLIKELY((uint64_t)ll + ml > (uint64_t)(d_end - d_ptr) || (size_t)(l_end - l_ptr) < ll))
             return ZXC_ERROR_OVERFLOW;
         ZXC_MEMCPY(d_ptr, l_ptr, ll);
         l_ptr += ll;
         d_ptr += ll;
 
         const uint8_t* match_src = d_ptr - offset;
-        if (UNLIKELY(match_src < dst || (size_t)(d_end - d_ptr) < ml)) return ZXC_ERROR_BAD_OFFSET;
+        if (UNLIKELY(match_src < dst)) return ZXC_ERROR_BAD_OFFSET;
 
         if (offset < ml) {
             for (size_t i = 0; i < ml; i++) d_ptr[i] = match_src[i];
@@ -1970,7 +1972,7 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(zxc_cctx_t* RESTRICT ctx,
     if (UNLIKELY(l_ptr > l_end)) return ZXC_ERROR_CORRUPT_DATA;
     const size_t remaining_literals = (size_t)(l_end - l_ptr);
     if (remaining_literals > 0) {
-        if (UNLIKELY(d_ptr + remaining_literals > d_end)) return ZXC_ERROR_OVERFLOW;
+        if (UNLIKELY((size_t)(d_end - d_ptr) < remaining_literals)) return ZXC_ERROR_OVERFLOW;
         ZXC_MEMCPY(d_ptr, l_ptr, remaining_literals);
         d_ptr += remaining_literals;
     }

--- a/src/lib/zxc_decompress.c
+++ b/src/lib/zxc_decompress.c
@@ -821,7 +821,8 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
             }
             if (UNLIKELY(ml1 == ZXC_TOKEN_ML_MASK)) {
                 ml1 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY(ll1 + ml1 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE >
+                if (UNLIKELY(ll1 + ml1 + ZXC_LZ_MIN_MATCH_LEN +
+                                 3U * ZXC_GLO_MAX_INLINE_OUT_PER_SEQ + ZXC_PAD_SIZE >
                              (size_t)(d_end - d_ptr)))
                     goto rollback_safe_4x;
             }
@@ -839,7 +840,8 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
             }
             if (UNLIKELY(ml2 == ZXC_TOKEN_ML_MASK)) {
                 ml2 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY(ll2 + ml2 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE >
+                if (UNLIKELY(ll2 + ml2 + ZXC_LZ_MIN_MATCH_LEN +
+                                 2U * ZXC_GLO_MAX_INLINE_OUT_PER_SEQ + ZXC_PAD_SIZE >
                              (size_t)(d_end - d_ptr)))
                     goto rollback_safe_4x;
             }
@@ -857,7 +859,8 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
             }
             if (UNLIKELY(ml3 == ZXC_TOKEN_ML_MASK)) {
                 ml3 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY(ll3 + ml3 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE >
+                if (UNLIKELY(ll3 + ml3 + ZXC_LZ_MIN_MATCH_LEN + ZXC_GLO_MAX_INLINE_OUT_PER_SEQ +
+                                 ZXC_PAD_SIZE >
                              (size_t)(d_end - d_ptr)))
                     goto rollback_safe_4x;
             }
@@ -931,7 +934,8 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
             }
             if (UNLIKELY(ml1 == ZXC_TOKEN_ML_MASK)) {
                 ml1 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY(ll1 + ml1 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE >
+                if (UNLIKELY(ll1 + ml1 + ZXC_LZ_MIN_MATCH_LEN +
+                                 3U * ZXC_GLO_MAX_INLINE_OUT_PER_SEQ + ZXC_PAD_SIZE >
                              (size_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
@@ -949,7 +953,8 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
             }
             if (UNLIKELY(ml2 == ZXC_TOKEN_ML_MASK)) {
                 ml2 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY(ll2 + ml2 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE >
+                if (UNLIKELY(ll2 + ml2 + ZXC_LZ_MIN_MATCH_LEN +
+                                 2U * ZXC_GLO_MAX_INLINE_OUT_PER_SEQ + ZXC_PAD_SIZE >
                              (size_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
@@ -967,7 +972,8 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
             }
             if (UNLIKELY(ml3 == ZXC_TOKEN_ML_MASK)) {
                 ml3 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY(ll3 + ml3 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE >
+                if (UNLIKELY(ll3 + ml3 + ZXC_LZ_MIN_MATCH_LEN + ZXC_GLO_MAX_INLINE_OUT_PER_SEQ +
+                                 ZXC_PAD_SIZE >
                              (size_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
@@ -1036,7 +1042,8 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
             }
             if (UNLIKELY(ml1 == ZXC_TOKEN_ML_MASK)) {
                 ml1 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY(ll1 + ml1 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE >
+                if (UNLIKELY(ll1 + ml1 + ZXC_LZ_MIN_MATCH_LEN +
+                                 3U * ZXC_GLO_MAX_INLINE_OUT_PER_SEQ + ZXC_PAD_SIZE >
                              (size_t)(d_end - d_ptr)))
                     goto rollback_fast_4x;
             }
@@ -1054,7 +1061,8 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
             }
             if (UNLIKELY(ml2 == ZXC_TOKEN_ML_MASK)) {
                 ml2 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY(ll2 + ml2 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE >
+                if (UNLIKELY(ll2 + ml2 + ZXC_LZ_MIN_MATCH_LEN +
+                                 2U * ZXC_GLO_MAX_INLINE_OUT_PER_SEQ + ZXC_PAD_SIZE >
                              (size_t)(d_end - d_ptr)))
                     goto rollback_fast_4x;
             }
@@ -1072,7 +1080,8 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
             }
             if (UNLIKELY(ml3 == ZXC_TOKEN_ML_MASK)) {
                 ml3 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY(ll3 + ml3 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE >
+                if (UNLIKELY(ll3 + ml3 + ZXC_LZ_MIN_MATCH_LEN + ZXC_GLO_MAX_INLINE_OUT_PER_SEQ +
+                                 ZXC_PAD_SIZE >
                              (size_t)(d_end - d_ptr)))
                     goto rollback_fast_4x;
             }
@@ -1144,7 +1153,8 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
             }
             if (UNLIKELY(ml1 == ZXC_TOKEN_ML_MASK)) {
                 ml1 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY(ll1 + ml1 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE >
+                if (UNLIKELY(ll1 + ml1 + ZXC_LZ_MIN_MATCH_LEN +
+                                 3U * ZXC_GLO_MAX_INLINE_OUT_PER_SEQ + ZXC_PAD_SIZE >
                              (size_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
@@ -1162,7 +1172,8 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
             }
             if (UNLIKELY(ml2 == ZXC_TOKEN_ML_MASK)) {
                 ml2 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY(ll2 + ml2 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE >
+                if (UNLIKELY(ll2 + ml2 + ZXC_LZ_MIN_MATCH_LEN +
+                                 2U * ZXC_GLO_MAX_INLINE_OUT_PER_SEQ + ZXC_PAD_SIZE >
                              (size_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
@@ -1180,7 +1191,8 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
             }
             if (UNLIKELY(ml3 == ZXC_TOKEN_ML_MASK)) {
                 ml3 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY(ll3 + ml3 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE >
+                if (UNLIKELY(ll3 + ml3 + ZXC_LZ_MIN_MATCH_LEN + ZXC_GLO_MAX_INLINE_OUT_PER_SEQ +
+                                 ZXC_PAD_SIZE >
                              (size_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
@@ -1467,7 +1479,8 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(zxc_cctx_t* RESTRICT ctx,
             uint64_t ml1 = m1b + ZXC_LZ_MIN_MATCH_LEN;
             if (UNLIKELY(m1b == ZXC_SEQ_ML_MASK)) {
                 ml1 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY(ll1 + ml1 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
+                if (UNLIKELY(ll1 + ml1 + 3U * ZXC_GHI_MAX_INLINE_OUT_PER_SEQ + ZXC_PAD_SIZE >
+                             (size_t)(d_end - d_ptr)))
                     goto rollback_safe_4x;
             }
             uint32_t off1 = (uint32_t)(s1 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
@@ -1485,7 +1498,8 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(zxc_cctx_t* RESTRICT ctx,
             uint64_t ml2 = m2b + ZXC_LZ_MIN_MATCH_LEN;
             if (UNLIKELY(m2b == ZXC_SEQ_ML_MASK)) {
                 ml2 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY(ll2 + ml2 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
+                if (UNLIKELY(ll2 + ml2 + 2U * ZXC_GHI_MAX_INLINE_OUT_PER_SEQ + ZXC_PAD_SIZE >
+                             (size_t)(d_end - d_ptr)))
                     goto rollback_safe_4x;
             }
             uint32_t off2 = (uint32_t)(s2 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
@@ -1503,7 +1517,8 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(zxc_cctx_t* RESTRICT ctx,
             uint64_t ml3 = m3b + ZXC_LZ_MIN_MATCH_LEN;
             if (UNLIKELY(m3b == ZXC_SEQ_ML_MASK)) {
                 ml3 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY(ll3 + ml3 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
+                if (UNLIKELY(ll3 + ml3 + ZXC_GHI_MAX_INLINE_OUT_PER_SEQ + ZXC_PAD_SIZE >
+                             (size_t)(d_end - d_ptr)))
                     goto rollback_safe_4x;
             }
             uint32_t off3 = (uint32_t)(s3 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
@@ -1558,7 +1573,8 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(zxc_cctx_t* RESTRICT ctx,
             uint64_t ml1 = m1b + ZXC_LZ_MIN_MATCH_LEN;
             if (UNLIKELY(m1b == ZXC_SEQ_ML_MASK)) {
                 ml1 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY(ll1 + ml1 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
+                if (UNLIKELY(ll1 + ml1 + 3U * ZXC_GHI_MAX_INLINE_OUT_PER_SEQ + ZXC_PAD_SIZE >
+                             (size_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
             uint32_t off1 = (uint32_t)(s1 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
@@ -1576,7 +1592,8 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(zxc_cctx_t* RESTRICT ctx,
             uint64_t ml2 = m2b + ZXC_LZ_MIN_MATCH_LEN;
             if (UNLIKELY(m2b == ZXC_SEQ_ML_MASK)) {
                 ml2 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY(ll2 + ml2 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
+                if (UNLIKELY(ll2 + ml2 + 2U * ZXC_GHI_MAX_INLINE_OUT_PER_SEQ + ZXC_PAD_SIZE >
+                             (size_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
             uint32_t off2 = (uint32_t)(s2 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
@@ -1594,7 +1611,8 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(zxc_cctx_t* RESTRICT ctx,
             uint64_t ml3 = m3b + ZXC_LZ_MIN_MATCH_LEN;
             if (UNLIKELY(m3b == ZXC_SEQ_ML_MASK)) {
                 ml3 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY(ll3 + ml3 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
+                if (UNLIKELY(ll3 + ml3 + ZXC_GHI_MAX_INLINE_OUT_PER_SEQ + ZXC_PAD_SIZE >
+                             (size_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
             uint32_t off3 = (uint32_t)(s3 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
@@ -1693,7 +1711,8 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(zxc_cctx_t* RESTRICT ctx,
             uint64_t ml1 = m1b + ZXC_LZ_MIN_MATCH_LEN;
             if (UNLIKELY(m1b == ZXC_SEQ_ML_MASK)) {
                 ml1 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY(ll1 + ml1 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
+                if (UNLIKELY(ll1 + ml1 + 3U * ZXC_GHI_MAX_INLINE_OUT_PER_SEQ + ZXC_PAD_SIZE >
+                             (size_t)(d_end - d_ptr)))
                     goto rollback_fast_4x;
             }
             uint32_t off1 = (uint32_t)(s1 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
@@ -1711,7 +1730,8 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(zxc_cctx_t* RESTRICT ctx,
             uint64_t ml2 = m2b + ZXC_LZ_MIN_MATCH_LEN;
             if (UNLIKELY(m2b == ZXC_SEQ_ML_MASK)) {
                 ml2 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY(ll2 + ml2 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
+                if (UNLIKELY(ll2 + ml2 + 2U * ZXC_GHI_MAX_INLINE_OUT_PER_SEQ + ZXC_PAD_SIZE >
+                             (size_t)(d_end - d_ptr)))
                     goto rollback_fast_4x;
             }
             uint32_t off2 = (uint32_t)(s2 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
@@ -1729,7 +1749,8 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(zxc_cctx_t* RESTRICT ctx,
             uint64_t ml3 = m3b + ZXC_LZ_MIN_MATCH_LEN;
             if (UNLIKELY(m3b == ZXC_SEQ_ML_MASK)) {
                 ml3 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY(ll3 + ml3 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
+                if (UNLIKELY(ll3 + ml3 + ZXC_GHI_MAX_INLINE_OUT_PER_SEQ + ZXC_PAD_SIZE >
+                             (size_t)(d_end - d_ptr)))
                     goto rollback_fast_4x;
             }
             uint32_t off3 = (uint32_t)(s3 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
@@ -1785,7 +1806,8 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(zxc_cctx_t* RESTRICT ctx,
             uint64_t ml1 = m1b + ZXC_LZ_MIN_MATCH_LEN;
             if (UNLIKELY(m1b == ZXC_SEQ_ML_MASK)) {
                 ml1 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY(ll1 + ml1 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
+                if (UNLIKELY(ll1 + ml1 + 3U * ZXC_GHI_MAX_INLINE_OUT_PER_SEQ + ZXC_PAD_SIZE >
+                             (size_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
             uint32_t off1 = (uint32_t)(s1 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
@@ -1803,7 +1825,8 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(zxc_cctx_t* RESTRICT ctx,
             uint64_t ml2 = m2b + ZXC_LZ_MIN_MATCH_LEN;
             if (UNLIKELY(m2b == ZXC_SEQ_ML_MASK)) {
                 ml2 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY(ll2 + ml2 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
+                if (UNLIKELY(ll2 + ml2 + 2U * ZXC_GHI_MAX_INLINE_OUT_PER_SEQ + ZXC_PAD_SIZE >
+                             (size_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
             uint32_t off2 = (uint32_t)(s2 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
@@ -1821,7 +1844,8 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(zxc_cctx_t* RESTRICT ctx,
             uint64_t ml3 = m3b + ZXC_LZ_MIN_MATCH_LEN;
             if (UNLIKELY(m3b == ZXC_SEQ_ML_MASK)) {
                 ml3 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY(ll3 + ml3 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
+                if (UNLIKELY(ll3 + ml3 + ZXC_GHI_MAX_INLINE_OUT_PER_SEQ + ZXC_PAD_SIZE >
+                             (size_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
             uint32_t off3 = (uint32_t)(s3 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;

--- a/src/lib/zxc_decompress.c
+++ b/src/lib/zxc_decompress.c
@@ -791,10 +791,6 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
             uint32_t tokens = zxc_le32(t_ptr);
             t_ptr += 4;
 
-            const uint32_t lit_reserve_1 = (tokens >> 28);
-            const uint32_t lit_reserve_2 = lit_reserve_1 + ((tokens >> 20) & 0xF);
-            const uint32_t lit_reserve_3 = lit_reserve_2 + ((tokens >> 12) & 0xF);
-
             uint32_t off1 = ZXC_LZ_OFFSET_BIAS, off2 = ZXC_LZ_OFFSET_BIAS,
                      off3 = ZXC_LZ_OFFSET_BIAS, off4 = ZXC_LZ_OFFSET_BIAS;
             if (gh.enc_off == 1) {
@@ -817,7 +813,9 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
             uint32_t ml1 = (tokens & 0x00F);
             if (UNLIKELY(ll1 == ZXC_TOKEN_LL_MASK)) {
                 ll1 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY((uint64_t)ll1 + lit_reserve_3 > (uint64_t)(l_end - l_ptr) ||
+                const uint32_t reserve =
+                    ((tokens >> 12) & 0xF) + ((tokens >> 20) & 0xF) + (tokens >> 28);
+                if (UNLIKELY((uint64_t)ll1 + reserve > (uint64_t)(l_end - l_ptr) ||
                              (uint64_t)ll1 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
                     goto rollback_safe_4x;
             }
@@ -834,7 +832,8 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
             uint32_t ml2 = (tokens & 0x00F00) >> 8;
             if (UNLIKELY(ll2 == ZXC_TOKEN_LL_MASK)) {
                 ll2 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY((uint64_t)ll2 + lit_reserve_2 > (uint64_t)(l_end - l_ptr) ||
+                const uint32_t reserve = ((tokens >> 20) & 0xF) + (tokens >> 28);
+                if (UNLIKELY((uint64_t)ll2 + reserve > (uint64_t)(l_end - l_ptr) ||
                              (uint64_t)ll2 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
                     goto rollback_safe_4x;
             }
@@ -851,7 +850,8 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
             uint32_t ml3 = (tokens & 0x00F0000) >> 16;
             if (UNLIKELY(ll3 == ZXC_TOKEN_LL_MASK)) {
                 ll3 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY((uint64_t)ll3 + lit_reserve_1 > (uint64_t)(l_end - l_ptr) ||
+                const uint32_t reserve = (tokens >> 28);
+                if (UNLIKELY((uint64_t)ll3 + reserve > (uint64_t)(l_end - l_ptr) ||
                              (uint64_t)ll3 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
                     goto rollback_safe_4x;
             }
@@ -899,10 +899,6 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
             uint32_t tokens = zxc_le32(t_ptr);
             t_ptr += 4;
 
-            const uint32_t lit_reserve_1 = (tokens >> 28);
-            const uint32_t lit_reserve_2 = lit_reserve_1 + ((tokens >> 20) & 0xF);
-            const uint32_t lit_reserve_3 = lit_reserve_2 + ((tokens >> 12) & 0xF);
-
             uint32_t off1 = ZXC_LZ_OFFSET_BIAS, off2 = ZXC_LZ_OFFSET_BIAS,
                      off3 = ZXC_LZ_OFFSET_BIAS, off4 = ZXC_LZ_OFFSET_BIAS;
             if (gh.enc_off == 1) {
@@ -927,7 +923,9 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
             uint32_t ml1 = (tokens & 0x00F);
             if (UNLIKELY(ll1 == ZXC_TOKEN_LL_MASK)) {
                 ll1 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY((uint64_t)ll1 + lit_reserve_3 > (uint64_t)(l_end - l_ptr) ||
+                const uint32_t reserve =
+                    ((tokens >> 12) & 0xF) + ((tokens >> 20) & 0xF) + (tokens >> 28);
+                if (UNLIKELY((uint64_t)ll1 + reserve > (uint64_t)(l_end - l_ptr) ||
                              (uint64_t)ll1 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
@@ -944,7 +942,8 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
             uint32_t ml2 = (tokens & 0x00F00) >> 8;
             if (UNLIKELY(ll2 == ZXC_TOKEN_LL_MASK)) {
                 ll2 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY((uint64_t)ll2 + lit_reserve_2 > (uint64_t)(l_end - l_ptr) ||
+                const uint32_t reserve = ((tokens >> 20) & 0xF) + (tokens >> 28);
+                if (UNLIKELY((uint64_t)ll2 + reserve > (uint64_t)(l_end - l_ptr) ||
                              (uint64_t)ll2 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
@@ -961,7 +960,8 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
             uint32_t ml3 = (tokens & 0x00F0000) >> 16;
             if (UNLIKELY(ll3 == ZXC_TOKEN_LL_MASK)) {
                 ll3 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY((uint64_t)ll3 + lit_reserve_1 > (uint64_t)(l_end - l_ptr) ||
+                const uint32_t reserve = (tokens >> 28);
+                if (UNLIKELY((uint64_t)ll3 + reserve > (uint64_t)(l_end - l_ptr) ||
                              (uint64_t)ll3 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
@@ -1006,10 +1006,6 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
             uint32_t tokens = zxc_le32(t_ptr);
             t_ptr += 4;
 
-            const uint32_t lit_reserve_1 = (tokens >> 28);
-            const uint32_t lit_reserve_2 = lit_reserve_1 + ((tokens >> 20) & 0xF);
-            const uint32_t lit_reserve_3 = lit_reserve_2 + ((tokens >> 12) & 0xF);
-
             uint32_t off1 = ZXC_LZ_OFFSET_BIAS, off2 = ZXC_LZ_OFFSET_BIAS,
                      off3 = ZXC_LZ_OFFSET_BIAS, off4 = ZXC_LZ_OFFSET_BIAS;
             if (gh.enc_off == 1) {
@@ -1032,7 +1028,9 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
             uint32_t ml1 = (tokens & 0x00F);
             if (UNLIKELY(ll1 == ZXC_TOKEN_LL_MASK)) {
                 ll1 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY((uint64_t)ll1 + lit_reserve_3 > (uint64_t)(l_end - l_ptr) ||
+                const uint32_t reserve =
+                    ((tokens >> 12) & 0xF) + ((tokens >> 20) & 0xF) + (tokens >> 28);
+                if (UNLIKELY((uint64_t)ll1 + reserve > (uint64_t)(l_end - l_ptr) ||
                              (uint64_t)ll1 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
                     goto rollback_fast_4x;
             }
@@ -1049,7 +1047,8 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
             uint32_t ml2 = (tokens & 0x00F00) >> 8;
             if (UNLIKELY(ll2 == ZXC_TOKEN_LL_MASK)) {
                 ll2 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY((uint64_t)ll2 + lit_reserve_2 > (uint64_t)(l_end - l_ptr) ||
+                const uint32_t reserve = ((tokens >> 20) & 0xF) + (tokens >> 28);
+                if (UNLIKELY((uint64_t)ll2 + reserve > (uint64_t)(l_end - l_ptr) ||
                              (uint64_t)ll2 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
                     goto rollback_fast_4x;
             }
@@ -1066,7 +1065,8 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
             uint32_t ml3 = (tokens & 0x00F0000) >> 16;
             if (UNLIKELY(ll3 == ZXC_TOKEN_LL_MASK)) {
                 ll3 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY((uint64_t)ll3 + lit_reserve_1 > (uint64_t)(l_end - l_ptr) ||
+                const uint32_t reserve = (tokens >> 28);
+                if (UNLIKELY((uint64_t)ll3 + reserve > (uint64_t)(l_end - l_ptr) ||
                              (uint64_t)ll3 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
                     goto rollback_fast_4x;
             }
@@ -1112,10 +1112,6 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
             uint32_t tokens = zxc_le32(t_ptr);
             t_ptr += 4;
 
-            const uint32_t lit_reserve_1 = (tokens >> 28);
-            const uint32_t lit_reserve_2 = lit_reserve_1 + ((tokens >> 20) & 0xF);
-            const uint32_t lit_reserve_3 = lit_reserve_2 + ((tokens >> 12) & 0xF);
-
             uint32_t off1 = ZXC_LZ_OFFSET_BIAS, off2 = ZXC_LZ_OFFSET_BIAS,
                      off3 = ZXC_LZ_OFFSET_BIAS, off4 = ZXC_LZ_OFFSET_BIAS;
             if (gh.enc_off == 1) {
@@ -1140,7 +1136,9 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
             uint32_t ml1 = (tokens & 0x00F);
             if (UNLIKELY(ll1 == ZXC_TOKEN_LL_MASK)) {
                 ll1 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY((uint64_t)ll1 + lit_reserve_3 > (uint64_t)(l_end - l_ptr) ||
+                const uint32_t reserve =
+                    ((tokens >> 12) & 0xF) + ((tokens >> 20) & 0xF) + (tokens >> 28);
+                if (UNLIKELY((uint64_t)ll1 + reserve > (uint64_t)(l_end - l_ptr) ||
                              (uint64_t)ll1 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
@@ -1157,7 +1155,8 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
             uint32_t ml2 = (tokens & 0x00F00) >> 8;
             if (UNLIKELY(ll2 == ZXC_TOKEN_LL_MASK)) {
                 ll2 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY((uint64_t)ll2 + lit_reserve_2 > (uint64_t)(l_end - l_ptr) ||
+                const uint32_t reserve = ((tokens >> 20) & 0xF) + (tokens >> 28);
+                if (UNLIKELY((uint64_t)ll2 + reserve > (uint64_t)(l_end - l_ptr) ||
                              (uint64_t)ll2 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
@@ -1174,7 +1173,8 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
             uint32_t ml3 = (tokens & 0x00F0000) >> 16;
             if (UNLIKELY(ll3 == ZXC_TOKEN_LL_MASK)) {
                 ll3 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY((uint64_t)ll3 + lit_reserve_1 > (uint64_t)(l_end - l_ptr) ||
+                const uint32_t reserve = (tokens >> 28);
+                if (UNLIKELY((uint64_t)ll3 + reserve > (uint64_t)(l_end - l_ptr) ||
                              (uint64_t)ll3 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
@@ -1455,14 +1455,11 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(zxc_cctx_t* RESTRICT ctx,
             uint32_t s4 = zxc_le32(seq_ptr + 12);
             seq_ptr += 16;
 
-            const uint32_t lit_reserve_1 = (s4 >> 24);
-            const uint32_t lit_reserve_2 = lit_reserve_1 + (s3 >> 24);
-            const uint32_t lit_reserve_3 = lit_reserve_2 + (s2 >> 24);
-
             uint32_t ll1 = (uint32_t)(s1 >> 24);
             if (UNLIKELY(ll1 == ZXC_SEQ_LL_MASK)) {
                 ll1 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY((uint64_t)ll1 + lit_reserve_3 > (uint64_t)(l_end - l_ptr) ||
+                const uint32_t reserve = (s2 >> 24) + (s3 >> 24) + (s4 >> 24);
+                if (UNLIKELY((uint64_t)ll1 + reserve > (uint64_t)(l_end - l_ptr) ||
                              (uint64_t)ll1 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
                     goto rollback_safe_4x;
             }
@@ -1479,7 +1476,8 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(zxc_cctx_t* RESTRICT ctx,
             uint32_t ll2 = (uint32_t)(s2 >> 24);
             if (UNLIKELY(ll2 == ZXC_SEQ_LL_MASK)) {
                 ll2 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY((uint64_t)ll2 + lit_reserve_2 > (uint64_t)(l_end - l_ptr) ||
+                const uint32_t reserve = (s3 >> 24) + (s4 >> 24);
+                if (UNLIKELY((uint64_t)ll2 + reserve > (uint64_t)(l_end - l_ptr) ||
                              (uint64_t)ll2 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
                     goto rollback_safe_4x;
             }
@@ -1496,7 +1494,8 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(zxc_cctx_t* RESTRICT ctx,
             uint32_t ll3 = (uint32_t)(s3 >> 24);
             if (UNLIKELY(ll3 == ZXC_SEQ_LL_MASK)) {
                 ll3 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY((uint64_t)ll3 + lit_reserve_1 > (uint64_t)(l_end - l_ptr) ||
+                const uint32_t reserve = (s4 >> 24);
+                if (UNLIKELY((uint64_t)ll3 + reserve > (uint64_t)(l_end - l_ptr) ||
                              (uint64_t)ll3 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
                     goto rollback_safe_4x;
             }
@@ -1547,14 +1546,11 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(zxc_cctx_t* RESTRICT ctx,
             uint32_t s4 = zxc_le32(seq_ptr + 12);
             seq_ptr += 16;
 
-            const uint32_t lit_reserve_1 = (s4 >> 24);
-            const uint32_t lit_reserve_2 = lit_reserve_1 + (s3 >> 24);
-            const uint32_t lit_reserve_3 = lit_reserve_2 + (s2 >> 24);
-
             uint32_t ll1 = (uint32_t)(s1 >> 24);
             if (UNLIKELY(ll1 == ZXC_SEQ_LL_MASK)) {
                 ll1 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY((uint64_t)ll1 + lit_reserve_3 > (uint64_t)(l_end - l_ptr) ||
+                const uint32_t reserve = (s2 >> 24) + (s3 >> 24) + (s4 >> 24);
+                if (UNLIKELY((uint64_t)ll1 + reserve > (uint64_t)(l_end - l_ptr) ||
                              (uint64_t)ll1 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
@@ -1571,7 +1567,8 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(zxc_cctx_t* RESTRICT ctx,
             uint32_t ll2 = (uint32_t)(s2 >> 24);
             if (UNLIKELY(ll2 == ZXC_SEQ_LL_MASK)) {
                 ll2 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY((uint64_t)ll2 + lit_reserve_2 > (uint64_t)(l_end - l_ptr) ||
+                const uint32_t reserve = (s3 >> 24) + (s4 >> 24);
+                if (UNLIKELY((uint64_t)ll2 + reserve > (uint64_t)(l_end - l_ptr) ||
                              (uint64_t)ll2 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
@@ -1588,7 +1585,8 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(zxc_cctx_t* RESTRICT ctx,
             uint32_t ll3 = (uint32_t)(s3 >> 24);
             if (UNLIKELY(ll3 == ZXC_SEQ_LL_MASK)) {
                 ll3 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY((uint64_t)ll3 + lit_reserve_1 > (uint64_t)(l_end - l_ptr) ||
+                const uint32_t reserve = (s4 >> 24);
+                if (UNLIKELY((uint64_t)ll3 + reserve > (uint64_t)(l_end - l_ptr) ||
                              (uint64_t)ll3 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
@@ -1678,17 +1676,14 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(zxc_cctx_t* RESTRICT ctx,
             uint32_t s4 = zxc_le32(seq_ptr + 12);
             seq_ptr += 16;
 
-            const uint32_t lit_reserve_1 = (s4 >> 24);
-            const uint32_t lit_reserve_2 = lit_reserve_1 + (s3 >> 24);
-            const uint32_t lit_reserve_3 = lit_reserve_2 + (s2 >> 24);
-
             // Prefetch ahead in literal and extras streams to hide memory latency
             ZXC_PREFETCH_READ(l_ptr + ZXC_CACHE_LINE_SIZE);
 
             uint32_t ll1 = (uint32_t)(s1 >> 24);
             if (UNLIKELY(ll1 == ZXC_SEQ_LL_MASK)) {
                 ll1 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY((uint64_t)ll1 + lit_reserve_3 > (uint64_t)(l_end - l_ptr) ||
+                const uint32_t reserve = (s2 >> 24) + (s3 >> 24) + (s4 >> 24);
+                if (UNLIKELY((uint64_t)ll1 + reserve > (uint64_t)(l_end - l_ptr) ||
                              (uint64_t)ll1 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
                     goto rollback_fast_4x;
             }
@@ -1705,7 +1700,8 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(zxc_cctx_t* RESTRICT ctx,
             uint32_t ll2 = (uint32_t)(s2 >> 24);
             if (UNLIKELY(ll2 == ZXC_SEQ_LL_MASK)) {
                 ll2 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY((uint64_t)ll2 + lit_reserve_2 > (uint64_t)(l_end - l_ptr) ||
+                const uint32_t reserve = (s3 >> 24) + (s4 >> 24);
+                if (UNLIKELY((uint64_t)ll2 + reserve > (uint64_t)(l_end - l_ptr) ||
                              (uint64_t)ll2 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
                     goto rollback_fast_4x;
             }
@@ -1722,7 +1718,8 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(zxc_cctx_t* RESTRICT ctx,
             uint32_t ll3 = (uint32_t)(s3 >> 24);
             if (UNLIKELY(ll3 == ZXC_SEQ_LL_MASK)) {
                 ll3 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY((uint64_t)ll3 + lit_reserve_1 > (uint64_t)(l_end - l_ptr) ||
+                const uint32_t reserve = (s4 >> 24);
+                if (UNLIKELY((uint64_t)ll3 + reserve > (uint64_t)(l_end - l_ptr) ||
                              (uint64_t)ll3 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
                     goto rollback_fast_4x;
             }
@@ -1771,17 +1768,14 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(zxc_cctx_t* RESTRICT ctx,
             uint32_t s4 = zxc_le32(seq_ptr + 12);
             seq_ptr += 16;
 
-            const uint32_t lit_reserve_1 = (s4 >> 24);
-            const uint32_t lit_reserve_2 = lit_reserve_1 + (s3 >> 24);
-            const uint32_t lit_reserve_3 = lit_reserve_2 + (s2 >> 24);
-
             // Prefetch ahead in literal and extras streams to hide memory latency
             ZXC_PREFETCH_READ(l_ptr + ZXC_CACHE_LINE_SIZE);
 
             uint32_t ll1 = (uint32_t)(s1 >> 24);
             if (UNLIKELY(ll1 == ZXC_SEQ_LL_MASK)) {
                 ll1 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY((uint64_t)ll1 + lit_reserve_3 > (uint64_t)(l_end - l_ptr) ||
+                const uint32_t reserve = (s2 >> 24) + (s3 >> 24) + (s4 >> 24);
+                if (UNLIKELY((uint64_t)ll1 + reserve > (uint64_t)(l_end - l_ptr) ||
                              (uint64_t)ll1 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
@@ -1798,7 +1792,8 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(zxc_cctx_t* RESTRICT ctx,
             uint32_t ll2 = (uint32_t)(s2 >> 24);
             if (UNLIKELY(ll2 == ZXC_SEQ_LL_MASK)) {
                 ll2 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY((uint64_t)ll2 + lit_reserve_2 > (uint64_t)(l_end - l_ptr) ||
+                const uint32_t reserve = (s3 >> 24) + (s4 >> 24);
+                if (UNLIKELY((uint64_t)ll2 + reserve > (uint64_t)(l_end - l_ptr) ||
                              (uint64_t)ll2 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
@@ -1815,7 +1810,8 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(zxc_cctx_t* RESTRICT ctx,
             uint32_t ll3 = (uint32_t)(s3 >> 24);
             if (UNLIKELY(ll3 == ZXC_SEQ_LL_MASK)) {
                 ll3 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY((uint64_t)ll3 + lit_reserve_1 > (uint64_t)(l_end - l_ptr) ||
+                const uint32_t reserve = (s4 >> 24);
+                if (UNLIKELY((uint64_t)ll3 + reserve > (uint64_t)(l_end - l_ptr) ||
                              (uint64_t)ll3 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }

--- a/src/lib/zxc_decompress.c
+++ b/src/lib/zxc_decompress.c
@@ -359,7 +359,7 @@ static int zxc_decode_block_num(const uint8_t* RESTRICT src, const size_t src_si
         offset += ZXC_NUM_CHUNK_HEADER_SIZE;
 
         if (UNLIKELY(nvals > vals_remaining || psize > src_size - offset ||
-                     (size_t)(d_end - d_ptr) < (size_t)nvals * sizeof(uint32_t) ||
+                     d_ptr + (size_t)nvals * sizeof(uint32_t) > d_end ||
                      bits > (sizeof(uint32_t) * CHAR_BIT)))
             return ZXC_ERROR_CORRUPT_DATA;
 
@@ -656,7 +656,7 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
                     // Raw copy (most common path): use ZXC_PAD_SIZE-byte wild copies
                     // token is 7-bit (0-127), so len is 1-128 bytes
                     const uint32_t len = (uint32_t)token + 1;
-                    if (UNLIKELY((size_t)(w_end - w_ptr) < len || (size_t)(r_end - r_ptr) < len))
+                    if (UNLIKELY(w_ptr + len > w_end || r_ptr + len > r_end))
                         return ZXC_ERROR_CORRUPT_DATA;
 
                     // Destination has ZXC_PAD_SIZE bytes of safe overrun space.
@@ -690,7 +690,7 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
                 } else {
                     // RLE run: fill with single byte
                     const uint32_t len = (token & ZXC_LIT_LEN_MASK) + 4;
-                    if (UNLIKELY((size_t)(w_end - w_ptr) < len || r_ptr >= r_end))
+                    if (UNLIKELY(w_ptr + len > w_end || r_ptr >= r_end))
                         return ZXC_ERROR_CORRUPT_DATA;
                     ZXC_MEMSET(w_ptr, *r_ptr++, len);
                     w_ptr += len;
@@ -1229,7 +1229,7 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
 
         if (UNLIKELY(ll == ZXC_TOKEN_LL_MASK)) {
             ll += zxc_read_varint(&e_ptr, e_end);
-            if (UNLIKELY((size_t)(l_end - l_ptr) < ll)) {
+            if (UNLIKELY(l_ptr + ll > l_end)) {
                 t_ptr = t_save;
                 o_ptr = o_save;
                 e_ptr = e_save;
@@ -1321,7 +1321,7 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
         if (UNLIKELY(ml == ZXC_TOKEN_ML_MASK)) ml += zxc_read_varint(&e_ptr, e_end);
         ml += ZXC_LZ_MIN_MATCH_LEN;
 
-        if (UNLIKELY(ll + ml > (size_t)(d_end - d_ptr) || (size_t)(l_end - l_ptr) < ll))
+        if (UNLIKELY(ll + ml > (size_t)(d_end - d_ptr) || l_ptr + ll > l_end))
             return ZXC_ERROR_OVERFLOW;
         ZXC_MEMCPY(d_ptr, l_ptr, ll);
         l_ptr += ll;
@@ -1344,7 +1344,7 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
     if (UNLIKELY(l_ptr > l_end)) return ZXC_ERROR_CORRUPT_DATA;
     const size_t remaining_literals = (size_t)(l_end - l_ptr);
     if (remaining_literals > 0) {
-        if (UNLIKELY((size_t)(d_end - d_ptr) < remaining_literals)) return ZXC_ERROR_OVERFLOW;
+        if (UNLIKELY(d_ptr + remaining_literals > d_end)) return ZXC_ERROR_OVERFLOW;
         ZXC_MEMCPY(d_ptr, l_ptr, remaining_literals);
         d_ptr += remaining_literals;
     }
@@ -1644,15 +1644,13 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(zxc_cctx_t* RESTRICT ctx,
         if (UNLIKELY(ll + ml + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr) ||
                      ll + ZXC_PAD_SIZE > (size_t)(l_end - l_ptr))) {
             // Fallback to exact copy (slow but safe)
-            if (UNLIKELY((size_t)(d_end - d_ptr) < ll || (size_t)(l_end - l_ptr) < ll))
-                return ZXC_ERROR_OVERFLOW;
+            if (UNLIKELY(d_ptr + ll > d_end || l_ptr + ll > l_end)) return ZXC_ERROR_OVERFLOW;
             ZXC_MEMCPY(d_ptr, l_ptr, ll);
             l_ptr += ll;
             d_ptr += ll;
             written += ll;
 
-            if (UNLIKELY(offset > written || (size_t)(d_end - d_ptr) < ml))
-                return ZXC_ERROR_BAD_OFFSET;
+            if (UNLIKELY(offset > written || d_ptr + ml > d_end)) return ZXC_ERROR_BAD_OFFSET;
             const uint8_t* match_src = d_ptr - offset;
 
             if (offset < ml) {
@@ -1870,7 +1868,7 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(zxc_cctx_t* RESTRICT ctx,
         uint64_t ll = (uint32_t)(seq >> 24);
         if (UNLIKELY(ll == ZXC_SEQ_LL_MASK)) {
             ll += zxc_read_varint(&extras_ptr, extras_end);
-            if (UNLIKELY((size_t)(l_end - l_ptr) < ll)) {
+            if (UNLIKELY(l_ptr + ll > l_end)) {
                 seq_ptr = seq_save;
                 extras_ptr = ext_save;
                 break;
@@ -1960,7 +1958,7 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(zxc_cctx_t* RESTRICT ctx,
         if (UNLIKELY(m_bits == ZXC_SEQ_ML_MASK)) ml += zxc_read_varint(&extras_ptr, extras_end);
         uint32_t offset = (uint32_t)(seq & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
 
-        if (UNLIKELY(ll + ml > (size_t)(d_end - d_ptr) || (size_t)(l_end - l_ptr) < ll))
+        if (UNLIKELY(ll + ml > (size_t)(d_end - d_ptr) || l_ptr + ll > l_end))
             return ZXC_ERROR_OVERFLOW;
         ZXC_MEMCPY(d_ptr, l_ptr, ll);
         l_ptr += ll;
@@ -1983,7 +1981,7 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(zxc_cctx_t* RESTRICT ctx,
     if (UNLIKELY(l_ptr > l_end)) return ZXC_ERROR_CORRUPT_DATA;
     const size_t remaining_literals = (size_t)(l_end - l_ptr);
     if (remaining_literals > 0) {
-        if (UNLIKELY((size_t)(d_end - d_ptr) < remaining_literals)) return ZXC_ERROR_OVERFLOW;
+        if (UNLIKELY(d_ptr + remaining_literals > d_end)) return ZXC_ERROR_OVERFLOW;
         ZXC_MEMCPY(d_ptr, l_ptr, remaining_literals);
         d_ptr += remaining_literals;
     }

--- a/src/lib/zxc_decompress.c
+++ b/src/lib/zxc_decompress.c
@@ -106,7 +106,10 @@ static ZXC_ALWAYS_INLINE uint32_t zxc_read_varint(const uint8_t** ptr, const uin
         return (b0 & 0x3F) | ((uint32_t)p[1] << 6);
     }
 
-    // 3 Bytes: 110xxxxx xxxxxxxx xxxxxxxx (21 bits) -> val < 2097152 (2^21)
+    // 3 Bytes: 110xxxxx xxxxxxxx xxxxxxxx (21 bits) -> val < 2097152 (2^21).
+    // This is the largest length a legitimate varint can take: block_size_max
+    // is 2^21 and varint values represent (ll - MASK) or (ml - MASK), which is
+    // always strictly less than block_size_max.
     if (LIKELY(b0 < 0xE0)) {
         if (UNLIKELY(p + 2 >= end)) {
             *ptr = end;
@@ -116,30 +119,9 @@ static ZXC_ALWAYS_INLINE uint32_t zxc_read_varint(const uint8_t** ptr, const uin
         return (b0 & 0x1F) | ((uint32_t)p[1] << 5) | ((uint32_t)p[2] << 13);
     }
 
-    // 4 Bytes: 1110xxxx ... (28 bits) -> val < 268435456 (2^28)
-    if (UNLIKELY(b0 < 0xF0)) {
-        if (UNLIKELY(p + 3 >= end)) {
-            *ptr = end;
-            return 0;
-        }
-        *ptr = p + 4;
-        return (b0 & 0x0F) | ((uint32_t)p[1] << 4) | ((uint32_t)p[2] << 12) |
-               ((uint32_t)p[3] << 20);
-    }
-
-    // 5 Bytes: 11110xxx ... (32 bits) -> val < 4294967296 (2^32)
-    if (UNLIKELY(p + 4 >= end)) {
-        *ptr = end;
-        return 0;
-    }
-    const uint32_t v5 = (b0 & 0x07) | ((uint32_t)p[1] << 3) | ((uint32_t)p[2] << 11) |
-                        ((uint32_t)p[3] << 19) | ((uint32_t)p[4] << 27);
-    if (UNLIKELY(v5 > ZXC_MAX_VARINT_VALUE)) {
-        *ptr = end;  // exhaust extras stream: caller treats as corrupt
-        return 0;
-    }
-    *ptr = p + 5;
-    return v5;
+    // 4- or 5-byte encoding: out-of-spec for the current format, reject.
+    *ptr = end;
+    return 0;
 }
 
 /**

--- a/src/lib/zxc_decompress.c
+++ b/src/lib/zxc_decompress.c
@@ -670,7 +670,7 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
                     // Raw copy (most common path): use ZXC_PAD_SIZE-byte wild copies
                     // token is 7-bit (0-127), so len is 1-128 bytes
                     const uint32_t len = (uint32_t)token + 1;
-                    if (UNLIKELY((size_t)(w_end - w_ptr) < len || (size_t)(r_end - r_ptr) < len))
+                    if (UNLIKELY(w_ptr + len > w_end || r_ptr + len > r_end))
                         return ZXC_ERROR_CORRUPT_DATA;
 
                     // Destination has ZXC_PAD_SIZE bytes of safe overrun space.
@@ -704,7 +704,7 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
                 } else {
                     // RLE run: fill with single byte
                     const uint32_t len = (token & ZXC_LIT_LEN_MASK) + 4;
-                    if (UNLIKELY((size_t)(w_end - w_ptr) < len || r_ptr >= r_end))
+                    if (UNLIKELY(w_ptr + len > w_end || r_ptr >= r_end))
                         return ZXC_ERROR_CORRUPT_DATA;
                     ZXC_MEMSET(w_ptr, *r_ptr++, len);
                     w_ptr += len;

--- a/src/lib/zxc_decompress.c
+++ b/src/lib/zxc_decompress.c
@@ -670,7 +670,7 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
                     // Raw copy (most common path): use ZXC_PAD_SIZE-byte wild copies
                     // token is 7-bit (0-127), so len is 1-128 bytes
                     const uint32_t len = (uint32_t)token + 1;
-                    if (UNLIKELY(w_ptr + len > w_end || r_ptr + len > r_end))
+                    if (UNLIKELY((size_t)(w_end - w_ptr) < len || (size_t)(r_end - r_ptr) < len))
                         return ZXC_ERROR_CORRUPT_DATA;
 
                     // Destination has ZXC_PAD_SIZE bytes of safe overrun space.
@@ -704,7 +704,7 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
                 } else {
                     // RLE run: fill with single byte
                     const uint32_t len = (token & ZXC_LIT_LEN_MASK) + 4;
-                    if (UNLIKELY(w_ptr + len > w_end || r_ptr >= r_end))
+                    if (UNLIKELY((size_t)(w_end - w_ptr) < len || r_ptr >= r_end))
                         return ZXC_ERROR_CORRUPT_DATA;
                     ZXC_MEMSET(w_ptr, *r_ptr++, len);
                     w_ptr += len;
@@ -813,12 +813,14 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
             uint32_t ml1 = (tokens & 0x00F);
             if (UNLIKELY(ll1 == ZXC_TOKEN_LL_MASK)) {
                 ll1 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY(l_ptr + ll1 > l_end || d_ptr + ll1 + ZXC_PAD_SIZE > d_end))
+                if (UNLIKELY((uint64_t)ll1 > (uint64_t)(l_end - l_ptr) ||
+                             (uint64_t)ll1 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
                     goto rollback_safe_4x;
             }
             if (UNLIKELY(ml1 == ZXC_TOKEN_ML_MASK)) {
                 ml1 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY(d_ptr + ll1 + ml1 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE > d_end))
+                if (UNLIKELY((uint64_t)ll1 + ml1 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE >
+                             (uint64_t)(d_end - d_ptr)))
                     goto rollback_safe_4x;
             }
             ml1 += ZXC_LZ_MIN_MATCH_LEN;
@@ -828,12 +830,14 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
             uint32_t ml2 = (tokens & 0x00F00) >> 8;
             if (UNLIKELY(ll2 == ZXC_TOKEN_LL_MASK)) {
                 ll2 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY(l_ptr + ll2 > l_end || d_ptr + ll2 + ZXC_PAD_SIZE > d_end))
+                if (UNLIKELY((uint64_t)ll2 > (uint64_t)(l_end - l_ptr) ||
+                             (uint64_t)ll2 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
                     goto rollback_safe_4x;
             }
             if (UNLIKELY(ml2 == ZXC_TOKEN_ML_MASK)) {
                 ml2 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY(d_ptr + ll2 + ml2 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE > d_end))
+                if (UNLIKELY((uint64_t)ll2 + ml2 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE >
+                             (uint64_t)(d_end - d_ptr)))
                     goto rollback_safe_4x;
             }
             ml2 += ZXC_LZ_MIN_MATCH_LEN;
@@ -843,12 +847,14 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
             uint32_t ml3 = (tokens & 0x00F0000) >> 16;
             if (UNLIKELY(ll3 == ZXC_TOKEN_LL_MASK)) {
                 ll3 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY(l_ptr + ll3 > l_end || d_ptr + ll3 + ZXC_PAD_SIZE > d_end))
+                if (UNLIKELY((uint64_t)ll3 > (uint64_t)(l_end - l_ptr) ||
+                             (uint64_t)ll3 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
                     goto rollback_safe_4x;
             }
             if (UNLIKELY(ml3 == ZXC_TOKEN_ML_MASK)) {
                 ml3 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY(d_ptr + ll3 + ml3 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE > d_end))
+                if (UNLIKELY((uint64_t)ll3 + ml3 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE >
+                             (uint64_t)(d_end - d_ptr)))
                     goto rollback_safe_4x;
             }
             ml3 += ZXC_LZ_MIN_MATCH_LEN;
@@ -858,12 +864,14 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
             uint32_t ml4 = (tokens >> 24) & 0x0F;
             if (UNLIKELY(ll4 == ZXC_TOKEN_LL_MASK)) {
                 ll4 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY(l_ptr + ll4 > l_end || d_ptr + ll4 + ZXC_PAD_SIZE > d_end))
+                if (UNLIKELY((uint64_t)ll4 > (uint64_t)(l_end - l_ptr) ||
+                             (uint64_t)ll4 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
                     goto rollback_safe_4x;
             }
             if (UNLIKELY(ml4 == ZXC_TOKEN_ML_MASK)) {
                 ml4 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY(d_ptr + ll4 + ml4 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE > d_end))
+                if (UNLIKELY((uint64_t)ll4 + ml4 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE >
+                             (uint64_t)(d_end - d_ptr)))
                     goto rollback_safe_4x;
             }
             ml4 += ZXC_LZ_MIN_MATCH_LEN;
@@ -911,12 +919,14 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
             uint32_t ml1 = (tokens & 0x00F);
             if (UNLIKELY(ll1 == ZXC_TOKEN_LL_MASK)) {
                 ll1 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY(l_ptr + ll1 > l_end || d_ptr + ll1 + ZXC_PAD_SIZE > d_end))
+                if (UNLIKELY((uint64_t)ll1 > (uint64_t)(l_end - l_ptr) ||
+                             (uint64_t)ll1 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
             if (UNLIKELY(ml1 == ZXC_TOKEN_ML_MASK)) {
                 ml1 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY(d_ptr + ll1 + ml1 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE > d_end))
+                if (UNLIKELY((uint64_t)ll1 + ml1 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE >
+                             (uint64_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
             ml1 += ZXC_LZ_MIN_MATCH_LEN;
@@ -926,12 +936,14 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
             uint32_t ml2 = (tokens & 0x00F00) >> 8;
             if (UNLIKELY(ll2 == ZXC_TOKEN_LL_MASK)) {
                 ll2 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY(l_ptr + ll2 > l_end || d_ptr + ll2 + ZXC_PAD_SIZE > d_end))
+                if (UNLIKELY((uint64_t)ll2 > (uint64_t)(l_end - l_ptr) ||
+                             (uint64_t)ll2 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
             if (UNLIKELY(ml2 == ZXC_TOKEN_ML_MASK)) {
                 ml2 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY(d_ptr + ll2 + ml2 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE > d_end))
+                if (UNLIKELY((uint64_t)ll2 + ml2 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE >
+                             (uint64_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
             ml2 += ZXC_LZ_MIN_MATCH_LEN;
@@ -941,12 +953,14 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
             uint32_t ml3 = (tokens & 0x00F0000) >> 16;
             if (UNLIKELY(ll3 == ZXC_TOKEN_LL_MASK)) {
                 ll3 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY(l_ptr + ll3 > l_end || d_ptr + ll3 + ZXC_PAD_SIZE > d_end))
+                if (UNLIKELY((uint64_t)ll3 > (uint64_t)(l_end - l_ptr) ||
+                             (uint64_t)ll3 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
             if (UNLIKELY(ml3 == ZXC_TOKEN_ML_MASK)) {
                 ml3 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY(d_ptr + ll3 + ml3 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE > d_end))
+                if (UNLIKELY((uint64_t)ll3 + ml3 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE >
+                             (uint64_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
             ml3 += ZXC_LZ_MIN_MATCH_LEN;
@@ -956,12 +970,14 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
             uint32_t ml4 = (tokens >> 24) & 0x0F;
             if (UNLIKELY(ll4 == ZXC_TOKEN_LL_MASK)) {
                 ll4 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY(l_ptr + ll4 > l_end || d_ptr + ll4 + ZXC_PAD_SIZE > d_end))
+                if (UNLIKELY((uint64_t)ll4 > (uint64_t)(l_end - l_ptr) ||
+                             (uint64_t)ll4 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
             if (UNLIKELY(ml4 == ZXC_TOKEN_ML_MASK)) {
                 ml4 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY(d_ptr + ll4 + ml4 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE > d_end))
+                if (UNLIKELY((uint64_t)ll4 + ml4 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE >
+                             (uint64_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
             ml4 += ZXC_LZ_MIN_MATCH_LEN;
@@ -1004,12 +1020,14 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
             uint32_t ml1 = (tokens & 0x00F);
             if (UNLIKELY(ll1 == ZXC_TOKEN_LL_MASK)) {
                 ll1 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY(l_ptr + ll1 > l_end || d_ptr + ll1 + ZXC_PAD_SIZE > d_end))
+                if (UNLIKELY((uint64_t)ll1 > (uint64_t)(l_end - l_ptr) ||
+                             (uint64_t)ll1 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
                     goto rollback_fast_4x;
             }
             if (UNLIKELY(ml1 == ZXC_TOKEN_ML_MASK)) {
                 ml1 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY(d_ptr + ll1 + ml1 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE > d_end))
+                if (UNLIKELY((uint64_t)ll1 + ml1 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE >
+                             (uint64_t)(d_end - d_ptr)))
                     goto rollback_fast_4x;
             }
             ml1 += ZXC_LZ_MIN_MATCH_LEN;
@@ -1019,12 +1037,14 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
             uint32_t ml2 = (tokens & 0x00F00) >> 8;
             if (UNLIKELY(ll2 == ZXC_TOKEN_LL_MASK)) {
                 ll2 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY(l_ptr + ll2 > l_end || d_ptr + ll2 + ZXC_PAD_SIZE > d_end))
+                if (UNLIKELY((uint64_t)ll2 > (uint64_t)(l_end - l_ptr) ||
+                             (uint64_t)ll2 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
                     goto rollback_fast_4x;
             }
             if (UNLIKELY(ml2 == ZXC_TOKEN_ML_MASK)) {
                 ml2 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY(d_ptr + ll2 + ml2 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE > d_end))
+                if (UNLIKELY((uint64_t)ll2 + ml2 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE >
+                             (uint64_t)(d_end - d_ptr)))
                     goto rollback_fast_4x;
             }
             ml2 += ZXC_LZ_MIN_MATCH_LEN;
@@ -1034,12 +1054,14 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
             uint32_t ml3 = (tokens & 0x00F0000) >> 16;
             if (UNLIKELY(ll3 == ZXC_TOKEN_LL_MASK)) {
                 ll3 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY(l_ptr + ll3 > l_end || d_ptr + ll3 + ZXC_PAD_SIZE > d_end))
+                if (UNLIKELY((uint64_t)ll3 > (uint64_t)(l_end - l_ptr) ||
+                             (uint64_t)ll3 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
                     goto rollback_fast_4x;
             }
             if (UNLIKELY(ml3 == ZXC_TOKEN_ML_MASK)) {
                 ml3 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY(d_ptr + ll3 + ml3 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE > d_end))
+                if (UNLIKELY((uint64_t)ll3 + ml3 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE >
+                             (uint64_t)(d_end - d_ptr)))
                     goto rollback_fast_4x;
             }
             ml3 += ZXC_LZ_MIN_MATCH_LEN;
@@ -1049,12 +1071,14 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
             uint32_t ml4 = (tokens >> 24) & 0x0F;
             if (UNLIKELY(ll4 == ZXC_TOKEN_LL_MASK)) {
                 ll4 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY(l_ptr + ll4 > l_end || d_ptr + ll4 + ZXC_PAD_SIZE > d_end))
+                if (UNLIKELY((uint64_t)ll4 > (uint64_t)(l_end - l_ptr) ||
+                             (uint64_t)ll4 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
                     goto rollback_fast_4x;
             }
             if (UNLIKELY(ml4 == ZXC_TOKEN_ML_MASK)) {
                 ml4 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY(d_ptr + ll4 + ml4 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE > d_end))
+                if (UNLIKELY((uint64_t)ll4 + ml4 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE >
+                             (uint64_t)(d_end - d_ptr)))
                     goto rollback_fast_4x;
             }
             ml4 += ZXC_LZ_MIN_MATCH_LEN;
@@ -1100,12 +1124,14 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
             uint32_t ml1 = (tokens & 0x00F);
             if (UNLIKELY(ll1 == ZXC_TOKEN_LL_MASK)) {
                 ll1 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY(l_ptr + ll1 > l_end || d_ptr + ll1 + ZXC_PAD_SIZE > d_end))
+                if (UNLIKELY((uint64_t)ll1 > (uint64_t)(l_end - l_ptr) ||
+                             (uint64_t)ll1 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
             if (UNLIKELY(ml1 == ZXC_TOKEN_ML_MASK)) {
                 ml1 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY(d_ptr + ll1 + ml1 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE > d_end))
+                if (UNLIKELY((uint64_t)ll1 + ml1 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE >
+                             (uint64_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
             ml1 += ZXC_LZ_MIN_MATCH_LEN;
@@ -1115,12 +1141,14 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
             uint32_t ml2 = (tokens & 0x00F00) >> 8;
             if (UNLIKELY(ll2 == ZXC_TOKEN_LL_MASK)) {
                 ll2 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY(l_ptr + ll2 > l_end || d_ptr + ll2 + ZXC_PAD_SIZE > d_end))
+                if (UNLIKELY((uint64_t)ll2 > (uint64_t)(l_end - l_ptr) ||
+                             (uint64_t)ll2 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
             if (UNLIKELY(ml2 == ZXC_TOKEN_ML_MASK)) {
                 ml2 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY(d_ptr + ll2 + ml2 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE > d_end))
+                if (UNLIKELY((uint64_t)ll2 + ml2 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE >
+                             (uint64_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
             ml2 += ZXC_LZ_MIN_MATCH_LEN;
@@ -1130,12 +1158,14 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
             uint32_t ml3 = (tokens & 0x00F0000) >> 16;
             if (UNLIKELY(ll3 == ZXC_TOKEN_LL_MASK)) {
                 ll3 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY(l_ptr + ll3 > l_end || d_ptr + ll3 + ZXC_PAD_SIZE > d_end))
+                if (UNLIKELY((uint64_t)ll3 > (uint64_t)(l_end - l_ptr) ||
+                             (uint64_t)ll3 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
             if (UNLIKELY(ml3 == ZXC_TOKEN_ML_MASK)) {
                 ml3 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY(d_ptr + ll3 + ml3 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE > d_end))
+                if (UNLIKELY((uint64_t)ll3 + ml3 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE >
+                             (uint64_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
             ml3 += ZXC_LZ_MIN_MATCH_LEN;
@@ -1145,12 +1175,14 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
             uint32_t ml4 = (tokens >> 24) & 0x0F;
             if (UNLIKELY(ll4 == ZXC_TOKEN_LL_MASK)) {
                 ll4 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY(l_ptr + ll4 > l_end || d_ptr + ll4 + ZXC_PAD_SIZE > d_end))
+                if (UNLIKELY((uint64_t)ll4 > (uint64_t)(l_end - l_ptr) ||
+                             (uint64_t)ll4 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
             if (UNLIKELY(ml4 == ZXC_TOKEN_ML_MASK)) {
                 ml4 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY(d_ptr + ll4 + ml4 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE > d_end))
+                if (UNLIKELY((uint64_t)ll4 + ml4 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE >
+                             (uint64_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
             ml4 += ZXC_LZ_MIN_MATCH_LEN;
@@ -1194,7 +1226,7 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
         ml += ZXC_LZ_MIN_MATCH_LEN;
 
         // Check bounds before wild copies - if too close to end, fall back to Safe Path
-        if (UNLIKELY(d_ptr + ll + ml + ZXC_PAD_SIZE > d_end)) {
+        if (UNLIKELY((uint64_t)ll + ml + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr))) {
             // Restore pointers and let Safe Path handle this sequence
             t_ptr = t_save;
             o_ptr = o_save;
@@ -1275,13 +1307,14 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
         if (UNLIKELY(ml == ZXC_TOKEN_ML_MASK)) ml += zxc_read_varint(&e_ptr, e_end);
         ml += ZXC_LZ_MIN_MATCH_LEN;
 
-        if (UNLIKELY(d_ptr + ll > d_end || l_ptr + ll > l_end)) return ZXC_ERROR_OVERFLOW;
+        if (UNLIKELY((size_t)(d_end - d_ptr) < ll || (size_t)(l_end - l_ptr) < ll))
+            return ZXC_ERROR_OVERFLOW;
         ZXC_MEMCPY(d_ptr, l_ptr, ll);
         l_ptr += ll;
         d_ptr += ll;
 
         const uint8_t* match_src = d_ptr - offset;
-        if (UNLIKELY(match_src < dst || d_ptr + ml > d_end)) return ZXC_ERROR_BAD_OFFSET;
+        if (UNLIKELY(match_src < dst || (size_t)(d_end - d_ptr) < ml)) return ZXC_ERROR_BAD_OFFSET;
 
         if (offset < ml) {
             for (size_t i = 0; i < ml; i++) d_ptr[i] = match_src[i];
@@ -1409,14 +1442,16 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(zxc_cctx_t* RESTRICT ctx,
             uint32_t ll1 = (uint32_t)(s1 >> 24);
             if (UNLIKELY(ll1 == ZXC_SEQ_LL_MASK)) {
                 ll1 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY(l_ptr + ll1 > l_end || d_ptr + ll1 + ZXC_PAD_SIZE > d_end))
+                if (UNLIKELY((uint64_t)ll1 > (uint64_t)(l_end - l_ptr) ||
+                             (uint64_t)ll1 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
                     goto rollback_safe_4x;
             }
             uint32_t m1b = (uint32_t)((s1 >> 16) & 0xFF);
             uint32_t ml1 = m1b + ZXC_LZ_MIN_MATCH_LEN;
             if (UNLIKELY(m1b == ZXC_SEQ_ML_MASK)) {
                 ml1 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY(d_ptr + ll1 + ml1 + ZXC_PAD_SIZE > d_end)) goto rollback_safe_4x;
+                if (UNLIKELY((uint64_t)ll1 + ml1 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
+                    goto rollback_safe_4x;
             }
             uint32_t off1 = (uint32_t)(s1 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
             DECODE_SEQ_SAFE(ll1, ml1, off1);
@@ -1424,14 +1459,16 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(zxc_cctx_t* RESTRICT ctx,
             uint32_t ll2 = (uint32_t)(s2 >> 24);
             if (UNLIKELY(ll2 == ZXC_SEQ_LL_MASK)) {
                 ll2 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY(l_ptr + ll2 > l_end || d_ptr + ll2 + ZXC_PAD_SIZE > d_end))
+                if (UNLIKELY((uint64_t)ll2 > (uint64_t)(l_end - l_ptr) ||
+                             (uint64_t)ll2 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
                     goto rollback_safe_4x;
             }
             uint32_t m2b = (uint32_t)((s2 >> 16) & 0xFF);
             uint32_t ml2 = m2b + ZXC_LZ_MIN_MATCH_LEN;
             if (UNLIKELY(m2b == ZXC_SEQ_ML_MASK)) {
                 ml2 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY(d_ptr + ll2 + ml2 + ZXC_PAD_SIZE > d_end)) goto rollback_safe_4x;
+                if (UNLIKELY((uint64_t)ll2 + ml2 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
+                    goto rollback_safe_4x;
             }
             uint32_t off2 = (uint32_t)(s2 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
             DECODE_SEQ_SAFE(ll2, ml2, off2);
@@ -1439,14 +1476,16 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(zxc_cctx_t* RESTRICT ctx,
             uint32_t ll3 = (uint32_t)(s3 >> 24);
             if (UNLIKELY(ll3 == ZXC_SEQ_LL_MASK)) {
                 ll3 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY(l_ptr + ll3 > l_end || d_ptr + ll3 + ZXC_PAD_SIZE > d_end))
+                if (UNLIKELY((uint64_t)ll3 > (uint64_t)(l_end - l_ptr) ||
+                             (uint64_t)ll3 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
                     goto rollback_safe_4x;
             }
             uint32_t m3b = (uint32_t)((s3 >> 16) & 0xFF);
             uint32_t ml3 = m3b + ZXC_LZ_MIN_MATCH_LEN;
             if (UNLIKELY(m3b == ZXC_SEQ_ML_MASK)) {
                 ml3 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY(d_ptr + ll3 + ml3 + ZXC_PAD_SIZE > d_end)) goto rollback_safe_4x;
+                if (UNLIKELY((uint64_t)ll3 + ml3 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
+                    goto rollback_safe_4x;
             }
             uint32_t off3 = (uint32_t)(s3 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
             DECODE_SEQ_SAFE(ll3, ml3, off3);
@@ -1454,14 +1493,16 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(zxc_cctx_t* RESTRICT ctx,
             uint32_t ll4 = (uint32_t)(s4 >> 24);
             if (UNLIKELY(ll4 == ZXC_SEQ_LL_MASK)) {
                 ll4 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY(l_ptr + ll4 > l_end || d_ptr + ll4 + ZXC_PAD_SIZE > d_end))
+                if (UNLIKELY((uint64_t)ll4 > (uint64_t)(l_end - l_ptr) ||
+                             (uint64_t)ll4 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
                     goto rollback_safe_4x;
             }
             uint32_t m4b = (uint32_t)((s4 >> 16) & 0xFF);
             uint32_t ml4 = m4b + ZXC_LZ_MIN_MATCH_LEN;
             if (UNLIKELY(m4b == ZXC_SEQ_ML_MASK)) {
                 ml4 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY(d_ptr + ll4 + ml4 + ZXC_PAD_SIZE > d_end)) goto rollback_safe_4x;
+                if (UNLIKELY((uint64_t)ll4 + ml4 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
+                    goto rollback_safe_4x;
             }
             uint32_t off4 = (uint32_t)(s4 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
             DECODE_SEQ_SAFE(ll4, ml4, off4);
@@ -1489,14 +1530,16 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(zxc_cctx_t* RESTRICT ctx,
             uint32_t ll1 = (uint32_t)(s1 >> 24);
             if (UNLIKELY(ll1 == ZXC_SEQ_LL_MASK)) {
                 ll1 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY(l_ptr + ll1 > l_end || d_ptr + ll1 + ZXC_PAD_SIZE > d_end))
+                if (UNLIKELY((uint64_t)ll1 > (uint64_t)(l_end - l_ptr) ||
+                             (uint64_t)ll1 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
             uint32_t m1b = (uint32_t)((s1 >> 16) & 0xFF);
             uint32_t ml1 = m1b + ZXC_LZ_MIN_MATCH_LEN;
             if (UNLIKELY(m1b == ZXC_SEQ_ML_MASK)) {
                 ml1 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY(d_ptr + ll1 + ml1 + ZXC_PAD_SIZE > d_end)) return ZXC_ERROR_OVERFLOW;
+                if (UNLIKELY((uint64_t)ll1 + ml1 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
+                    return ZXC_ERROR_OVERFLOW;
             }
             uint32_t off1 = (uint32_t)(s1 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
             DECODE_SEQ_SAFE(ll1, ml1, off1);
@@ -1504,14 +1547,16 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(zxc_cctx_t* RESTRICT ctx,
             uint32_t ll2 = (uint32_t)(s2 >> 24);
             if (UNLIKELY(ll2 == ZXC_SEQ_LL_MASK)) {
                 ll2 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY(l_ptr + ll2 > l_end || d_ptr + ll2 + ZXC_PAD_SIZE > d_end))
+                if (UNLIKELY((uint64_t)ll2 > (uint64_t)(l_end - l_ptr) ||
+                             (uint64_t)ll2 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
             uint32_t m2b = (uint32_t)((s2 >> 16) & 0xFF);
             uint32_t ml2 = m2b + ZXC_LZ_MIN_MATCH_LEN;
             if (UNLIKELY(m2b == ZXC_SEQ_ML_MASK)) {
                 ml2 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY(d_ptr + ll2 + ml2 + ZXC_PAD_SIZE > d_end)) return ZXC_ERROR_OVERFLOW;
+                if (UNLIKELY((uint64_t)ll2 + ml2 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
+                    return ZXC_ERROR_OVERFLOW;
             }
             uint32_t off2 = (uint32_t)(s2 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
             DECODE_SEQ_SAFE(ll2, ml2, off2);
@@ -1519,14 +1564,16 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(zxc_cctx_t* RESTRICT ctx,
             uint32_t ll3 = (uint32_t)(s3 >> 24);
             if (UNLIKELY(ll3 == ZXC_SEQ_LL_MASK)) {
                 ll3 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY(l_ptr + ll3 > l_end || d_ptr + ll3 + ZXC_PAD_SIZE > d_end))
+                if (UNLIKELY((uint64_t)ll3 > (uint64_t)(l_end - l_ptr) ||
+                             (uint64_t)ll3 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
             uint32_t m3b = (uint32_t)((s3 >> 16) & 0xFF);
             uint32_t ml3 = m3b + ZXC_LZ_MIN_MATCH_LEN;
             if (UNLIKELY(m3b == ZXC_SEQ_ML_MASK)) {
                 ml3 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY(d_ptr + ll3 + ml3 + ZXC_PAD_SIZE > d_end)) return ZXC_ERROR_OVERFLOW;
+                if (UNLIKELY((uint64_t)ll3 + ml3 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
+                    return ZXC_ERROR_OVERFLOW;
             }
             uint32_t off3 = (uint32_t)(s3 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
             DECODE_SEQ_SAFE(ll3, ml3, off3);
@@ -1534,14 +1581,16 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(zxc_cctx_t* RESTRICT ctx,
             uint32_t ll4 = (uint32_t)(s4 >> 24);
             if (UNLIKELY(ll4 == ZXC_SEQ_LL_MASK)) {
                 ll4 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY(l_ptr + ll4 > l_end || d_ptr + ll4 + ZXC_PAD_SIZE > d_end))
+                if (UNLIKELY((uint64_t)ll4 > (uint64_t)(l_end - l_ptr) ||
+                             (uint64_t)ll4 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
             uint32_t m4b = (uint32_t)((s4 >> 16) & 0xFF);
             uint32_t ml4 = m4b + ZXC_LZ_MIN_MATCH_LEN;
             if (UNLIKELY(m4b == ZXC_SEQ_ML_MASK)) {
                 ml4 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY(d_ptr + ll4 + ml4 + ZXC_PAD_SIZE > d_end)) return ZXC_ERROR_OVERFLOW;
+                if (UNLIKELY((uint64_t)ll4 + ml4 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
+                    return ZXC_ERROR_OVERFLOW;
             }
             uint32_t off4 = (uint32_t)(s4 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
             DECODE_SEQ_SAFE(ll4, ml4, off4);
@@ -1566,7 +1615,8 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(zxc_cctx_t* RESTRICT ctx,
 
         // Strict bounds check: sequence must fit, AND wild copies must not overshoot
         // Check both destination (d_ptr) and source literal stream (l_ptr)
-        if (UNLIKELY(d_ptr + ll + ml + ZXC_PAD_SIZE > d_end || l_ptr + ll + ZXC_PAD_SIZE > l_end)) {
+        if (UNLIKELY((uint64_t)ll + ml + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr) ||
+                     (uint64_t)ll + ZXC_PAD_SIZE > (uint64_t)(l_end - l_ptr))) {
             // Fallback to exact copy (slow but safe)
             if (UNLIKELY(d_ptr + ll > d_end || l_ptr + ll > l_end)) return ZXC_ERROR_OVERFLOW;
             ZXC_MEMCPY(d_ptr, l_ptr, ll);
@@ -1610,14 +1660,16 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(zxc_cctx_t* RESTRICT ctx,
             uint32_t ll1 = (uint32_t)(s1 >> 24);
             if (UNLIKELY(ll1 == ZXC_SEQ_LL_MASK)) {
                 ll1 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY(l_ptr + ll1 > l_end || d_ptr + ll1 + ZXC_PAD_SIZE > d_end))
+                if (UNLIKELY((uint64_t)ll1 > (uint64_t)(l_end - l_ptr) ||
+                             (uint64_t)ll1 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
                     goto rollback_fast_4x;
             }
             uint32_t m1b = (uint32_t)((s1 >> 16) & 0xFF);
             uint32_t ml1 = m1b + ZXC_LZ_MIN_MATCH_LEN;
             if (UNLIKELY(m1b == ZXC_SEQ_ML_MASK)) {
                 ml1 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY(d_ptr + ll1 + ml1 + ZXC_PAD_SIZE > d_end)) goto rollback_fast_4x;
+                if (UNLIKELY((uint64_t)ll1 + ml1 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
+                    goto rollback_fast_4x;
             }
             uint32_t off1 = (uint32_t)(s1 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
             DECODE_SEQ_FAST(ll1, ml1, off1);
@@ -1625,14 +1677,16 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(zxc_cctx_t* RESTRICT ctx,
             uint32_t ll2 = (uint32_t)(s2 >> 24);
             if (UNLIKELY(ll2 == ZXC_SEQ_LL_MASK)) {
                 ll2 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY(l_ptr + ll2 > l_end || d_ptr + ll2 + ZXC_PAD_SIZE > d_end))
+                if (UNLIKELY((uint64_t)ll2 > (uint64_t)(l_end - l_ptr) ||
+                             (uint64_t)ll2 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
                     goto rollback_fast_4x;
             }
             uint32_t m2b = (uint32_t)((s2 >> 16) & 0xFF);
             uint32_t ml2 = m2b + ZXC_LZ_MIN_MATCH_LEN;
             if (UNLIKELY(m2b == ZXC_SEQ_ML_MASK)) {
                 ml2 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY(d_ptr + ll2 + ml2 + ZXC_PAD_SIZE > d_end)) goto rollback_fast_4x;
+                if (UNLIKELY((uint64_t)ll2 + ml2 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
+                    goto rollback_fast_4x;
             }
             uint32_t off2 = (uint32_t)(s2 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
             DECODE_SEQ_FAST(ll2, ml2, off2);
@@ -1640,14 +1694,16 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(zxc_cctx_t* RESTRICT ctx,
             uint32_t ll3 = (uint32_t)(s3 >> 24);
             if (UNLIKELY(ll3 == ZXC_SEQ_LL_MASK)) {
                 ll3 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY(l_ptr + ll3 > l_end || d_ptr + ll3 + ZXC_PAD_SIZE > d_end))
+                if (UNLIKELY((uint64_t)ll3 > (uint64_t)(l_end - l_ptr) ||
+                             (uint64_t)ll3 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
                     goto rollback_fast_4x;
             }
             uint32_t m3b = (uint32_t)((s3 >> 16) & 0xFF);
             uint32_t ml3 = m3b + ZXC_LZ_MIN_MATCH_LEN;
             if (UNLIKELY(m3b == ZXC_SEQ_ML_MASK)) {
                 ml3 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY(d_ptr + ll3 + ml3 + ZXC_PAD_SIZE > d_end)) goto rollback_fast_4x;
+                if (UNLIKELY((uint64_t)ll3 + ml3 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
+                    goto rollback_fast_4x;
             }
             uint32_t off3 = (uint32_t)(s3 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
             DECODE_SEQ_FAST(ll3, ml3, off3);
@@ -1655,14 +1711,16 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(zxc_cctx_t* RESTRICT ctx,
             uint32_t ll4 = (uint32_t)(s4 >> 24);
             if (UNLIKELY(ll4 == ZXC_SEQ_LL_MASK)) {
                 ll4 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY(l_ptr + ll4 > l_end || d_ptr + ll4 + ZXC_PAD_SIZE > d_end))
+                if (UNLIKELY((uint64_t)ll4 > (uint64_t)(l_end - l_ptr) ||
+                             (uint64_t)ll4 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
                     goto rollback_fast_4x;
             }
             uint32_t m4b = (uint32_t)((s4 >> 16) & 0xFF);
             uint32_t ml4 = m4b + ZXC_LZ_MIN_MATCH_LEN;
             if (UNLIKELY(m4b == ZXC_SEQ_ML_MASK)) {
                 ml4 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY(d_ptr + ll4 + ml4 + ZXC_PAD_SIZE > d_end)) goto rollback_fast_4x;
+                if (UNLIKELY((uint64_t)ll4 + ml4 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
+                    goto rollback_fast_4x;
             }
             uint32_t off4 = (uint32_t)(s4 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
             DECODE_SEQ_FAST(ll4, ml4, off4);
@@ -1691,14 +1749,16 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(zxc_cctx_t* RESTRICT ctx,
             uint32_t ll1 = (uint32_t)(s1 >> 24);
             if (UNLIKELY(ll1 == ZXC_SEQ_LL_MASK)) {
                 ll1 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY(l_ptr + ll1 > l_end || d_ptr + ll1 + ZXC_PAD_SIZE > d_end))
+                if (UNLIKELY((uint64_t)ll1 > (uint64_t)(l_end - l_ptr) ||
+                             (uint64_t)ll1 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
             uint32_t m1b = (uint32_t)((s1 >> 16) & 0xFF);
             uint32_t ml1 = m1b + ZXC_LZ_MIN_MATCH_LEN;
             if (UNLIKELY(m1b == ZXC_SEQ_ML_MASK)) {
                 ml1 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY(d_ptr + ll1 + ml1 + ZXC_PAD_SIZE > d_end)) return ZXC_ERROR_OVERFLOW;
+                if (UNLIKELY((uint64_t)ll1 + ml1 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
+                    return ZXC_ERROR_OVERFLOW;
             }
             uint32_t off1 = (uint32_t)(s1 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
             DECODE_SEQ_FAST(ll1, ml1, off1);
@@ -1706,14 +1766,16 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(zxc_cctx_t* RESTRICT ctx,
             uint32_t ll2 = (uint32_t)(s2 >> 24);
             if (UNLIKELY(ll2 == ZXC_SEQ_LL_MASK)) {
                 ll2 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY(l_ptr + ll2 > l_end || d_ptr + ll2 + ZXC_PAD_SIZE > d_end))
+                if (UNLIKELY((uint64_t)ll2 > (uint64_t)(l_end - l_ptr) ||
+                             (uint64_t)ll2 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
             uint32_t m2b = (uint32_t)((s2 >> 16) & 0xFF);
             uint32_t ml2 = m2b + ZXC_LZ_MIN_MATCH_LEN;
             if (UNLIKELY(m2b == ZXC_SEQ_ML_MASK)) {
                 ml2 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY(d_ptr + ll2 + ml2 + ZXC_PAD_SIZE > d_end)) return ZXC_ERROR_OVERFLOW;
+                if (UNLIKELY((uint64_t)ll2 + ml2 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
+                    return ZXC_ERROR_OVERFLOW;
             }
             uint32_t off2 = (uint32_t)(s2 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
             DECODE_SEQ_FAST(ll2, ml2, off2);
@@ -1721,14 +1783,16 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(zxc_cctx_t* RESTRICT ctx,
             uint32_t ll3 = (uint32_t)(s3 >> 24);
             if (UNLIKELY(ll3 == ZXC_SEQ_LL_MASK)) {
                 ll3 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY(l_ptr + ll3 > l_end || d_ptr + ll3 + ZXC_PAD_SIZE > d_end))
+                if (UNLIKELY((uint64_t)ll3 > (uint64_t)(l_end - l_ptr) ||
+                             (uint64_t)ll3 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
             uint32_t m3b = (uint32_t)((s3 >> 16) & 0xFF);
             uint32_t ml3 = m3b + ZXC_LZ_MIN_MATCH_LEN;
             if (UNLIKELY(m3b == ZXC_SEQ_ML_MASK)) {
                 ml3 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY(d_ptr + ll3 + ml3 + ZXC_PAD_SIZE > d_end)) return ZXC_ERROR_OVERFLOW;
+                if (UNLIKELY((uint64_t)ll3 + ml3 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
+                    return ZXC_ERROR_OVERFLOW;
             }
             uint32_t off3 = (uint32_t)(s3 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
             DECODE_SEQ_FAST(ll3, ml3, off3);
@@ -1736,14 +1800,16 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(zxc_cctx_t* RESTRICT ctx,
             uint32_t ll4 = (uint32_t)(s4 >> 24);
             if (UNLIKELY(ll4 == ZXC_SEQ_LL_MASK)) {
                 ll4 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY(l_ptr + ll4 > l_end || d_ptr + ll4 + ZXC_PAD_SIZE > d_end))
+                if (UNLIKELY((uint64_t)ll4 > (uint64_t)(l_end - l_ptr) ||
+                             (uint64_t)ll4 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
             uint32_t m4b = (uint32_t)((s4 >> 16) & 0xFF);
             uint32_t ml4 = m4b + ZXC_LZ_MIN_MATCH_LEN;
             if (UNLIKELY(m4b == ZXC_SEQ_ML_MASK)) {
                 ml4 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY(d_ptr + ll4 + ml4 + ZXC_PAD_SIZE > d_end)) return ZXC_ERROR_OVERFLOW;
+                if (UNLIKELY((uint64_t)ll4 + ml4 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
+                    return ZXC_ERROR_OVERFLOW;
             }
             uint32_t off4 = (uint32_t)(s4 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
             DECODE_SEQ_FAST(ll4, ml4, off4);
@@ -1776,7 +1842,7 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(zxc_cctx_t* RESTRICT ctx,
         if (UNLIKELY(m_bits == ZXC_SEQ_ML_MASK)) ml += zxc_read_varint(&extras_ptr, extras_end);
 
         // Strict bounds checks (including wild copy overrun safety)
-        if (UNLIKELY(d_ptr + ll + ml + ZXC_PAD_SIZE > d_end)) {
+        if (UNLIKELY((uint64_t)ll + ml + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr))) {
             // Restore state and break to Safe Path
             seq_ptr = seq_save;
             extras_ptr = ext_save;
@@ -1853,13 +1919,14 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(zxc_cctx_t* RESTRICT ctx,
         if (UNLIKELY(m_bits == ZXC_SEQ_ML_MASK)) ml += zxc_read_varint(&extras_ptr, extras_end);
         uint32_t offset = (uint32_t)(seq & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
 
-        if (UNLIKELY(d_ptr + ll > d_end || l_ptr + ll > l_end)) return ZXC_ERROR_OVERFLOW;
+        if (UNLIKELY((size_t)(d_end - d_ptr) < ll || (size_t)(l_end - l_ptr) < ll))
+            return ZXC_ERROR_OVERFLOW;
         ZXC_MEMCPY(d_ptr, l_ptr, ll);
         l_ptr += ll;
         d_ptr += ll;
 
         const uint8_t* match_src = d_ptr - offset;
-        if (UNLIKELY(match_src < dst || d_ptr + ml > d_end)) return ZXC_ERROR_BAD_OFFSET;
+        if (UNLIKELY(match_src < dst || (size_t)(d_end - d_ptr) < ml)) return ZXC_ERROR_BAD_OFFSET;
 
         if (offset < ml) {
             for (size_t i = 0; i < ml; i++) d_ptr[i] = match_src[i];

--- a/src/lib/zxc_decompress.c
+++ b/src/lib/zxc_decompress.c
@@ -791,6 +791,10 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
             uint32_t tokens = zxc_le32(t_ptr);
             t_ptr += 4;
 
+            const uint32_t lit_reserve_1 = (tokens >> 28);
+            const uint32_t lit_reserve_2 = lit_reserve_1 + ((tokens >> 20) & 0xF);
+            const uint32_t lit_reserve_3 = lit_reserve_2 + ((tokens >> 12) & 0xF);
+
             uint32_t off1 = ZXC_LZ_OFFSET_BIAS, off2 = ZXC_LZ_OFFSET_BIAS,
                      off3 = ZXC_LZ_OFFSET_BIAS, off4 = ZXC_LZ_OFFSET_BIAS;
             if (gh.enc_off == 1) {
@@ -813,7 +817,7 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
             uint32_t ml1 = (tokens & 0x00F);
             if (UNLIKELY(ll1 == ZXC_TOKEN_LL_MASK)) {
                 ll1 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY((uint64_t)ll1 > (uint64_t)(l_end - l_ptr) ||
+                if (UNLIKELY((uint64_t)ll1 + lit_reserve_3 > (uint64_t)(l_end - l_ptr) ||
                              (uint64_t)ll1 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
                     goto rollback_safe_4x;
             }
@@ -830,7 +834,7 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
             uint32_t ml2 = (tokens & 0x00F00) >> 8;
             if (UNLIKELY(ll2 == ZXC_TOKEN_LL_MASK)) {
                 ll2 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY((uint64_t)ll2 > (uint64_t)(l_end - l_ptr) ||
+                if (UNLIKELY((uint64_t)ll2 + lit_reserve_2 > (uint64_t)(l_end - l_ptr) ||
                              (uint64_t)ll2 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
                     goto rollback_safe_4x;
             }
@@ -847,7 +851,7 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
             uint32_t ml3 = (tokens & 0x00F0000) >> 16;
             if (UNLIKELY(ll3 == ZXC_TOKEN_LL_MASK)) {
                 ll3 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY((uint64_t)ll3 > (uint64_t)(l_end - l_ptr) ||
+                if (UNLIKELY((uint64_t)ll3 + lit_reserve_1 > (uint64_t)(l_end - l_ptr) ||
                              (uint64_t)ll3 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
                     goto rollback_safe_4x;
             }
@@ -895,6 +899,10 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
             uint32_t tokens = zxc_le32(t_ptr);
             t_ptr += 4;
 
+            const uint32_t lit_reserve_1 = (tokens >> 28);
+            const uint32_t lit_reserve_2 = lit_reserve_1 + ((tokens >> 20) & 0xF);
+            const uint32_t lit_reserve_3 = lit_reserve_2 + ((tokens >> 12) & 0xF);
+
             uint32_t off1 = ZXC_LZ_OFFSET_BIAS, off2 = ZXC_LZ_OFFSET_BIAS,
                      off3 = ZXC_LZ_OFFSET_BIAS, off4 = ZXC_LZ_OFFSET_BIAS;
             if (gh.enc_off == 1) {
@@ -919,7 +927,7 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
             uint32_t ml1 = (tokens & 0x00F);
             if (UNLIKELY(ll1 == ZXC_TOKEN_LL_MASK)) {
                 ll1 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY((uint64_t)ll1 > (uint64_t)(l_end - l_ptr) ||
+                if (UNLIKELY((uint64_t)ll1 + lit_reserve_3 > (uint64_t)(l_end - l_ptr) ||
                              (uint64_t)ll1 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
@@ -936,7 +944,7 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
             uint32_t ml2 = (tokens & 0x00F00) >> 8;
             if (UNLIKELY(ll2 == ZXC_TOKEN_LL_MASK)) {
                 ll2 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY((uint64_t)ll2 > (uint64_t)(l_end - l_ptr) ||
+                if (UNLIKELY((uint64_t)ll2 + lit_reserve_2 > (uint64_t)(l_end - l_ptr) ||
                              (uint64_t)ll2 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
@@ -953,7 +961,7 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
             uint32_t ml3 = (tokens & 0x00F0000) >> 16;
             if (UNLIKELY(ll3 == ZXC_TOKEN_LL_MASK)) {
                 ll3 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY((uint64_t)ll3 > (uint64_t)(l_end - l_ptr) ||
+                if (UNLIKELY((uint64_t)ll3 + lit_reserve_1 > (uint64_t)(l_end - l_ptr) ||
                              (uint64_t)ll3 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
@@ -998,6 +1006,10 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
             uint32_t tokens = zxc_le32(t_ptr);
             t_ptr += 4;
 
+            const uint32_t lit_reserve_1 = (tokens >> 28);
+            const uint32_t lit_reserve_2 = lit_reserve_1 + ((tokens >> 20) & 0xF);
+            const uint32_t lit_reserve_3 = lit_reserve_2 + ((tokens >> 12) & 0xF);
+
             uint32_t off1 = ZXC_LZ_OFFSET_BIAS, off2 = ZXC_LZ_OFFSET_BIAS,
                      off3 = ZXC_LZ_OFFSET_BIAS, off4 = ZXC_LZ_OFFSET_BIAS;
             if (gh.enc_off == 1) {
@@ -1020,7 +1032,7 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
             uint32_t ml1 = (tokens & 0x00F);
             if (UNLIKELY(ll1 == ZXC_TOKEN_LL_MASK)) {
                 ll1 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY((uint64_t)ll1 > (uint64_t)(l_end - l_ptr) ||
+                if (UNLIKELY((uint64_t)ll1 + lit_reserve_3 > (uint64_t)(l_end - l_ptr) ||
                              (uint64_t)ll1 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
                     goto rollback_fast_4x;
             }
@@ -1037,7 +1049,7 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
             uint32_t ml2 = (tokens & 0x00F00) >> 8;
             if (UNLIKELY(ll2 == ZXC_TOKEN_LL_MASK)) {
                 ll2 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY((uint64_t)ll2 > (uint64_t)(l_end - l_ptr) ||
+                if (UNLIKELY((uint64_t)ll2 + lit_reserve_2 > (uint64_t)(l_end - l_ptr) ||
                              (uint64_t)ll2 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
                     goto rollback_fast_4x;
             }
@@ -1054,7 +1066,7 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
             uint32_t ml3 = (tokens & 0x00F0000) >> 16;
             if (UNLIKELY(ll3 == ZXC_TOKEN_LL_MASK)) {
                 ll3 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY((uint64_t)ll3 > (uint64_t)(l_end - l_ptr) ||
+                if (UNLIKELY((uint64_t)ll3 + lit_reserve_1 > (uint64_t)(l_end - l_ptr) ||
                              (uint64_t)ll3 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
                     goto rollback_fast_4x;
             }
@@ -1100,6 +1112,10 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
             uint32_t tokens = zxc_le32(t_ptr);
             t_ptr += 4;
 
+            const uint32_t lit_reserve_1 = (tokens >> 28);
+            const uint32_t lit_reserve_2 = lit_reserve_1 + ((tokens >> 20) & 0xF);
+            const uint32_t lit_reserve_3 = lit_reserve_2 + ((tokens >> 12) & 0xF);
+
             uint32_t off1 = ZXC_LZ_OFFSET_BIAS, off2 = ZXC_LZ_OFFSET_BIAS,
                      off3 = ZXC_LZ_OFFSET_BIAS, off4 = ZXC_LZ_OFFSET_BIAS;
             if (gh.enc_off == 1) {
@@ -1124,7 +1140,7 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
             uint32_t ml1 = (tokens & 0x00F);
             if (UNLIKELY(ll1 == ZXC_TOKEN_LL_MASK)) {
                 ll1 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY((uint64_t)ll1 > (uint64_t)(l_end - l_ptr) ||
+                if (UNLIKELY((uint64_t)ll1 + lit_reserve_3 > (uint64_t)(l_end - l_ptr) ||
                              (uint64_t)ll1 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
@@ -1141,7 +1157,7 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
             uint32_t ml2 = (tokens & 0x00F00) >> 8;
             if (UNLIKELY(ll2 == ZXC_TOKEN_LL_MASK)) {
                 ll2 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY((uint64_t)ll2 > (uint64_t)(l_end - l_ptr) ||
+                if (UNLIKELY((uint64_t)ll2 + lit_reserve_2 > (uint64_t)(l_end - l_ptr) ||
                              (uint64_t)ll2 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
@@ -1158,7 +1174,7 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
             uint32_t ml3 = (tokens & 0x00F0000) >> 16;
             if (UNLIKELY(ll3 == ZXC_TOKEN_LL_MASK)) {
                 ll3 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY((uint64_t)ll3 > (uint64_t)(l_end - l_ptr) ||
+                if (UNLIKELY((uint64_t)ll3 + lit_reserve_1 > (uint64_t)(l_end - l_ptr) ||
                              (uint64_t)ll3 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
@@ -1439,10 +1455,14 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(zxc_cctx_t* RESTRICT ctx,
             uint32_t s4 = zxc_le32(seq_ptr + 12);
             seq_ptr += 16;
 
+            const uint32_t lit_reserve_1 = (s4 >> 24);
+            const uint32_t lit_reserve_2 = lit_reserve_1 + (s3 >> 24);
+            const uint32_t lit_reserve_3 = lit_reserve_2 + (s2 >> 24);
+
             uint32_t ll1 = (uint32_t)(s1 >> 24);
             if (UNLIKELY(ll1 == ZXC_SEQ_LL_MASK)) {
                 ll1 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY((uint64_t)ll1 > (uint64_t)(l_end - l_ptr) ||
+                if (UNLIKELY((uint64_t)ll1 + lit_reserve_3 > (uint64_t)(l_end - l_ptr) ||
                              (uint64_t)ll1 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
                     goto rollback_safe_4x;
             }
@@ -1459,7 +1479,7 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(zxc_cctx_t* RESTRICT ctx,
             uint32_t ll2 = (uint32_t)(s2 >> 24);
             if (UNLIKELY(ll2 == ZXC_SEQ_LL_MASK)) {
                 ll2 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY((uint64_t)ll2 > (uint64_t)(l_end - l_ptr) ||
+                if (UNLIKELY((uint64_t)ll2 + lit_reserve_2 > (uint64_t)(l_end - l_ptr) ||
                              (uint64_t)ll2 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
                     goto rollback_safe_4x;
             }
@@ -1476,7 +1496,7 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(zxc_cctx_t* RESTRICT ctx,
             uint32_t ll3 = (uint32_t)(s3 >> 24);
             if (UNLIKELY(ll3 == ZXC_SEQ_LL_MASK)) {
                 ll3 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY((uint64_t)ll3 > (uint64_t)(l_end - l_ptr) ||
+                if (UNLIKELY((uint64_t)ll3 + lit_reserve_1 > (uint64_t)(l_end - l_ptr) ||
                              (uint64_t)ll3 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
                     goto rollback_safe_4x;
             }
@@ -1527,10 +1547,14 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(zxc_cctx_t* RESTRICT ctx,
             uint32_t s4 = zxc_le32(seq_ptr + 12);
             seq_ptr += 16;
 
+            const uint32_t lit_reserve_1 = (s4 >> 24);
+            const uint32_t lit_reserve_2 = lit_reserve_1 + (s3 >> 24);
+            const uint32_t lit_reserve_3 = lit_reserve_2 + (s2 >> 24);
+
             uint32_t ll1 = (uint32_t)(s1 >> 24);
             if (UNLIKELY(ll1 == ZXC_SEQ_LL_MASK)) {
                 ll1 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY((uint64_t)ll1 > (uint64_t)(l_end - l_ptr) ||
+                if (UNLIKELY((uint64_t)ll1 + lit_reserve_3 > (uint64_t)(l_end - l_ptr) ||
                              (uint64_t)ll1 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
@@ -1547,7 +1571,7 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(zxc_cctx_t* RESTRICT ctx,
             uint32_t ll2 = (uint32_t)(s2 >> 24);
             if (UNLIKELY(ll2 == ZXC_SEQ_LL_MASK)) {
                 ll2 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY((uint64_t)ll2 > (uint64_t)(l_end - l_ptr) ||
+                if (UNLIKELY((uint64_t)ll2 + lit_reserve_2 > (uint64_t)(l_end - l_ptr) ||
                              (uint64_t)ll2 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
@@ -1564,7 +1588,7 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(zxc_cctx_t* RESTRICT ctx,
             uint32_t ll3 = (uint32_t)(s3 >> 24);
             if (UNLIKELY(ll3 == ZXC_SEQ_LL_MASK)) {
                 ll3 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY((uint64_t)ll3 > (uint64_t)(l_end - l_ptr) ||
+                if (UNLIKELY((uint64_t)ll3 + lit_reserve_1 > (uint64_t)(l_end - l_ptr) ||
                              (uint64_t)ll3 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
@@ -1654,13 +1678,17 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(zxc_cctx_t* RESTRICT ctx,
             uint32_t s4 = zxc_le32(seq_ptr + 12);
             seq_ptr += 16;
 
+            const uint32_t lit_reserve_1 = (s4 >> 24);
+            const uint32_t lit_reserve_2 = lit_reserve_1 + (s3 >> 24);
+            const uint32_t lit_reserve_3 = lit_reserve_2 + (s2 >> 24);
+
             // Prefetch ahead in literal and extras streams to hide memory latency
             ZXC_PREFETCH_READ(l_ptr + ZXC_CACHE_LINE_SIZE);
 
             uint32_t ll1 = (uint32_t)(s1 >> 24);
             if (UNLIKELY(ll1 == ZXC_SEQ_LL_MASK)) {
                 ll1 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY((uint64_t)ll1 > (uint64_t)(l_end - l_ptr) ||
+                if (UNLIKELY((uint64_t)ll1 + lit_reserve_3 > (uint64_t)(l_end - l_ptr) ||
                              (uint64_t)ll1 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
                     goto rollback_fast_4x;
             }
@@ -1677,7 +1705,7 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(zxc_cctx_t* RESTRICT ctx,
             uint32_t ll2 = (uint32_t)(s2 >> 24);
             if (UNLIKELY(ll2 == ZXC_SEQ_LL_MASK)) {
                 ll2 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY((uint64_t)ll2 > (uint64_t)(l_end - l_ptr) ||
+                if (UNLIKELY((uint64_t)ll2 + lit_reserve_2 > (uint64_t)(l_end - l_ptr) ||
                              (uint64_t)ll2 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
                     goto rollback_fast_4x;
             }
@@ -1694,7 +1722,7 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(zxc_cctx_t* RESTRICT ctx,
             uint32_t ll3 = (uint32_t)(s3 >> 24);
             if (UNLIKELY(ll3 == ZXC_SEQ_LL_MASK)) {
                 ll3 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY((uint64_t)ll3 > (uint64_t)(l_end - l_ptr) ||
+                if (UNLIKELY((uint64_t)ll3 + lit_reserve_1 > (uint64_t)(l_end - l_ptr) ||
                              (uint64_t)ll3 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
                     goto rollback_fast_4x;
             }
@@ -1743,13 +1771,17 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(zxc_cctx_t* RESTRICT ctx,
             uint32_t s4 = zxc_le32(seq_ptr + 12);
             seq_ptr += 16;
 
+            const uint32_t lit_reserve_1 = (s4 >> 24);
+            const uint32_t lit_reserve_2 = lit_reserve_1 + (s3 >> 24);
+            const uint32_t lit_reserve_3 = lit_reserve_2 + (s2 >> 24);
+
             // Prefetch ahead in literal and extras streams to hide memory latency
             ZXC_PREFETCH_READ(l_ptr + ZXC_CACHE_LINE_SIZE);
 
             uint32_t ll1 = (uint32_t)(s1 >> 24);
             if (UNLIKELY(ll1 == ZXC_SEQ_LL_MASK)) {
                 ll1 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY((uint64_t)ll1 > (uint64_t)(l_end - l_ptr) ||
+                if (UNLIKELY((uint64_t)ll1 + lit_reserve_3 > (uint64_t)(l_end - l_ptr) ||
                              (uint64_t)ll1 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
@@ -1766,7 +1798,7 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(zxc_cctx_t* RESTRICT ctx,
             uint32_t ll2 = (uint32_t)(s2 >> 24);
             if (UNLIKELY(ll2 == ZXC_SEQ_LL_MASK)) {
                 ll2 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY((uint64_t)ll2 > (uint64_t)(l_end - l_ptr) ||
+                if (UNLIKELY((uint64_t)ll2 + lit_reserve_2 > (uint64_t)(l_end - l_ptr) ||
                              (uint64_t)ll2 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
@@ -1783,7 +1815,7 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(zxc_cctx_t* RESTRICT ctx,
             uint32_t ll3 = (uint32_t)(s3 >> 24);
             if (UNLIKELY(ll3 == ZXC_SEQ_LL_MASK)) {
                 ll3 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY((uint64_t)ll3 > (uint64_t)(l_end - l_ptr) ||
+                if (UNLIKELY((uint64_t)ll3 + lit_reserve_1 > (uint64_t)(l_end - l_ptr) ||
                              (uint64_t)ll3 + ZXC_PAD_SIZE > (uint64_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }

--- a/src/lib/zxc_decompress.c
+++ b/src/lib/zxc_decompress.c
@@ -119,7 +119,7 @@ static ZXC_ALWAYS_INLINE uint32_t zxc_read_varint(const uint8_t** ptr, const uin
         return (b0 & 0x1F) | ((uint32_t)p[1] << 5) | ((uint32_t)p[2] << 13);
     }
 
-    // 4- or 5-byte encoding: out-of-spec for the current format, reject.
+    // extra encoding: out-of-spec for the current format, reject.
     *ptr = end;
     return 0;
 }

--- a/src/lib/zxc_decompress.c
+++ b/src/lib/zxc_decompress.c
@@ -670,7 +670,7 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
                     // Raw copy (most common path): use ZXC_PAD_SIZE-byte wild copies
                     // token is 7-bit (0-127), so len is 1-128 bytes
                     const uint32_t len = (uint32_t)token + 1;
-                    if (UNLIKELY(w_ptr + len > w_end || r_ptr + len > r_end))
+                    if (UNLIKELY((size_t)(w_end - w_ptr) < len || (size_t)(r_end - r_ptr) < len))
                         return ZXC_ERROR_CORRUPT_DATA;
 
                     // Destination has ZXC_PAD_SIZE bytes of safe overrun space.
@@ -704,7 +704,7 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
                 } else {
                     // RLE run: fill with single byte
                     const uint32_t len = (token & ZXC_LIT_LEN_MASK) + 4;
-                    if (UNLIKELY(w_ptr + len > w_end || r_ptr >= r_end))
+                    if (UNLIKELY((size_t)(w_end - w_ptr) < len || r_ptr >= r_end))
                         return ZXC_ERROR_CORRUPT_DATA;
                     ZXC_MEMSET(w_ptr, *r_ptr++, len);
                     w_ptr += len;

--- a/src/lib/zxc_decompress.c
+++ b/src/lib/zxc_decompress.c
@@ -1557,7 +1557,7 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(zxc_cctx_t* RESTRICT ctx,
             break;
         }
     } else {
-        while (n_seq >= 4 && d_ptr < d_end_safe && l_ptr < l_end_safe_4x &&
+        while (n_seq >= 4 && d_ptr < d_end_fast && l_ptr < l_end_safe_4x &&
                written < bounds_threshold) {
             uint32_t s1 = zxc_le32(seq_ptr);
             uint32_t s2 = zxc_le32(seq_ptr + sizeof(uint32_t));
@@ -1900,7 +1900,8 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(zxc_cctx_t* RESTRICT ctx,
         if (UNLIKELY(m_bits == ZXC_SEQ_ML_MASK)) ml += zxc_read_varint(&extras_ptr, extras_end);
 
         // Strict bounds checks (including wild copy overrun safety)
-        if (UNLIKELY(ll + ml + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr))) {
+        if (UNLIKELY(ll + ml + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr) ||
+                     ll + ZXC_PAD_SIZE > (size_t)(l_end - l_ptr))) {
             // Restore state and break to Safe Path
             seq_ptr = seq_save;
             extras_ptr = ext_save;

--- a/src/lib/zxc_decompress.c
+++ b/src/lib/zxc_decompress.c
@@ -132,10 +132,14 @@ static ZXC_ALWAYS_INLINE uint32_t zxc_read_varint(const uint8_t** ptr, const uin
         *ptr = end;
         return 0;
     }
-
+    const uint32_t v5 = (b0 & 0x07) | ((uint32_t)p[1] << 3) | ((uint32_t)p[2] << 11) |
+                        ((uint32_t)p[3] << 19) | ((uint32_t)p[4] << 27);
+    if (UNLIKELY(v5 > ZXC_MAX_VARINT_VALUE)) {
+        *ptr = end;  // exhaust extras stream: caller treats as corrupt
+        return 0;
+    }
     *ptr = p + 5;
-    return (b0 & 0x07) | ((uint32_t)p[1] << 3) | ((uint32_t)p[2] << 11) | ((uint32_t)p[3] << 19) |
-           ((uint32_t)p[4] << 27);
+    return v5;
 }
 
 /**

--- a/src/lib/zxc_decompress.c
+++ b/src/lib/zxc_decompress.c
@@ -674,7 +674,7 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
                     // Raw copy (most common path): use ZXC_PAD_SIZE-byte wild copies
                     // token is 7-bit (0-127), so len is 1-128 bytes
                     const uint32_t len = (uint32_t)token + 1;
-                    if (UNLIKELY((size_t)(w_end - w_ptr) < len || (size_t)(r_end - r_ptr) < len))
+                    if (UNLIKELY(w_ptr + len > w_end || r_ptr + len > r_end))
                         return ZXC_ERROR_CORRUPT_DATA;
 
                     // Destination has ZXC_PAD_SIZE bytes of safe overrun space.
@@ -708,7 +708,7 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
                 } else {
                     // RLE run: fill with single byte
                     const uint32_t len = (token & ZXC_LIT_LEN_MASK) + 4;
-                    if (UNLIKELY((size_t)(w_end - w_ptr) < len || r_ptr >= r_end))
+                    if (UNLIKELY(w_ptr + len > w_end || r_ptr >= r_end))
                         return ZXC_ERROR_CORRUPT_DATA;
                     ZXC_MEMSET(w_ptr, *r_ptr++, len);
                     w_ptr += len;
@@ -819,15 +819,14 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
                 ll1 += zxc_read_varint(&e_ptr, e_end);
                 const uint64_t reserve =
                     ((tokens >> 12) & 0xF) + ((tokens >> 20) & 0xF) + (tokens >> 28);
-                if (UNLIKELY(ll1 + reserve > (size_t)(l_end - l_ptr) ||
-                             ll1 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
+                if (UNLIKELY(l_ptr + ll1 + reserve > l_end || d_ptr + ll1 + ZXC_PAD_SIZE > d_end))
                     goto rollback_safe_4x;
             }
             if (UNLIKELY(ml1 == ZXC_TOKEN_ML_MASK)) {
                 ml1 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY(ll1 + ml1 + ZXC_LZ_MIN_MATCH_LEN +
+                if (UNLIKELY(d_ptr + ll1 + ml1 + ZXC_LZ_MIN_MATCH_LEN +
                                  3U * ZXC_GLO_MAX_INLINE_OUT_PER_SEQ + ZXC_PAD_SIZE >
-                             (size_t)(d_end - d_ptr)))
+                             d_end))
                     goto rollback_safe_4x;
             }
             ml1 += ZXC_LZ_MIN_MATCH_LEN;
@@ -838,15 +837,14 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
             if (UNLIKELY(ll2 == ZXC_TOKEN_LL_MASK)) {
                 ll2 += zxc_read_varint(&e_ptr, e_end);
                 const uint64_t reserve = ((tokens >> 20) & 0xF) + (tokens >> 28);
-                if (UNLIKELY(ll2 + reserve > (size_t)(l_end - l_ptr) ||
-                             ll2 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
+                if (UNLIKELY(l_ptr + ll2 + reserve > l_end || d_ptr + ll2 + ZXC_PAD_SIZE > d_end))
                     goto rollback_safe_4x;
             }
             if (UNLIKELY(ml2 == ZXC_TOKEN_ML_MASK)) {
                 ml2 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY(ll2 + ml2 + ZXC_LZ_MIN_MATCH_LEN +
+                if (UNLIKELY(d_ptr + ll2 + ml2 + ZXC_LZ_MIN_MATCH_LEN +
                                  2U * ZXC_GLO_MAX_INLINE_OUT_PER_SEQ + ZXC_PAD_SIZE >
-                             (size_t)(d_end - d_ptr)))
+                             d_end))
                     goto rollback_safe_4x;
             }
             ml2 += ZXC_LZ_MIN_MATCH_LEN;
@@ -857,15 +855,14 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
             if (UNLIKELY(ll3 == ZXC_TOKEN_LL_MASK)) {
                 ll3 += zxc_read_varint(&e_ptr, e_end);
                 const uint64_t reserve = (tokens >> 28);
-                if (UNLIKELY(ll3 + reserve > (size_t)(l_end - l_ptr) ||
-                             ll3 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
+                if (UNLIKELY(l_ptr + ll3 + reserve > l_end || d_ptr + ll3 + ZXC_PAD_SIZE > d_end))
                     goto rollback_safe_4x;
             }
             if (UNLIKELY(ml3 == ZXC_TOKEN_ML_MASK)) {
                 ml3 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY(ll3 + ml3 + ZXC_LZ_MIN_MATCH_LEN + ZXC_GLO_MAX_INLINE_OUT_PER_SEQ +
-                                 ZXC_PAD_SIZE >
-                             (size_t)(d_end - d_ptr)))
+                if (UNLIKELY(d_ptr + ll3 + ml3 + ZXC_LZ_MIN_MATCH_LEN +
+                                 ZXC_GLO_MAX_INLINE_OUT_PER_SEQ + ZXC_PAD_SIZE >
+                             d_end))
                     goto rollback_safe_4x;
             }
             ml3 += ZXC_LZ_MIN_MATCH_LEN;
@@ -875,14 +872,12 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
             uint64_t ml4 = (tokens >> 24) & 0x0F;
             if (UNLIKELY(ll4 == ZXC_TOKEN_LL_MASK)) {
                 ll4 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY(ll4 > (size_t)(l_end - l_ptr) ||
-                             ll4 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
+                if (UNLIKELY(l_ptr + ll4 > l_end || d_ptr + ll4 + ZXC_PAD_SIZE > d_end))
                     goto rollback_safe_4x;
             }
             if (UNLIKELY(ml4 == ZXC_TOKEN_ML_MASK)) {
                 ml4 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY(ll4 + ml4 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE >
-                             (size_t)(d_end - d_ptr)))
+                if (UNLIKELY(d_ptr + ll4 + ml4 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE > d_end))
                     goto rollback_safe_4x;
             }
             ml4 += ZXC_LZ_MIN_MATCH_LEN;
@@ -932,15 +927,14 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
                 ll1 += zxc_read_varint(&e_ptr, e_end);
                 const uint64_t reserve =
                     ((tokens >> 12) & 0xF) + ((tokens >> 20) & 0xF) + (tokens >> 28);
-                if (UNLIKELY(ll1 + reserve > (size_t)(l_end - l_ptr) ||
-                             ll1 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
+                if (UNLIKELY(l_ptr + ll1 + reserve > l_end || d_ptr + ll1 + ZXC_PAD_SIZE > d_end))
                     return ZXC_ERROR_OVERFLOW;
             }
             if (UNLIKELY(ml1 == ZXC_TOKEN_ML_MASK)) {
                 ml1 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY(ll1 + ml1 + ZXC_LZ_MIN_MATCH_LEN +
+                if (UNLIKELY(d_ptr + ll1 + ml1 + ZXC_LZ_MIN_MATCH_LEN +
                                  3U * ZXC_GLO_MAX_INLINE_OUT_PER_SEQ + ZXC_PAD_SIZE >
-                             (size_t)(d_end - d_ptr)))
+                             d_end))
                     return ZXC_ERROR_OVERFLOW;
             }
             ml1 += ZXC_LZ_MIN_MATCH_LEN;
@@ -951,15 +945,14 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
             if (UNLIKELY(ll2 == ZXC_TOKEN_LL_MASK)) {
                 ll2 += zxc_read_varint(&e_ptr, e_end);
                 const uint64_t reserve = ((tokens >> 20) & 0xF) + (tokens >> 28);
-                if (UNLIKELY(ll2 + reserve > (size_t)(l_end - l_ptr) ||
-                             ll2 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
+                if (UNLIKELY(l_ptr + ll2 + reserve > l_end || d_ptr + ll2 + ZXC_PAD_SIZE > d_end))
                     return ZXC_ERROR_OVERFLOW;
             }
             if (UNLIKELY(ml2 == ZXC_TOKEN_ML_MASK)) {
                 ml2 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY(ll2 + ml2 + ZXC_LZ_MIN_MATCH_LEN +
+                if (UNLIKELY(d_ptr + ll2 + ml2 + ZXC_LZ_MIN_MATCH_LEN +
                                  2U * ZXC_GLO_MAX_INLINE_OUT_PER_SEQ + ZXC_PAD_SIZE >
-                             (size_t)(d_end - d_ptr)))
+                             d_end))
                     return ZXC_ERROR_OVERFLOW;
             }
             ml2 += ZXC_LZ_MIN_MATCH_LEN;
@@ -970,15 +963,14 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
             if (UNLIKELY(ll3 == ZXC_TOKEN_LL_MASK)) {
                 ll3 += zxc_read_varint(&e_ptr, e_end);
                 const uint64_t reserve = (tokens >> 28);
-                if (UNLIKELY(ll3 + reserve > (size_t)(l_end - l_ptr) ||
-                             ll3 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
+                if (UNLIKELY(l_ptr + ll3 + reserve > l_end || d_ptr + ll3 + ZXC_PAD_SIZE > d_end))
                     return ZXC_ERROR_OVERFLOW;
             }
             if (UNLIKELY(ml3 == ZXC_TOKEN_ML_MASK)) {
                 ml3 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY(ll3 + ml3 + ZXC_LZ_MIN_MATCH_LEN + ZXC_GLO_MAX_INLINE_OUT_PER_SEQ +
-                                 ZXC_PAD_SIZE >
-                             (size_t)(d_end - d_ptr)))
+                if (UNLIKELY(d_ptr + ll3 + ml3 + ZXC_LZ_MIN_MATCH_LEN +
+                                 ZXC_GLO_MAX_INLINE_OUT_PER_SEQ + ZXC_PAD_SIZE >
+                             d_end))
                     return ZXC_ERROR_OVERFLOW;
             }
             ml3 += ZXC_LZ_MIN_MATCH_LEN;
@@ -988,14 +980,12 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
             uint64_t ml4 = (tokens >> 24) & 0x0F;
             if (UNLIKELY(ll4 == ZXC_TOKEN_LL_MASK)) {
                 ll4 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY(ll4 > (size_t)(l_end - l_ptr) ||
-                             ll4 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
+                if (UNLIKELY(l_ptr + ll4 > l_end || d_ptr + ll4 + ZXC_PAD_SIZE > d_end))
                     return ZXC_ERROR_OVERFLOW;
             }
             if (UNLIKELY(ml4 == ZXC_TOKEN_ML_MASK)) {
                 ml4 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY(ll4 + ml4 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE >
-                             (size_t)(d_end - d_ptr)))
+                if (UNLIKELY(d_ptr + ll4 + ml4 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE > d_end))
                     return ZXC_ERROR_OVERFLOW;
             }
             ml4 += ZXC_LZ_MIN_MATCH_LEN;
@@ -1040,15 +1030,14 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
                 ll1 += zxc_read_varint(&e_ptr, e_end);
                 const uint64_t reserve =
                     ((tokens >> 12) & 0xF) + ((tokens >> 20) & 0xF) + (tokens >> 28);
-                if (UNLIKELY(ll1 + reserve > (size_t)(l_end - l_ptr) ||
-                             ll1 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
+                if (UNLIKELY(l_ptr + ll1 + reserve > l_end || d_ptr + ll1 + ZXC_PAD_SIZE > d_end))
                     goto rollback_fast_4x;
             }
             if (UNLIKELY(ml1 == ZXC_TOKEN_ML_MASK)) {
                 ml1 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY(ll1 + ml1 + ZXC_LZ_MIN_MATCH_LEN +
+                if (UNLIKELY(d_ptr + ll1 + ml1 + ZXC_LZ_MIN_MATCH_LEN +
                                  3U * ZXC_GLO_MAX_INLINE_OUT_PER_SEQ + ZXC_PAD_SIZE >
-                             (size_t)(d_end - d_ptr)))
+                             d_end))
                     goto rollback_fast_4x;
             }
             ml1 += ZXC_LZ_MIN_MATCH_LEN;
@@ -1059,15 +1048,14 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
             if (UNLIKELY(ll2 == ZXC_TOKEN_LL_MASK)) {
                 ll2 += zxc_read_varint(&e_ptr, e_end);
                 const uint64_t reserve = ((tokens >> 20) & 0xF) + (tokens >> 28);
-                if (UNLIKELY(ll2 + reserve > (size_t)(l_end - l_ptr) ||
-                             ll2 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
+                if (UNLIKELY(l_ptr + ll2 + reserve > l_end || d_ptr + ll2 + ZXC_PAD_SIZE > d_end))
                     goto rollback_fast_4x;
             }
             if (UNLIKELY(ml2 == ZXC_TOKEN_ML_MASK)) {
                 ml2 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY(ll2 + ml2 + ZXC_LZ_MIN_MATCH_LEN +
+                if (UNLIKELY(d_ptr + ll2 + ml2 + ZXC_LZ_MIN_MATCH_LEN +
                                  2U * ZXC_GLO_MAX_INLINE_OUT_PER_SEQ + ZXC_PAD_SIZE >
-                             (size_t)(d_end - d_ptr)))
+                             d_end))
                     goto rollback_fast_4x;
             }
             ml2 += ZXC_LZ_MIN_MATCH_LEN;
@@ -1078,15 +1066,14 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
             if (UNLIKELY(ll3 == ZXC_TOKEN_LL_MASK)) {
                 ll3 += zxc_read_varint(&e_ptr, e_end);
                 const uint64_t reserve = (tokens >> 28);
-                if (UNLIKELY(ll3 + reserve > (size_t)(l_end - l_ptr) ||
-                             ll3 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
+                if (UNLIKELY(l_ptr + ll3 + reserve > l_end || d_ptr + ll3 + ZXC_PAD_SIZE > d_end))
                     goto rollback_fast_4x;
             }
             if (UNLIKELY(ml3 == ZXC_TOKEN_ML_MASK)) {
                 ml3 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY(ll3 + ml3 + ZXC_LZ_MIN_MATCH_LEN + ZXC_GLO_MAX_INLINE_OUT_PER_SEQ +
-                                 ZXC_PAD_SIZE >
-                             (size_t)(d_end - d_ptr)))
+                if (UNLIKELY(d_ptr + ll3 + ml3 + ZXC_LZ_MIN_MATCH_LEN +
+                                 ZXC_GLO_MAX_INLINE_OUT_PER_SEQ + ZXC_PAD_SIZE >
+                             d_end))
                     goto rollback_fast_4x;
             }
             ml3 += ZXC_LZ_MIN_MATCH_LEN;
@@ -1096,14 +1083,12 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
             uint64_t ml4 = (tokens >> 24) & 0x0F;
             if (UNLIKELY(ll4 == ZXC_TOKEN_LL_MASK)) {
                 ll4 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY(ll4 > (size_t)(l_end - l_ptr) ||
-                             ll4 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
+                if (UNLIKELY(l_ptr + ll4 > l_end || d_ptr + ll4 + ZXC_PAD_SIZE > d_end))
                     goto rollback_fast_4x;
             }
             if (UNLIKELY(ml4 == ZXC_TOKEN_ML_MASK)) {
                 ml4 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY(ll4 + ml4 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE >
-                             (size_t)(d_end - d_ptr)))
+                if (UNLIKELY(d_ptr + ll4 + ml4 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE > d_end))
                     goto rollback_fast_4x;
             }
             ml4 += ZXC_LZ_MIN_MATCH_LEN;
@@ -1151,15 +1136,14 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
                 ll1 += zxc_read_varint(&e_ptr, e_end);
                 const uint64_t reserve =
                     ((tokens >> 12) & 0xF) + ((tokens >> 20) & 0xF) + (tokens >> 28);
-                if (UNLIKELY(ll1 + reserve > (size_t)(l_end - l_ptr) ||
-                             ll1 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
+                if (UNLIKELY(l_ptr + ll1 + reserve > l_end || d_ptr + ll1 + ZXC_PAD_SIZE > d_end))
                     return ZXC_ERROR_OVERFLOW;
             }
             if (UNLIKELY(ml1 == ZXC_TOKEN_ML_MASK)) {
                 ml1 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY(ll1 + ml1 + ZXC_LZ_MIN_MATCH_LEN +
+                if (UNLIKELY(d_ptr + ll1 + ml1 + ZXC_LZ_MIN_MATCH_LEN +
                                  3U * ZXC_GLO_MAX_INLINE_OUT_PER_SEQ + ZXC_PAD_SIZE >
-                             (size_t)(d_end - d_ptr)))
+                             d_end))
                     return ZXC_ERROR_OVERFLOW;
             }
             ml1 += ZXC_LZ_MIN_MATCH_LEN;
@@ -1170,15 +1154,14 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
             if (UNLIKELY(ll2 == ZXC_TOKEN_LL_MASK)) {
                 ll2 += zxc_read_varint(&e_ptr, e_end);
                 const uint64_t reserve = ((tokens >> 20) & 0xF) + (tokens >> 28);
-                if (UNLIKELY(ll2 + reserve > (size_t)(l_end - l_ptr) ||
-                             ll2 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
+                if (UNLIKELY(l_ptr + ll2 + reserve > l_end || d_ptr + ll2 + ZXC_PAD_SIZE > d_end))
                     return ZXC_ERROR_OVERFLOW;
             }
             if (UNLIKELY(ml2 == ZXC_TOKEN_ML_MASK)) {
                 ml2 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY(ll2 + ml2 + ZXC_LZ_MIN_MATCH_LEN +
+                if (UNLIKELY(d_ptr + ll2 + ml2 + ZXC_LZ_MIN_MATCH_LEN +
                                  2U * ZXC_GLO_MAX_INLINE_OUT_PER_SEQ + ZXC_PAD_SIZE >
-                             (size_t)(d_end - d_ptr)))
+                             d_end))
                     return ZXC_ERROR_OVERFLOW;
             }
             ml2 += ZXC_LZ_MIN_MATCH_LEN;
@@ -1189,15 +1172,14 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
             if (UNLIKELY(ll3 == ZXC_TOKEN_LL_MASK)) {
                 ll3 += zxc_read_varint(&e_ptr, e_end);
                 const uint64_t reserve = (tokens >> 28);
-                if (UNLIKELY(ll3 + reserve > (size_t)(l_end - l_ptr) ||
-                             ll3 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
+                if (UNLIKELY(l_ptr + ll3 + reserve > l_end || d_ptr + ll3 + ZXC_PAD_SIZE > d_end))
                     return ZXC_ERROR_OVERFLOW;
             }
             if (UNLIKELY(ml3 == ZXC_TOKEN_ML_MASK)) {
                 ml3 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY(ll3 + ml3 + ZXC_LZ_MIN_MATCH_LEN + ZXC_GLO_MAX_INLINE_OUT_PER_SEQ +
-                                 ZXC_PAD_SIZE >
-                             (size_t)(d_end - d_ptr)))
+                if (UNLIKELY(d_ptr + ll3 + ml3 + ZXC_LZ_MIN_MATCH_LEN +
+                                 ZXC_GLO_MAX_INLINE_OUT_PER_SEQ + ZXC_PAD_SIZE >
+                             d_end))
                     return ZXC_ERROR_OVERFLOW;
             }
             ml3 += ZXC_LZ_MIN_MATCH_LEN;
@@ -1207,14 +1189,12 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
             uint64_t ml4 = (tokens >> 24) & 0x0F;
             if (UNLIKELY(ll4 == ZXC_TOKEN_LL_MASK)) {
                 ll4 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY(ll4 > (size_t)(l_end - l_ptr) ||
-                             ll4 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
+                if (UNLIKELY(l_ptr + ll4 > l_end || d_ptr + ll4 + ZXC_PAD_SIZE > d_end))
                     return ZXC_ERROR_OVERFLOW;
             }
             if (UNLIKELY(ml4 == ZXC_TOKEN_ML_MASK)) {
                 ml4 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY(ll4 + ml4 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE >
-                             (size_t)(d_end - d_ptr)))
+                if (UNLIKELY(d_ptr + ll4 + ml4 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE > d_end))
                     return ZXC_ERROR_OVERFLOW;
             }
             ml4 += ZXC_LZ_MIN_MATCH_LEN;
@@ -1247,7 +1227,7 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
 
         if (UNLIKELY(ll == ZXC_TOKEN_LL_MASK)) {
             ll += zxc_read_varint(&e_ptr, e_end);
-            if (UNLIKELY((size_t)(l_end - l_ptr) < ll)) {
+            if (UNLIKELY(l_ptr + ll > l_end)) {
                 t_ptr = t_save;
                 o_ptr = o_save;
                 e_ptr = e_save;
@@ -1258,7 +1238,7 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
         ml += ZXC_LZ_MIN_MATCH_LEN;
 
         // Check bounds before wild copies - if too close to end, fall back to Safe Path
-        if (UNLIKELY(ll + ml + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr))) {
+        if (UNLIKELY(d_ptr + ll + ml + ZXC_PAD_SIZE > d_end)) {
             // Restore pointers and let Safe Path handle this sequence
             t_ptr = t_save;
             o_ptr = o_save;
@@ -1339,8 +1319,7 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
         if (UNLIKELY(ml == ZXC_TOKEN_ML_MASK)) ml += zxc_read_varint(&e_ptr, e_end);
         ml += ZXC_LZ_MIN_MATCH_LEN;
 
-        if (UNLIKELY(ll + ml > (size_t)(d_end - d_ptr) || (size_t)(l_end - l_ptr) < ll))
-            return ZXC_ERROR_OVERFLOW;
+        if (UNLIKELY(d_ptr + ll + ml > d_end || l_ptr + ll > l_end)) return ZXC_ERROR_OVERFLOW;
         ZXC_MEMCPY(d_ptr, l_ptr, ll);
         l_ptr += ll;
         d_ptr += ll;
@@ -1362,7 +1341,7 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
     if (UNLIKELY(l_ptr > l_end)) return ZXC_ERROR_CORRUPT_DATA;
     const size_t remaining_literals = (size_t)(l_end - l_ptr);
     if (remaining_literals > 0) {
-        if (UNLIKELY((size_t)(d_end - d_ptr) < remaining_literals)) return ZXC_ERROR_OVERFLOW;
+        if (UNLIKELY(d_ptr + remaining_literals > d_end)) return ZXC_ERROR_OVERFLOW;
         ZXC_MEMCPY(d_ptr, l_ptr, remaining_literals);
         d_ptr += remaining_literals;
     }
@@ -1475,16 +1454,16 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(zxc_cctx_t* RESTRICT ctx,
             if (UNLIKELY(ll1 == ZXC_SEQ_LL_MASK)) {
                 ll1 += zxc_read_varint(&extras_ptr, extras_end);
                 const uint64_t reserve = (s2 >> 24) + (s3 >> 24) + (s4 >> 24);
-                if (UNLIKELY(ll1 + reserve > (size_t)(l_end - l_ptr) ||
-                             ll1 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
+                if (UNLIKELY(l_ptr + ll1 + reserve > l_end || d_ptr + ll1 + ZXC_PAD_SIZE > d_end))
                     goto rollback_safe_4x;
             }
             uint32_t m1b = (uint32_t)((s1 >> 16) & 0xFF);
             uint64_t ml1 = m1b + ZXC_LZ_MIN_MATCH_LEN;
             if (UNLIKELY(m1b == ZXC_SEQ_ML_MASK)) {
                 ml1 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY(ll1 + ml1 + 3U * ZXC_GHI_MAX_INLINE_OUT_PER_SEQ + ZXC_PAD_SIZE >
-                             (size_t)(d_end - d_ptr)))
+                if (UNLIKELY(d_ptr + ll1 + ml1 + 3U * ZXC_GHI_MAX_INLINE_OUT_PER_SEQ +
+                                 ZXC_PAD_SIZE >
+                             d_end))
                     goto rollback_safe_4x;
             }
             uint32_t off1 = (uint32_t)(s1 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
@@ -1494,16 +1473,16 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(zxc_cctx_t* RESTRICT ctx,
             if (UNLIKELY(ll2 == ZXC_SEQ_LL_MASK)) {
                 ll2 += zxc_read_varint(&extras_ptr, extras_end);
                 const uint64_t reserve = (s3 >> 24) + (s4 >> 24);
-                if (UNLIKELY(ll2 + reserve > (size_t)(l_end - l_ptr) ||
-                             ll2 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
+                if (UNLIKELY(l_ptr + ll2 + reserve > l_end || d_ptr + ll2 + ZXC_PAD_SIZE > d_end))
                     goto rollback_safe_4x;
             }
             uint32_t m2b = (uint32_t)((s2 >> 16) & 0xFF);
             uint64_t ml2 = m2b + ZXC_LZ_MIN_MATCH_LEN;
             if (UNLIKELY(m2b == ZXC_SEQ_ML_MASK)) {
                 ml2 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY(ll2 + ml2 + 2U * ZXC_GHI_MAX_INLINE_OUT_PER_SEQ + ZXC_PAD_SIZE >
-                             (size_t)(d_end - d_ptr)))
+                if (UNLIKELY(d_ptr + ll2 + ml2 + 2U * ZXC_GHI_MAX_INLINE_OUT_PER_SEQ +
+                                 ZXC_PAD_SIZE >
+                             d_end))
                     goto rollback_safe_4x;
             }
             uint32_t off2 = (uint32_t)(s2 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
@@ -1513,16 +1492,15 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(zxc_cctx_t* RESTRICT ctx,
             if (UNLIKELY(ll3 == ZXC_SEQ_LL_MASK)) {
                 ll3 += zxc_read_varint(&extras_ptr, extras_end);
                 const uint64_t reserve = (s4 >> 24);
-                if (UNLIKELY(ll3 + reserve > (size_t)(l_end - l_ptr) ||
-                             ll3 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
+                if (UNLIKELY(l_ptr + ll3 + reserve > l_end || d_ptr + ll3 + ZXC_PAD_SIZE > d_end))
                     goto rollback_safe_4x;
             }
             uint32_t m3b = (uint32_t)((s3 >> 16) & 0xFF);
             uint64_t ml3 = m3b + ZXC_LZ_MIN_MATCH_LEN;
             if (UNLIKELY(m3b == ZXC_SEQ_ML_MASK)) {
                 ml3 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY(ll3 + ml3 + ZXC_GHI_MAX_INLINE_OUT_PER_SEQ + ZXC_PAD_SIZE >
-                             (size_t)(d_end - d_ptr)))
+                if (UNLIKELY(d_ptr + ll3 + ml3 + ZXC_GHI_MAX_INLINE_OUT_PER_SEQ + ZXC_PAD_SIZE >
+                             d_end))
                     goto rollback_safe_4x;
             }
             uint32_t off3 = (uint32_t)(s3 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
@@ -1531,16 +1509,14 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(zxc_cctx_t* RESTRICT ctx,
             uint64_t ll4 = (uint32_t)(s4 >> 24);
             if (UNLIKELY(ll4 == ZXC_SEQ_LL_MASK)) {
                 ll4 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY(ll4 > (size_t)(l_end - l_ptr) ||
-                             ll4 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
+                if (UNLIKELY(l_ptr + ll4 > l_end || d_ptr + ll4 + ZXC_PAD_SIZE > d_end))
                     goto rollback_safe_4x;
             }
             uint32_t m4b = (uint32_t)((s4 >> 16) & 0xFF);
             uint64_t ml4 = m4b + ZXC_LZ_MIN_MATCH_LEN;
             if (UNLIKELY(m4b == ZXC_SEQ_ML_MASK)) {
                 ml4 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY(ll4 + ml4 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
-                    goto rollback_safe_4x;
+                if (UNLIKELY(d_ptr + ll4 + ml4 + ZXC_PAD_SIZE > d_end)) goto rollback_safe_4x;
             }
             uint32_t off4 = (uint32_t)(s4 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
             DECODE_SEQ_SAFE(ll4, ml4, off4);
@@ -1569,16 +1545,16 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(zxc_cctx_t* RESTRICT ctx,
             if (UNLIKELY(ll1 == ZXC_SEQ_LL_MASK)) {
                 ll1 += zxc_read_varint(&extras_ptr, extras_end);
                 const uint64_t reserve = (s2 >> 24) + (s3 >> 24) + (s4 >> 24);
-                if (UNLIKELY(ll1 + reserve > (size_t)(l_end - l_ptr) ||
-                             ll1 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
+                if (UNLIKELY(l_ptr + ll1 + reserve > l_end || d_ptr + ll1 + ZXC_PAD_SIZE > d_end))
                     return ZXC_ERROR_OVERFLOW;
             }
             uint32_t m1b = (uint32_t)((s1 >> 16) & 0xFF);
             uint64_t ml1 = m1b + ZXC_LZ_MIN_MATCH_LEN;
             if (UNLIKELY(m1b == ZXC_SEQ_ML_MASK)) {
                 ml1 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY(ll1 + ml1 + 3U * ZXC_GHI_MAX_INLINE_OUT_PER_SEQ + ZXC_PAD_SIZE >
-                             (size_t)(d_end - d_ptr)))
+                if (UNLIKELY(d_ptr + ll1 + ml1 + 3U * ZXC_GHI_MAX_INLINE_OUT_PER_SEQ +
+                                 ZXC_PAD_SIZE >
+                             d_end))
                     return ZXC_ERROR_OVERFLOW;
             }
             uint32_t off1 = (uint32_t)(s1 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
@@ -1588,16 +1564,16 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(zxc_cctx_t* RESTRICT ctx,
             if (UNLIKELY(ll2 == ZXC_SEQ_LL_MASK)) {
                 ll2 += zxc_read_varint(&extras_ptr, extras_end);
                 const uint64_t reserve = (s3 >> 24) + (s4 >> 24);
-                if (UNLIKELY(ll2 + reserve > (size_t)(l_end - l_ptr) ||
-                             ll2 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
+                if (UNLIKELY(l_ptr + ll2 + reserve > l_end || d_ptr + ll2 + ZXC_PAD_SIZE > d_end))
                     return ZXC_ERROR_OVERFLOW;
             }
             uint32_t m2b = (uint32_t)((s2 >> 16) & 0xFF);
             uint64_t ml2 = m2b + ZXC_LZ_MIN_MATCH_LEN;
             if (UNLIKELY(m2b == ZXC_SEQ_ML_MASK)) {
                 ml2 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY(ll2 + ml2 + 2U * ZXC_GHI_MAX_INLINE_OUT_PER_SEQ + ZXC_PAD_SIZE >
-                             (size_t)(d_end - d_ptr)))
+                if (UNLIKELY(d_ptr + ll2 + ml2 + 2U * ZXC_GHI_MAX_INLINE_OUT_PER_SEQ +
+                                 ZXC_PAD_SIZE >
+                             d_end))
                     return ZXC_ERROR_OVERFLOW;
             }
             uint32_t off2 = (uint32_t)(s2 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
@@ -1607,16 +1583,15 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(zxc_cctx_t* RESTRICT ctx,
             if (UNLIKELY(ll3 == ZXC_SEQ_LL_MASK)) {
                 ll3 += zxc_read_varint(&extras_ptr, extras_end);
                 const uint64_t reserve = (s4 >> 24);
-                if (UNLIKELY(ll3 + reserve > (size_t)(l_end - l_ptr) ||
-                             ll3 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
+                if (UNLIKELY(l_ptr + ll3 + reserve > l_end || d_ptr + ll3 + ZXC_PAD_SIZE > d_end))
                     return ZXC_ERROR_OVERFLOW;
             }
             uint32_t m3b = (uint32_t)((s3 >> 16) & 0xFF);
             uint64_t ml3 = m3b + ZXC_LZ_MIN_MATCH_LEN;
             if (UNLIKELY(m3b == ZXC_SEQ_ML_MASK)) {
                 ml3 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY(ll3 + ml3 + ZXC_GHI_MAX_INLINE_OUT_PER_SEQ + ZXC_PAD_SIZE >
-                             (size_t)(d_end - d_ptr)))
+                if (UNLIKELY(d_ptr + ll3 + ml3 + ZXC_GHI_MAX_INLINE_OUT_PER_SEQ + ZXC_PAD_SIZE >
+                             d_end))
                     return ZXC_ERROR_OVERFLOW;
             }
             uint32_t off3 = (uint32_t)(s3 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
@@ -1625,16 +1600,14 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(zxc_cctx_t* RESTRICT ctx,
             uint64_t ll4 = (uint32_t)(s4 >> 24);
             if (UNLIKELY(ll4 == ZXC_SEQ_LL_MASK)) {
                 ll4 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY(ll4 > (size_t)(l_end - l_ptr) ||
-                             ll4 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
+                if (UNLIKELY(l_ptr + ll4 > l_end || d_ptr + ll4 + ZXC_PAD_SIZE > d_end))
                     return ZXC_ERROR_OVERFLOW;
             }
             uint32_t m4b = (uint32_t)((s4 >> 16) & 0xFF);
             uint64_t ml4 = m4b + ZXC_LZ_MIN_MATCH_LEN;
             if (UNLIKELY(m4b == ZXC_SEQ_ML_MASK)) {
                 ml4 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY(ll4 + ml4 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
-                    return ZXC_ERROR_OVERFLOW;
+                if (UNLIKELY(d_ptr + ll4 + ml4 + ZXC_PAD_SIZE > d_end)) return ZXC_ERROR_OVERFLOW;
             }
             uint32_t off4 = (uint32_t)(s4 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
             DECODE_SEQ_SAFE(ll4, ml4, off4);
@@ -1659,18 +1632,15 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(zxc_cctx_t* RESTRICT ctx,
 
         // Strict bounds check: sequence must fit, AND wild copies must not overshoot
         // Check both destination (d_ptr) and source literal stream (l_ptr)
-        if (UNLIKELY(ll + ml + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr) ||
-                     ll + ZXC_PAD_SIZE > (size_t)(l_end - l_ptr))) {
+        if (UNLIKELY(d_ptr + ll + ml + ZXC_PAD_SIZE > d_end || l_ptr + ll + ZXC_PAD_SIZE > l_end)) {
             // Fallback to exact copy (slow but safe)
-            if (UNLIKELY((size_t)(d_end - d_ptr) < ll || (size_t)(l_end - l_ptr) < ll))
-                return ZXC_ERROR_OVERFLOW;
+            if (UNLIKELY(d_ptr + ll > d_end || l_ptr + ll > l_end)) return ZXC_ERROR_OVERFLOW;
             ZXC_MEMCPY(d_ptr, l_ptr, ll);
             l_ptr += ll;
             d_ptr += ll;
             written += ll;
 
-            if (UNLIKELY(offset > written || (size_t)(d_end - d_ptr) < ml))
-                return ZXC_ERROR_BAD_OFFSET;
+            if (UNLIKELY(offset > written || d_ptr + ml > d_end)) return ZXC_ERROR_BAD_OFFSET;
             const uint8_t* match_src = d_ptr - offset;
 
             if (offset < ml) {
@@ -1707,16 +1677,16 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(zxc_cctx_t* RESTRICT ctx,
             if (UNLIKELY(ll1 == ZXC_SEQ_LL_MASK)) {
                 ll1 += zxc_read_varint(&extras_ptr, extras_end);
                 const uint64_t reserve = (s2 >> 24) + (s3 >> 24) + (s4 >> 24);
-                if (UNLIKELY(ll1 + reserve > (size_t)(l_end - l_ptr) ||
-                             ll1 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
+                if (UNLIKELY(l_ptr + ll1 + reserve > l_end || d_ptr + ll1 + ZXC_PAD_SIZE > d_end))
                     goto rollback_fast_4x;
             }
             uint32_t m1b = (uint32_t)((s1 >> 16) & 0xFF);
             uint64_t ml1 = m1b + ZXC_LZ_MIN_MATCH_LEN;
             if (UNLIKELY(m1b == ZXC_SEQ_ML_MASK)) {
                 ml1 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY(ll1 + ml1 + 3U * ZXC_GHI_MAX_INLINE_OUT_PER_SEQ + ZXC_PAD_SIZE >
-                             (size_t)(d_end - d_ptr)))
+                if (UNLIKELY(d_ptr + ll1 + ml1 + 3U * ZXC_GHI_MAX_INLINE_OUT_PER_SEQ +
+                                 ZXC_PAD_SIZE >
+                             d_end))
                     goto rollback_fast_4x;
             }
             uint32_t off1 = (uint32_t)(s1 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
@@ -1726,16 +1696,16 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(zxc_cctx_t* RESTRICT ctx,
             if (UNLIKELY(ll2 == ZXC_SEQ_LL_MASK)) {
                 ll2 += zxc_read_varint(&extras_ptr, extras_end);
                 const uint64_t reserve = (s3 >> 24) + (s4 >> 24);
-                if (UNLIKELY(ll2 + reserve > (size_t)(l_end - l_ptr) ||
-                             ll2 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
+                if (UNLIKELY(l_ptr + ll2 + reserve > l_end || d_ptr + ll2 + ZXC_PAD_SIZE > d_end))
                     goto rollback_fast_4x;
             }
             uint32_t m2b = (uint32_t)((s2 >> 16) & 0xFF);
             uint64_t ml2 = m2b + ZXC_LZ_MIN_MATCH_LEN;
             if (UNLIKELY(m2b == ZXC_SEQ_ML_MASK)) {
                 ml2 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY(ll2 + ml2 + 2U * ZXC_GHI_MAX_INLINE_OUT_PER_SEQ + ZXC_PAD_SIZE >
-                             (size_t)(d_end - d_ptr)))
+                if (UNLIKELY(d_ptr + ll2 + ml2 + 2U * ZXC_GHI_MAX_INLINE_OUT_PER_SEQ +
+                                 ZXC_PAD_SIZE >
+                             d_end))
                     goto rollback_fast_4x;
             }
             uint32_t off2 = (uint32_t)(s2 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
@@ -1745,16 +1715,15 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(zxc_cctx_t* RESTRICT ctx,
             if (UNLIKELY(ll3 == ZXC_SEQ_LL_MASK)) {
                 ll3 += zxc_read_varint(&extras_ptr, extras_end);
                 const uint64_t reserve = (s4 >> 24);
-                if (UNLIKELY(ll3 + reserve > (size_t)(l_end - l_ptr) ||
-                             ll3 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
+                if (UNLIKELY(l_ptr + ll3 + reserve > l_end || d_ptr + ll3 + ZXC_PAD_SIZE > d_end))
                     goto rollback_fast_4x;
             }
             uint32_t m3b = (uint32_t)((s3 >> 16) & 0xFF);
             uint64_t ml3 = m3b + ZXC_LZ_MIN_MATCH_LEN;
             if (UNLIKELY(m3b == ZXC_SEQ_ML_MASK)) {
                 ml3 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY(ll3 + ml3 + ZXC_GHI_MAX_INLINE_OUT_PER_SEQ + ZXC_PAD_SIZE >
-                             (size_t)(d_end - d_ptr)))
+                if (UNLIKELY(d_ptr + ll3 + ml3 + ZXC_GHI_MAX_INLINE_OUT_PER_SEQ + ZXC_PAD_SIZE >
+                             d_end))
                     goto rollback_fast_4x;
             }
             uint32_t off3 = (uint32_t)(s3 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
@@ -1763,16 +1732,14 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(zxc_cctx_t* RESTRICT ctx,
             uint64_t ll4 = (uint32_t)(s4 >> 24);
             if (UNLIKELY(ll4 == ZXC_SEQ_LL_MASK)) {
                 ll4 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY(ll4 > (size_t)(l_end - l_ptr) ||
-                             ll4 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
+                if (UNLIKELY(l_ptr + ll4 > l_end || d_ptr + ll4 + ZXC_PAD_SIZE > d_end))
                     goto rollback_fast_4x;
             }
             uint32_t m4b = (uint32_t)((s4 >> 16) & 0xFF);
             uint64_t ml4 = m4b + ZXC_LZ_MIN_MATCH_LEN;
             if (UNLIKELY(m4b == ZXC_SEQ_ML_MASK)) {
                 ml4 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY(ll4 + ml4 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
-                    goto rollback_fast_4x;
+                if (UNLIKELY(d_ptr + ll4 + ml4 + ZXC_PAD_SIZE > d_end)) goto rollback_fast_4x;
             }
             uint32_t off4 = (uint32_t)(s4 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
             DECODE_SEQ_FAST(ll4, ml4, off4);
@@ -1802,16 +1769,16 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(zxc_cctx_t* RESTRICT ctx,
             if (UNLIKELY(ll1 == ZXC_SEQ_LL_MASK)) {
                 ll1 += zxc_read_varint(&extras_ptr, extras_end);
                 const uint64_t reserve = (s2 >> 24) + (s3 >> 24) + (s4 >> 24);
-                if (UNLIKELY(ll1 + reserve > (size_t)(l_end - l_ptr) ||
-                             ll1 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
+                if (UNLIKELY(l_ptr + ll1 + reserve > l_end || d_ptr + ll1 + ZXC_PAD_SIZE > d_end))
                     return ZXC_ERROR_OVERFLOW;
             }
             uint32_t m1b = (uint32_t)((s1 >> 16) & 0xFF);
             uint64_t ml1 = m1b + ZXC_LZ_MIN_MATCH_LEN;
             if (UNLIKELY(m1b == ZXC_SEQ_ML_MASK)) {
                 ml1 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY(ll1 + ml1 + 3U * ZXC_GHI_MAX_INLINE_OUT_PER_SEQ + ZXC_PAD_SIZE >
-                             (size_t)(d_end - d_ptr)))
+                if (UNLIKELY(d_ptr + ll1 + ml1 + 3U * ZXC_GHI_MAX_INLINE_OUT_PER_SEQ +
+                                 ZXC_PAD_SIZE >
+                             d_end))
                     return ZXC_ERROR_OVERFLOW;
             }
             uint32_t off1 = (uint32_t)(s1 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
@@ -1821,16 +1788,16 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(zxc_cctx_t* RESTRICT ctx,
             if (UNLIKELY(ll2 == ZXC_SEQ_LL_MASK)) {
                 ll2 += zxc_read_varint(&extras_ptr, extras_end);
                 const uint64_t reserve = (s3 >> 24) + (s4 >> 24);
-                if (UNLIKELY(ll2 + reserve > (size_t)(l_end - l_ptr) ||
-                             ll2 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
+                if (UNLIKELY(l_ptr + ll2 + reserve > l_end || d_ptr + ll2 + ZXC_PAD_SIZE > d_end))
                     return ZXC_ERROR_OVERFLOW;
             }
             uint32_t m2b = (uint32_t)((s2 >> 16) & 0xFF);
             uint64_t ml2 = m2b + ZXC_LZ_MIN_MATCH_LEN;
             if (UNLIKELY(m2b == ZXC_SEQ_ML_MASK)) {
                 ml2 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY(ll2 + ml2 + 2U * ZXC_GHI_MAX_INLINE_OUT_PER_SEQ + ZXC_PAD_SIZE >
-                             (size_t)(d_end - d_ptr)))
+                if (UNLIKELY(d_ptr + ll2 + ml2 + 2U * ZXC_GHI_MAX_INLINE_OUT_PER_SEQ +
+                                 ZXC_PAD_SIZE >
+                             d_end))
                     return ZXC_ERROR_OVERFLOW;
             }
             uint32_t off2 = (uint32_t)(s2 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
@@ -1840,16 +1807,15 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(zxc_cctx_t* RESTRICT ctx,
             if (UNLIKELY(ll3 == ZXC_SEQ_LL_MASK)) {
                 ll3 += zxc_read_varint(&extras_ptr, extras_end);
                 const uint64_t reserve = (s4 >> 24);
-                if (UNLIKELY(ll3 + reserve > (size_t)(l_end - l_ptr) ||
-                             ll3 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
+                if (UNLIKELY(l_ptr + ll3 + reserve > l_end || d_ptr + ll3 + ZXC_PAD_SIZE > d_end))
                     return ZXC_ERROR_OVERFLOW;
             }
             uint32_t m3b = (uint32_t)((s3 >> 16) & 0xFF);
             uint64_t ml3 = m3b + ZXC_LZ_MIN_MATCH_LEN;
             if (UNLIKELY(m3b == ZXC_SEQ_ML_MASK)) {
                 ml3 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY(ll3 + ml3 + ZXC_GHI_MAX_INLINE_OUT_PER_SEQ + ZXC_PAD_SIZE >
-                             (size_t)(d_end - d_ptr)))
+                if (UNLIKELY(d_ptr + ll3 + ml3 + ZXC_GHI_MAX_INLINE_OUT_PER_SEQ + ZXC_PAD_SIZE >
+                             d_end))
                     return ZXC_ERROR_OVERFLOW;
             }
             uint32_t off3 = (uint32_t)(s3 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
@@ -1858,16 +1824,14 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(zxc_cctx_t* RESTRICT ctx,
             uint64_t ll4 = (uint32_t)(s4 >> 24);
             if (UNLIKELY(ll4 == ZXC_SEQ_LL_MASK)) {
                 ll4 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY(ll4 > (size_t)(l_end - l_ptr) ||
-                             ll4 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
+                if (UNLIKELY(l_ptr + ll4 > l_end || d_ptr + ll4 + ZXC_PAD_SIZE > d_end))
                     return ZXC_ERROR_OVERFLOW;
             }
             uint32_t m4b = (uint32_t)((s4 >> 16) & 0xFF);
             uint64_t ml4 = m4b + ZXC_LZ_MIN_MATCH_LEN;
             if (UNLIKELY(m4b == ZXC_SEQ_ML_MASK)) {
                 ml4 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY(ll4 + ml4 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
-                    return ZXC_ERROR_OVERFLOW;
+                if (UNLIKELY(d_ptr + ll4 + ml4 + ZXC_PAD_SIZE > d_end)) return ZXC_ERROR_OVERFLOW;
             }
             uint32_t off4 = (uint32_t)(s4 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
             DECODE_SEQ_FAST(ll4, ml4, off4);
@@ -1888,7 +1852,7 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(zxc_cctx_t* RESTRICT ctx,
         uint64_t ll = (uint32_t)(seq >> 24);
         if (UNLIKELY(ll == ZXC_SEQ_LL_MASK)) {
             ll += zxc_read_varint(&extras_ptr, extras_end);
-            if (UNLIKELY((size_t)(l_end - l_ptr) < ll)) {
+            if (UNLIKELY(l_ptr + ll > l_end)) {
                 seq_ptr = seq_save;
                 extras_ptr = ext_save;
                 break;
@@ -1900,7 +1864,7 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(zxc_cctx_t* RESTRICT ctx,
         if (UNLIKELY(m_bits == ZXC_SEQ_ML_MASK)) ml += zxc_read_varint(&extras_ptr, extras_end);
 
         // Strict bounds checks (including wild copy overrun safety)
-        if (UNLIKELY(ll + ml + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr))) {
+        if (UNLIKELY(d_ptr + ll + ml + ZXC_PAD_SIZE > d_end)) {
             // Restore state and break to Safe Path
             seq_ptr = seq_save;
             extras_ptr = ext_save;
@@ -1977,8 +1941,7 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(zxc_cctx_t* RESTRICT ctx,
         if (UNLIKELY(m_bits == ZXC_SEQ_ML_MASK)) ml += zxc_read_varint(&extras_ptr, extras_end);
         uint32_t offset = (uint32_t)(seq & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
 
-        if (UNLIKELY(ll + ml > (size_t)(d_end - d_ptr) || (size_t)(l_end - l_ptr) < ll))
-            return ZXC_ERROR_OVERFLOW;
+        if (UNLIKELY(d_ptr + ll + ml > d_end || l_ptr + ll > l_end)) return ZXC_ERROR_OVERFLOW;
         ZXC_MEMCPY(d_ptr, l_ptr, ll);
         l_ptr += ll;
         d_ptr += ll;
@@ -2000,7 +1963,7 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(zxc_cctx_t* RESTRICT ctx,
     if (UNLIKELY(l_ptr > l_end)) return ZXC_ERROR_CORRUPT_DATA;
     const size_t remaining_literals = (size_t)(l_end - l_ptr);
     if (remaining_literals > 0) {
-        if (UNLIKELY((size_t)(d_end - d_ptr) < remaining_literals)) return ZXC_ERROR_OVERFLOW;
+        if (UNLIKELY(d_ptr + remaining_literals > d_end)) return ZXC_ERROR_OVERFLOW;
         ZXC_MEMCPY(d_ptr, l_ptr, remaining_literals);
         d_ptr += remaining_literals;
     }

--- a/src/lib/zxc_decompress.c
+++ b/src/lib/zxc_decompress.c
@@ -793,20 +793,20 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
             const uint8_t* const l_save = l_ptr;
             const size_t w_save = written;
             uint32_t tokens = zxc_le32(t_ptr);
-            t_ptr += 4;
+            t_ptr += sizeof(uint32_t);
 
             uint32_t off1 = ZXC_LZ_OFFSET_BIAS, off2 = ZXC_LZ_OFFSET_BIAS,
                      off3 = ZXC_LZ_OFFSET_BIAS, off4 = ZXC_LZ_OFFSET_BIAS;
             if (gh.enc_off == 1) {
                 uint32_t offsets = zxc_le32(o_ptr);
-                o_ptr += 4;
+                o_ptr += sizeof(uint32_t);
                 off1 += offsets & 0xFF;
                 off2 += (offsets >> 8) & 0xFF;
                 off3 += (offsets >> 16) & 0xFF;
                 off4 += (offsets >> 24) & 0xFF;
             } else {
                 uint64_t offsets = zxc_le64(o_ptr);
-                o_ptr += 8;
+                o_ptr += sizeof(uint64_t);
                 off1 += (uint32_t)(offsets & 0xFFFF);
                 off2 += (uint32_t)((offsets >> 16) & 0xFFFF);
                 off3 += (uint32_t)((offsets >> 32) & 0xFFFF);
@@ -904,14 +904,14 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
         while (n_seq >= 4 && d_ptr < d_end_safe && l_ptr < l_end_safe_4x &&
                written < bounds_threshold) {
             uint32_t tokens = zxc_le32(t_ptr);
-            t_ptr += 4;
+            t_ptr += sizeof(uint32_t);
 
             uint32_t off1 = ZXC_LZ_OFFSET_BIAS, off2 = ZXC_LZ_OFFSET_BIAS,
                      off3 = ZXC_LZ_OFFSET_BIAS, off4 = ZXC_LZ_OFFSET_BIAS;
             if (gh.enc_off == 1) {
                 // Read 4 x 1-byte offsets
                 uint32_t offsets = zxc_le32(o_ptr);
-                o_ptr += 4;
+                o_ptr += sizeof(uint32_t);
                 off1 += offsets & 0xFF;
                 off2 += (offsets >> 8) & 0xFF;
                 off3 += (offsets >> 16) & 0xFF;
@@ -919,7 +919,7 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
             } else {
                 // Read 4 x 2-byte offsets
                 uint64_t offsets = zxc_le64(o_ptr);
-                o_ptr += 8;
+                o_ptr += sizeof(uint64_t);
                 off1 += (uint32_t)(offsets & 0xFFFF);
                 off2 += (uint32_t)((offsets >> 16) & 0xFFFF);
                 off3 += (uint32_t)((offsets >> 32) & 0xFFFF);
@@ -1014,20 +1014,20 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
             uint8_t* const d_save = d_ptr;
             const uint8_t* const l_save = l_ptr;
             uint32_t tokens = zxc_le32(t_ptr);
-            t_ptr += 4;
+            t_ptr += sizeof(uint32_t);
 
             uint32_t off1 = ZXC_LZ_OFFSET_BIAS, off2 = ZXC_LZ_OFFSET_BIAS,
                      off3 = ZXC_LZ_OFFSET_BIAS, off4 = ZXC_LZ_OFFSET_BIAS;
             if (gh.enc_off == 1) {
                 uint32_t offsets = zxc_le32(o_ptr);
-                o_ptr += 4;
+                o_ptr += sizeof(uint32_t);
                 off1 += offsets & 0xFF;
                 off2 += (offsets >> 8) & 0xFF;
                 off3 += (offsets >> 16) & 0xFF;
                 off4 += (offsets >> 24) & 0xFF;
             } else {
                 uint64_t offsets = zxc_le64(o_ptr);
-                o_ptr += 8;
+                o_ptr += sizeof(uint64_t);
                 off1 += (uint32_t)(offsets & 0xFFFF);
                 off2 += (uint32_t)((offsets >> 16) & 0xFFFF);
                 off3 += (uint32_t)((offsets >> 32) & 0xFFFF);
@@ -1123,14 +1123,14 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
     } else {
         while (n_seq >= 4 && d_ptr < d_end_safe && l_ptr < l_end_safe_4x) {
             uint32_t tokens = zxc_le32(t_ptr);
-            t_ptr += 4;
+            t_ptr += sizeof(uint32_t);
 
             uint32_t off1 = ZXC_LZ_OFFSET_BIAS, off2 = ZXC_LZ_OFFSET_BIAS,
                      off3 = ZXC_LZ_OFFSET_BIAS, off4 = ZXC_LZ_OFFSET_BIAS;
             if (gh.enc_off == 1) {
                 // Read 4 x 1-byte offsets
                 uint32_t offsets = zxc_le32(o_ptr);
-                o_ptr += 4;
+                o_ptr += sizeof(uint32_t);
                 off1 += offsets & 0xFF;
                 off2 += (offsets >> 8) & 0xFF;
                 off3 += (offsets >> 16) & 0xFF;
@@ -1138,7 +1138,7 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
             } else {
                 // Read 4 x 2-byte offsets
                 uint64_t offsets = zxc_le64(o_ptr);
-                o_ptr += 8;
+                o_ptr += sizeof(uint64_t);
                 off1 += (uint32_t)(offsets & 0xFFFF);
                 off2 += (uint32_t)((offsets >> 16) & 0xFFFF);
                 off3 += (uint32_t)((offsets >> 32) & 0xFFFF);
@@ -1242,7 +1242,7 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
             offset += *o_ptr++;  // 1-byte offset (biased)
         } else {
             offset += zxc_le16(o_ptr);  // 2-byte offset (biased)
-            o_ptr += 2;
+            o_ptr += sizeof(uint16_t);
         }
 
         if (UNLIKELY(ll == ZXC_TOKEN_LL_MASK)) {
@@ -1332,7 +1332,7 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
             offset += *o_ptr++;  // 1-byte offset (biased)
         } else {
             offset += zxc_le16(o_ptr);  // 2-byte offset (biased)
-            o_ptr += 2;
+            o_ptr += sizeof(uint16_t);
         }
 
         if (UNLIKELY(ll == ZXC_TOKEN_LL_MASK)) ll += zxc_read_varint(&e_ptr, e_end);
@@ -1466,10 +1466,10 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(zxc_cctx_t* RESTRICT ctx,
             const uint8_t* const l_save = l_ptr;
             const size_t w_save = written;
             uint32_t s1 = zxc_le32(seq_ptr);
-            uint32_t s2 = zxc_le32(seq_ptr + 4);
-            uint32_t s3 = zxc_le32(seq_ptr + 8);
-            uint32_t s4 = zxc_le32(seq_ptr + 12);
-            seq_ptr += 16;
+            uint32_t s2 = zxc_le32(seq_ptr + sizeof(uint32_t));
+            uint32_t s3 = zxc_le32(seq_ptr + 2 * sizeof(uint32_t));
+            uint32_t s4 = zxc_le32(seq_ptr + 3 * sizeof(uint32_t));
+            seq_ptr += 4 * sizeof(uint32_t);
 
             uint64_t ll1 = (uint32_t)(s1 >> 24);
             if (UNLIKELY(ll1 == ZXC_SEQ_LL_MASK)) {
@@ -1560,10 +1560,10 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(zxc_cctx_t* RESTRICT ctx,
         while (n_seq >= 4 && d_ptr < d_end_safe && l_ptr < l_end_safe_4x &&
                written < bounds_threshold) {
             uint32_t s1 = zxc_le32(seq_ptr);
-            uint32_t s2 = zxc_le32(seq_ptr + 4);
-            uint32_t s3 = zxc_le32(seq_ptr + 8);
-            uint32_t s4 = zxc_le32(seq_ptr + 12);
-            seq_ptr += 16;
+            uint32_t s2 = zxc_le32(seq_ptr + sizeof(uint32_t));
+            uint32_t s3 = zxc_le32(seq_ptr + 2 * sizeof(uint32_t));
+            uint32_t s4 = zxc_le32(seq_ptr + 3 * sizeof(uint32_t));
+            seq_ptr += 4 * sizeof(uint32_t);
 
             uint64_t ll1 = (uint32_t)(s1 >> 24);
             if (UNLIKELY(ll1 == ZXC_SEQ_LL_MASK)) {
@@ -1646,7 +1646,7 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(zxc_cctx_t* RESTRICT ctx,
     // --- SAFE Loop tail: remaining sequences with offset validation (1x) ---
     while (n_seq > 0 && d_ptr < d_end_safe && written < bounds_threshold) {
         uint32_t seq = zxc_le32(seq_ptr);
-        seq_ptr += 4;
+        seq_ptr += sizeof(uint32_t);
 
         uint64_t ll = (uint32_t)(seq >> 24);
         if (UNLIKELY(ll == ZXC_SEQ_LL_MASK)) ll += zxc_read_varint(&extras_ptr, extras_end);
@@ -1695,10 +1695,10 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(zxc_cctx_t* RESTRICT ctx,
             uint8_t* const d_save = d_ptr;
             const uint8_t* const l_save = l_ptr;
             uint32_t s1 = zxc_le32(seq_ptr);
-            uint32_t s2 = zxc_le32(seq_ptr + 4);
-            uint32_t s3 = zxc_le32(seq_ptr + 8);
-            uint32_t s4 = zxc_le32(seq_ptr + 12);
-            seq_ptr += 16;
+            uint32_t s2 = zxc_le32(seq_ptr + sizeof(uint32_t));
+            uint32_t s3 = zxc_le32(seq_ptr + 2 * sizeof(uint32_t));
+            uint32_t s4 = zxc_le32(seq_ptr + 3 * sizeof(uint32_t));
+            seq_ptr += 4 * sizeof(uint32_t);
 
             // Prefetch ahead in literal and extras streams to hide memory latency
             ZXC_PREFETCH_READ(l_ptr + ZXC_CACHE_LINE_SIZE);
@@ -1790,10 +1790,10 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(zxc_cctx_t* RESTRICT ctx,
     } else {
         while (n_seq >= 4 && d_ptr < d_end_fast && l_ptr < l_end_safe_4x) {
             uint32_t s1 = zxc_le32(seq_ptr);
-            uint32_t s2 = zxc_le32(seq_ptr + 4);
-            uint32_t s3 = zxc_le32(seq_ptr + 8);
-            uint32_t s4 = zxc_le32(seq_ptr + 12);
-            seq_ptr += 16;
+            uint32_t s2 = zxc_le32(seq_ptr + sizeof(uint32_t));
+            uint32_t s3 = zxc_le32(seq_ptr + 2 * sizeof(uint32_t));
+            uint32_t s4 = zxc_le32(seq_ptr + 3 * sizeof(uint32_t));
+            seq_ptr += 4 * sizeof(uint32_t);
 
             // Prefetch ahead in literal and extras streams to hide memory latency
             ZXC_PREFETCH_READ(l_ptr + ZXC_CACHE_LINE_SIZE);
@@ -1883,7 +1883,7 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(zxc_cctx_t* RESTRICT ctx,
         const uint8_t* ext_save = extras_ptr;
 
         const uint32_t seq = zxc_le32(seq_ptr);
-        seq_ptr += 4;
+        seq_ptr += sizeof(uint32_t);
 
         uint64_t ll = (uint32_t)(seq >> 24);
         if (UNLIKELY(ll == ZXC_SEQ_LL_MASK)) {
@@ -1967,7 +1967,7 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(zxc_cctx_t* RESTRICT ctx,
     // --- Safe Path for Remaining Sequences ---
     while (n_seq > 0) {
         uint32_t seq = zxc_le32(seq_ptr);
-        seq_ptr += 4;
+        seq_ptr += sizeof(uint32_t);
 
         uint64_t ll = (uint32_t)(seq >> 24);
         if (UNLIKELY(ll == ZXC_SEQ_LL_MASK)) ll += zxc_read_varint(&extras_ptr, extras_end);

--- a/src/lib/zxc_decompress.c
+++ b/src/lib/zxc_decompress.c
@@ -674,7 +674,7 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
                     // Raw copy (most common path): use ZXC_PAD_SIZE-byte wild copies
                     // token is 7-bit (0-127), so len is 1-128 bytes
                     const uint32_t len = (uint32_t)token + 1;
-                    if (UNLIKELY(w_ptr + len > w_end || r_ptr + len > r_end))
+                    if (UNLIKELY((size_t)(w_end - w_ptr) < len || (size_t)(r_end - r_ptr) < len))
                         return ZXC_ERROR_CORRUPT_DATA;
 
                     // Destination has ZXC_PAD_SIZE bytes of safe overrun space.
@@ -708,7 +708,7 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
                 } else {
                     // RLE run: fill with single byte
                     const uint32_t len = (token & ZXC_LIT_LEN_MASK) + 4;
-                    if (UNLIKELY(w_ptr + len > w_end || r_ptr >= r_end))
+                    if (UNLIKELY((size_t)(w_end - w_ptr) < len || r_ptr >= r_end))
                         return ZXC_ERROR_CORRUPT_DATA;
                     ZXC_MEMSET(w_ptr, *r_ptr++, len);
                     w_ptr += len;
@@ -819,14 +819,15 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
                 ll1 += zxc_read_varint(&e_ptr, e_end);
                 const uint64_t reserve =
                     ((tokens >> 12) & 0xF) + ((tokens >> 20) & 0xF) + (tokens >> 28);
-                if (UNLIKELY(l_ptr + ll1 + reserve > l_end || d_ptr + ll1 + ZXC_PAD_SIZE > d_end))
+                if (UNLIKELY(ll1 + reserve > (size_t)(l_end - l_ptr) ||
+                             ll1 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
                     goto rollback_safe_4x;
             }
             if (UNLIKELY(ml1 == ZXC_TOKEN_ML_MASK)) {
                 ml1 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY(d_ptr + ll1 + ml1 + ZXC_LZ_MIN_MATCH_LEN +
+                if (UNLIKELY(ll1 + ml1 + ZXC_LZ_MIN_MATCH_LEN +
                                  3U * ZXC_GLO_MAX_INLINE_OUT_PER_SEQ + ZXC_PAD_SIZE >
-                             d_end))
+                             (size_t)(d_end - d_ptr)))
                     goto rollback_safe_4x;
             }
             ml1 += ZXC_LZ_MIN_MATCH_LEN;
@@ -837,14 +838,15 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
             if (UNLIKELY(ll2 == ZXC_TOKEN_LL_MASK)) {
                 ll2 += zxc_read_varint(&e_ptr, e_end);
                 const uint64_t reserve = ((tokens >> 20) & 0xF) + (tokens >> 28);
-                if (UNLIKELY(l_ptr + ll2 + reserve > l_end || d_ptr + ll2 + ZXC_PAD_SIZE > d_end))
+                if (UNLIKELY(ll2 + reserve > (size_t)(l_end - l_ptr) ||
+                             ll2 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
                     goto rollback_safe_4x;
             }
             if (UNLIKELY(ml2 == ZXC_TOKEN_ML_MASK)) {
                 ml2 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY(d_ptr + ll2 + ml2 + ZXC_LZ_MIN_MATCH_LEN +
+                if (UNLIKELY(ll2 + ml2 + ZXC_LZ_MIN_MATCH_LEN +
                                  2U * ZXC_GLO_MAX_INLINE_OUT_PER_SEQ + ZXC_PAD_SIZE >
-                             d_end))
+                             (size_t)(d_end - d_ptr)))
                     goto rollback_safe_4x;
             }
             ml2 += ZXC_LZ_MIN_MATCH_LEN;
@@ -855,14 +857,15 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
             if (UNLIKELY(ll3 == ZXC_TOKEN_LL_MASK)) {
                 ll3 += zxc_read_varint(&e_ptr, e_end);
                 const uint64_t reserve = (tokens >> 28);
-                if (UNLIKELY(l_ptr + ll3 + reserve > l_end || d_ptr + ll3 + ZXC_PAD_SIZE > d_end))
+                if (UNLIKELY(ll3 + reserve > (size_t)(l_end - l_ptr) ||
+                             ll3 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
                     goto rollback_safe_4x;
             }
             if (UNLIKELY(ml3 == ZXC_TOKEN_ML_MASK)) {
                 ml3 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY(d_ptr + ll3 + ml3 + ZXC_LZ_MIN_MATCH_LEN +
-                                 ZXC_GLO_MAX_INLINE_OUT_PER_SEQ + ZXC_PAD_SIZE >
-                             d_end))
+                if (UNLIKELY(ll3 + ml3 + ZXC_LZ_MIN_MATCH_LEN + ZXC_GLO_MAX_INLINE_OUT_PER_SEQ +
+                                 ZXC_PAD_SIZE >
+                             (size_t)(d_end - d_ptr)))
                     goto rollback_safe_4x;
             }
             ml3 += ZXC_LZ_MIN_MATCH_LEN;
@@ -872,12 +875,14 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
             uint64_t ml4 = (tokens >> 24) & 0x0F;
             if (UNLIKELY(ll4 == ZXC_TOKEN_LL_MASK)) {
                 ll4 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY(l_ptr + ll4 > l_end || d_ptr + ll4 + ZXC_PAD_SIZE > d_end))
+                if (UNLIKELY(ll4 > (size_t)(l_end - l_ptr) ||
+                             ll4 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
                     goto rollback_safe_4x;
             }
             if (UNLIKELY(ml4 == ZXC_TOKEN_ML_MASK)) {
                 ml4 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY(d_ptr + ll4 + ml4 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE > d_end))
+                if (UNLIKELY(ll4 + ml4 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE >
+                             (size_t)(d_end - d_ptr)))
                     goto rollback_safe_4x;
             }
             ml4 += ZXC_LZ_MIN_MATCH_LEN;
@@ -927,14 +932,15 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
                 ll1 += zxc_read_varint(&e_ptr, e_end);
                 const uint64_t reserve =
                     ((tokens >> 12) & 0xF) + ((tokens >> 20) & 0xF) + (tokens >> 28);
-                if (UNLIKELY(l_ptr + ll1 + reserve > l_end || d_ptr + ll1 + ZXC_PAD_SIZE > d_end))
+                if (UNLIKELY(ll1 + reserve > (size_t)(l_end - l_ptr) ||
+                             ll1 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
             if (UNLIKELY(ml1 == ZXC_TOKEN_ML_MASK)) {
                 ml1 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY(d_ptr + ll1 + ml1 + ZXC_LZ_MIN_MATCH_LEN +
+                if (UNLIKELY(ll1 + ml1 + ZXC_LZ_MIN_MATCH_LEN +
                                  3U * ZXC_GLO_MAX_INLINE_OUT_PER_SEQ + ZXC_PAD_SIZE >
-                             d_end))
+                             (size_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
             ml1 += ZXC_LZ_MIN_MATCH_LEN;
@@ -945,14 +951,15 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
             if (UNLIKELY(ll2 == ZXC_TOKEN_LL_MASK)) {
                 ll2 += zxc_read_varint(&e_ptr, e_end);
                 const uint64_t reserve = ((tokens >> 20) & 0xF) + (tokens >> 28);
-                if (UNLIKELY(l_ptr + ll2 + reserve > l_end || d_ptr + ll2 + ZXC_PAD_SIZE > d_end))
+                if (UNLIKELY(ll2 + reserve > (size_t)(l_end - l_ptr) ||
+                             ll2 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
             if (UNLIKELY(ml2 == ZXC_TOKEN_ML_MASK)) {
                 ml2 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY(d_ptr + ll2 + ml2 + ZXC_LZ_MIN_MATCH_LEN +
+                if (UNLIKELY(ll2 + ml2 + ZXC_LZ_MIN_MATCH_LEN +
                                  2U * ZXC_GLO_MAX_INLINE_OUT_PER_SEQ + ZXC_PAD_SIZE >
-                             d_end))
+                             (size_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
             ml2 += ZXC_LZ_MIN_MATCH_LEN;
@@ -963,14 +970,15 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
             if (UNLIKELY(ll3 == ZXC_TOKEN_LL_MASK)) {
                 ll3 += zxc_read_varint(&e_ptr, e_end);
                 const uint64_t reserve = (tokens >> 28);
-                if (UNLIKELY(l_ptr + ll3 + reserve > l_end || d_ptr + ll3 + ZXC_PAD_SIZE > d_end))
+                if (UNLIKELY(ll3 + reserve > (size_t)(l_end - l_ptr) ||
+                             ll3 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
             if (UNLIKELY(ml3 == ZXC_TOKEN_ML_MASK)) {
                 ml3 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY(d_ptr + ll3 + ml3 + ZXC_LZ_MIN_MATCH_LEN +
-                                 ZXC_GLO_MAX_INLINE_OUT_PER_SEQ + ZXC_PAD_SIZE >
-                             d_end))
+                if (UNLIKELY(ll3 + ml3 + ZXC_LZ_MIN_MATCH_LEN + ZXC_GLO_MAX_INLINE_OUT_PER_SEQ +
+                                 ZXC_PAD_SIZE >
+                             (size_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
             ml3 += ZXC_LZ_MIN_MATCH_LEN;
@@ -980,12 +988,14 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
             uint64_t ml4 = (tokens >> 24) & 0x0F;
             if (UNLIKELY(ll4 == ZXC_TOKEN_LL_MASK)) {
                 ll4 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY(l_ptr + ll4 > l_end || d_ptr + ll4 + ZXC_PAD_SIZE > d_end))
+                if (UNLIKELY(ll4 > (size_t)(l_end - l_ptr) ||
+                             ll4 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
             if (UNLIKELY(ml4 == ZXC_TOKEN_ML_MASK)) {
                 ml4 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY(d_ptr + ll4 + ml4 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE > d_end))
+                if (UNLIKELY(ll4 + ml4 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE >
+                             (size_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
             ml4 += ZXC_LZ_MIN_MATCH_LEN;
@@ -1030,14 +1040,15 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
                 ll1 += zxc_read_varint(&e_ptr, e_end);
                 const uint64_t reserve =
                     ((tokens >> 12) & 0xF) + ((tokens >> 20) & 0xF) + (tokens >> 28);
-                if (UNLIKELY(l_ptr + ll1 + reserve > l_end || d_ptr + ll1 + ZXC_PAD_SIZE > d_end))
+                if (UNLIKELY(ll1 + reserve > (size_t)(l_end - l_ptr) ||
+                             ll1 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
                     goto rollback_fast_4x;
             }
             if (UNLIKELY(ml1 == ZXC_TOKEN_ML_MASK)) {
                 ml1 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY(d_ptr + ll1 + ml1 + ZXC_LZ_MIN_MATCH_LEN +
+                if (UNLIKELY(ll1 + ml1 + ZXC_LZ_MIN_MATCH_LEN +
                                  3U * ZXC_GLO_MAX_INLINE_OUT_PER_SEQ + ZXC_PAD_SIZE >
-                             d_end))
+                             (size_t)(d_end - d_ptr)))
                     goto rollback_fast_4x;
             }
             ml1 += ZXC_LZ_MIN_MATCH_LEN;
@@ -1048,14 +1059,15 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
             if (UNLIKELY(ll2 == ZXC_TOKEN_LL_MASK)) {
                 ll2 += zxc_read_varint(&e_ptr, e_end);
                 const uint64_t reserve = ((tokens >> 20) & 0xF) + (tokens >> 28);
-                if (UNLIKELY(l_ptr + ll2 + reserve > l_end || d_ptr + ll2 + ZXC_PAD_SIZE > d_end))
+                if (UNLIKELY(ll2 + reserve > (size_t)(l_end - l_ptr) ||
+                             ll2 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
                     goto rollback_fast_4x;
             }
             if (UNLIKELY(ml2 == ZXC_TOKEN_ML_MASK)) {
                 ml2 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY(d_ptr + ll2 + ml2 + ZXC_LZ_MIN_MATCH_LEN +
+                if (UNLIKELY(ll2 + ml2 + ZXC_LZ_MIN_MATCH_LEN +
                                  2U * ZXC_GLO_MAX_INLINE_OUT_PER_SEQ + ZXC_PAD_SIZE >
-                             d_end))
+                             (size_t)(d_end - d_ptr)))
                     goto rollback_fast_4x;
             }
             ml2 += ZXC_LZ_MIN_MATCH_LEN;
@@ -1066,14 +1078,15 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
             if (UNLIKELY(ll3 == ZXC_TOKEN_LL_MASK)) {
                 ll3 += zxc_read_varint(&e_ptr, e_end);
                 const uint64_t reserve = (tokens >> 28);
-                if (UNLIKELY(l_ptr + ll3 + reserve > l_end || d_ptr + ll3 + ZXC_PAD_SIZE > d_end))
+                if (UNLIKELY(ll3 + reserve > (size_t)(l_end - l_ptr) ||
+                             ll3 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
                     goto rollback_fast_4x;
             }
             if (UNLIKELY(ml3 == ZXC_TOKEN_ML_MASK)) {
                 ml3 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY(d_ptr + ll3 + ml3 + ZXC_LZ_MIN_MATCH_LEN +
-                                 ZXC_GLO_MAX_INLINE_OUT_PER_SEQ + ZXC_PAD_SIZE >
-                             d_end))
+                if (UNLIKELY(ll3 + ml3 + ZXC_LZ_MIN_MATCH_LEN + ZXC_GLO_MAX_INLINE_OUT_PER_SEQ +
+                                 ZXC_PAD_SIZE >
+                             (size_t)(d_end - d_ptr)))
                     goto rollback_fast_4x;
             }
             ml3 += ZXC_LZ_MIN_MATCH_LEN;
@@ -1083,12 +1096,14 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
             uint64_t ml4 = (tokens >> 24) & 0x0F;
             if (UNLIKELY(ll4 == ZXC_TOKEN_LL_MASK)) {
                 ll4 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY(l_ptr + ll4 > l_end || d_ptr + ll4 + ZXC_PAD_SIZE > d_end))
+                if (UNLIKELY(ll4 > (size_t)(l_end - l_ptr) ||
+                             ll4 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
                     goto rollback_fast_4x;
             }
             if (UNLIKELY(ml4 == ZXC_TOKEN_ML_MASK)) {
                 ml4 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY(d_ptr + ll4 + ml4 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE > d_end))
+                if (UNLIKELY(ll4 + ml4 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE >
+                             (size_t)(d_end - d_ptr)))
                     goto rollback_fast_4x;
             }
             ml4 += ZXC_LZ_MIN_MATCH_LEN;
@@ -1136,14 +1151,15 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
                 ll1 += zxc_read_varint(&e_ptr, e_end);
                 const uint64_t reserve =
                     ((tokens >> 12) & 0xF) + ((tokens >> 20) & 0xF) + (tokens >> 28);
-                if (UNLIKELY(l_ptr + ll1 + reserve > l_end || d_ptr + ll1 + ZXC_PAD_SIZE > d_end))
+                if (UNLIKELY(ll1 + reserve > (size_t)(l_end - l_ptr) ||
+                             ll1 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
             if (UNLIKELY(ml1 == ZXC_TOKEN_ML_MASK)) {
                 ml1 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY(d_ptr + ll1 + ml1 + ZXC_LZ_MIN_MATCH_LEN +
+                if (UNLIKELY(ll1 + ml1 + ZXC_LZ_MIN_MATCH_LEN +
                                  3U * ZXC_GLO_MAX_INLINE_OUT_PER_SEQ + ZXC_PAD_SIZE >
-                             d_end))
+                             (size_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
             ml1 += ZXC_LZ_MIN_MATCH_LEN;
@@ -1154,14 +1170,15 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
             if (UNLIKELY(ll2 == ZXC_TOKEN_LL_MASK)) {
                 ll2 += zxc_read_varint(&e_ptr, e_end);
                 const uint64_t reserve = ((tokens >> 20) & 0xF) + (tokens >> 28);
-                if (UNLIKELY(l_ptr + ll2 + reserve > l_end || d_ptr + ll2 + ZXC_PAD_SIZE > d_end))
+                if (UNLIKELY(ll2 + reserve > (size_t)(l_end - l_ptr) ||
+                             ll2 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
             if (UNLIKELY(ml2 == ZXC_TOKEN_ML_MASK)) {
                 ml2 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY(d_ptr + ll2 + ml2 + ZXC_LZ_MIN_MATCH_LEN +
+                if (UNLIKELY(ll2 + ml2 + ZXC_LZ_MIN_MATCH_LEN +
                                  2U * ZXC_GLO_MAX_INLINE_OUT_PER_SEQ + ZXC_PAD_SIZE >
-                             d_end))
+                             (size_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
             ml2 += ZXC_LZ_MIN_MATCH_LEN;
@@ -1172,14 +1189,15 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
             if (UNLIKELY(ll3 == ZXC_TOKEN_LL_MASK)) {
                 ll3 += zxc_read_varint(&e_ptr, e_end);
                 const uint64_t reserve = (tokens >> 28);
-                if (UNLIKELY(l_ptr + ll3 + reserve > l_end || d_ptr + ll3 + ZXC_PAD_SIZE > d_end))
+                if (UNLIKELY(ll3 + reserve > (size_t)(l_end - l_ptr) ||
+                             ll3 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
             if (UNLIKELY(ml3 == ZXC_TOKEN_ML_MASK)) {
                 ml3 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY(d_ptr + ll3 + ml3 + ZXC_LZ_MIN_MATCH_LEN +
-                                 ZXC_GLO_MAX_INLINE_OUT_PER_SEQ + ZXC_PAD_SIZE >
-                             d_end))
+                if (UNLIKELY(ll3 + ml3 + ZXC_LZ_MIN_MATCH_LEN + ZXC_GLO_MAX_INLINE_OUT_PER_SEQ +
+                                 ZXC_PAD_SIZE >
+                             (size_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
             ml3 += ZXC_LZ_MIN_MATCH_LEN;
@@ -1189,12 +1207,14 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
             uint64_t ml4 = (tokens >> 24) & 0x0F;
             if (UNLIKELY(ll4 == ZXC_TOKEN_LL_MASK)) {
                 ll4 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY(l_ptr + ll4 > l_end || d_ptr + ll4 + ZXC_PAD_SIZE > d_end))
+                if (UNLIKELY(ll4 > (size_t)(l_end - l_ptr) ||
+                             ll4 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
             if (UNLIKELY(ml4 == ZXC_TOKEN_ML_MASK)) {
                 ml4 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY(d_ptr + ll4 + ml4 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE > d_end))
+                if (UNLIKELY(ll4 + ml4 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE >
+                             (size_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
             ml4 += ZXC_LZ_MIN_MATCH_LEN;
@@ -1227,7 +1247,7 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
 
         if (UNLIKELY(ll == ZXC_TOKEN_LL_MASK)) {
             ll += zxc_read_varint(&e_ptr, e_end);
-            if (UNLIKELY(l_ptr + ll > l_end)) {
+            if (UNLIKELY((size_t)(l_end - l_ptr) < ll)) {
                 t_ptr = t_save;
                 o_ptr = o_save;
                 e_ptr = e_save;
@@ -1238,7 +1258,7 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
         ml += ZXC_LZ_MIN_MATCH_LEN;
 
         // Check bounds before wild copies - if too close to end, fall back to Safe Path
-        if (UNLIKELY(d_ptr + ll + ml + ZXC_PAD_SIZE > d_end)) {
+        if (UNLIKELY(ll + ml + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr))) {
             // Restore pointers and let Safe Path handle this sequence
             t_ptr = t_save;
             o_ptr = o_save;
@@ -1319,7 +1339,8 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
         if (UNLIKELY(ml == ZXC_TOKEN_ML_MASK)) ml += zxc_read_varint(&e_ptr, e_end);
         ml += ZXC_LZ_MIN_MATCH_LEN;
 
-        if (UNLIKELY(d_ptr + ll + ml > d_end || l_ptr + ll > l_end)) return ZXC_ERROR_OVERFLOW;
+        if (UNLIKELY(ll + ml > (size_t)(d_end - d_ptr) || (size_t)(l_end - l_ptr) < ll))
+            return ZXC_ERROR_OVERFLOW;
         ZXC_MEMCPY(d_ptr, l_ptr, ll);
         l_ptr += ll;
         d_ptr += ll;
@@ -1341,7 +1362,7 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
     if (UNLIKELY(l_ptr > l_end)) return ZXC_ERROR_CORRUPT_DATA;
     const size_t remaining_literals = (size_t)(l_end - l_ptr);
     if (remaining_literals > 0) {
-        if (UNLIKELY(d_ptr + remaining_literals > d_end)) return ZXC_ERROR_OVERFLOW;
+        if (UNLIKELY((size_t)(d_end - d_ptr) < remaining_literals)) return ZXC_ERROR_OVERFLOW;
         ZXC_MEMCPY(d_ptr, l_ptr, remaining_literals);
         d_ptr += remaining_literals;
     }
@@ -1454,16 +1475,16 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(zxc_cctx_t* RESTRICT ctx,
             if (UNLIKELY(ll1 == ZXC_SEQ_LL_MASK)) {
                 ll1 += zxc_read_varint(&extras_ptr, extras_end);
                 const uint64_t reserve = (s2 >> 24) + (s3 >> 24) + (s4 >> 24);
-                if (UNLIKELY(l_ptr + ll1 + reserve > l_end || d_ptr + ll1 + ZXC_PAD_SIZE > d_end))
+                if (UNLIKELY(ll1 + reserve > (size_t)(l_end - l_ptr) ||
+                             ll1 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
                     goto rollback_safe_4x;
             }
             uint32_t m1b = (uint32_t)((s1 >> 16) & 0xFF);
             uint64_t ml1 = m1b + ZXC_LZ_MIN_MATCH_LEN;
             if (UNLIKELY(m1b == ZXC_SEQ_ML_MASK)) {
                 ml1 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY(d_ptr + ll1 + ml1 + 3U * ZXC_GHI_MAX_INLINE_OUT_PER_SEQ +
-                                 ZXC_PAD_SIZE >
-                             d_end))
+                if (UNLIKELY(ll1 + ml1 + 3U * ZXC_GHI_MAX_INLINE_OUT_PER_SEQ + ZXC_PAD_SIZE >
+                             (size_t)(d_end - d_ptr)))
                     goto rollback_safe_4x;
             }
             uint32_t off1 = (uint32_t)(s1 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
@@ -1473,16 +1494,16 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(zxc_cctx_t* RESTRICT ctx,
             if (UNLIKELY(ll2 == ZXC_SEQ_LL_MASK)) {
                 ll2 += zxc_read_varint(&extras_ptr, extras_end);
                 const uint64_t reserve = (s3 >> 24) + (s4 >> 24);
-                if (UNLIKELY(l_ptr + ll2 + reserve > l_end || d_ptr + ll2 + ZXC_PAD_SIZE > d_end))
+                if (UNLIKELY(ll2 + reserve > (size_t)(l_end - l_ptr) ||
+                             ll2 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
                     goto rollback_safe_4x;
             }
             uint32_t m2b = (uint32_t)((s2 >> 16) & 0xFF);
             uint64_t ml2 = m2b + ZXC_LZ_MIN_MATCH_LEN;
             if (UNLIKELY(m2b == ZXC_SEQ_ML_MASK)) {
                 ml2 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY(d_ptr + ll2 + ml2 + 2U * ZXC_GHI_MAX_INLINE_OUT_PER_SEQ +
-                                 ZXC_PAD_SIZE >
-                             d_end))
+                if (UNLIKELY(ll2 + ml2 + 2U * ZXC_GHI_MAX_INLINE_OUT_PER_SEQ + ZXC_PAD_SIZE >
+                             (size_t)(d_end - d_ptr)))
                     goto rollback_safe_4x;
             }
             uint32_t off2 = (uint32_t)(s2 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
@@ -1492,15 +1513,16 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(zxc_cctx_t* RESTRICT ctx,
             if (UNLIKELY(ll3 == ZXC_SEQ_LL_MASK)) {
                 ll3 += zxc_read_varint(&extras_ptr, extras_end);
                 const uint64_t reserve = (s4 >> 24);
-                if (UNLIKELY(l_ptr + ll3 + reserve > l_end || d_ptr + ll3 + ZXC_PAD_SIZE > d_end))
+                if (UNLIKELY(ll3 + reserve > (size_t)(l_end - l_ptr) ||
+                             ll3 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
                     goto rollback_safe_4x;
             }
             uint32_t m3b = (uint32_t)((s3 >> 16) & 0xFF);
             uint64_t ml3 = m3b + ZXC_LZ_MIN_MATCH_LEN;
             if (UNLIKELY(m3b == ZXC_SEQ_ML_MASK)) {
                 ml3 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY(d_ptr + ll3 + ml3 + ZXC_GHI_MAX_INLINE_OUT_PER_SEQ + ZXC_PAD_SIZE >
-                             d_end))
+                if (UNLIKELY(ll3 + ml3 + ZXC_GHI_MAX_INLINE_OUT_PER_SEQ + ZXC_PAD_SIZE >
+                             (size_t)(d_end - d_ptr)))
                     goto rollback_safe_4x;
             }
             uint32_t off3 = (uint32_t)(s3 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
@@ -1509,14 +1531,16 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(zxc_cctx_t* RESTRICT ctx,
             uint64_t ll4 = (uint32_t)(s4 >> 24);
             if (UNLIKELY(ll4 == ZXC_SEQ_LL_MASK)) {
                 ll4 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY(l_ptr + ll4 > l_end || d_ptr + ll4 + ZXC_PAD_SIZE > d_end))
+                if (UNLIKELY(ll4 > (size_t)(l_end - l_ptr) ||
+                             ll4 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
                     goto rollback_safe_4x;
             }
             uint32_t m4b = (uint32_t)((s4 >> 16) & 0xFF);
             uint64_t ml4 = m4b + ZXC_LZ_MIN_MATCH_LEN;
             if (UNLIKELY(m4b == ZXC_SEQ_ML_MASK)) {
                 ml4 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY(d_ptr + ll4 + ml4 + ZXC_PAD_SIZE > d_end)) goto rollback_safe_4x;
+                if (UNLIKELY(ll4 + ml4 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
+                    goto rollback_safe_4x;
             }
             uint32_t off4 = (uint32_t)(s4 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
             DECODE_SEQ_SAFE(ll4, ml4, off4);
@@ -1545,16 +1569,16 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(zxc_cctx_t* RESTRICT ctx,
             if (UNLIKELY(ll1 == ZXC_SEQ_LL_MASK)) {
                 ll1 += zxc_read_varint(&extras_ptr, extras_end);
                 const uint64_t reserve = (s2 >> 24) + (s3 >> 24) + (s4 >> 24);
-                if (UNLIKELY(l_ptr + ll1 + reserve > l_end || d_ptr + ll1 + ZXC_PAD_SIZE > d_end))
+                if (UNLIKELY(ll1 + reserve > (size_t)(l_end - l_ptr) ||
+                             ll1 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
             uint32_t m1b = (uint32_t)((s1 >> 16) & 0xFF);
             uint64_t ml1 = m1b + ZXC_LZ_MIN_MATCH_LEN;
             if (UNLIKELY(m1b == ZXC_SEQ_ML_MASK)) {
                 ml1 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY(d_ptr + ll1 + ml1 + 3U * ZXC_GHI_MAX_INLINE_OUT_PER_SEQ +
-                                 ZXC_PAD_SIZE >
-                             d_end))
+                if (UNLIKELY(ll1 + ml1 + 3U * ZXC_GHI_MAX_INLINE_OUT_PER_SEQ + ZXC_PAD_SIZE >
+                             (size_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
             uint32_t off1 = (uint32_t)(s1 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
@@ -1564,16 +1588,16 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(zxc_cctx_t* RESTRICT ctx,
             if (UNLIKELY(ll2 == ZXC_SEQ_LL_MASK)) {
                 ll2 += zxc_read_varint(&extras_ptr, extras_end);
                 const uint64_t reserve = (s3 >> 24) + (s4 >> 24);
-                if (UNLIKELY(l_ptr + ll2 + reserve > l_end || d_ptr + ll2 + ZXC_PAD_SIZE > d_end))
+                if (UNLIKELY(ll2 + reserve > (size_t)(l_end - l_ptr) ||
+                             ll2 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
             uint32_t m2b = (uint32_t)((s2 >> 16) & 0xFF);
             uint64_t ml2 = m2b + ZXC_LZ_MIN_MATCH_LEN;
             if (UNLIKELY(m2b == ZXC_SEQ_ML_MASK)) {
                 ml2 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY(d_ptr + ll2 + ml2 + 2U * ZXC_GHI_MAX_INLINE_OUT_PER_SEQ +
-                                 ZXC_PAD_SIZE >
-                             d_end))
+                if (UNLIKELY(ll2 + ml2 + 2U * ZXC_GHI_MAX_INLINE_OUT_PER_SEQ + ZXC_PAD_SIZE >
+                             (size_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
             uint32_t off2 = (uint32_t)(s2 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
@@ -1583,15 +1607,16 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(zxc_cctx_t* RESTRICT ctx,
             if (UNLIKELY(ll3 == ZXC_SEQ_LL_MASK)) {
                 ll3 += zxc_read_varint(&extras_ptr, extras_end);
                 const uint64_t reserve = (s4 >> 24);
-                if (UNLIKELY(l_ptr + ll3 + reserve > l_end || d_ptr + ll3 + ZXC_PAD_SIZE > d_end))
+                if (UNLIKELY(ll3 + reserve > (size_t)(l_end - l_ptr) ||
+                             ll3 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
             uint32_t m3b = (uint32_t)((s3 >> 16) & 0xFF);
             uint64_t ml3 = m3b + ZXC_LZ_MIN_MATCH_LEN;
             if (UNLIKELY(m3b == ZXC_SEQ_ML_MASK)) {
                 ml3 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY(d_ptr + ll3 + ml3 + ZXC_GHI_MAX_INLINE_OUT_PER_SEQ + ZXC_PAD_SIZE >
-                             d_end))
+                if (UNLIKELY(ll3 + ml3 + ZXC_GHI_MAX_INLINE_OUT_PER_SEQ + ZXC_PAD_SIZE >
+                             (size_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
             uint32_t off3 = (uint32_t)(s3 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
@@ -1600,14 +1625,16 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(zxc_cctx_t* RESTRICT ctx,
             uint64_t ll4 = (uint32_t)(s4 >> 24);
             if (UNLIKELY(ll4 == ZXC_SEQ_LL_MASK)) {
                 ll4 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY(l_ptr + ll4 > l_end || d_ptr + ll4 + ZXC_PAD_SIZE > d_end))
+                if (UNLIKELY(ll4 > (size_t)(l_end - l_ptr) ||
+                             ll4 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
             uint32_t m4b = (uint32_t)((s4 >> 16) & 0xFF);
             uint64_t ml4 = m4b + ZXC_LZ_MIN_MATCH_LEN;
             if (UNLIKELY(m4b == ZXC_SEQ_ML_MASK)) {
                 ml4 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY(d_ptr + ll4 + ml4 + ZXC_PAD_SIZE > d_end)) return ZXC_ERROR_OVERFLOW;
+                if (UNLIKELY(ll4 + ml4 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
+                    return ZXC_ERROR_OVERFLOW;
             }
             uint32_t off4 = (uint32_t)(s4 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
             DECODE_SEQ_SAFE(ll4, ml4, off4);
@@ -1632,15 +1659,18 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(zxc_cctx_t* RESTRICT ctx,
 
         // Strict bounds check: sequence must fit, AND wild copies must not overshoot
         // Check both destination (d_ptr) and source literal stream (l_ptr)
-        if (UNLIKELY(d_ptr + ll + ml + ZXC_PAD_SIZE > d_end || l_ptr + ll + ZXC_PAD_SIZE > l_end)) {
+        if (UNLIKELY(ll + ml + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr) ||
+                     ll + ZXC_PAD_SIZE > (size_t)(l_end - l_ptr))) {
             // Fallback to exact copy (slow but safe)
-            if (UNLIKELY(d_ptr + ll > d_end || l_ptr + ll > l_end)) return ZXC_ERROR_OVERFLOW;
+            if (UNLIKELY((size_t)(d_end - d_ptr) < ll || (size_t)(l_end - l_ptr) < ll))
+                return ZXC_ERROR_OVERFLOW;
             ZXC_MEMCPY(d_ptr, l_ptr, ll);
             l_ptr += ll;
             d_ptr += ll;
             written += ll;
 
-            if (UNLIKELY(offset > written || d_ptr + ml > d_end)) return ZXC_ERROR_BAD_OFFSET;
+            if (UNLIKELY(offset > written || (size_t)(d_end - d_ptr) < ml))
+                return ZXC_ERROR_BAD_OFFSET;
             const uint8_t* match_src = d_ptr - offset;
 
             if (offset < ml) {
@@ -1677,16 +1707,16 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(zxc_cctx_t* RESTRICT ctx,
             if (UNLIKELY(ll1 == ZXC_SEQ_LL_MASK)) {
                 ll1 += zxc_read_varint(&extras_ptr, extras_end);
                 const uint64_t reserve = (s2 >> 24) + (s3 >> 24) + (s4 >> 24);
-                if (UNLIKELY(l_ptr + ll1 + reserve > l_end || d_ptr + ll1 + ZXC_PAD_SIZE > d_end))
+                if (UNLIKELY(ll1 + reserve > (size_t)(l_end - l_ptr) ||
+                             ll1 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
                     goto rollback_fast_4x;
             }
             uint32_t m1b = (uint32_t)((s1 >> 16) & 0xFF);
             uint64_t ml1 = m1b + ZXC_LZ_MIN_MATCH_LEN;
             if (UNLIKELY(m1b == ZXC_SEQ_ML_MASK)) {
                 ml1 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY(d_ptr + ll1 + ml1 + 3U * ZXC_GHI_MAX_INLINE_OUT_PER_SEQ +
-                                 ZXC_PAD_SIZE >
-                             d_end))
+                if (UNLIKELY(ll1 + ml1 + 3U * ZXC_GHI_MAX_INLINE_OUT_PER_SEQ + ZXC_PAD_SIZE >
+                             (size_t)(d_end - d_ptr)))
                     goto rollback_fast_4x;
             }
             uint32_t off1 = (uint32_t)(s1 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
@@ -1696,16 +1726,16 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(zxc_cctx_t* RESTRICT ctx,
             if (UNLIKELY(ll2 == ZXC_SEQ_LL_MASK)) {
                 ll2 += zxc_read_varint(&extras_ptr, extras_end);
                 const uint64_t reserve = (s3 >> 24) + (s4 >> 24);
-                if (UNLIKELY(l_ptr + ll2 + reserve > l_end || d_ptr + ll2 + ZXC_PAD_SIZE > d_end))
+                if (UNLIKELY(ll2 + reserve > (size_t)(l_end - l_ptr) ||
+                             ll2 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
                     goto rollback_fast_4x;
             }
             uint32_t m2b = (uint32_t)((s2 >> 16) & 0xFF);
             uint64_t ml2 = m2b + ZXC_LZ_MIN_MATCH_LEN;
             if (UNLIKELY(m2b == ZXC_SEQ_ML_MASK)) {
                 ml2 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY(d_ptr + ll2 + ml2 + 2U * ZXC_GHI_MAX_INLINE_OUT_PER_SEQ +
-                                 ZXC_PAD_SIZE >
-                             d_end))
+                if (UNLIKELY(ll2 + ml2 + 2U * ZXC_GHI_MAX_INLINE_OUT_PER_SEQ + ZXC_PAD_SIZE >
+                             (size_t)(d_end - d_ptr)))
                     goto rollback_fast_4x;
             }
             uint32_t off2 = (uint32_t)(s2 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
@@ -1715,15 +1745,16 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(zxc_cctx_t* RESTRICT ctx,
             if (UNLIKELY(ll3 == ZXC_SEQ_LL_MASK)) {
                 ll3 += zxc_read_varint(&extras_ptr, extras_end);
                 const uint64_t reserve = (s4 >> 24);
-                if (UNLIKELY(l_ptr + ll3 + reserve > l_end || d_ptr + ll3 + ZXC_PAD_SIZE > d_end))
+                if (UNLIKELY(ll3 + reserve > (size_t)(l_end - l_ptr) ||
+                             ll3 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
                     goto rollback_fast_4x;
             }
             uint32_t m3b = (uint32_t)((s3 >> 16) & 0xFF);
             uint64_t ml3 = m3b + ZXC_LZ_MIN_MATCH_LEN;
             if (UNLIKELY(m3b == ZXC_SEQ_ML_MASK)) {
                 ml3 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY(d_ptr + ll3 + ml3 + ZXC_GHI_MAX_INLINE_OUT_PER_SEQ + ZXC_PAD_SIZE >
-                             d_end))
+                if (UNLIKELY(ll3 + ml3 + ZXC_GHI_MAX_INLINE_OUT_PER_SEQ + ZXC_PAD_SIZE >
+                             (size_t)(d_end - d_ptr)))
                     goto rollback_fast_4x;
             }
             uint32_t off3 = (uint32_t)(s3 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
@@ -1732,14 +1763,16 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(zxc_cctx_t* RESTRICT ctx,
             uint64_t ll4 = (uint32_t)(s4 >> 24);
             if (UNLIKELY(ll4 == ZXC_SEQ_LL_MASK)) {
                 ll4 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY(l_ptr + ll4 > l_end || d_ptr + ll4 + ZXC_PAD_SIZE > d_end))
+                if (UNLIKELY(ll4 > (size_t)(l_end - l_ptr) ||
+                             ll4 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
                     goto rollback_fast_4x;
             }
             uint32_t m4b = (uint32_t)((s4 >> 16) & 0xFF);
             uint64_t ml4 = m4b + ZXC_LZ_MIN_MATCH_LEN;
             if (UNLIKELY(m4b == ZXC_SEQ_ML_MASK)) {
                 ml4 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY(d_ptr + ll4 + ml4 + ZXC_PAD_SIZE > d_end)) goto rollback_fast_4x;
+                if (UNLIKELY(ll4 + ml4 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
+                    goto rollback_fast_4x;
             }
             uint32_t off4 = (uint32_t)(s4 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
             DECODE_SEQ_FAST(ll4, ml4, off4);
@@ -1769,16 +1802,16 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(zxc_cctx_t* RESTRICT ctx,
             if (UNLIKELY(ll1 == ZXC_SEQ_LL_MASK)) {
                 ll1 += zxc_read_varint(&extras_ptr, extras_end);
                 const uint64_t reserve = (s2 >> 24) + (s3 >> 24) + (s4 >> 24);
-                if (UNLIKELY(l_ptr + ll1 + reserve > l_end || d_ptr + ll1 + ZXC_PAD_SIZE > d_end))
+                if (UNLIKELY(ll1 + reserve > (size_t)(l_end - l_ptr) ||
+                             ll1 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
             uint32_t m1b = (uint32_t)((s1 >> 16) & 0xFF);
             uint64_t ml1 = m1b + ZXC_LZ_MIN_MATCH_LEN;
             if (UNLIKELY(m1b == ZXC_SEQ_ML_MASK)) {
                 ml1 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY(d_ptr + ll1 + ml1 + 3U * ZXC_GHI_MAX_INLINE_OUT_PER_SEQ +
-                                 ZXC_PAD_SIZE >
-                             d_end))
+                if (UNLIKELY(ll1 + ml1 + 3U * ZXC_GHI_MAX_INLINE_OUT_PER_SEQ + ZXC_PAD_SIZE >
+                             (size_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
             uint32_t off1 = (uint32_t)(s1 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
@@ -1788,16 +1821,16 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(zxc_cctx_t* RESTRICT ctx,
             if (UNLIKELY(ll2 == ZXC_SEQ_LL_MASK)) {
                 ll2 += zxc_read_varint(&extras_ptr, extras_end);
                 const uint64_t reserve = (s3 >> 24) + (s4 >> 24);
-                if (UNLIKELY(l_ptr + ll2 + reserve > l_end || d_ptr + ll2 + ZXC_PAD_SIZE > d_end))
+                if (UNLIKELY(ll2 + reserve > (size_t)(l_end - l_ptr) ||
+                             ll2 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
             uint32_t m2b = (uint32_t)((s2 >> 16) & 0xFF);
             uint64_t ml2 = m2b + ZXC_LZ_MIN_MATCH_LEN;
             if (UNLIKELY(m2b == ZXC_SEQ_ML_MASK)) {
                 ml2 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY(d_ptr + ll2 + ml2 + 2U * ZXC_GHI_MAX_INLINE_OUT_PER_SEQ +
-                                 ZXC_PAD_SIZE >
-                             d_end))
+                if (UNLIKELY(ll2 + ml2 + 2U * ZXC_GHI_MAX_INLINE_OUT_PER_SEQ + ZXC_PAD_SIZE >
+                             (size_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
             uint32_t off2 = (uint32_t)(s2 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
@@ -1807,15 +1840,16 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(zxc_cctx_t* RESTRICT ctx,
             if (UNLIKELY(ll3 == ZXC_SEQ_LL_MASK)) {
                 ll3 += zxc_read_varint(&extras_ptr, extras_end);
                 const uint64_t reserve = (s4 >> 24);
-                if (UNLIKELY(l_ptr + ll3 + reserve > l_end || d_ptr + ll3 + ZXC_PAD_SIZE > d_end))
+                if (UNLIKELY(ll3 + reserve > (size_t)(l_end - l_ptr) ||
+                             ll3 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
             uint32_t m3b = (uint32_t)((s3 >> 16) & 0xFF);
             uint64_t ml3 = m3b + ZXC_LZ_MIN_MATCH_LEN;
             if (UNLIKELY(m3b == ZXC_SEQ_ML_MASK)) {
                 ml3 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY(d_ptr + ll3 + ml3 + ZXC_GHI_MAX_INLINE_OUT_PER_SEQ + ZXC_PAD_SIZE >
-                             d_end))
+                if (UNLIKELY(ll3 + ml3 + ZXC_GHI_MAX_INLINE_OUT_PER_SEQ + ZXC_PAD_SIZE >
+                             (size_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
             uint32_t off3 = (uint32_t)(s3 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
@@ -1824,14 +1858,16 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(zxc_cctx_t* RESTRICT ctx,
             uint64_t ll4 = (uint32_t)(s4 >> 24);
             if (UNLIKELY(ll4 == ZXC_SEQ_LL_MASK)) {
                 ll4 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY(l_ptr + ll4 > l_end || d_ptr + ll4 + ZXC_PAD_SIZE > d_end))
+                if (UNLIKELY(ll4 > (size_t)(l_end - l_ptr) ||
+                             ll4 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
             uint32_t m4b = (uint32_t)((s4 >> 16) & 0xFF);
             uint64_t ml4 = m4b + ZXC_LZ_MIN_MATCH_LEN;
             if (UNLIKELY(m4b == ZXC_SEQ_ML_MASK)) {
                 ml4 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY(d_ptr + ll4 + ml4 + ZXC_PAD_SIZE > d_end)) return ZXC_ERROR_OVERFLOW;
+                if (UNLIKELY(ll4 + ml4 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
+                    return ZXC_ERROR_OVERFLOW;
             }
             uint32_t off4 = (uint32_t)(s4 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
             DECODE_SEQ_FAST(ll4, ml4, off4);
@@ -1852,7 +1888,7 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(zxc_cctx_t* RESTRICT ctx,
         uint64_t ll = (uint32_t)(seq >> 24);
         if (UNLIKELY(ll == ZXC_SEQ_LL_MASK)) {
             ll += zxc_read_varint(&extras_ptr, extras_end);
-            if (UNLIKELY(l_ptr + ll > l_end)) {
+            if (UNLIKELY((size_t)(l_end - l_ptr) < ll)) {
                 seq_ptr = seq_save;
                 extras_ptr = ext_save;
                 break;
@@ -1864,7 +1900,7 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(zxc_cctx_t* RESTRICT ctx,
         if (UNLIKELY(m_bits == ZXC_SEQ_ML_MASK)) ml += zxc_read_varint(&extras_ptr, extras_end);
 
         // Strict bounds checks (including wild copy overrun safety)
-        if (UNLIKELY(d_ptr + ll + ml + ZXC_PAD_SIZE > d_end)) {
+        if (UNLIKELY(ll + ml + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr))) {
             // Restore state and break to Safe Path
             seq_ptr = seq_save;
             extras_ptr = ext_save;
@@ -1941,7 +1977,8 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(zxc_cctx_t* RESTRICT ctx,
         if (UNLIKELY(m_bits == ZXC_SEQ_ML_MASK)) ml += zxc_read_varint(&extras_ptr, extras_end);
         uint32_t offset = (uint32_t)(seq & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
 
-        if (UNLIKELY(d_ptr + ll + ml > d_end || l_ptr + ll > l_end)) return ZXC_ERROR_OVERFLOW;
+        if (UNLIKELY(ll + ml > (size_t)(d_end - d_ptr) || (size_t)(l_end - l_ptr) < ll))
+            return ZXC_ERROR_OVERFLOW;
         ZXC_MEMCPY(d_ptr, l_ptr, ll);
         l_ptr += ll;
         d_ptr += ll;
@@ -1963,7 +2000,7 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(zxc_cctx_t* RESTRICT ctx,
     if (UNLIKELY(l_ptr > l_end)) return ZXC_ERROR_CORRUPT_DATA;
     const size_t remaining_literals = (size_t)(l_end - l_ptr);
     if (remaining_literals > 0) {
-        if (UNLIKELY(d_ptr + remaining_literals > d_end)) return ZXC_ERROR_OVERFLOW;
+        if (UNLIKELY((size_t)(d_end - d_ptr) < remaining_literals)) return ZXC_ERROR_OVERFLOW;
         ZXC_MEMCPY(d_ptr, l_ptr, remaining_literals);
         d_ptr += remaining_literals;
     }

--- a/src/lib/zxc_dispatch.c
+++ b/src/lib/zxc_dispatch.c
@@ -1038,6 +1038,11 @@ int64_t zxc_compress_block(zxc_cctx* cctx, const void* RESTRICT src, const size_
     if (UNLIKELY(!cctx || !src || !dst || src_size == 0 || dst_capacity == 0))
         return ZXC_ERROR_NULL_INPUT;
 
+    /* Block API processes a single format-conformant block: src_size must not
+     * exceed ZXC_BLOCK_SIZE_MAX. Callers with larger inputs should use the
+     * frame or streaming APIs which chunk transparently. */
+    if (UNLIKELY(src_size > ZXC_BLOCK_SIZE_MAX)) return ZXC_ERROR_BAD_BLOCK_SIZE;
+
     const int checksum_enabled = opts ? opts->checksum_enabled : cctx->stored_checksum;
     const int level = (opts && opts->level > 0) ? opts->level : cctx->stored_level;
     /* For block API, block_size == src_size (the caller compresses one block at a time). */
@@ -1083,6 +1088,13 @@ int64_t zxc_decompress_block(zxc_dctx* dctx, const void* RESTRICT src, const siz
                              const zxc_decompress_opts_t* opts) {
     if (UNLIKELY(!dctx || !src || !dst || src_size < ZXC_BLOCK_HEADER_SIZE || dst_capacity == 0))
         return ZXC_ERROR_NULL_INPUT;
+
+    /* Block API decompresses a single format-conformant block. Decoded payload
+     * cannot exceed ZXC_BLOCK_SIZE_MAX; dst_capacity is bounded accordingly to
+     * include the tail-pad needed for safe wild copies. Callers expecting
+     * larger outputs should use the frame or streaming APIs. */
+    if (UNLIKELY(dst_capacity > ZXC_BLOCK_SIZE_MAX + ZXC_DECOMPRESS_TAIL_PAD))
+        return ZXC_ERROR_BAD_BLOCK_SIZE;
 
     const int checksum_enabled = opts ? opts->checksum_enabled : 0;
 
@@ -1139,6 +1151,10 @@ int64_t zxc_decompress_block_safe(zxc_dctx* dctx, const void* RESTRICT src, cons
                                   const zxc_decompress_opts_t* opts) {
     if (UNLIKELY(!dctx || !src || !dst || src_size < ZXC_BLOCK_HEADER_SIZE || dst_capacity == 0))
         return ZXC_ERROR_NULL_INPUT;
+
+    /* Same single-block constraint as zxc_decompress_block. */
+    if (UNLIKELY(dst_capacity > ZXC_BLOCK_SIZE_MAX + ZXC_DECOMPRESS_TAIL_PAD))
+        return ZXC_ERROR_BAD_BLOCK_SIZE;
 
     const uint8_t type = ((const uint8_t*)src)[0];
     /* NUM/RAW never wild-write past dst_capacity: route to the existing fast API. */

--- a/src/lib/zxc_dispatch.c
+++ b/src/lib/zxc_dispatch.c
@@ -1152,9 +1152,8 @@ int64_t zxc_decompress_block_safe(zxc_dctx* dctx, const void* RESTRICT src, cons
     if (UNLIKELY(!dctx || !src || !dst || src_size < ZXC_BLOCK_HEADER_SIZE || dst_capacity == 0))
         return ZXC_ERROR_NULL_INPUT;
 
-    /* Same single-block constraint as zxc_decompress_block. */
-    if (UNLIKELY(dst_capacity > ZXC_BLOCK_SIZE_MAX + ZXC_DECOMPRESS_TAIL_PAD))
-        return ZXC_ERROR_BAD_BLOCK_SIZE;
+    /* Strict-tail variant: dst_capacity matches the exact uncompressed size */
+    if (UNLIKELY(dst_capacity > ZXC_BLOCK_SIZE_MAX)) return ZXC_ERROR_BAD_BLOCK_SIZE;
 
     const uint8_t type = ((const uint8_t*)src)[0];
     /* NUM/RAW never wild-write past dst_capacity: route to the existing fast API. */

--- a/src/lib/zxc_internal.h
+++ b/src/lib/zxc_internal.h
@@ -437,16 +437,13 @@ extern "C" {
 #define ZXC_LZ_MIN_MATCH_LEN 5
 /** @brief Maximum legitimate value a varint can decode to.
  *
- * The 5-byte varint encoding accepts values up to 2^32-1, but no legitimate
- * compressor ever emits values beyond block_size. Capping the decoder rejects
- * crafted inputs that exceed this bound, preventing integer-overflow attacks
- * in downstream bounds arithmetic while preserving backward compatibility
- * with files containing any legitimate varint value (val < 2^31).
- *
- * 2^31 - 1 (2 GB) is the largest cap that still guarantees uint32 safety in
- * the bounds checks: worst-case (MASK + cap) * 2 + PAD + reserve stays below
- * UINT32_MAX, so all downstream arithmetic remains wrap-free by construction. */
-#define ZXC_MAX_VARINT_VALUE ((uint32_t)((1U << 31) - 1))
+ * A varint value represents (ll - MASK) or (ml - MASK) and is therefore always
+ * strictly less than ZXC_BLOCK_SIZE_MAX (enforced by the Block API entry
+ * points). The cap is set to (ZXC_BLOCK_SIZE_MAX - 1), which fits cleanly in a
+ * 3-byte varint (21 bits): the decoder rejects any 4- or 5-byte encoding, and
+ * the encoder refuses to emit values above this bound. Together they bound the
+ * varint surface to exactly the format-defined block size limit. */
+#define ZXC_MAX_VARINT_VALUE ((uint32_t)(ZXC_BLOCK_SIZE_MAX - 1U))
 /** @brief Maximum decoded output of a single sequence with INLINE ll/ml
  *         (non-varint). Used by 4x decoder bounds checks to reserve space for
  *         subsequent inline sequences in the same batch when the current

--- a/src/lib/zxc_internal.h
+++ b/src/lib/zxc_internal.h
@@ -332,6 +332,15 @@ extern "C" {
 /** @brief Binary size of a GHI block sub-header. */
 #define ZXC_GHI_HEADER_BINARY_SIZE 16
 
+/** @brief Worst-case format overhead inside a single block beyond the outer
+ *  8-byte block header and the optional 4-byte checksum.
+ *
+ *  Covers the inner GLO/GHI sub-header (16 B) plus four section descriptors
+ *  (4 x 8 = 32 B) = 48 B, with a 16 B safety margin for future format
+ *  evolution. Used by zxc_compress_block_bound() and zxc_compress_bound()
+ *  to size the destination buffer in the worst (incompressible) case. */
+#define ZXC_BLOCK_FORMAT_OVERHEAD 64
+
 /** @brief Binary size of a NUM chunk sub-frame header (nvals + bits + base + psize). */
 #define ZXC_NUM_CHUNK_HEADER_SIZE 16
 /** @brief Number of numeric values to decode in a single SIMD batch (NUM block). */

--- a/src/lib/zxc_internal.h
+++ b/src/lib/zxc_internal.h
@@ -435,6 +435,14 @@ extern "C" {
 #define ZXC_LZ_WINDOW_MASK (ZXC_LZ_WINDOW_SIZE - 1U)
 /** @brief Minimum match length for an LZ77 match. */
 #define ZXC_LZ_MIN_MATCH_LEN 5
+/** @brief Maximum decoded output of a single sequence with INLINE ll/ml
+ *         (non-varint). Used by 4x decoder bounds checks to reserve space for
+ *         subsequent inline sequences in the same batch when the current
+ *         sequence has a varint-extended ml. */
+#define ZXC_GLO_MAX_INLINE_OUT_PER_SEQ \
+    ((ZXC_TOKEN_LL_MASK - 1U) + (ZXC_TOKEN_ML_MASK - 1U) + ZXC_LZ_MIN_MATCH_LEN) /* 33 */
+#define ZXC_GHI_MAX_INLINE_OUT_PER_SEQ \
+    ((ZXC_SEQ_LL_MASK - 1U) + (ZXC_SEQ_ML_MASK - 1U) + ZXC_LZ_MIN_MATCH_LEN) /* 513 */
 /** @brief Base bias added to encoded offsets (stored = actual - bias). */
 #define ZXC_LZ_OFFSET_BIAS 1
 /** @brief Maximum allowed offset distance. */

--- a/src/lib/zxc_internal.h
+++ b/src/lib/zxc_internal.h
@@ -435,6 +435,18 @@ extern "C" {
 #define ZXC_LZ_WINDOW_MASK (ZXC_LZ_WINDOW_SIZE - 1U)
 /** @brief Minimum match length for an LZ77 match. */
 #define ZXC_LZ_MIN_MATCH_LEN 5
+/** @brief Maximum legitimate value a varint can decode to.
+ *
+ * The 5-byte varint encoding accepts values up to 2^32-1, but no legitimate
+ * compressor ever emits values beyond block_size. Capping the decoder rejects
+ * crafted inputs that exceed this bound, preventing integer-overflow attacks
+ * in downstream bounds arithmetic while preserving backward compatibility
+ * with files containing any legitimate varint value (val < 2^31).
+ *
+ * 2^31 - 1 (2 GB) is the largest cap that still guarantees uint32 safety in
+ * the bounds checks: worst-case (MASK + cap) * 2 + PAD + reserve stays below
+ * UINT32_MAX, so all downstream arithmetic remains wrap-free by construction. */
+#define ZXC_MAX_VARINT_VALUE ((uint32_t)((1U << 31) - 1))
 /** @brief Maximum decoded output of a single sequence with INLINE ll/ml
  *         (non-varint). Used by 4x decoder bounds checks to reserve space for
  *         subsequent inline sequences in the same batch when the current

--- a/tests/test_block_api.c
+++ b/tests/test_block_api.c
@@ -580,7 +580,16 @@ int test_block_api_large_block_varint() {
             goto per_case_cleanup;
         }
 
-        printf("  [PASS] %s correctly rejected by both compress and decompress\n",
+        const int64_t dssize =
+            zxc_decompress_block_safe(dctx, src, sz, decompressed, sz, &dopts);
+        if (dssize != ZXC_ERROR_BAD_BLOCK_SIZE) {
+            printf("  [FAIL] %s decompress_safe: expected ZXC_ERROR_BAD_BLOCK_SIZE (%d), got %lld\n",
+                   cases[i].name, ZXC_ERROR_BAD_BLOCK_SIZE, (long long)dssize);
+            failures++;
+            goto per_case_cleanup;
+        }
+
+        printf("  [PASS] %s correctly rejected by compress, decompress, and decompress_safe\n",
                cases[i].name);
 
     per_case_cleanup:

--- a/tests/test_block_api.c
+++ b/tests/test_block_api.c
@@ -521,20 +521,16 @@ int test_block_api_boundary_sizes() {
 }
 
 /*
- * Regression test for blocks > 2 MiB.
+ * Regression test: the Block API enforces the format-level block size cap
+ * (ZXC_BLOCK_SIZE_MAX = 2 MiB).
  *
- * Before the varint extension, zxc_write_varint silently truncated LL/ML
- * values >= 2^21 (21 bits), corrupting the output for any block that
- * produced a literal run or match length exceeding 2 MiB. The encoder
- * now writes 4- and 5-byte varints (28/32 bits), matching the decoder
- * which already supported them.
- *
- * This test round-trips highly repetitive data in blocks of 3, 4 and 8 MiB.
- * The LZ77 path on such data produces match lengths close to block size,
- * reliably exercising the 4-byte varint branch.
+ * Inputs larger than ZXC_BLOCK_SIZE_MAX must be rejected upfront with
+ * ZXC_ERROR_BAD_BLOCK_SIZE; callers with bigger payloads must use the frame
+ * or streaming APIs which chunk transparently. The same cap bounds the
+ * varint value space, neutralizing wrap-around attacks downstream.
  */
 int test_block_api_large_block_varint() {
-    printf("=== TEST: Block API - Varint >21 bits (blocks > 2 MiB) ===\n");
+    printf("=== TEST: Block API - Reject blocks > ZXC_BLOCK_SIZE_MAX ===\n");
 
     const struct {
         size_t size;
@@ -551,7 +547,7 @@ int test_block_api_large_block_varint() {
     for (int i = 0; i < num_cases; i++) {
         const size_t sz = cases[i].size;
         uint8_t* src = malloc(sz);
-        const uint64_t bound = zxc_compress_block_bound(sz);
+        const uint64_t bound = zxc_compress_block_bound(ZXC_BLOCK_SIZE_MAX);
         uint8_t* compressed = bound ? malloc((size_t)bound) : NULL;
         uint8_t* decompressed = malloc(sz);
         zxc_cctx* cctx = zxc_create_cctx(NULL);
@@ -563,42 +559,29 @@ int test_block_api_large_block_varint() {
             goto per_case_cleanup;
         }
 
-        /* Repetitive pattern: after the initial ~400 byte literal run, the
-         * rest of the buffer matches, producing a match length close to sz
-         * (well above 2^21) triggering the 4-byte varint encoding path. */
         gen_lz_data(src, sz);
-
-        for (int lvl = 1; lvl <= 5; lvl++) {
-            zxc_compress_opts_t copts = {.level = lvl, .checksum_enabled = 1};
-            const int64_t csize = zxc_compress_block(cctx, src, sz, compressed,
-                                                     (size_t)bound, &copts);
-            if (csize <= 0) {
-                printf("  [FAIL] %s lvl=%d: compress returned %lld\n",
-                       cases[i].name, lvl, (long long)csize);
-                failures++;
-                continue;
-            }
-
-            zxc_decompress_opts_t dopts = {.checksum_enabled = 1};
-            const int64_t dsize = zxc_decompress_block(dctx, compressed, (size_t)csize,
-                                                      decompressed, sz, &dopts);
-            if (dsize != (int64_t)sz) {
-                printf("  [FAIL] %s lvl=%d: decompress returned %lld (expected %zu)\n",
-                       cases[i].name, lvl, (long long)dsize, sz);
-                failures++;
-                continue;
-            }
-            if (memcmp(src, decompressed, sz) != 0) {
-                printf("  [FAIL] %s lvl=%d: content mismatch after roundtrip\n",
-                       cases[i].name, lvl);
-                failures++;
-                continue;
-            }
+        zxc_compress_opts_t copts = {.level = 1, .checksum_enabled = 1};
+        const int64_t csize =
+            zxc_compress_block(cctx, src, sz, compressed, (size_t)bound, &copts);
+        if (csize != ZXC_ERROR_BAD_BLOCK_SIZE) {
+            printf("  [FAIL] %s compress: expected ZXC_ERROR_BAD_BLOCK_SIZE (%d), got %lld\n",
+                   cases[i].name, ZXC_ERROR_BAD_BLOCK_SIZE, (long long)csize);
+            failures++;
+            goto per_case_cleanup;
         }
 
-        if (!failures) {
-            printf("  [PASS] %s roundtrip OK across levels 1-5\n", cases[i].name);
+        zxc_decompress_opts_t dopts = {.checksum_enabled = 1};
+        const int64_t dsize =
+            zxc_decompress_block(dctx, src, sz, decompressed, sz, &dopts);
+        if (dsize != ZXC_ERROR_BAD_BLOCK_SIZE) {
+            printf("  [FAIL] %s decompress: expected ZXC_ERROR_BAD_BLOCK_SIZE (%d), got %lld\n",
+                   cases[i].name, ZXC_ERROR_BAD_BLOCK_SIZE, (long long)dsize);
+            failures++;
+            goto per_case_cleanup;
         }
+
+        printf("  [PASS] %s correctly rejected by both compress and decompress\n",
+               cases[i].name);
 
     per_case_cleanup:
         free(src);


### PR DESCRIPTION
Rewrites pointer arithmetic bounds checks. This prevents integer overflows in length calculations that could lead to incorrect boundary validation and potential out-of-bounds memory access during decompression, enhancing security and robustness.
