### PR TITLE
ci: Update ClusterFuzzLite base image and enable Dependabot

### DIFF
--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -4,7 +4,7 @@
 #  This source code is licensed under the BSD-style license found in the
 #  LICENSE file in the root directory of this source tree.
 
-FROM gcr.io/oss-fuzz-base/base-builder:v1@sha256:b2ac08d613b128064d77f5622ac363cbf6818329be6d3f1852a9728a998abd0a
+FROM gcr.io/oss-fuzz-base/base-builder:v1@sha256:fd6ca3a7a6b8e1dcbdd4f03cfdc0fc2603c7a1097aed1d730de2ca4124e0a405
 
 COPY . $SRC/zxc
 WORKDIR $SRC/zxc

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,3 +21,7 @@ updates:
     directory: /wrappers/go
     schedule:
       interval: monthly
+  - package-ecosystem: docker
+    directory: /.clusterfuzzlite
+    schedule:
+      interval: monthly


### PR DESCRIPTION
The ClusterFuzzLite Dockerfile now uses the latest `oss-fuzz-base/base-builder:v1` image. Dependabot is also configured to monitor this image monthly, ensuring the fuzzing environment stays up-to-date with security fixes and improvements automatically.
