### PR TITLE
perf: Improve Huffman leaf sorting with bucket sort

### DIFF
--- a/src/lib/zxc_compress.c
+++ b/src/lib/zxc_compress.c
@@ -278,47 +278,75 @@ static ZXC_ALWAYS_INLINE zxc_match_t zxc_lz77_find_best_match(
                     goto _match_len_done;
                 }
             }
-#elif defined(ZXC_USE_NEON64) || defined(ZXC_USE_NEON32)
-            const uint8_t* limit_16 = iend - 16;
-            while (ip + mlen < limit_16) {
-                const uint8x16_t v_src = vld1q_u8(ip + mlen);
-                const uint8x16_t v_ref = vld1q_u8(ref + mlen);
-                const uint8x16_t v_cmp = vceqq_u8(v_src, v_ref);
-#if defined(ZXC_USE_NEON64)
-                /* Compress 128-bit byte-mask -> 64-bit nibble-mask via
-                 * SHRN: each 0x00/0xFF byte becomes a 0x0/0xF nibble. */
-                const uint64_t mask = vget_lane_u64(
-                    vreinterpret_u64_u8(vshrn_n_u16(vreinterpretq_u16_u8(v_cmp), 4)), 0);
-                if (LIKELY(mask == ~(uint64_t)0)) {
-                    mlen += 16;
-                } else {
-                    mlen += (uint32_t)(zxc_ctz64(~mask) >> 2);
-                    goto _match_len_done;
+#elif defined(ZXC_USE_NEON64)
+            {
+                const uint8_t* limit_32 = iend - 32;
+                while (ip + mlen < limit_32) {
+                    const uint8x16_t s0 = vld1q_u8(ip + mlen);
+                    const uint8x16_t r0 = vld1q_u8(ref + mlen);
+                    const uint8x16_t c0 = vceqq_u8(s0, r0);
+                    const uint64_t m0 = vget_lane_u64(
+                        vreinterpret_u64_u8(vshrn_n_u16(vreinterpretq_u16_u8(c0), 4)), 0);
+                    if (UNLIKELY(m0 != ~(uint64_t)0)) {
+                        mlen += (uint32_t)(zxc_ctz64(~m0) >> 2);
+                        goto _match_len_done;
+                    }
+                    const uint8x16_t s1 = vld1q_u8(ip + mlen + 16);
+                    const uint8x16_t r1 = vld1q_u8(ref + mlen + 16);
+                    const uint8x16_t c1 = vceqq_u8(s1, r1);
+                    const uint64_t m1 = vget_lane_u64(
+                        vreinterpret_u64_u8(vshrn_n_u16(vreinterpretq_u16_u8(c1), 4)), 0);
+                    if (UNLIKELY(m1 != ~(uint64_t)0)) {
+                        mlen += 16 + (uint32_t)(zxc_ctz64(~m1) >> 2);
+                        goto _match_len_done;
+                    }
+                    mlen += 32;
                 }
-#else
-                uint8x8_t p1 = vpmin_u8(vget_low_u8(v_cmp), vget_high_u8(v_cmp));
-                uint8x8_t p2 = vpmin_u8(p1, p1);
-                uint8x8_t p3 = vpmin_u8(p2, p2);
-                uint8x8_t p4 = vpmin_u8(p3, p3);
-                uint8_t min_val = vget_lane_u8(p4, 0);
-                if (min_val == 0xFF)
-                    mlen += 16;
-                else {
-                    uint8x16_t v_diff = vmvnq_u8(v_cmp);
-                    uint64_t lo = (uint64_t)vgetq_lane_u32(vreinterpretq_u32_u8(v_diff), 0) |
-                                  ((uint64_t)vgetq_lane_u32(vreinterpretq_u32_u8(v_diff), 1) << 32);
-                    if (lo != 0)
-                        mlen += (zxc_ctz64(lo) >> 3);
-                    else
-                        mlen +=
-                            8 +
-                            (zxc_ctz64((uint64_t)vgetq_lane_u32(vreinterpretq_u32_u8(v_diff), 2) |
-                                       ((uint64_t)vgetq_lane_u32(vreinterpretq_u32_u8(v_diff), 3)
-                                        << 32)) >>
-                             3);
-                    goto _match_len_done;
+                if (ip + mlen < iend - 16) {
+                    const uint8x16_t v_src = vld1q_u8(ip + mlen);
+                    const uint8x16_t v_ref = vld1q_u8(ref + mlen);
+                    const uint8x16_t v_cmp = vceqq_u8(v_src, v_ref);
+                    const uint64_t mask = vget_lane_u64(
+                        vreinterpret_u64_u8(vshrn_n_u16(vreinterpretq_u16_u8(v_cmp), 4)), 0);
+                    if (LIKELY(mask == ~(uint64_t)0))
+                        mlen += 16;
+                    else {
+                        mlen += (uint32_t)(zxc_ctz64(~mask) >> 2);
+                        goto _match_len_done;
+                    }
                 }
-#endif
+            }
+#elif defined(ZXC_USE_NEON32)
+            {
+                const uint8_t* limit_16 = iend - 16;
+                while (ip + mlen < limit_16) {
+                    const uint8x16_t v_src = vld1q_u8(ip + mlen);
+                    const uint8x16_t v_ref = vld1q_u8(ref + mlen);
+                    const uint8x16_t v_cmp = vceqq_u8(v_src, v_ref);
+                    uint8x8_t p1 = vpmin_u8(vget_low_u8(v_cmp), vget_high_u8(v_cmp));
+                    uint8x8_t p2 = vpmin_u8(p1, p1);
+                    uint8x8_t p3 = vpmin_u8(p2, p2);
+                    uint8x8_t p4 = vpmin_u8(p3, p3);
+                    uint8_t min_val = vget_lane_u8(p4, 0);
+                    if (min_val == 0xFF)
+                        mlen += 16;
+                    else {
+                        uint8x16_t v_diff = vmvnq_u8(v_cmp);
+                        uint64_t lo =
+                            (uint64_t)vgetq_lane_u32(vreinterpretq_u32_u8(v_diff), 0) |
+                            ((uint64_t)vgetq_lane_u32(vreinterpretq_u32_u8(v_diff), 1) << 32);
+                        if (lo != 0)
+                            mlen += (zxc_ctz64(lo) >> 3);
+                        else
+                            mlen +=
+                                8 + (zxc_ctz64(
+                                         (uint64_t)vgetq_lane_u32(vreinterpretq_u32_u8(v_diff), 2) |
+                                         ((uint64_t)vgetq_lane_u32(vreinterpretq_u32_u8(v_diff), 3)
+                                          << 32)) >>
+                                     3);
+                        goto _match_len_done;
+                    }
+                }
             }
 #endif
             while (ip + mlen < limit_8) {

--- a/src/lib/zxc_deps.h
+++ b/src/lib/zxc_deps.h
@@ -84,12 +84,6 @@
 #define ZXC_FREE(ptr) free(ptr)
 #endif
 
-/** @def ZXC_QSORT
- *  @brief Generic in-place sort. Default: libc @c qsort. */
-#ifndef ZXC_QSORT
-#define ZXC_QSORT(base, nmemb, size, cmp) qsort(base, nmemb, size, cmp)
-#endif
-
 /** @} */ /* end of Heap Allocator Abstraction */
 
 /**

--- a/src/lib/zxc_huffman.c
+++ b/src/lib/zxc_huffman.c
@@ -94,12 +94,15 @@ typedef zxc_huf_pm_frame_t frame_t;
 static void pm_leaves_sort(pm_leaf_t* RESTRICT leaves, const int n) {
     enum { NB = 32 };
     int count[NB];
-    int offset[NB];
+    int offset[NB + 1]; /* +1 sentinel = n, avoids end-of-bucket branch. */
+    uint8_t bkt[ZXC_HUF_NUM_SYMBOLS];
     pm_leaf_t tmp[ZXC_HUF_NUM_SYMBOLS];
 
     ZXC_MEMSET(count, 0, sizeof(count));
     for (int i = 0; i < n; i++) {
-        count[zxc_log2_u32(leaves[i].w)]++;
+        const unsigned b = zxc_log2_u32(leaves[i].w);
+        bkt[i] = (uint8_t)b;
+        count[b]++;
     }
 
     int acc = 0;
@@ -107,17 +110,18 @@ static void pm_leaves_sort(pm_leaf_t* RESTRICT leaves, const int n) {
         offset[b] = acc;
         acc += count[b];
     }
+    offset[NB] = n;
 
     int pos[NB];
     ZXC_MEMCPY(pos, offset, sizeof(pos));
     for (int i = 0; i < n; i++) {
-        const unsigned b = zxc_log2_u32(leaves[i].w);
-        tmp[pos[b]++] = leaves[i];
+        tmp[pos[bkt[i]]++] = leaves[i];
     }
 
     for (int b = 0; b < NB; b++) {
+        if (count[b] < 2) continue;
         const int s = offset[b];
-        const int e = (b + 1 < NB) ? offset[b + 1] : n;
+        const int e = offset[b + 1];
         for (int i = s + 1; i < e; i++) {
             const pm_leaf_t key = tmp[i];
             int j = i - 1;

--- a/src/lib/zxc_huffman.c
+++ b/src/lib/zxc_huffman.c
@@ -92,33 +92,35 @@ typedef zxc_huf_pm_frame_t frame_t;
  * by the caller before this runs).
  */
 static void pm_leaves_sort(pm_leaf_t* RESTRICT leaves, const int n) {
-    enum { NB = 32 };
-    int count[NB];
-    int offset[NB + 1]; /* +1 sentinel = n, avoids end-of-bucket branch. */
-    uint8_t bkt[ZXC_HUF_NUM_SYMBOLS];
+    /* One bucket per possible value of floor(log2(weight)) for a 32-bit
+     * weight, i.e. 32 buckets. */
+    enum { NUM_BUCKETS = 32 };
+    int count[NUM_BUCKETS];
+    int offset[NUM_BUCKETS + 1]; /* +1 sentinel = n, avoids end-of-bucket branch. */
+    uint8_t bucket_of[ZXC_HUF_NUM_SYMBOLS];
     pm_leaf_t tmp[ZXC_HUF_NUM_SYMBOLS];
 
     ZXC_MEMSET(count, 0, sizeof(count));
     for (int i = 0; i < n; i++) {
         const unsigned b = zxc_log2_u32(leaves[i].w);
-        bkt[i] = (uint8_t)b;
+        bucket_of[i] = (uint8_t)b;
         count[b]++;
     }
 
     int acc = 0;
-    for (int b = 0; b < NB; b++) {
+    for (int b = 0; b < NUM_BUCKETS; b++) {
         offset[b] = acc;
         acc += count[b];
     }
-    offset[NB] = n;
+    offset[NUM_BUCKETS] = n;
 
-    int pos[NB];
+    int pos[NUM_BUCKETS];
     ZXC_MEMCPY(pos, offset, sizeof(pos));
     for (int i = 0; i < n; i++) {
-        tmp[pos[bkt[i]]++] = leaves[i];
+        tmp[pos[bucket_of[i]]++] = leaves[i];
     }
 
-    for (int b = 0; b < NB; b++) {
+    for (int b = 0; b < NUM_BUCKETS; b++) {
         if (count[b] < 2) continue;
         const int s = offset[b];
         const int e = offset[b + 1];

--- a/src/lib/zxc_huffman.c
+++ b/src/lib/zxc_huffman.c
@@ -79,21 +79,57 @@ typedef struct {
 typedef zxc_huf_pm_frame_t frame_t;
 
 /**
- * @brief qsort comparator for `pm_leaf_t` arrays.
+ * @brief Sort `pm_leaf_t` array by ascending weight, ties broken by ascending symbol.
  *
- * Orders leaves by ascending weight, breaking ties by ascending symbol value
- * so the resulting code-length assignment is deterministic across runs.
+ * Bucket sort on `floor(log2(weight))` (32 buckets), with insertion sort
+ * inside each bucket. Replaces a libc `qsort` call: the comparator's
+ * indirect call dominated, and frequency distributions cluster naturally
+ * across ~10-14 magnitude buckets, so intra-bucket lists stay short and
+ * insertion sort is branch-friendly. Deterministic tie-break on `sym` is
+ * applied inside the insertion sort.
  *
- * @param[in] a Pointer to a `pm_leaf_t` (cast from `const void*`).
- * @param[in] b Pointer to a `pm_leaf_t` (cast from `const void*`).
- * @return Negative / zero / positive per the `qsort` convention.
+ * Precondition: all weights are > 0 (zero-frequency symbols are filtered
+ * by the caller before this runs).
  */
-static int pm_leaf_cmp(const void* a, const void* b) {
-    const pm_leaf_t* const la = (const pm_leaf_t*)a;
-    const pm_leaf_t* const lb = (const pm_leaf_t*)b;
-    if (la->w < lb->w) return -1;
-    if (la->w > lb->w) return 1;
-    return la->sym - lb->sym;
+static void pm_leaves_sort(pm_leaf_t* RESTRICT leaves, const int n) {
+    enum { NB = 32 };
+    int count[NB];
+    int offset[NB];
+    pm_leaf_t tmp[ZXC_HUF_NUM_SYMBOLS];
+
+    ZXC_MEMSET(count, 0, sizeof(count));
+    for (int i = 0; i < n; i++) {
+        count[zxc_log2_u32(leaves[i].w)]++;
+    }
+
+    int acc = 0;
+    for (int b = 0; b < NB; b++) {
+        offset[b] = acc;
+        acc += count[b];
+    }
+
+    int pos[NB];
+    ZXC_MEMCPY(pos, offset, sizeof(pos));
+    for (int i = 0; i < n; i++) {
+        const unsigned b = zxc_log2_u32(leaves[i].w);
+        tmp[pos[b]++] = leaves[i];
+    }
+
+    for (int b = 0; b < NB; b++) {
+        const int s = offset[b];
+        const int e = (b + 1 < NB) ? offset[b + 1] : n;
+        for (int i = s + 1; i < e; i++) {
+            const pm_leaf_t key = tmp[i];
+            int j = i - 1;
+            while (j >= s && (tmp[j].w > key.w || (tmp[j].w == key.w && tmp[j].sym > key.sym))) {
+                tmp[j + 1] = tmp[j];
+                j--;
+            }
+            tmp[j + 1] = key;
+        }
+    }
+
+    ZXC_MEMCPY(leaves, tmp, (size_t)n * sizeof(pm_leaf_t));
 }
 
 /**
@@ -132,7 +168,7 @@ int zxc_huf_build_code_lengths(const uint32_t* RESTRICT freq, uint8_t* RESTRICT 
         return ZXC_OK;
     }
 
-    ZXC_QSORT(leaves, (size_t)n, sizeof(pm_leaf_t), pm_leaf_cmp);
+    pm_leaves_sort(leaves, n);
 
     /* n <= 256 <= 2^ZXC_HUF_MAX_CODE_LEN, so length-limit is always feasible. */
     const int max_per_level = 2 * n;

--- a/src/lib/zxc_internal.h
+++ b/src/lib/zxc_internal.h
@@ -27,7 +27,7 @@
 #define ZXC_INTERNAL_H
 
 #include "zxc_deps.h" /* libc deps: <limits.h>, <stdint.h>, <stdlib.h>, <string.h>,
-                        and the ZXC_MALLOC / ZXC_ALIGNED_MALLOC / ZXC_QSORT macros.
+                        and the ZXC_MALLOC / ZXC_ALIGNED_MALLOC macros.
                         Vendor this file to retarget non-libc environments. */
 
 #include "../../include/zxc_buffer.h"


### PR DESCRIPTION
Replaces the generic `qsort` with a specialized bucket sort and insertion sort hybrid for `pm_leaf_t` arrays. The previous `qsort`'s indirect comparator calls were a performance bottleneck. This custom implementation exploits the natural clustering of frequency weights, leading to short intra-bucket lists where insertion sort is branch-friendly and significantly faster.
