### PR TITLE
ci: Refines benchmark CI workflow

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-26-xlarge]
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-26, macos-26-xlarge]
 
     env:
         LZBENCH_DIR: lzbench

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, ubuntu-24.04-arm, macos-26, macos-26-xlarge]
+        os: ${{ fromJSON(github.event_name == 'pull_request' && '["ubuntu-latest","macos-26"]' || '["ubuntu-latest","macos-26-xlarge"]') }}
 
     env:
         LZBENCH_DIR: lzbench
@@ -102,7 +102,7 @@ jobs:
         working-directory: ${{ env.LZBENCH_DIR }}
         run: |
           if [ "${{ github.event_name }}" = "pull_request" ]; then
-            CODECS="memcpy/zxc/lz4"
+            CODECS="memcpy/zxc/lz4/lz4fast,17/lz4hc,9"
           else
             CODECS="memcpy/zxc/lz4/lz4fast,17/lz4hc,9/lzav,1/snappy/zstd_fast,-1/zstd,1/zlib,1"
           fi


### PR DESCRIPTION
Adjusts the benchmark workflow to conditionally use different macOS runners based on the event type. For pull requests, it uses `macos-26` to optimize resource consumption, while for pushes to the main branch, it utilizes `macos-26-xlarge` for more extensive benchmarking.

Expands the set of codecs tested within pull request benchmarks to include `lz4fast,17` and `lz4hc,9`. This ensures more comprehensive performance analysis earlier in the development cycle.