### PR TITLE
api: Introduces static context API for caller-managed workspaces

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -408,6 +408,7 @@ if(ZXC_BUILD_TESTS)
         tests/test_buffer_api.c
         tests/test_block_api.c
         tests/test_context_api.c
+        tests/test_static_ctx.c
         tests/test_pstream_api.c
         tests/test_stream_api.c
         tests/test_seekable.c

--- a/docs/API.md
+++ b/docs/API.md
@@ -24,6 +24,7 @@ For the on-disk binary format see [`FORMAT.md`](FORMAT.md).
 - [7. Buffer API](#7-buffer-api)
 - [8. Block API](#8-block-api)
 - [9. Reusable Context API](#9-reusable-context-api)
+- [9b. Static Context API](#9b-static-context-api)
 - [10. Streaming API](#10-streaming-api)
 - [10b. Push Streaming API](#10b-push-streaming-api)
 - [11. Seekable API](#11-seekable-api)
@@ -571,6 +572,166 @@ Same as `zxc_decompress()` but reuses buffers from `dctx`.
 
 ---
 
+## 9b. Static Context API
+
+Declared in `zxc_buffer.h`. Mirrors the Reusable Context API but places the
+entire context, opaque handle plus every persistent sub-buffer, inside a
+**single buffer allocated and owned by the caller**. This pattern is
+mandatory for environments where the library cannot call into the host
+allocator on the hot path: Linux kernel filesystems (one workspace per mount,
+served via `vmalloc` / `kmalloc` up front), embedded targets without a heap
+(`.bss` or stack-allocated workspace), sandboxed runtimes with a fixed
+memory budget, etc.
+
+Trade-off vs the dynamic API: the workspace is **pinned** to a single `block_size` at init time;
+subsequent compress / decompress calls cannot enlarge the footprint, so a
+workload that needs to mix block sizes must size the workspace for the
+maximum block size up front.
+
+### Properties
+
+- **Single allocation.** All hash tables, chain table, sequence buffers,
+  literal scratch, work buffer, and (at `ZXC_LEVEL_DENSITY`) the optimal-
+  parser scratch live inside the caller-supplied buffer. No further
+  `ZXC_MALLOC` / `ZXC_ALIGNED_MALLOC` is performed for the lifetime of
+  the context.
+- **`zxc_free_*ctx` is a no-op** on a static handle. The caller owns the
+  workspace.
+- **`block_size` is locked.** A subsequent call passing a different
+  `block_size` returns `ZXC_ERROR_BAD_BLOCK_SIZE` without re-initialising.
+  `level` and `checksum_enabled` may still vary per call (they affect only
+  the encoder state, not the buffer layout).
+- **Workspace alignment.** Must be at least cache-line (64-byte) aligned.
+  Use `posix_memalign(..., 64, ...)`, `aligned_alloc(64, ...)`, the slab
+  allocator (kmalloc returns ≥ `ARCH_KMALLOC_MINALIGN`), or a
+  `_Alignas(64)` static array.
+
+### `zxc_static_cctx_workspace_size`
+
+```c
+ZXC_EXPORT size_t zxc_static_cctx_workspace_size(
+    const size_t block_size,
+    const int    level
+);
+```
+
+Returns the exact byte count required by a static compression workspace
+for the given `block_size` and `level`. Sum of the opaque `zxc_cctx`
+wrapper plus every persistent sub-buffer the library would partition.
+
+**Returns**: workspace size in bytes, or `0` if either argument is invalid
+(non-power-of-two `block_size`, out-of-range level, ...).
+
+**Note**: level 6 (`ZXC_LEVEL_DENSITY`) adds the optimal-parser scratch
+(~8.125 × `block_size`); levels 1–5 share the same workspace size.
+
+### `zxc_init_static_cctx`
+
+```c
+ZXC_EXPORT zxc_cctx* zxc_init_static_cctx(
+    void*                       workspace,
+    const size_t                workspace_size,
+    const zxc_compress_opts_t*  opts
+);
+```
+
+Initialises a compression context inside a caller-supplied workspace.
+`workspace_size` must be at least `zxc_static_cctx_workspace_size` for the
+same `block_size` / `level`. `opts` is **required**: `block_size` and
+`level` are pinned at init time and must be set explicitly.
+
+The returned handle points **inside** `workspace`; the workspace must
+remain valid for the lifetime of the handle. `zxc_free_cctx` is a no-op.
+
+**Returns**: handle pointing inside `workspace`, or `NULL` if the
+workspace is too small, the options are invalid, or `workspace` / `opts`
+is `NULL`.
+
+### `zxc_static_dctx_workspace_size`
+
+```c
+ZXC_EXPORT size_t zxc_static_dctx_workspace_size(
+    const size_t block_size
+);
+```
+
+Returns the exact byte count required by a static decompression workspace
+for the given `block_size`. Unlike the compression variant, this size is
+**independent of the source archive's level**: `lit_buffer` is always
+provisioned worst-case because the decoder cannot predict the per-block
+literal encoding (RAW / RLE / HUFFMAN) until it sees each block header.
+
+**Returns**: workspace size in bytes, or `0` if `block_size` is invalid.
+
+### `zxc_init_static_dctx`
+
+```c
+ZXC_EXPORT zxc_dctx* zxc_init_static_dctx(
+    void*         workspace,
+    const size_t  workspace_size,
+    const size_t  block_size
+);
+```
+
+Initialises a decompression context inside a caller-supplied workspace.
+`block_size` is **pinned** at init time: feeding the returned handle an
+archive whose file header declares a different `block_size` returns
+`ZXC_ERROR_BAD_BLOCK_SIZE`.
+
+The returned handle points inside `workspace`; the workspace must remain
+valid for the lifetime of the handle. `zxc_free_dctx` is a no-op.
+
+**Returns**: handle pointing inside `workspace`, or `NULL` if the
+workspace is too small, `block_size` is invalid, or `workspace` is
+`NULL`.
+
+### Typical usage
+
+```c
+#include <zxc.h>
+
+#define BLOCK_SZ   (64 * 1024)   /* must match the archive's block_size at decode */
+#define LEVEL      ZXC_LEVEL_DEFAULT
+
+/* --- Compression side --- */
+size_t cws_sz = zxc_static_cctx_workspace_size(BLOCK_SZ, LEVEL);
+void  *cws    = NULL;
+posix_memalign(&cws, 64, cws_sz);                  /* or kmalloc / vmalloc / .bss */
+
+zxc_compress_opts_t copts = { .level = LEVEL, .block_size = BLOCK_SZ };
+zxc_cctx *cctx = zxc_init_static_cctx(cws, cws_sz, &copts);
+
+for (/* each block */) {
+    zxc_compress_cctx(cctx, src, n, dst, cap, NULL);  /* no allocation */
+}
+zxc_free_cctx(cctx);  /* no-op for static */
+free(cws);            /* caller owns the workspace */
+
+/* --- Decompression side --- */
+size_t dws_sz = zxc_static_dctx_workspace_size(BLOCK_SZ);
+void  *dws    = NULL;
+posix_memalign(&dws, 64, dws_sz);
+
+zxc_dctx *dctx = zxc_init_static_dctx(dws, dws_sz, BLOCK_SZ);
+zxc_decompress_dctx(dctx, in, in_sz, out, out_cap, NULL);
+zxc_free_dctx(dctx);  /* no-op */
+free(dws);
+```
+
+### Sizing notes
+
+| `block_size` | level 1–5 cctx | level 6 cctx | dctx |
+|---|---|---|---|
+| 4 KB        | ~280 KB         | ~320 KB       | ~9 KB  |
+| 64 KB       | ~410 KB         | ~930 KB       | ~129 KB |
+| 512 KB      | ~1.5 MB         | ~5.7 MB       | ~1 MB  |
+| 2 MB        | ~5.0 MB         | ~21 MB        | ~4 MB  |
+
+(Exact figures depend on architecture and alignment padding; always query
+`zxc_static_*_workspace_size` rather than hard-coding.)
+
+---
+
 ## 10. Streaming API
 
 Declared in `zxc_stream.h` — the umbrella for every `FILE*`-flavored entry
@@ -1068,6 +1229,7 @@ if (result < 0) {
 | **Buffer API** | Yes (stateless) | Each call is self-contained.  Multiple threads can compress/decompress simultaneously with independent buffers. |
 | **Block API** | Per-context | Uses `zxc_cctx` / `zxc_dctx`: same rule as Context API.  Create one context per thread. |
 | **Context API** | Per-context | A single `zxc_cctx` / `zxc_dctx` must not be shared between threads.  Create one context per thread. |
+| **Static Context API** | Per-handle | Same per-context rule as the dynamic Context API.  Allocate one workspace per thread; the static handle does not introduce any cross-thread synchronisation. |
 | **Streaming API** | Per-call | Each `zxc_stream_*` call manages its own thread pool internally.  Do not call from multiple threads on the same `FILE*`. |
 | **Seekable API** | Per-handle | A single `zxc_seekable` handle must not be shared between threads for single-threaded decompression.  Use `zxc_seekable_decompress_range_mt()` for parallel access. |
 | `zxc_error_name` | Yes | Returns a pointer to a static string. |
@@ -1100,33 +1262,37 @@ The shared library exports **47 symbols** (verified with `nm -gU`):
 | 18 | `zxc_create_dctx` | Context | `zxc_buffer.h` |
 | 19 | `zxc_free_dctx` | Context | `zxc_buffer.h` |
 | 20 | `zxc_decompress_dctx` | Context | `zxc_buffer.h` |
-| 21 | `zxc_stream_compress` | Streaming | `zxc_stream.h` |
-| 22 | `zxc_stream_decompress` | Streaming | `zxc_stream.h` |
-| 23 | `zxc_stream_get_decompressed_size` | Streaming | `zxc_stream.h` |
-| 24 | `zxc_cstream_create` | Push Streaming | `zxc_pstream.h` |
-| 25 | `zxc_cstream_free` | Push Streaming | `zxc_pstream.h` |
-| 26 | `zxc_cstream_compress` | Push Streaming | `zxc_pstream.h` |
-| 27 | `zxc_cstream_end` | Push Streaming | `zxc_pstream.h` |
-| 28 | `zxc_cstream_in_size` | Push Streaming | `zxc_pstream.h` |
-| 29 | `zxc_cstream_out_size` | Push Streaming | `zxc_pstream.h` |
-| 30 | `zxc_dstream_create` | Push Streaming | `zxc_pstream.h` |
-| 31 | `zxc_dstream_free` | Push Streaming | `zxc_pstream.h` |
-| 32 | `zxc_dstream_decompress` | Push Streaming | `zxc_pstream.h` |
-| 33 | `zxc_dstream_finished` | Push Streaming | `zxc_pstream.h` |
-| 34 | `zxc_dstream_in_size` | Push Streaming | `zxc_pstream.h` |
-| 35 | `zxc_dstream_out_size` | Push Streaming | `zxc_pstream.h` |
-| 36 | `zxc_seekable_open` | Seekable | `zxc_seekable.h` |
-| 37 | `zxc_seekable_open_file` | Seekable | `zxc_stream.h` |
-| 38 | `zxc_seekable_get_num_blocks` | Seekable | `zxc_seekable.h` |
-| 39 | `zxc_seekable_get_decompressed_size` | Seekable | `zxc_seekable.h` |
-| 40 | `zxc_seekable_get_block_comp_size` | Seekable | `zxc_seekable.h` |
-| 41 | `zxc_seekable_get_block_decomp_size` | Seekable | `zxc_seekable.h` |
-| 42 | `zxc_seekable_decompress_range` | Seekable | `zxc_seekable.h` |
-| 43 | `zxc_seekable_decompress_range_mt` | Seekable | `zxc_seekable.h` |
-| 44 | `zxc_seekable_free` | Seekable | `zxc_seekable.h` |
-| 45 | `zxc_write_seek_table` | Seekable | `zxc_seekable.h` |
-| 46 | `zxc_seek_table_size` | Seekable | `zxc_seekable.h` |
-| 47 | `zxc_error_name` | Error | `zxc_error.h` |
+| 21 | `zxc_static_cctx_workspace_size` | Static Context | `zxc_buffer.h` |
+| 22 | `zxc_init_static_cctx` | Static Context | `zxc_buffer.h` |
+| 23 | `zxc_static_dctx_workspace_size` | Static Context | `zxc_buffer.h` |
+| 24 | `zxc_init_static_dctx` | Static Context | `zxc_buffer.h` |
+| 25 | `zxc_stream_compress` | Streaming | `zxc_stream.h` |
+| 26 | `zxc_stream_decompress` | Streaming | `zxc_stream.h` |
+| 27 | `zxc_stream_get_decompressed_size` | Streaming | `zxc_stream.h` |
+| 28 | `zxc_cstream_create` | Push Streaming | `zxc_pstream.h` |
+| 29 | `zxc_cstream_free` | Push Streaming | `zxc_pstream.h` |
+| 30 | `zxc_cstream_compress` | Push Streaming | `zxc_pstream.h` |
+| 31 | `zxc_cstream_end` | Push Streaming | `zxc_pstream.h` |
+| 32 | `zxc_cstream_in_size` | Push Streaming | `zxc_pstream.h` |
+| 33 | `zxc_cstream_out_size` | Push Streaming | `zxc_pstream.h` |
+| 34 | `zxc_dstream_create` | Push Streaming | `zxc_pstream.h` |
+| 35 | `zxc_dstream_free` | Push Streaming | `zxc_pstream.h` |
+| 36 | `zxc_dstream_decompress` | Push Streaming | `zxc_pstream.h` |
+| 37 | `zxc_dstream_finished` | Push Streaming | `zxc_pstream.h` |
+| 38 | `zxc_dstream_in_size` | Push Streaming | `zxc_pstream.h` |
+| 39 | `zxc_dstream_out_size` | Push Streaming | `zxc_pstream.h` |
+| 40 | `zxc_seekable_open` | Seekable | `zxc_seekable.h` |
+| 41 | `zxc_seekable_open_file` | Seekable | `zxc_stream.h` |
+| 42 | `zxc_seekable_get_num_blocks` | Seekable | `zxc_seekable.h` |
+| 43 | `zxc_seekable_get_decompressed_size` | Seekable | `zxc_seekable.h` |
+| 44 | `zxc_seekable_get_block_comp_size` | Seekable | `zxc_seekable.h` |
+| 45 | `zxc_seekable_get_block_decomp_size` | Seekable | `zxc_seekable.h` |
+| 46 | `zxc_seekable_decompress_range` | Seekable | `zxc_seekable.h` |
+| 47 | `zxc_seekable_decompress_range_mt` | Seekable | `zxc_seekable.h` |
+| 48 | `zxc_seekable_free` | Seekable | `zxc_seekable.h` |
+| 49 | `zxc_write_seek_table` | Seekable | `zxc_seekable.h` |
+| 50 | `zxc_seek_table_size` | Seekable | `zxc_seekable.h` |
+| 51 | `zxc_error_name` | Error | `zxc_error.h` |
 
 No internal symbols leak into the public ABI. FMV dispatch variants
 (`_default`, `_neon`, `_avx2`, `_avx512`) are compiled with

--- a/docs/API.md
+++ b/docs/API.md
@@ -730,6 +730,68 @@ free(dws);
 (Exact figures depend on architecture and alignment padding; always query
 `zxc_static_*_workspace_size` rather than hard-coding.)
 
+### Discovering `block_size` at decode time
+
+`zxc_init_static_dctx` pins `block_size` at workspace creation, so the caller
+must know it *before* calling `init`. Four patterns cover every use case:
+
+1. **Pinned by contract.** Producer and consumer agree on `block_size` at
+   deployment time (kernel module, embedded firmware, intra-application
+   pipeline). The constant lives in a shared header — no runtime
+   discovery needed. This is the canonical static-context use case.
+
+2. **Seekable archive — read the SEK table.** The block size is recoverable
+   from the table opened in any backing mode (buffer, `FILE*`, or
+   `zxc_reader_t`):
+
+   ```c
+   zxc_seekable* s = zxc_seekable_open_reader(&r);  /* parses SEK table only */
+   const uint32_t bs = zxc_seekable_get_block_decomp_size(s, 0);
+   /* For multi-block archives, block index 0 is always a full block.
+    * For a single-block archive, bs equals the total decompressed size. */
+   ```
+
+3. **Stream / buffer archive — peek the 16-byte file header.** The block
+   size is encoded at offset `0x05` (the *Chunk Size Code*, see
+   [FORMAT.md §3](FORMAT.md)). Read the first `ZXC_FILE_HEADER_SIZE`
+   bytes, validate the magic word, then decode:
+
+   ```c
+   uint8_t hdr[ZXC_FILE_HEADER_SIZE];
+   /* fread / read / pread the first 16 bytes of the archive */
+
+   const uint32_t magic = (uint32_t)hdr[0]       | ((uint32_t)hdr[1] << 8)
+                        | ((uint32_t)hdr[2] << 16) | ((uint32_t)hdr[3] << 24);
+   if (magic != 0x9CB02EF5U) { /* not a ZXC archive */ }
+
+   const uint8_t code = hdr[5];
+   size_t block_size;
+   if (code >= ZXC_BLOCK_SIZE_MIN_LOG2 && code <= ZXC_BLOCK_SIZE_MAX_LOG2)
+       block_size = (size_t)1U << code;       /* current encoders: 4 KB..2 MB */
+   else if (code == 64)
+       block_size = 256U * 1024U;             /* legacy encoder: 256 KB */
+   else
+       /* invalid archive */;
+   ```
+
+   After peeking, rewind the input (or keep the 16-byte prefix) and feed
+   the whole archive to `zxc_decompress_dctx` / streaming decoder
+   normally — the decoder re-parses the header.
+
+4. **Worst-case sizing fallback.** When the archive's block size cannot be
+   pre-fetched (e.g., a one-shot streaming decoder that consumes the
+   header in the same pass), size the dctx workspace for
+   `ZXC_BLOCK_SIZE_MAX` (2 MB). The handle accepts any conforming
+   archive at the cost of over-allocation (~4 MB dctx).
+
+   ```c
+   size_t dws_sz = zxc_static_dctx_workspace_size(ZXC_BLOCK_SIZE_MAX);
+   ```
+
+   If the workspace pool must stay tight and worst-case sizing is too
+   expensive, fall back to the dynamic Context API (`zxc_create_dctx`)
+   — its `block_size` is set per call.
+
 ---
 
 ## 10. Streaming API

--- a/include/zxc_buffer.h
+++ b/include/zxc_buffer.h
@@ -433,6 +433,133 @@ ZXC_EXPORT void zxc_free_dctx(zxc_dctx* dctx);
 ZXC_EXPORT int64_t zxc_decompress_dctx(zxc_dctx* dctx, const void* src, size_t src_size, void* dst,
                                        size_t dst_capacity, const zxc_decompress_opts_t* opts);
 
+/* ========================================================================= */
+/*  Static Context API (caller-allocated workspace)                          */
+/* ========================================================================= */
+
+/**
+ * @defgroup static_context_api Static Context API
+ * @brief Caller-allocated, fixed-footprint compression / decompression
+ *        contexts.
+ *
+ * Mirrors the dynamic Reusable Context API but places the entire context
+ * (handle + persistent buffers) inside a single buffer allocated and owned
+ * by the caller.  This pattern is mandatory for environments where the
+ * library cannot call into the host allocator on the hot path: Linux
+ * kernel filesystems (one workspace per mount, served via @c vmalloc /
+ * @c kmalloc up front), embedded targets without a heap (`.bss` or
+ * stack-allocated workspace), sandboxed runtimes with a fixed memory
+ * budget, etc.
+ *
+ * The trade-off vs the dynamic API: the workspace is pinned to a single @c block_size and @c level
+ * at init time; subsequent compress/decompress calls cannot enlarge the footprint, so a workload
+ * that needs to mix block sizes must size the workspace for the maximum block_size up front.
+ *
+ * @par Typical usage
+ * @code
+ * size_t ws_sz = zxc_static_cctx_workspace_size(64 * 1024, ZXC_LEVEL_DEFAULT);
+ * void *ws = aligned_alloc(64, ws_sz);                   // or kmalloc, vmalloc, .bss
+ * zxc_compress_opts_t opts = { .level = ZXC_LEVEL_DEFAULT, .block_size = 64 * 1024 };
+ * zxc_cctx *cctx = zxc_init_static_cctx(ws, ws_sz, &opts);
+ *
+ * for (each block) zxc_compress_cctx(cctx, src, n, dst, cap, NULL);
+ *
+ * // zxc_free_cctx is a no-op on a static cctx; the caller owns @c ws.
+ * free(ws);
+ * @endcode
+ * @{
+ */
+
+/**
+ * @brief Returns the exact byte count required by a static compression
+ *        workspace for the given @p block_size and @p level.
+ *
+ * The value is the sum of the opaque @ref zxc_cctx wrapper plus every
+ * persistent sub-buffer the library would partition (hash tables, chain
+ * table, sequence buffers, literal scratch, plus the optimal-parser
+ * scratch at @ref ZXC_LEVEL_DENSITY). Round up to your allocator's
+ * alignment before calling @c posix_memalign / @c aligned_alloc, the
+ * workspace must be at least cache-line aligned.
+ *
+ * @param[in] block_size  Block size in bytes (must satisfy the regular
+ *                        block-size constraints: power of two in
+ *                        [@ref ZXC_BLOCK_SIZE_MIN, @ref ZXC_BLOCK_SIZE_MAX]).
+ * @param[in] level       Compression level (1..6); higher levels at
+ *                        @ref ZXC_LEVEL_DENSITY add the optimal-parser
+ *                        scratch (~8.125 x block_size).
+ * @return Workspace size in bytes, or 0 if either argument is invalid.
+ */
+ZXC_EXPORT size_t zxc_static_cctx_workspace_size(const size_t block_size, const int level);
+
+/**
+ * @brief Initialises a compression context inside a caller-supplied
+ *        workspace.
+ *
+ * @p workspace_size must be at least @ref zxc_static_cctx_workspace_size
+ * for the same @c block_size and @c level.  The workspace must remain
+ * valid for the lifetime of the returned handle and must be cache-line
+ * (64-byte) aligned.  The caller owns the workspace; @ref zxc_free_cctx
+ * is a no-op on the returned handle.
+ *
+ * @par Locked parameters
+ * The @c block_size, @c level, and @c checksum_enabled fields of @p opts
+ * are pinned at init time.  Subsequent @ref zxc_compress_cctx calls that
+ * pass options requesting a different @c block_size return
+ * @ref ZXC_ERROR_BAD_BLOCK_SIZE without re-initialising.  A different
+ * @c level / @c checksum_enabled is honoured per-call without
+ * re-partitioning.
+ *
+ * @param[in,out] workspace       Caller-allocated buffer, cache-line aligned.
+ * @param[in]     workspace_size  Capacity of @p workspace in bytes.
+ * @param[in]     opts            Must be non-NULL: @c block_size and
+ *                                @c level must be set explicitly to size
+ *                                the workspace correctly.
+ * @return Handle pointing inside @p workspace on success, or @c NULL if
+ *         the workspace is too small or the options are invalid.
+ */
+ZXC_EXPORT zxc_cctx* zxc_init_static_cctx(void* workspace, const size_t workspace_size,
+                                          const zxc_compress_opts_t* opts);
+
+/**
+ * @brief Returns the exact byte count required by a static decompression
+ *        workspace for the given @p block_size.
+ *
+ * Unlike the compression variant, this size is independent of the source
+ * archive's level: @c lit_buffer is always provisioned worst-case because
+ * the decoder cannot predict the per-block literal encoding until it sees
+ * each block header.
+ *
+ * @param[in] block_size  Maximum block size the decoder will encounter
+ *                        (must satisfy the regular block-size constraints).
+ * @return Workspace size in bytes, or 0 if @p block_size is invalid.
+ */
+ZXC_EXPORT size_t zxc_static_dctx_workspace_size(const size_t block_size);
+
+/**
+ * @brief Initialises a decompression context inside a caller-supplied
+ *        workspace.
+ *
+ * @p workspace_size must be at least @ref zxc_static_dctx_workspace_size
+ * for the same @p block_size.  The workspace must remain valid for the
+ * lifetime of the returned handle and must be cache-line aligned.  The
+ * caller owns the workspace; @ref zxc_free_dctx is a no-op on the
+ * returned handle.
+ *
+ * @par Locked block size
+ * @p block_size is pinned at init time: feeding the returned handle an
+ * archive whose header declares a different @c block_size returns
+ * @ref ZXC_ERROR_BAD_BLOCK_SIZE.
+ *
+ * @param[in,out] workspace       Caller-allocated buffer, cache-line aligned.
+ * @param[in]     workspace_size  Capacity of @p workspace in bytes.
+ * @param[in]     block_size      Block size the decoder will accept.
+ * @return Handle pointing inside @p workspace on success, or @c NULL if
+ *         the workspace is too small or @p block_size is invalid.
+ */
+ZXC_EXPORT zxc_dctx* zxc_init_static_dctx(void* workspace, const size_t workspace_size,
+                                          const size_t block_size);
+
+/** @} */ /* end of static_context_api */
 /** @} */ /* end of context_api */
 /** @} */ /* end of buffer_api */
 

--- a/src/lib/zxc_common.c
+++ b/src/lib/zxc_common.c
@@ -724,51 +724,21 @@ uint64_t zxc_decompress_block_bound(const size_t uncompressed_size) {
 /*
  * @brief Estimates the total buffer bytes allocated inside a cctx for a block.
  *
- * Mirrors the persistent allocation layout in zxc_cctx_init(): each sub-buffer
- * is rounded up to the cache-line boundary, so the returned value matches the
- * single aligned allocation performed by the initializer.
+ * Thin wrapper around @ref zxc_cctx_compute_workspace_size for @c mode == 1
+ * (compress), with @c src_size clamped up to a valid block size via
+ * @ref zxc_block_size_ceil.  The opaque wrapper struct allocated by
+ * @ref zxc_create_cctx adds a fixed overhead (< 128 B) that is negligible
+ * next to the per-chunk buffers and is intentionally omitted.
  *
- * For @p level >= 6 the figure also includes ctx->opt_scratch (~8.125 bytes
- * per chunk_size byte: dp + parent_len + parent_off + a 1-bit-per-position
- * match-end bitmap), the cache-line-aligned scratch used by the optimal
- * parser. It is lazy-allocated on the first level-6 call and persists for
- * the lifetime of the cctx (no per-block malloc/free).
+ * For @p level >= 6 the figure includes the optimal-parser scratch
+ * (@c opt_scratch, ~8.125 bytes per chunk_size byte) used by the optimal
+ * parser and reused as transient package-merge scratch for the Huffman
+ * code-length builder.
  */
 uint64_t zxc_estimate_cctx_size(const size_t src_size, const int level) {
     if (UNLIKELY(src_size == 0)) return 0;
-
     const size_t chunk_size = zxc_block_size_ceil(src_size);
-    const uint32_t offset_bits = zxc_log2_u32((uint32_t)chunk_size);
-    const size_t max_seq = chunk_size / ZXC_LZ_MIN_MATCH_LEN + 16;
-    const size_t vbyte_len = (offset_bits + 6) / 7;
-
-    uint64_t total = 0;
-    total += ZXC_ALIGN_CL(ZXC_LZ_HASH_SIZE * sizeof(uint32_t));   /* hash_table */
-    total += ZXC_ALIGN_CL(ZXC_LZ_HASH_SIZE * sizeof(uint8_t));    /* hash_tags */
-    total += ZXC_ALIGN_CL(ZXC_LZ_WINDOW_SIZE * sizeof(uint16_t)); /* chain_table (ring) */
-    /* sequences / tokens+offsets alias the same region (see zxc_cctx_init). */
-    total += ZXC_ALIGN_CL(max_seq * sizeof(uint32_t)); /* seq_union */
-    total += ZXC_ALIGN_CL(max_seq * 2 * vbyte_len);    /* buf_extras */
-    total += ZXC_ALIGN_CL(chunk_size + ZXC_PAD_SIZE);  /* literals */
-
-    /* The opaque wrapper struct allocated by zxc_create_cctx() adds a tiny
-     * fixed overhead (< 128 B) that is negligible next to the per-chunk
-     * buffers above and is intentionally omitted. */
-
-    if (level >= ZXC_LEVEL_DENSITY) {
-        const size_t n_bm_words = ZXC_BITMAP_WORDS(chunk_size + 1);
-        size_t opt = ZXC_ALIGN_CL((chunk_size + 1) * sizeof(uint32_t)); /* dp             */
-        opt += ZXC_ALIGN_CL((chunk_size + 1) * sizeof(uint16_t));       /* parent_len     */
-        opt += ZXC_ALIGN_CL((chunk_size + 1) * sizeof(uint16_t));       /* parent_off     */
-        opt += ZXC_ALIGN_CL(n_bm_words * sizeof(uint64_t));             /* match_end_bits */
-        /* opt_scratch is sized to hold both the DP arrays and (transiently)
-         * the package-merge scratch for the Huffman code-length builder;
-         * report the larger of the two. */
-        const size_t huf = ZXC_ALIGN_CL(ZXC_HUF_BUILD_SCRATCH_SIZE);
-        total += (opt > huf) ? opt : huf;
-    }
-
-    return total;
+    return (uint64_t)zxc_cctx_compute_workspace_size(chunk_size, 1, level);
 }
 
 /*

--- a/src/lib/zxc_common.c
+++ b/src/lib/zxc_common.c
@@ -83,7 +83,35 @@ int zxc_cctx_init(zxc_cctx_t* RESTRICT ctx, const size_t chunk_size, const int m
     ctx->offset_mask = (uint32_t)((1ULL << offset_bits) - 1);
     ctx->max_epoch = (uint32_t)(1ULL << (32 - offset_bits));
 
-    if (mode == 0) return ZXC_OK;
+    /* Decompress mode: two padded scratch buffers (work_buf and lit_buffer)
+     * are the only persistent allocations; the rest of the cctx hot/warm
+     * zones are compress-only. Both are partitioned inside memory_block so
+     * a static-cctx workspace sees one contiguous allocation.
+     *
+     * lit_buffer is sized for the worst case (chunk_size + ZXC_PAD_SIZE)
+     * because the decoder cannot predict the per-block literal encoding
+     * (RAW / RLE / HUFFMAN) at init time.
+     */
+    if (mode == 0) {
+        const size_t sz_work = chunk_size + ZXC_PAD_SIZE;
+        const size_t sz_lit = chunk_size + ZXC_PAD_SIZE;
+
+        size_t total_size = 0;
+        const size_t off_work = total_size;
+        total_size += ZXC_ALIGN_CL(sz_work);
+        const size_t off_lit = total_size;
+        total_size += ZXC_ALIGN_CL(sz_lit);
+
+        uint8_t* const mem = (uint8_t*)ZXC_ALIGNED_MALLOC(total_size, ZXC_CACHE_LINE_SIZE);
+        if (UNLIKELY(!mem)) return ZXC_ERROR_MEMORY;
+
+        ctx->memory_block = mem;
+        ctx->work_buf = mem + off_work;
+        ctx->work_buf_cap = sz_work;
+        ctx->lit_buffer = mem + off_lit;
+        ctx->lit_buffer_cap = sz_lit;
+        return ZXC_OK;
+    }
 
     const size_t max_seq = chunk_size / ZXC_LZ_MIN_MATCH_LEN + 16;
     const size_t sz_hash_pos = ZXC_LZ_HASH_SIZE * sizeof(uint32_t);
@@ -96,6 +124,20 @@ int zxc_cctx_init(zxc_cctx_t* RESTRICT ctx, const size_t chunk_size, const int m
     const size_t vbyte_len = (offset_bits + 6) / 7;
     const size_t sz_extras = max_seq * 2 * vbyte_len;
     const size_t sz_lit = chunk_size + ZXC_PAD_SIZE;
+
+    /* opt_scratch (level >= 6 only): DP arrays for the optimal parser, also
+     * reused transiently as the package-merge scratch for the length-limited
+     * Huffman code-length builder. Sized to the larger of the two demands. */
+    size_t sz_opt = 0;
+    if (level >= ZXC_LEVEL_DENSITY) {
+        const size_t sz_dp = ZXC_ALIGN_CL((chunk_size + 1) * sizeof(uint32_t));
+        const size_t sz_pl = ZXC_ALIGN_CL((chunk_size + 1) * sizeof(uint16_t));
+        const size_t sz_po = ZXC_ALIGN_CL((chunk_size + 1) * sizeof(uint16_t));
+        const size_t n_bm_words = ZXC_BITMAP_WORDS(chunk_size + 1);
+        const size_t sz_bm = ZXC_ALIGN_CL(n_bm_words * sizeof(uint64_t));
+        const size_t dp_needed = sz_dp + sz_pl + sz_po + sz_bm;
+        sz_opt = (dp_needed > ZXC_HUF_BUILD_SCRATCH_SIZE) ? dp_needed : ZXC_HUF_BUILD_SCRATCH_SIZE;
+    }
 
     /* Calculate sizes with alignment padding (64 bytes for cache line alignment) */
     size_t total_size = 0;
@@ -111,6 +153,13 @@ int zxc_cctx_init(zxc_cctx_t* RESTRICT ctx, const size_t chunk_size, const int m
     total_size += ZXC_ALIGN_CL(sz_extras);
     const size_t off_lit = total_size;
     total_size += ZXC_ALIGN_CL(sz_lit);
+    /* opt_scratch is appended last so it is absent for levels 1..5 (zero
+     * waste on the common path) and only inflates the workspace at level 6. */
+    size_t off_opt = 0;
+    if (sz_opt) {
+        off_opt = total_size;
+        total_size += ZXC_ALIGN_CL(sz_opt);
+    }
 
     uint8_t* const mem = (uint8_t*)ZXC_ALIGNED_MALLOC(total_size, ZXC_CACHE_LINE_SIZE);
     if (UNLIKELY(!mem)) return ZXC_ERROR_MEMORY;
@@ -124,6 +173,10 @@ int zxc_cctx_init(zxc_cctx_t* RESTRICT ctx, const size_t chunk_size, const int m
     ctx->buf_tokens = (uint8_t*)(mem + off_seq_union) + max_seq * sizeof(uint16_t);
     ctx->buf_extras = (uint8_t*)(mem + off_extras);
     ctx->literals = (uint8_t*)(mem + off_lit);
+    if (sz_opt) {
+        ctx->opt_scratch = mem + off_opt;
+        ctx->opt_scratch_cap = sz_opt;
+    }
 
     ctx->compression_level = level;
     ctx->epoch = 1;
@@ -147,21 +200,7 @@ void zxc_cctx_free(zxc_cctx_t* ctx) {
         ctx->memory_block = NULL;
     }
 
-    if (ctx->lit_buffer) {
-        ZXC_FREE(ctx->lit_buffer);
-        ctx->lit_buffer = NULL;
-    }
-
-    if (ctx->work_buf) {
-        ZXC_FREE(ctx->work_buf);
-        ctx->work_buf = NULL;
-    }
-
-    if (ctx->opt_scratch) {
-        ZXC_ALIGNED_FREE(ctx->opt_scratch);
-        ctx->opt_scratch = NULL;
-    }
-
+    ctx->lit_buffer = NULL;
     ctx->hash_table = NULL;
     ctx->hash_tags = NULL;
     ctx->chain_table = NULL;
@@ -170,6 +209,8 @@ void zxc_cctx_free(zxc_cctx_t* ctx) {
     ctx->buf_offsets = NULL;
     ctx->buf_extras = NULL;
     ctx->literals = NULL;
+    ctx->work_buf = NULL;
+    ctx->opt_scratch = NULL;
 
     ctx->epoch = 0;
     ctx->lit_buffer_cap = 0;
@@ -663,7 +704,7 @@ uint64_t zxc_estimate_cctx_size(const size_t src_size, const int level) {
      * buffers above and is intentionally omitted. */
 
     if (level >= ZXC_LEVEL_DENSITY) {
-        const size_t n_bm_words = (chunk_size + 1 + 63) / 64;
+        const size_t n_bm_words = ZXC_BITMAP_WORDS(chunk_size + 1);
         size_t opt = ZXC_ALIGN_CL((chunk_size + 1) * sizeof(uint32_t)); /* dp             */
         opt += ZXC_ALIGN_CL((chunk_size + 1) * sizeof(uint16_t));       /* parent_len     */
         opt += ZXC_ALIGN_CL((chunk_size + 1) * sizeof(uint16_t));       /* parent_off     */

--- a/src/lib/zxc_common.c
+++ b/src/lib/zxc_common.c
@@ -87,10 +87,10 @@ static zxc_cctx_layout_t compute_cctx_layout(const size_t chunk_size, const int 
 
     if (mode == 0) {
         /* Decompress: work_buf + lit_buffer, both padded for wild-copy
-         * overshoot and sized worst-case (chunk_size + PAD).  lit_buffer is
-         * provisioned regardless of level because the decoder cannot
+         * overshoot and sized worst-case (chunk_size + ZXC_DECOMPRESS_TAIL_PAD).
+         * lit_buffer is provisioned regardless of level because the decoder cannot
          * predict the per-block literal encoding (RAW / RLE / HUFFMAN). */
-        const size_t sz_work = chunk_size + ZXC_PAD_SIZE;
+        const size_t sz_work = chunk_size + ZXC_DECOMPRESS_TAIL_PAD;
         const size_t sz_lit = chunk_size + ZXC_PAD_SIZE;
 
         layout.off_work = layout.total;
@@ -178,7 +178,7 @@ int zxc_cctx_init_in_workspace(zxc_cctx_t* RESTRICT ctx, void* RESTRICT workspac
 
     if (mode == 0) {
         ctx->work_buf = mem + layout.off_work;
-        ctx->work_buf_cap = chunk_size + ZXC_PAD_SIZE;
+        ctx->work_buf_cap = chunk_size + ZXC_DECOMPRESS_TAIL_PAD;
         ctx->lit_buffer = mem + layout.off_lit_dctx;
         ctx->lit_buffer_cap = chunk_size + ZXC_PAD_SIZE;
         return ZXC_OK;

--- a/src/lib/zxc_common.c
+++ b/src/lib/zxc_common.c
@@ -57,78 +57,67 @@ void zxc_aligned_free(void* ptr) {
 }
 
 /*
- * @brief Initialises a compression context, allocating all internal buffers.
- *
- * A single cache-line-aligned allocation is carved into hash table, chain
- * table, sequence buffers, token buffers, offset buffers, extra-length
- * buffers, and a literal buffer.
- *
- * @param[out] ctx              Context to initialise (zeroed on entry).
- * @param[in]  chunk_size       Maximum uncompressed chunk size (bytes).
- * @param[in]  mode             0 = decompression (skip buffer alloc), 1 = compression.
- * @param[in]  level            Compression level (stored in ctx).
- * @param[in]  checksum_enabled Non-zero to enable checksum generation/verification.
- * @return @ref ZXC_OK on success, or @ref ZXC_ERROR_MEMORY on allocation failure.
+ * Layout of the persistent buffer carved by every cctx/dctx init: both modes
+ * (compress, decompress) compute the same offset table, used by the workspace
+ * sizer and the in-place init.
  */
-int zxc_cctx_init(zxc_cctx_t* RESTRICT ctx, const size_t chunk_size, const int mode,
-                  const int level, const int checksum_enabled) {
-    ZXC_MEMSET(ctx, 0, sizeof(zxc_cctx_t));
+typedef struct {
+    size_t total;
+    /* mode == 0 (decompress) */
+    size_t off_work;
+    size_t off_lit_dctx;
+    /* mode == 1 (compress) */
+    size_t off_hash_pos;
+    size_t off_hash_tags;
+    size_t off_chain;
+    size_t off_seq_union;
+    size_t off_extras;
+    size_t off_lit_cctx;
+    size_t off_opt; /* meaningful only when sz_opt > 0 (level >= 6). */
+    /* Sub-buffer sizes (re-used by the partitioning step + zero-init). */
+    size_t sz_hash_pos;
+    size_t sz_hash_tags;
+    size_t sz_opt;
+    size_t max_seq;
+} zxc_cctx_layout_t;
 
-    ctx->checksum_enabled = checksum_enabled;
+static zxc_cctx_layout_t compute_cctx_layout(const size_t chunk_size, const int mode,
+                                             const int level) {
+    zxc_cctx_layout_t layout = {0};
 
-    /* Compute block-size derived parameters. */
-    ctx->chunk_size = chunk_size;
-    const uint32_t offset_bits = zxc_log2_u32((uint32_t)chunk_size);
-    ctx->offset_bits = offset_bits;
-    ctx->offset_mask = (uint32_t)((1ULL << offset_bits) - 1);
-    ctx->max_epoch = (uint32_t)(1ULL << (32 - offset_bits));
-
-    /* Decompress mode: two padded scratch buffers (work_buf and lit_buffer)
-     * are the only persistent allocations; the rest of the cctx hot/warm
-     * zones are compress-only. Both are partitioned inside memory_block so
-     * a static-cctx workspace sees one contiguous allocation.
-     *
-     * lit_buffer is sized for the worst case (chunk_size + ZXC_PAD_SIZE)
-     * because the decoder cannot predict the per-block literal encoding
-     * (RAW / RLE / HUFFMAN) at init time.
-     */
     if (mode == 0) {
+        /* Decompress: work_buf + lit_buffer, both padded for wild-copy
+         * overshoot and sized worst-case (chunk_size + PAD).  lit_buffer is
+         * provisioned regardless of level because the decoder cannot
+         * predict the per-block literal encoding (RAW / RLE / HUFFMAN). */
         const size_t sz_work = chunk_size + ZXC_PAD_SIZE;
         const size_t sz_lit = chunk_size + ZXC_PAD_SIZE;
 
-        size_t total_size = 0;
-        const size_t off_work = total_size;
-        total_size += ZXC_ALIGN_CL(sz_work);
-        const size_t off_lit = total_size;
-        total_size += ZXC_ALIGN_CL(sz_lit);
-
-        uint8_t* const mem = (uint8_t*)ZXC_ALIGNED_MALLOC(total_size, ZXC_CACHE_LINE_SIZE);
-        if (UNLIKELY(!mem)) return ZXC_ERROR_MEMORY;
-
-        ctx->memory_block = mem;
-        ctx->work_buf = mem + off_work;
-        ctx->work_buf_cap = sz_work;
-        ctx->lit_buffer = mem + off_lit;
-        ctx->lit_buffer_cap = sz_lit;
-        return ZXC_OK;
+        layout.off_work = layout.total;
+        layout.total += ZXC_ALIGN_CL(sz_work);
+        layout.off_lit_dctx = layout.total;
+        layout.total += ZXC_ALIGN_CL(sz_lit);
+        return layout;
     }
 
-    const size_t max_seq = chunk_size / ZXC_LZ_MIN_MATCH_LEN + 16;
-    const size_t sz_hash_pos = ZXC_LZ_HASH_SIZE * sizeof(uint32_t);
-    const size_t sz_hash_tags = ZXC_LZ_HASH_SIZE * sizeof(uint8_t);
+    /* Compress: 6 partitions + optional opt_scratch at level >= 6. */
+    const uint32_t offset_bits = zxc_log2_u32((uint32_t)chunk_size);
+    layout.max_seq = chunk_size / ZXC_LZ_MIN_MATCH_LEN + 16;
+    layout.sz_hash_pos = ZXC_LZ_HASH_SIZE * sizeof(uint32_t);
+    layout.sz_hash_tags = ZXC_LZ_HASH_SIZE * sizeof(uint8_t);
     const size_t sz_chain = ZXC_LZ_WINDOW_SIZE * sizeof(uint16_t);
     /* buf_sequences (GHI, level <= 2) aliases buf_offsets + buf_tokens (GLO,
      * level >= 3). Mutually exclusive per block; sized for the larger. */
-    const size_t sz_seq_union = max_seq * sizeof(uint32_t);
-    /* Varint bytes per LL/ML: scales with chunk_size. */
+    const size_t sz_seq_union = layout.max_seq * sizeof(uint32_t);
     const size_t vbyte_len = (offset_bits + 6) / 7;
-    const size_t sz_extras = max_seq * 2 * vbyte_len;
+    const size_t sz_extras = layout.max_seq * 2 * vbyte_len;
     const size_t sz_lit = chunk_size + ZXC_PAD_SIZE;
 
     /* opt_scratch (level >= 6 only): DP arrays for the optimal parser, also
      * reused transiently as the package-merge scratch for the length-limited
-     * Huffman code-length builder. Sized to the larger of the two demands. */
-    size_t sz_opt = 0;
+     * Huffman code-length builder. Sized to the larger of the two demands.
+     * The formula must stay in sync with zxc_estimate_cctx_size() and the
+     * consumer in zxc_compress.c. */
     if (level >= ZXC_LEVEL_DENSITY) {
         const size_t sz_dp = ZXC_ALIGN_CL((chunk_size + 1) * sizeof(uint32_t));
         const size_t sz_pl = ZXC_ALIGN_CL((chunk_size + 1) * sizeof(uint16_t));
@@ -136,53 +125,116 @@ int zxc_cctx_init(zxc_cctx_t* RESTRICT ctx, const size_t chunk_size, const int m
         const size_t n_bm_words = ZXC_BITMAP_WORDS(chunk_size + 1);
         const size_t sz_bm = ZXC_ALIGN_CL(n_bm_words * sizeof(uint64_t));
         const size_t dp_needed = sz_dp + sz_pl + sz_po + sz_bm;
-        sz_opt = (dp_needed > ZXC_HUF_BUILD_SCRATCH_SIZE) ? dp_needed : ZXC_HUF_BUILD_SCRATCH_SIZE;
+        layout.sz_opt =
+            (dp_needed > ZXC_HUF_BUILD_SCRATCH_SIZE) ? dp_needed : ZXC_HUF_BUILD_SCRATCH_SIZE;
     }
 
-    /* Calculate sizes with alignment padding (64 bytes for cache line alignment) */
-    size_t total_size = 0;
-    const size_t off_hash_pos = total_size;
-    total_size += ZXC_ALIGN_CL(sz_hash_pos);
-    const size_t off_hash_tags = total_size;
-    total_size += ZXC_ALIGN_CL(sz_hash_tags);
-    const size_t off_chain = total_size;
-    total_size += ZXC_ALIGN_CL(sz_chain);
-    const size_t off_seq_union = total_size;
-    total_size += ZXC_ALIGN_CL(sz_seq_union);
-    const size_t off_extras = total_size;
-    total_size += ZXC_ALIGN_CL(sz_extras);
-    const size_t off_lit = total_size;
-    total_size += ZXC_ALIGN_CL(sz_lit);
+    layout.off_hash_pos = layout.total;
+    layout.total += ZXC_ALIGN_CL(layout.sz_hash_pos);
+    layout.off_hash_tags = layout.total;
+    layout.total += ZXC_ALIGN_CL(layout.sz_hash_tags);
+    layout.off_chain = layout.total;
+    layout.total += ZXC_ALIGN_CL(sz_chain);
+    layout.off_seq_union = layout.total;
+    layout.total += ZXC_ALIGN_CL(sz_seq_union);
+    layout.off_extras = layout.total;
+    layout.total += ZXC_ALIGN_CL(sz_extras);
+    layout.off_lit_cctx = layout.total;
+    layout.total += ZXC_ALIGN_CL(sz_lit);
     /* opt_scratch is appended last so it is absent for levels 1..5 (zero
      * waste on the common path) and only inflates the workspace at level 6. */
-    size_t off_opt = 0;
-    if (sz_opt) {
-        off_opt = total_size;
-        total_size += ZXC_ALIGN_CL(sz_opt);
+    if (layout.sz_opt) {
+        layout.off_opt = layout.total;
+        layout.total += ZXC_ALIGN_CL(layout.sz_opt);
+    }
+    return layout;
+}
+
+size_t zxc_cctx_compute_workspace_size(const size_t chunk_size, const int mode, const int level) {
+    if (UNLIKELY(chunk_size == 0)) return 0;
+    return compute_cctx_layout(chunk_size, mode, level).total;
+}
+
+int zxc_cctx_init_in_workspace(zxc_cctx_t* RESTRICT ctx, void* RESTRICT workspace,
+                               const size_t workspace_size, const size_t chunk_size, const int mode,
+                               const int level, const int checksum_enabled) {
+    if (UNLIKELY(!ctx || !workspace || chunk_size == 0)) return ZXC_ERROR_NULL_INPUT;
+
+    const zxc_cctx_layout_t layout = compute_cctx_layout(chunk_size, mode, level);
+    if (UNLIKELY(workspace_size < layout.total)) return ZXC_ERROR_DST_TOO_SMALL;
+
+    ZXC_MEMSET(ctx, 0, sizeof(zxc_cctx_t));
+    ctx->checksum_enabled = checksum_enabled;
+    ctx->chunk_size = chunk_size;
+    const uint32_t offset_bits = zxc_log2_u32((uint32_t)chunk_size);
+    ctx->offset_bits = offset_bits;
+    ctx->offset_mask = (uint32_t)((1ULL << offset_bits) - 1);
+    ctx->max_epoch = (uint32_t)(1ULL << (32 - offset_bits));
+
+    /* memory_block stays NULL on the static-init path so zxc_cctx_free does
+     * not try to free the caller's workspace.  Sub-buffer pointers carry the
+     * partition; ownership is implicit (the caller owns @p workspace). */
+    uint8_t* const mem = (uint8_t*)workspace;
+
+    if (mode == 0) {
+        ctx->work_buf = mem + layout.off_work;
+        ctx->work_buf_cap = chunk_size + ZXC_PAD_SIZE;
+        ctx->lit_buffer = mem + layout.off_lit_dctx;
+        ctx->lit_buffer_cap = chunk_size + ZXC_PAD_SIZE;
+        return ZXC_OK;
     }
 
-    uint8_t* const mem = (uint8_t*)ZXC_ALIGNED_MALLOC(total_size, ZXC_CACHE_LINE_SIZE);
-    if (UNLIKELY(!mem)) return ZXC_ERROR_MEMORY;
-
-    ctx->memory_block = mem;
-    ctx->hash_table = (uint32_t*)(mem + off_hash_pos);
-    ctx->hash_tags = (uint8_t*)(mem + off_hash_tags);
-    ctx->chain_table = (uint16_t*)(mem + off_chain);
-    ctx->buf_sequences = (uint32_t*)(mem + off_seq_union);
-    ctx->buf_offsets = (uint16_t*)(mem + off_seq_union);
-    ctx->buf_tokens = (uint8_t*)(mem + off_seq_union) + max_seq * sizeof(uint16_t);
-    ctx->buf_extras = (uint8_t*)(mem + off_extras);
-    ctx->literals = (uint8_t*)(mem + off_lit);
-    if (sz_opt) {
-        ctx->opt_scratch = mem + off_opt;
-        ctx->opt_scratch_cap = sz_opt;
+    ctx->hash_table = (uint32_t*)(mem + layout.off_hash_pos);
+    ctx->hash_tags = (uint8_t*)(mem + layout.off_hash_tags);
+    ctx->chain_table = (uint16_t*)(mem + layout.off_chain);
+    ctx->buf_sequences = (uint32_t*)(mem + layout.off_seq_union);
+    ctx->buf_offsets = (uint16_t*)(mem + layout.off_seq_union);
+    ctx->buf_tokens = (uint8_t*)(mem + layout.off_seq_union) + layout.max_seq * sizeof(uint16_t);
+    ctx->buf_extras = (uint8_t*)(mem + layout.off_extras);
+    ctx->literals = (uint8_t*)(mem + layout.off_lit_cctx);
+    if (layout.sz_opt) {
+        ctx->opt_scratch = mem + layout.off_opt;
+        ctx->opt_scratch_cap = layout.sz_opt;
     }
 
     ctx->compression_level = level;
     ctx->epoch = 1;
 
-    ZXC_MEMSET(ctx->hash_table, 0, sz_hash_pos);
-    ZXC_MEMSET(ctx->hash_tags, 0, sz_hash_tags);
+    ZXC_MEMSET(ctx->hash_table, 0, layout.sz_hash_pos);
+    ZXC_MEMSET(ctx->hash_tags, 0, layout.sz_hash_tags);
+    return ZXC_OK;
+}
+
+/*
+ * @brief Initialises a compression / decompression context, allocating the
+ *        persistent buffer with @c ZXC_ALIGNED_MALLOC.
+ *
+ * Thin wrapper around @ref zxc_cctx_init_in_workspace: sizes the buffer via
+ * @ref zxc_cctx_compute_workspace_size, allocates it, then partitions it.
+ * The pointer is stored in @c ctx->memory_block so @ref zxc_cctx_free can
+ * release it.  The static-cctx public API (see @c zxc_buffer.h) bypasses
+ * this wrapper and partitions a caller-supplied workspace directly.
+ *
+ * @return @ref ZXC_OK on success, @ref ZXC_ERROR_MEMORY on allocation failure.
+ */
+int zxc_cctx_init(zxc_cctx_t* RESTRICT ctx, const size_t chunk_size, const int mode,
+                  const int level, const int checksum_enabled) {
+    const size_t total = zxc_cctx_compute_workspace_size(chunk_size, mode, level);
+    if (UNLIKELY(total == 0)) return ZXC_ERROR_NULL_INPUT;
+
+    uint8_t* const mem = (uint8_t*)ZXC_ALIGNED_MALLOC(total, ZXC_CACHE_LINE_SIZE);
+    if (UNLIKELY(!mem)) return ZXC_ERROR_MEMORY;
+
+    const int rc =
+        zxc_cctx_init_in_workspace(ctx, mem, total, chunk_size, mode, level, checksum_enabled);
+    if (UNLIKELY(rc != ZXC_OK)) {
+        // LCOV_EXCL_START
+        ZXC_ALIGNED_FREE(mem);
+        return rc;
+        // LCOV_EXCL_STOP
+    }
+    /* Library-owned buffer: record the allocation so zxc_cctx_free frees it. */
+    ctx->memory_block = mem;
     return ZXC_OK;
 }
 

--- a/src/lib/zxc_compress.c
+++ b/src/lib/zxc_compress.c
@@ -932,21 +932,17 @@ static int zxc_lz77_optimal_parse_glo(zxc_cctx_t* RESTRICT ctx, const uint8_t* R
     const size_t sz_dp = ZXC_ALIGN_CL((chunk + 1) * sizeof(uint32_t));
     const size_t sz_pl = ZXC_ALIGN_CL((chunk + 1) * sizeof(uint16_t));
     const size_t sz_po = ZXC_ALIGN_CL((chunk + 1) * sizeof(uint16_t));
-    const size_t n_bm_words = (chunk + 1 + 63) / 64;
+    const size_t n_bm_words = ZXC_BITMAP_WORDS(chunk + 1);
     const size_t sz_bm = ZXC_ALIGN_CL(n_bm_words * sizeof(uint64_t));
     const size_t dp_needed = sz_dp + sz_pl + sz_po + sz_bm;
     const size_t needed =
         (dp_needed > ZXC_HUF_BUILD_SCRATCH_SIZE) ? dp_needed : ZXC_HUF_BUILD_SCRATCH_SIZE;
 
-    if (UNLIKELY(ctx->opt_scratch_cap < needed)) {
-        if (ctx->opt_scratch) ZXC_ALIGNED_FREE(ctx->opt_scratch);
-        ctx->opt_scratch = (uint8_t*)ZXC_ALIGNED_MALLOC(needed, ZXC_CACHE_LINE_SIZE);
-        if (UNLIKELY(!ctx->opt_scratch)) {
-            ctx->opt_scratch_cap = 0;
-            return ZXC_ERROR_MEMORY;
-        }
-        ctx->opt_scratch_cap = needed;
-    }
+    /* opt_scratch is now pre-allocated inside ctx->memory_block by
+     * zxc_cctx_init when level >= ZXC_LEVEL_DENSITY. The formula above must
+     * stay byte-for-byte in sync with the one in zxc_cctx_init() and
+     * zxc_estimate_cctx_size(). */
+    (void)needed;
 
     /* Per-block literal cost: */
     const uint32_t lit_cost = zxc_opt_estimate_lit_bits(src, src_sz, ctx->opt_scratch);

--- a/src/lib/zxc_compress.c
+++ b/src/lib/zxc_compress.c
@@ -874,19 +874,16 @@ static uint32_t zxc_opt_estimate_lit_bits(const uint8_t* RESTRICT src, const siz
  * @param[out] extras_sz_out    Number of bytes written into @p buf_extras.
  * @param[out] max_offset_out   Largest biased offset emitted (used by the caller
  *                              to choose 1-byte vs 2-byte offset encoding).
- *
- * @return `ZXC_OK` on success, or `ZXC_ERROR_MEMORY` if the DP scratch
- *         allocations fail.
  */
-static int zxc_lz77_optimal_parse_glo(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRICT src,
-                                      const size_t src_sz, uint32_t* RESTRICT hash_table,
-                                      uint8_t* RESTRICT hash_tags, uint16_t* RESTRICT chain_table,
-                                      const uint32_t epoch_mark, const uint32_t offset_mask,
-                                      const int level, uint8_t* RESTRICT literals,
-                                      uint8_t* RESTRICT buf_tokens, uint16_t* RESTRICT buf_offsets,
-                                      uint8_t* RESTRICT buf_extras, uint32_t* RESTRICT seq_c_out,
-                                      size_t* RESTRICT lit_c_out, size_t* RESTRICT extras_sz_out,
-                                      uint16_t* RESTRICT max_offset_out) {
+static void zxc_lz77_optimal_parse_glo(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRICT src,
+                                       const size_t src_sz, uint32_t* RESTRICT hash_table,
+                                       uint8_t* RESTRICT hash_tags, uint16_t* RESTRICT chain_table,
+                                       const uint32_t epoch_mark, const uint32_t offset_mask,
+                                       const int level, uint8_t* RESTRICT literals,
+                                       uint8_t* RESTRICT buf_tokens, uint16_t* RESTRICT buf_offsets,
+                                       uint8_t* RESTRICT buf_extras, uint32_t* RESTRICT seq_c_out,
+                                       size_t* RESTRICT lit_c_out, size_t* RESTRICT extras_sz_out,
+                                       uint16_t* RESTRICT max_offset_out) {
     zxc_lz77_params_t lzp_opt = zxc_get_lz77_params(level);
     lzp_opt.use_lazy = 0;  // guard
 
@@ -899,7 +896,7 @@ static int zxc_lz77_optimal_parse_glo(zxc_cctx_t* RESTRICT ctx, const uint8_t* R
         *seq_c_out = 0;
         *extras_sz_out = 0;
         *max_offset_out = 0;
-        return ZXC_OK;
+        return;
     }
 
     const size_t mflimit_pos = src_sz - 12;
@@ -1121,8 +1118,6 @@ static int zxc_lz77_optimal_parse_glo(zxc_cctx_t* RESTRICT ctx, const uint8_t* R
     *lit_c_out = lit_c;
     *extras_sz_out = extras_sz;
     *max_offset_out = max_offset;
-
-    return ZXC_OK;
 }
 
 /**
@@ -1206,10 +1201,9 @@ static int zxc_encode_block_glo(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRIC
     /* Level 6+: price-based optimal parser (fills outputs and skips the
      * lazy loop + last_lits handling below via `goto parse_done`). */
     if (level >= ZXC_LEVEL_DENSITY) {
-        const int rc_opt = zxc_lz77_optimal_parse_glo(
-            ctx, src, src_sz, hash_table, hash_tags, chain_table, epoch_mark, offset_mask, level,
-            literals, buf_tokens, buf_offsets, buf_extras, &seq_c, &lit_c, &extras_sz, &max_offset);
-        if (UNLIKELY(rc_opt != ZXC_OK)) return rc_opt;
+        zxc_lz77_optimal_parse_glo(ctx, src, src_sz, hash_table, hash_tags, chain_table, epoch_mark,
+                                   offset_mask, level, literals, buf_tokens, buf_offsets,
+                                   buf_extras, &seq_c, &lit_c, &extras_sz, &max_offset);
         goto parse_done;
     }
 

--- a/src/lib/zxc_decompress.c
+++ b/src/lib/zxc_decompress.c
@@ -634,17 +634,9 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
             if (UNLIKELY(required_size > dst_capacity || required_size > SIZE_MAX - ZXC_PAD_SIZE))
                 return ZXC_ERROR_DST_TOO_SMALL;
             const size_t alloc_size = required_size + ZXC_PAD_SIZE;
-            if (UNLIKELY(ctx->lit_buffer_cap < alloc_size)) {
-                uint8_t* new_buf = (uint8_t*)ZXC_REALLOC(ctx->lit_buffer, alloc_size);
-                if (UNLIKELY(!new_buf)) {
-                    ZXC_FREE(ctx->lit_buffer);
-                    ctx->lit_buffer = NULL;
-                    ctx->lit_buffer_cap = 0;
-                    return ZXC_ERROR_MEMORY;
-                }
-                ctx->lit_buffer = new_buf;
-                ctx->lit_buffer_cap = alloc_size;
-            }
+            /* lit_buffer is pre-allocated to chunk_size + ZXC_PAD_SIZE by
+             * zxc_cctx_init (mode == 0). */
+            if (UNLIKELY(ctx->lit_buffer_cap < alloc_size)) return ZXC_ERROR_CORRUPT_DATA;
             const int rc =
                 zxc_huf_decode_section(p_curr, lit_stream_size, ctx->lit_buffer, required_size);
             if (UNLIKELY(rc != ZXC_OK)) return rc;
@@ -659,17 +651,9 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
                 return ZXC_ERROR_DST_TOO_SMALL;
             const size_t alloc_size = required_size + ZXC_PAD_SIZE;
 
-            if (UNLIKELY(ctx->lit_buffer_cap < alloc_size)) {
-                uint8_t* new_buf = (uint8_t*)ZXC_REALLOC(ctx->lit_buffer, alloc_size);
-                if (UNLIKELY(!new_buf)) {
-                    ZXC_FREE(ctx->lit_buffer);
-                    ctx->lit_buffer = NULL;
-                    ctx->lit_buffer_cap = 0;
-                    return ZXC_ERROR_MEMORY;
-                }
-                ctx->lit_buffer = new_buf;
-                ctx->lit_buffer_cap = alloc_size;
-            }
+            /* lit_buffer is pre-allocated to chunk_size + ZXC_PAD_SIZE by
+             * zxc_cctx_init (mode == 0).*/
+            if (UNLIKELY(ctx->lit_buffer_cap < alloc_size)) return ZXC_ERROR_CORRUPT_DATA;
 
             rle_buf = ctx->lit_buffer;
             if (UNLIKELY(!rle_buf || lit_stream_size > (size_t)(src + src_size - p_curr)))

--- a/src/lib/zxc_dispatch.c
+++ b/src/lib/zxc_dispatch.c
@@ -642,10 +642,10 @@ int64_t zxc_decompress(const void* RESTRICT src, const size_t src_size, void* RE
 
     ip += ZXC_FILE_HEADER_SIZE;
 
-    // work_buf is sized to runtime_chunk_size + ZXC_PAD_SIZE inside
-    // zxc_cctx_init (mode == 0): GLO/GHI wild copies overshoot by up to
-    // ZXC_PAD_SIZE and land in this padded scratch.
-    const size_t work_sz = runtime_chunk_size + ZXC_PAD_SIZE;
+    // work_buf is sized to runtime_chunk_size + ZXC_DECOMPRESS_TAIL_PAD
+    // inside zxc_cctx_init (mode == 0).  The threshold below must match so
+    // the fast-path / bounce decision uses the actual work_buf capacity.
+    const size_t work_sz = runtime_chunk_size + ZXC_DECOMPRESS_TAIL_PAD;
 
     // Block decompression loop
     uint32_t global_hash = 0;
@@ -973,10 +973,10 @@ int64_t zxc_decompress_dctx(zxc_dctx* dctx, const void* RESTRICT src, const size
     zxc_cctx_t* const ctx = &dctx->inner;
     ip += ZXC_FILE_HEADER_SIZE;
 
-    /* work_buf was pre-sized to runtime_chunk_size + ZXC_PAD_SIZE inside the
-     * matching zxc_cctx_init call above; the re-init guard ensures it stays
-     * in sync when chunk_size changes between calls. */
-    const size_t work_sz = runtime_chunk_size + ZXC_PAD_SIZE;
+    /* work_buf was pre-sized to runtime_chunk_size + ZXC_DECOMPRESS_TAIL_PAD
+     * inside the matching zxc_cctx_init call above; the re-init guard ensures
+     * it stays in sync when chunk_size changes between calls. */
+    const size_t work_sz = runtime_chunk_size + ZXC_DECOMPRESS_TAIL_PAD;
 
     while (ip < ip_end) {
         const size_t rem_src = (size_t)(ip_end - ip);
@@ -1105,9 +1105,9 @@ int64_t zxc_decompress_block(zxc_dctx* dctx, const void* RESTRICT src, const siz
 
     zxc_cctx_t* const ctx = &dctx->inner;
 
-    /* work_buf was pre-sized to block_size + ZXC_PAD_SIZE inside the
-     * matching zxc_cctx_init call above. */
-    const size_t work_sz = block_size + ZXC_PAD_SIZE;
+    /* work_buf was pre-sized to block_size + ZXC_DECOMPRESS_TAIL_PAD inside
+     * the matching zxc_cctx_init call above. */
+    const size_t work_sz = block_size + ZXC_DECOMPRESS_TAIL_PAD;
 
     int res;
     if (LIKELY(dst_capacity >= work_sz)) {

--- a/src/lib/zxc_dispatch.c
+++ b/src/lib/zxc_dispatch.c
@@ -642,19 +642,10 @@ int64_t zxc_decompress(const void* RESTRICT src, const size_t src_size, void* RE
 
     ip += ZXC_FILE_HEADER_SIZE;
 
-    // Decode into a padded scratch buffer, then memcpy the exact result out.
-    const size_t work_sz = runtime_chunk_size + ZXC_DECOMPRESS_TAIL_PAD;
-    if (ctx.work_buf_cap < work_sz) {
-        ZXC_FREE(ctx.work_buf);
-        ctx.work_buf = (uint8_t*)ZXC_MALLOC(work_sz);
-        // LCOV_EXCL_START
-        if (UNLIKELY(!ctx.work_buf)) {
-            zxc_cctx_free(&ctx);
-            return ZXC_ERROR_MEMORY;
-        }
-        // LCOV_EXCL_STOP
-        ctx.work_buf_cap = work_sz;
-    }
+    // work_buf is sized to runtime_chunk_size + ZXC_PAD_SIZE inside
+    // zxc_cctx_init (mode == 0): GLO/GHI wild copies overshoot by up to
+    // ZXC_PAD_SIZE and land in this padded scratch.
+    const size_t work_sz = runtime_chunk_size + ZXC_PAD_SIZE;
 
     // Block decompression loop
     uint32_t global_hash = 0;
@@ -959,14 +950,10 @@ int64_t zxc_decompress_dctx(zxc_dctx* dctx, const void* RESTRICT src, const size
     zxc_cctx_t* const ctx = &dctx->inner;
     ip += ZXC_FILE_HEADER_SIZE;
 
-    /* Ensure scratch buffer is large enough. */
-    const size_t work_sz = runtime_chunk_size + ZXC_DECOMPRESS_TAIL_PAD;
-    if (UNLIKELY(ctx->work_buf_cap < work_sz)) {
-        ZXC_FREE(ctx->work_buf);
-        ctx->work_buf = (uint8_t*)ZXC_MALLOC(work_sz);
-        if (UNLIKELY(!ctx->work_buf)) return ZXC_ERROR_MEMORY;  // LCOV_EXCL_LINE
-        ctx->work_buf_cap = work_sz;
-    }
+    /* work_buf was pre-sized to runtime_chunk_size + ZXC_PAD_SIZE inside the
+     * matching zxc_cctx_init call above; the re-init guard ensures it stays
+     * in sync when chunk_size changes between calls. */
+    const size_t work_sz = runtime_chunk_size + ZXC_PAD_SIZE;
 
     while (ip < ip_end) {
         const size_t rem_src = (size_t)(ip_end - ip);
@@ -1095,14 +1082,9 @@ int64_t zxc_decompress_block(zxc_dctx* dctx, const void* RESTRICT src, const siz
 
     zxc_cctx_t* const ctx = &dctx->inner;
 
-    /* Ensure scratch buffer for safe-path wild copies. */
-    const size_t work_sz = block_size + ZXC_DECOMPRESS_TAIL_PAD;
-    if (ctx->work_buf_cap < work_sz) {
-        ZXC_FREE(ctx->work_buf);
-        ctx->work_buf = (uint8_t*)ZXC_MALLOC(work_sz);
-        if (UNLIKELY(!ctx->work_buf)) return ZXC_ERROR_MEMORY;  // LCOV_EXCL_LINE
-        ctx->work_buf_cap = work_sz;
-    }
+    /* work_buf was pre-sized to block_size + ZXC_PAD_SIZE inside the
+     * matching zxc_cctx_init call above. */
+    const size_t work_sz = block_size + ZXC_PAD_SIZE;
 
     int res;
     if (LIKELY(dst_capacity >= work_sz)) {

--- a/src/lib/zxc_dispatch.c
+++ b/src/lib/zxc_dispatch.c
@@ -761,6 +761,9 @@ uint64_t zxc_get_decompressed_size(const void* src, const size_t src_size) {
 struct zxc_cctx_s {
     zxc_cctx_t inner;       /* existing internal context */
     int initialized;        /* 1 if inner has live allocations */
+    int owns_workspace;     /* 0 = library-allocated (free in zxc_free_cctx),
+                               1 = caller-supplied static workspace (no-op free,
+                               block_size pinned at init) */
     size_t last_block_size; /* block size used for last init */
     /* Sticky options (remembered from create or last compress call). */
     int stored_level;
@@ -796,6 +799,9 @@ zxc_cctx* zxc_create_cctx(const zxc_compress_opts_t* opts) {
 
 void zxc_free_cctx(zxc_cctx* cctx) {
     if (UNLIKELY(!cctx)) return;
+    /* Static cctx: handle + inner buffers live inside the caller's workspace,
+     * which we do not own. Free is a no-op; the caller owns the workspace. */
+    if (cctx->owns_workspace) return;
     if (cctx->initialized) zxc_cctx_free(&cctx->inner);
     ZXC_FREE(cctx);
 }
@@ -811,11 +817,17 @@ int64_t zxc_compress_cctx(zxc_cctx* cctx, const void* RESTRICT src, const size_t
     const size_t block_size =
         (opts && opts->block_size > 0) ? opts->block_size : cctx->stored_block_size;
 
+    if (UNLIKELY(!zxc_validate_block_size(block_size))) return ZXC_ERROR_BAD_BLOCK_SIZE;
+
+    /* Static cctx: block_size is locked at workspace init.  Reject any opts
+     * that would force a re-partition, since the workspace cannot grow.
+     * level / checksum_enabled may still vary per call. */
+    if (UNLIKELY(cctx->owns_workspace && block_size != cctx->last_block_size))
+        return ZXC_ERROR_BAD_BLOCK_SIZE;
+
     cctx->stored_level = level;
     cctx->stored_block_size = block_size;
     cctx->stored_checksum = checksum_enabled;
-
-    if (UNLIKELY(!zxc_validate_block_size(block_size))) return ZXC_ERROR_BAD_BLOCK_SIZE;
 
     /* Re-init only when block_size changed (it drives buffer sizes). */
     if (UNLIKELY(!cctx->initialized || cctx->last_block_size != block_size)) {
@@ -894,6 +906,9 @@ struct zxc_dctx_s {
     zxc_cctx_t inner;       /* reuses the same internal context type */
     size_t last_block_size; /* block size from last header parse */
     int initialized;        /* 1 if inner has live allocations */
+    int owns_workspace;     /* 0 = library-allocated (free in zxc_free_dctx),
+                               1 = caller-supplied static workspace (no-op free,
+                               block_size pinned at init) */
 };
 
 zxc_dctx* zxc_create_dctx(void) {
@@ -903,6 +918,9 @@ zxc_dctx* zxc_create_dctx(void) {
 
 void zxc_free_dctx(zxc_dctx* dctx) {
     if (UNLIKELY(!dctx)) return;
+    /* Static dctx: handle + inner buffers live inside the caller's workspace,
+     * which we do not own. Free is a no-op; the caller owns the workspace. */
+    if (dctx->owns_workspace) return;
     if (dctx->initialized) zxc_cctx_free(&dctx->inner);
     ZXC_FREE(dctx);
 }
@@ -927,6 +945,11 @@ int64_t zxc_decompress_dctx(zxc_dctx* dctx, const void* RESTRICT src, const size
     if (UNLIKELY(zxc_read_file_header(ip, src_size, &runtime_chunk_size, &file_has_checksums) !=
                  ZXC_OK))
         return ZXC_ERROR_BAD_HEADER;
+
+    /* Static dctx: block_size is locked at workspace init; reject any
+     * archive whose declared block_size would require a re-partition. */
+    if (UNLIKELY(dctx->owns_workspace && runtime_chunk_size != dctx->last_block_size))
+        return ZXC_ERROR_BAD_BLOCK_SIZE;
 
     /* Re-init only when block size changed. */
     if (UNLIKELY(!dctx->initialized || dctx->last_block_size != runtime_chunk_size)) {
@@ -1145,4 +1168,92 @@ int64_t zxc_decompress_block_safe(zxc_dctx* dctx, const void* RESTRICT src, cons
                                                              src_size, (uint8_t*)dst, dst_capacity);
     if (UNLIKELY(res < 0)) return res;
     return (int64_t)res;
+}
+
+/*
+ * ============================================================================
+ * STATIC CONTEXT API (caller-allocated workspace)
+ * ============================================================================
+ * Places the public handle struct at the start of the workspace, then carves
+ * the persistent buffer (via zxc_cctx_init_in_workspace) in the remaining
+ * cache-line-aligned tail.  The caller owns the whole workspace; free
+ * functions become no-ops via the owns_workspace flag.
+ */
+
+/* Size occupied by the opaque handle at the start of the workspace, rounded
+ * up to a cache-line boundary so the persistent buffer (which expects 64 B
+ * alignment for the hot zones) starts aligned. */
+#define ZXC_STATIC_CCTX_HDR_SIZE ZXC_ALIGN_CL(sizeof(struct zxc_cctx_s))
+#define ZXC_STATIC_DCTX_HDR_SIZE ZXC_ALIGN_CL(sizeof(struct zxc_dctx_s))
+
+size_t zxc_static_cctx_workspace_size(const size_t block_size, const int level) {
+    if (UNLIKELY(!zxc_validate_block_size(block_size))) return 0;
+    if (UNLIKELY(level < ZXC_LEVEL_FASTEST || level > ZXC_LEVEL_DENSITY)) return 0;
+    const size_t inner_sz = zxc_cctx_compute_workspace_size(block_size, 1, level);
+    if (UNLIKELY(inner_sz == 0)) return 0;
+    return ZXC_STATIC_CCTX_HDR_SIZE + inner_sz;
+}
+
+zxc_cctx* zxc_init_static_cctx(void* RESTRICT workspace, const size_t workspace_size,
+                               const zxc_compress_opts_t* RESTRICT opts) {
+    if (UNLIKELY(!workspace || !opts)) return NULL;
+
+    const int level = (opts->level > 0) ? opts->level : ZXC_LEVEL_DEFAULT;
+    const size_t block_size = (opts->block_size > 0) ? opts->block_size : ZXC_BLOCK_SIZE_DEFAULT;
+    const int checksum_enabled = opts->checksum_enabled;
+
+    if (UNLIKELY(!zxc_validate_block_size(block_size))) return NULL;
+    if (UNLIKELY(level < ZXC_LEVEL_FASTEST || level > ZXC_LEVEL_DENSITY)) return NULL;
+
+    const size_t inner_sz = zxc_cctx_compute_workspace_size(block_size, 1, level);
+    if (UNLIKELY(inner_sz == 0)) return NULL;
+    if (UNLIKELY(workspace_size < ZXC_STATIC_CCTX_HDR_SIZE + inner_sz)) return NULL;
+
+    zxc_cctx* const cctx = (zxc_cctx*)workspace;
+    ZXC_MEMSET(cctx, 0, sizeof(*cctx));
+
+    uint8_t* const inner_ws = (uint8_t*)workspace + ZXC_STATIC_CCTX_HDR_SIZE;
+    if (UNLIKELY(zxc_cctx_init_in_workspace(&cctx->inner, inner_ws, inner_sz, block_size, 1, level,
+                                            checksum_enabled) != ZXC_OK))
+        return NULL;
+
+    cctx->owns_workspace = 1;
+    cctx->initialized = 1;
+    cctx->last_block_size = block_size;
+    cctx->stored_level = level;
+    cctx->stored_block_size = block_size;
+    cctx->stored_checksum = checksum_enabled;
+    return cctx;
+}
+
+size_t zxc_static_dctx_workspace_size(const size_t block_size) {
+    if (UNLIKELY(!zxc_validate_block_size(block_size))) return 0;
+    const size_t inner_sz = zxc_cctx_compute_workspace_size(block_size, 0, 0);
+    if (UNLIKELY(inner_sz == 0)) return 0;
+    return ZXC_STATIC_DCTX_HDR_SIZE + inner_sz;
+}
+
+zxc_dctx* zxc_init_static_dctx(void* RESTRICT workspace, const size_t workspace_size,
+                               const size_t block_size) {
+    if (UNLIKELY(!workspace)) return NULL;
+    if (UNLIKELY(!zxc_validate_block_size(block_size))) return NULL;
+
+    const size_t inner_sz = zxc_cctx_compute_workspace_size(block_size, 0, 0);
+    if (UNLIKELY(inner_sz == 0)) return NULL;
+    if (UNLIKELY(workspace_size < ZXC_STATIC_DCTX_HDR_SIZE + inner_sz)) return NULL;
+
+    zxc_dctx* const dctx = (zxc_dctx*)workspace;
+    ZXC_MEMSET(dctx, 0, sizeof(*dctx));
+
+    uint8_t* const inner_ws = (uint8_t*)workspace + ZXC_STATIC_DCTX_HDR_SIZE;
+    /* mode == 0 init: checksum_enabled is updated per-call from the file
+     * header flags, so it does not need to be locked at workspace init. */
+    if (UNLIKELY(zxc_cctx_init_in_workspace(&dctx->inner, inner_ws, inner_sz, block_size, 0, 0,
+                                            0) != ZXC_OK))
+        return NULL;
+
+    dctx->owns_workspace = 1;
+    dctx->initialized = 1;
+    dctx->last_block_size = block_size;
+    return dctx;
 }

--- a/src/lib/zxc_internal.h
+++ b/src/lib/zxc_internal.h
@@ -1564,6 +1564,48 @@ int zxc_cctx_init(zxc_cctx_t* ctx, const size_t chunk_size, const int mode, cons
                   const int checksum_enabled);
 
 /**
+ * @brief Returns the byte count that @ref zxc_cctx_init would allocate for
+ *        the given parameters.
+ *
+ * Used by the static-cctx public API to size a caller-supplied workspace
+ * before calling @ref zxc_cctx_init_in_workspace.
+ *
+ * @param[in] chunk_size  Block size in bytes (must satisfy
+ *                        @ref zxc_validate_block_size).
+ * @param[in] mode        1 = compression, 0 = decompression.
+ * @param[in] level       Compression level (only consulted when @p mode == 1).
+ * @return Size in bytes, or 0 if the parameters are invalid.
+ */
+size_t zxc_cctx_compute_workspace_size(const size_t chunk_size, const int mode, const int level);
+
+/**
+ * @brief Initialises a compression / decompression context inside a
+ *        caller-supplied workspace.
+ *
+ * Identical to @ref zxc_cctx_init except that the persistent buffer is
+ * carved out of @p workspace instead of being @c ZXC_ALIGNED_MALLOC'd
+ * internally.  @p workspace must be cache-line aligned and at least as
+ * large as @ref zxc_cctx_compute_workspace_size for the same parameters.
+ *
+ * The caller owns @p workspace and must keep it alive for the lifetime of
+ * @p ctx.  @ref zxc_cctx_free becomes a no-op for contexts initialised
+ * this way (the workspace is not freed by the library).
+ *
+ * @param[out] ctx               Context to initialise (zeroed on entry).
+ * @param[in]  workspace         Caller-allocated, cache-line-aligned buffer.
+ * @param[in]  workspace_size    Capacity of @p workspace in bytes.
+ * @param[in]  chunk_size        Block size in bytes.
+ * @param[in]  mode              1 = compression, 0 = decompression.
+ * @param[in]  level             Compression level (ignored when @p mode == 0).
+ * @param[in]  checksum_enabled  Non-zero to enable checksum computation.
+ * @return @c ZXC_OK on success, @c ZXC_ERROR_DST_TOO_SMALL if the workspace
+ *         is too small, or another negative @ref zxc_error_t.
+ */
+int zxc_cctx_init_in_workspace(zxc_cctx_t* RESTRICT ctx, void* RESTRICT workspace,
+                               const size_t workspace_size, const size_t chunk_size, const int mode,
+                               const int level, const int checksum_enabled);
+
+/**
  * @brief Releases the internal buffers owned by a context.
  *
  * Does NOT free @p ctx itself - the caller owns the struct storage. The

--- a/src/lib/zxc_internal.h
+++ b/src/lib/zxc_internal.h
@@ -309,6 +309,13 @@ extern "C" {
 /** @brief Round @p x up to the next cache-line boundary. */
 #define ZXC_ALIGN_CL(x) (((x) + ZXC_ALIGNMENT_MASK) & ~(size_t)ZXC_ALIGNMENT_MASK)
 
+/**
+ * @brief Number of @c uint64_t words needed to hold a bitmap of @p n_bits.
+ *
+ * Equivalent to @c ceil(n_bits / 64).
+ */
+#define ZXC_BITMAP_WORDS(n_bits) (((n_bits) + 63) / 64)
+
 /** @brief Bit flag in the Flags byte indicating checksum presence (bit 7). */
 #define ZXC_FILE_FLAG_HAS_CHECKSUM 0x80U
 /** @brief Mask for the checksum algorithm id (bits 0-3). */
@@ -1519,7 +1526,7 @@ typedef struct {
     uint8_t* literals;       /**< Buffer for literal bytes. */
 
     /* Cold zone: configuration / scratch / resizeable. */
-    uint8_t* lit_buffer;    /**< Scratch buffer for literals (RLE). */
+    uint8_t* lit_buffer;    /**< Scratch buffer for literals (RLE / Huffman). */
     size_t lit_buffer_cap;  /**< Current capacity of the scratch buffer. */
     uint8_t* work_buf;      /**< Padded scratch buffer for buffer-API decompression. */
     size_t work_buf_cap;    /**< Capacity of the work buffer. */

--- a/src/lib/zxc_seekable.c
+++ b/src/lib/zxc_seekable.c
@@ -637,18 +637,7 @@ static void* zxc_seek_mt_worker(void* arg) {
         return NULL;
     }
     // LCOV_EXCL_STOP
-
-    /* Allocate work buffer for decompressed output */
     const size_t work_sz = (size_t)s->block_size + ZXC_DECOMPRESS_TAIL_PAD;
-    dctx.work_buf = (uint8_t*)ZXC_MALLOC(work_sz);
-    // LCOV_EXCL_START
-    if (UNLIKELY(!dctx.work_buf)) {
-        zxc_cctx_free(&dctx);
-        job->result = ZXC_ERROR_MEMORY;
-        return NULL;
-    }
-    // LCOV_EXCL_STOP
-    dctx.work_buf_cap = work_sz;
 
     /* Read compressed block */
     const uint32_t csz = s->comp_sizes[bi];

--- a/src/lib/zxc_seekable.c
+++ b/src/lib/zxc_seekable.c
@@ -510,9 +510,9 @@ int64_t zxc_seekable_decompress_range(zxc_seekable* s, void* dst, const size_t d
         s->dctx_initialized = 1;
     }
 
-    /* work_buf is pre-sized to block_size + ZXC_PAD_SIZE by the matching
-     * zxc_cctx_init above. */
-    const size_t work_sz = (size_t)s->block_size + ZXC_PAD_SIZE;
+    /* work_buf is pre-sized to block_size + ZXC_DECOMPRESS_TAIL_PAD by the
+     * matching zxc_cctx_init above. */
+    const size_t work_sz = (size_t)s->block_size + ZXC_DECOMPRESS_TAIL_PAD;
 
     /* Find block range - O(1) division */
     const uint32_t blk_start = zxc_seek_find_block(s->block_size, offset);

--- a/src/lib/zxc_seekable.c
+++ b/src/lib/zxc_seekable.c
@@ -510,14 +510,9 @@ int64_t zxc_seekable_decompress_range(zxc_seekable* s, void* dst, const size_t d
         s->dctx_initialized = 1;
     }
 
-    /* Ensure work buffer is large enough */
-    const size_t work_sz = (size_t)s->block_size + ZXC_DECOMPRESS_TAIL_PAD;
-    if (s->dctx.work_buf_cap < work_sz) {
-        ZXC_FREE(s->dctx.work_buf);
-        s->dctx.work_buf = (uint8_t*)ZXC_MALLOC(work_sz);
-        if (UNLIKELY(!s->dctx.work_buf)) return ZXC_ERROR_MEMORY;  // LCOV_EXCL_LINE
-        s->dctx.work_buf_cap = work_sz;
-    }
+    /* work_buf is pre-sized to block_size + ZXC_PAD_SIZE by the matching
+     * zxc_cctx_init above. */
+    const size_t work_sz = (size_t)s->block_size + ZXC_PAD_SIZE;
 
     /* Find block range - O(1) division */
     const uint32_t blk_start = zxc_seek_find_block(s->block_size, offset);

--- a/tests/test_common.h
+++ b/tests/test_common.h
@@ -74,6 +74,13 @@ int test_decompress_block_bound(void);
 int test_opaque_context_api(void);
 int test_estimate_cctx_size(void);
 
+/* Static Context API */
+int test_static_ctx_roundtrip_all_levels(void);
+int test_static_ctx_size_query(void);
+int test_static_ctx_workspace_too_small(void);
+int test_static_ctx_block_size_locked(void);
+int test_static_ctx_null_inputs(void);
+
 /* Stream API */
 int test_null_output_decompression(void);
 int test_invalid_arguments(void);

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -65,6 +65,13 @@ static const test_entry_t g_tests[] = {
     TEST_CASE(test_opaque_context_api),
     TEST_CASE(test_estimate_cctx_size),
 
+    /* --- Static Context API --- */
+    TEST_CASE(test_static_ctx_size_query),
+    TEST_CASE(test_static_ctx_workspace_too_small),
+    TEST_CASE(test_static_ctx_block_size_locked),
+    TEST_CASE(test_static_ctx_null_inputs),
+    TEST_CASE(test_static_ctx_roundtrip_all_levels),
+
     /* --- Stream API --- */
     TEST_CASE(test_null_output_decompression),
     TEST_CASE(test_invalid_arguments),

--- a/tests/test_static_ctx.c
+++ b/tests/test_static_ctx.c
@@ -1,0 +1,266 @@
+/*
+ * ZXC - High-performance lossless compression
+ *
+ * Copyright (c) 2025-2026 Bertrand Lebonnois and contributors.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include "test_common.h"
+
+/* Helper: produce a deterministic compressible payload. */
+static void fill_payload(uint8_t* dst, size_t n) {
+    for (size_t i = 0; i < n; ++i) dst[i] = (uint8_t)((i * 31u) ^ (i >> 8));
+}
+
+/* Roundtrip through a caller-allocated cctx + dctx workspace, at every level. */
+int test_static_ctx_roundtrip_all_levels(void) {
+    printf("=== TEST: Static Context API - roundtrip at every level ===\n");
+
+    const size_t block_size = 64 * 1024;
+    const size_t src_sz = 200 * 1024; /* spans multiple blocks */
+
+    uint8_t* const src = (uint8_t*)malloc(src_sz);
+    if (!src) {
+        printf("  [FAIL] malloc(src)\n");
+        return 0;
+    }
+    fill_payload(src, src_sz);
+
+    const size_t cap = (size_t)zxc_compress_bound(src_sz);
+    uint8_t* const enc = (uint8_t*)malloc(cap);
+    uint8_t* const dec = (uint8_t*)malloc(src_sz);
+    if (!enc || !dec) {
+        printf("  [FAIL] malloc(enc/dec)\n");
+        free(src);
+        free(enc);
+        free(dec);
+        return 0;
+    }
+
+    for (int lvl = zxc_min_level(); lvl <= zxc_max_level(); ++lvl) {
+        /* Size the cctx workspace exactly. */
+        const size_t cctx_ws_sz = zxc_static_cctx_workspace_size(block_size, lvl);
+        if (cctx_ws_sz == 0) {
+            printf("  [FAIL] level %d: cctx_ws_sz == 0\n", lvl);
+            goto fail;
+        }
+        void* cctx_ws = NULL;
+        if (posix_memalign(&cctx_ws, 64, cctx_ws_sz) != 0) {
+            printf("  [FAIL] level %d: posix_memalign(cctx_ws)\n", lvl);
+            goto fail;
+        }
+
+        zxc_compress_opts_t copts = {
+            .level = lvl, .block_size = block_size, .checksum_enabled = 1};
+        zxc_cctx* const cctx = zxc_init_static_cctx(cctx_ws, cctx_ws_sz, &copts);
+        if (!cctx) {
+            printf("  [FAIL] level %d: zxc_init_static_cctx returned NULL\n", lvl);
+            free(cctx_ws);
+            goto fail;
+        }
+
+        const int64_t csz = zxc_compress_cctx(cctx, src, src_sz, enc, cap, NULL);
+        zxc_free_cctx(cctx); /* no-op for static */
+        free(cctx_ws);
+        if (csz <= 0) {
+            printf("  [FAIL] level %d: compress returned %lld\n", lvl, (long long)csz);
+            goto fail;
+        }
+
+        /* Size + init the dctx workspace. */
+        const size_t dctx_ws_sz = zxc_static_dctx_workspace_size(block_size);
+        if (dctx_ws_sz == 0) {
+            printf("  [FAIL] level %d: dctx_ws_sz == 0\n", lvl);
+            goto fail;
+        }
+        void* dctx_ws = NULL;
+        if (posix_memalign(&dctx_ws, 64, dctx_ws_sz) != 0) {
+            printf("  [FAIL] level %d: posix_memalign(dctx_ws)\n", lvl);
+            goto fail;
+        }
+        zxc_dctx* const dctx = zxc_init_static_dctx(dctx_ws, dctx_ws_sz, block_size);
+        if (!dctx) {
+            printf("  [FAIL] level %d: zxc_init_static_dctx returned NULL\n", lvl);
+            free(dctx_ws);
+            goto fail;
+        }
+
+        zxc_decompress_opts_t dopts = {.checksum_enabled = 1};
+        const int64_t dsz = zxc_decompress_dctx(dctx, enc, (size_t)csz, dec, src_sz, &dopts);
+        zxc_free_dctx(dctx); /* no-op for static */
+        free(dctx_ws);
+        if (dsz != (int64_t)src_sz || memcmp(src, dec, src_sz) != 0) {
+            printf("  [FAIL] level %d: roundtrip mismatch (dsz=%lld)\n", lvl, (long long)dsz);
+            goto fail;
+        }
+
+        printf("  [PASS] level %d: roundtrip OK (%lld bytes -> %lld bytes)\n", lvl,
+               (long long)src_sz, (long long)csz);
+    }
+
+    free(src);
+    free(enc);
+    free(dec);
+    return 1;
+
+fail:
+    free(src);
+    free(enc);
+    free(dec);
+    return 0;
+}
+
+/* Verify the workspace sizers reject invalid inputs and accept the smallest
+ * valid configuration. */
+int test_static_ctx_size_query(void) {
+    printf("=== TEST: Static Context API - workspace_size queries ===\n");
+
+    /* Invalid: zero block_size. */
+    if (zxc_static_cctx_workspace_size(0, ZXC_LEVEL_DEFAULT) != 0) {
+        printf("  [FAIL] cctx_size(0) should be 0\n");
+        return 0;
+    }
+    if (zxc_static_dctx_workspace_size(0) != 0) {
+        printf("  [FAIL] dctx_size(0) should be 0\n");
+        return 0;
+    }
+    /* Invalid: non-power-of-two block_size. */
+    if (zxc_static_cctx_workspace_size(63 * 1024, ZXC_LEVEL_DEFAULT) != 0) {
+        printf("  [FAIL] cctx_size(non-pow2) should be 0\n");
+        return 0;
+    }
+    /* Invalid: out-of-range level. */
+    if (zxc_static_cctx_workspace_size(64 * 1024, 0) != 0) {
+        printf("  [FAIL] cctx_size(level=0) should be 0\n");
+        return 0;
+    }
+    if (zxc_static_cctx_workspace_size(64 * 1024, 99) != 0) {
+        printf("  [FAIL] cctx_size(level=99) should be 0\n");
+        return 0;
+    }
+
+    /* Valid sizes are strictly increasing across levels (level 6 adds opt_scratch). */
+    const size_t s3 = zxc_static_cctx_workspace_size(64 * 1024, 3);
+    const size_t s5 = zxc_static_cctx_workspace_size(64 * 1024, 5);
+    const size_t s6 = zxc_static_cctx_workspace_size(64 * 1024, 6);
+    if (s3 == 0 || s5 == 0 || s6 == 0) {
+        printf("  [FAIL] one of s3/s5/s6 is 0\n");
+        return 0;
+    }
+    if (s3 != s5) {
+        printf("  [FAIL] s3 (%zu) should equal s5 (%zu); only level 6 adds opt_scratch\n", s3, s5);
+        return 0;
+    }
+    if (s6 <= s5) {
+        printf("  [FAIL] s6 (%zu) should exceed s5 (%zu)\n", s6, s5);
+        return 0;
+    }
+    printf("  [PASS] level-1..5 share workspace size; level 6 adds opt_scratch\n");
+    return 1;
+}
+
+/* Verify that init returns NULL when the workspace is too small. */
+int test_static_ctx_workspace_too_small(void) {
+    printf("=== TEST: Static Context API - workspace too small ===\n");
+
+    const size_t block_size = 64 * 1024;
+    const size_t needed = zxc_static_cctx_workspace_size(block_size, ZXC_LEVEL_DEFAULT);
+    /* Provide exactly one byte less than needed. */
+    void* ws = NULL;
+    if (posix_memalign(&ws, 64, needed) != 0) {
+        printf("  [FAIL] posix_memalign\n");
+        return 0;
+    }
+
+    zxc_compress_opts_t opts = {.level = ZXC_LEVEL_DEFAULT, .block_size = block_size};
+    if (zxc_init_static_cctx(ws, needed - 1, &opts) != NULL) {
+        printf("  [FAIL] init should reject undersized workspace\n");
+        free(ws);
+        return 0;
+    }
+    /* Same size: should succeed. */
+    zxc_cctx* const cctx = zxc_init_static_cctx(ws, needed, &opts);
+    if (!cctx) {
+        printf("  [FAIL] init should accept exact-sized workspace\n");
+        free(ws);
+        return 0;
+    }
+    zxc_free_cctx(cctx); /* no-op */
+    free(ws);
+    printf("  [PASS] init rejects undersized, accepts exact-sized workspace\n");
+    return 1;
+}
+
+/* Verify the block_size lock on a static cctx: compressing with a different
+ * block_size in opts must return ZXC_ERROR_BAD_BLOCK_SIZE without crashing. */
+int test_static_ctx_block_size_locked(void) {
+    printf("=== TEST: Static Context API - block_size lock ===\n");
+
+    const size_t pinned_bs = 64 * 1024;
+    const size_t ws_sz = zxc_static_cctx_workspace_size(pinned_bs, ZXC_LEVEL_DEFAULT);
+    void* ws = NULL;
+    if (posix_memalign(&ws, 64, ws_sz) != 0) {
+        printf("  [FAIL] posix_memalign\n");
+        return 0;
+    }
+
+    zxc_compress_opts_t opts = {.level = ZXC_LEVEL_DEFAULT, .block_size = pinned_bs};
+    zxc_cctx* const cctx = zxc_init_static_cctx(ws, ws_sz, &opts);
+    if (!cctx) {
+        printf("  [FAIL] init_static_cctx\n");
+        free(ws);
+        return 0;
+    }
+
+    /* A subsequent compress with a different block_size must fail. */
+    uint8_t src[256] = {0};
+    uint8_t dst[1024];
+    zxc_compress_opts_t opts2 = {.level = ZXC_LEVEL_DEFAULT, .block_size = pinned_bs * 2};
+    const int64_t rc =
+        zxc_compress_cctx(cctx, src, sizeof(src), dst, sizeof(dst), &opts2);
+    if (rc != ZXC_ERROR_BAD_BLOCK_SIZE) {
+        printf("  [FAIL] expected ZXC_ERROR_BAD_BLOCK_SIZE, got %lld\n", (long long)rc);
+        zxc_free_cctx(cctx);
+        free(ws);
+        return 0;
+    }
+
+    /* Same block_size still works. */
+    const int64_t rc2 = zxc_compress_cctx(cctx, src, sizeof(src), dst, sizeof(dst), NULL);
+    if (rc2 <= 0) {
+        printf("  [FAIL] same-block_size compress returned %lld\n", (long long)rc2);
+        zxc_free_cctx(cctx);
+        free(ws);
+        return 0;
+    }
+
+    zxc_free_cctx(cctx);
+    free(ws);
+    printf("  [PASS] mismatched block_size rejected; matching one accepted\n");
+    return 1;
+}
+
+/* Verify NULL inputs are gracefully rejected. */
+int test_static_ctx_null_inputs(void) {
+    printf("=== TEST: Static Context API - NULL inputs ===\n");
+
+    zxc_compress_opts_t opts = {.level = 3, .block_size = 4096};
+    if (zxc_init_static_cctx(NULL, 65536, &opts) != NULL) {
+        printf("  [FAIL] init_static_cctx(NULL workspace) should fail\n");
+        return 0;
+    }
+    uint8_t ws[16384];
+    if (zxc_init_static_cctx(ws, sizeof(ws), NULL) != NULL) {
+        printf("  [FAIL] init_static_cctx(NULL opts) should fail\n");
+        return 0;
+    }
+    if (zxc_init_static_dctx(NULL, 65536, 4096) != NULL) {
+        printf("  [FAIL] init_static_dctx(NULL workspace) should fail\n");
+        return 0;
+    }
+    /* zxc_free_*ctx must accept a NULL pointer (idempotency). */
+    zxc_free_cctx(NULL);
+    zxc_free_dctx(NULL);
+    printf("  [PASS] NULL inputs rejected; NULL free is idempotent\n");
+    return 1;
+}

--- a/tests/test_static_ctx.c
+++ b/tests/test_static_ctx.c
@@ -7,6 +7,21 @@
 
 #include "test_common.h"
 
+#if defined(_WIN32)
+#include <malloc.h>
+static void* test_aligned_alloc(size_t alignment, size_t size) {
+    return _aligned_malloc(size, alignment);
+}
+static void test_aligned_free(void* p) { _aligned_free(p); }
+#else
+static void* test_aligned_alloc(size_t alignment, size_t size) {
+    void* p = NULL;
+    if (posix_memalign(&p, alignment, size) != 0) return NULL;
+    return p;
+}
+static void test_aligned_free(void* p) { free(p); }
+#endif
+
 /* Helper: produce a deterministic compressible payload. */
 static void fill_payload(uint8_t* dst, size_t n) {
     for (size_t i = 0; i < n; ++i) dst[i] = (uint8_t)((i * 31u) ^ (i >> 8));
@@ -44,9 +59,9 @@ int test_static_ctx_roundtrip_all_levels(void) {
             printf("  [FAIL] level %d: cctx_ws_sz == 0\n", lvl);
             goto fail;
         }
-        void* cctx_ws = NULL;
-        if (posix_memalign(&cctx_ws, 64, cctx_ws_sz) != 0) {
-            printf("  [FAIL] level %d: posix_memalign(cctx_ws)\n", lvl);
+        void* const cctx_ws = test_aligned_alloc(64, cctx_ws_sz);
+        if (!cctx_ws) {
+            printf("  [FAIL] level %d: aligned_alloc(cctx_ws)\n", lvl);
             goto fail;
         }
 
@@ -55,13 +70,13 @@ int test_static_ctx_roundtrip_all_levels(void) {
         zxc_cctx* const cctx = zxc_init_static_cctx(cctx_ws, cctx_ws_sz, &copts);
         if (!cctx) {
             printf("  [FAIL] level %d: zxc_init_static_cctx returned NULL\n", lvl);
-            free(cctx_ws);
+            test_aligned_free(cctx_ws);
             goto fail;
         }
 
         const int64_t csz = zxc_compress_cctx(cctx, src, src_sz, enc, cap, NULL);
         zxc_free_cctx(cctx); /* no-op for static */
-        free(cctx_ws);
+        test_aligned_free(cctx_ws);
         if (csz <= 0) {
             printf("  [FAIL] level %d: compress returned %lld\n", lvl, (long long)csz);
             goto fail;
@@ -73,22 +88,22 @@ int test_static_ctx_roundtrip_all_levels(void) {
             printf("  [FAIL] level %d: dctx_ws_sz == 0\n", lvl);
             goto fail;
         }
-        void* dctx_ws = NULL;
-        if (posix_memalign(&dctx_ws, 64, dctx_ws_sz) != 0) {
-            printf("  [FAIL] level %d: posix_memalign(dctx_ws)\n", lvl);
+        void* const dctx_ws = test_aligned_alloc(64, dctx_ws_sz);
+        if (!dctx_ws) {
+            printf("  [FAIL] level %d: aligned_alloc(dctx_ws)\n", lvl);
             goto fail;
         }
         zxc_dctx* const dctx = zxc_init_static_dctx(dctx_ws, dctx_ws_sz, block_size);
         if (!dctx) {
             printf("  [FAIL] level %d: zxc_init_static_dctx returned NULL\n", lvl);
-            free(dctx_ws);
+            test_aligned_free(dctx_ws);
             goto fail;
         }
 
         zxc_decompress_opts_t dopts = {.checksum_enabled = 1};
         const int64_t dsz = zxc_decompress_dctx(dctx, enc, (size_t)csz, dec, src_sz, &dopts);
         zxc_free_dctx(dctx); /* no-op for static */
-        free(dctx_ws);
+        test_aligned_free(dctx_ws);
         if (dsz != (int64_t)src_sz || memcmp(src, dec, src_sz) != 0) {
             printf("  [FAIL] level %d: roundtrip mismatch (dsz=%lld)\n", lvl, (long long)dsz);
             goto fail;
@@ -166,27 +181,27 @@ int test_static_ctx_workspace_too_small(void) {
     const size_t block_size = 64 * 1024;
     const size_t needed = zxc_static_cctx_workspace_size(block_size, ZXC_LEVEL_DEFAULT);
     /* Provide exactly one byte less than needed. */
-    void* ws = NULL;
-    if (posix_memalign(&ws, 64, needed) != 0) {
-        printf("  [FAIL] posix_memalign\n");
+    void* const ws = test_aligned_alloc(64, needed);
+    if (!ws) {
+        printf("  [FAIL] aligned_alloc\n");
         return 0;
     }
 
     zxc_compress_opts_t opts = {.level = ZXC_LEVEL_DEFAULT, .block_size = block_size};
     if (zxc_init_static_cctx(ws, needed - 1, &opts) != NULL) {
         printf("  [FAIL] init should reject undersized workspace\n");
-        free(ws);
+        test_aligned_free(ws);
         return 0;
     }
     /* Same size: should succeed. */
     zxc_cctx* const cctx = zxc_init_static_cctx(ws, needed, &opts);
     if (!cctx) {
         printf("  [FAIL] init should accept exact-sized workspace\n");
-        free(ws);
+        test_aligned_free(ws);
         return 0;
     }
     zxc_free_cctx(cctx); /* no-op */
-    free(ws);
+    test_aligned_free(ws);
     printf("  [PASS] init rejects undersized, accepts exact-sized workspace\n");
     return 1;
 }
@@ -198,9 +213,9 @@ int test_static_ctx_block_size_locked(void) {
 
     const size_t pinned_bs = 64 * 1024;
     const size_t ws_sz = zxc_static_cctx_workspace_size(pinned_bs, ZXC_LEVEL_DEFAULT);
-    void* ws = NULL;
-    if (posix_memalign(&ws, 64, ws_sz) != 0) {
-        printf("  [FAIL] posix_memalign\n");
+    void* const ws = test_aligned_alloc(64, ws_sz);
+    if (!ws) {
+        printf("  [FAIL] aligned_alloc\n");
         return 0;
     }
 
@@ -208,7 +223,7 @@ int test_static_ctx_block_size_locked(void) {
     zxc_cctx* const cctx = zxc_init_static_cctx(ws, ws_sz, &opts);
     if (!cctx) {
         printf("  [FAIL] init_static_cctx\n");
-        free(ws);
+        test_aligned_free(ws);
         return 0;
     }
 
@@ -221,7 +236,7 @@ int test_static_ctx_block_size_locked(void) {
     if (rc != ZXC_ERROR_BAD_BLOCK_SIZE) {
         printf("  [FAIL] expected ZXC_ERROR_BAD_BLOCK_SIZE, got %lld\n", (long long)rc);
         zxc_free_cctx(cctx);
-        free(ws);
+        test_aligned_free(ws);
         return 0;
     }
 
@@ -230,12 +245,12 @@ int test_static_ctx_block_size_locked(void) {
     if (rc2 <= 0) {
         printf("  [FAIL] same-block_size compress returned %lld\n", (long long)rc2);
         zxc_free_cctx(cctx);
-        free(ws);
+        test_aligned_free(ws);
         return 0;
     }
 
     zxc_free_cctx(cctx);
-    free(ws);
+    test_aligned_free(ws);
     printf("  [PASS] mismatched block_size rejected; matching one accepted\n");
     return 1;
 }


### PR DESCRIPTION
Adds a new Static Context API that allows callers to provide their own memory buffer for compression and decompression contexts. This feature is crucial for environments with strict memory management requirements, such as:
- Linux kernel filesystems (using `vmalloc`/`kmalloc`)
- Embedded targets without a heap (`.bss` or stack-allocated workspaces)
- Sandboxed runtimes with fixed memory budgets

This API eliminates dynamic memory allocations on the hot path once the context is initialized, making it suitable for scenarios where `malloc`/`free` calls are disallowed or incur too much overhead.

Key changes include:
- **New API Functions:** Introduces `zxc_static_cctx_workspace_size`, `zxc_init_static_cctx`, `zxc_static_dctx_workspace_size`, and `zxc_init_static_dctx` to query workspace sizes and initialize contexts in caller-supplied buffers.
- **Memory Consolidation:** Refactors internal compression and decompression contexts to use a single, pre-allocated memory block for all persistent sub-buffers (hash tables, chain table, sequence buffers, literal scratch, work buffer, and optimal-parser scratch). This consolidation enables the static context API and removes dynamic reallocations during compression/decompression operations.
- **Context Management:** Updates `zxc_free_cctx` and `zxc_free_dctx` to be no-ops when managing a static context, as the caller retains ownership of the workspace.
- **Pinned Block Size:** Static contexts lock the `block_size` at initialization; subsequent calls attempting to use a different `block_size` will fail without re-initialization, as the workspace cannot be resized.
- **Documentation & Tests:** Adds comprehensive documentation for the new API in `API.md` and `zxc_buffer.h`, along with a dedicated test suite to verify functionality and constraints.