### PR TITLE
fix: Adjust decompressor output buffer tail padding

### DIFF
--- a/src/lib/zxc_driver.c
+++ b/src/lib/zxc_driver.c
@@ -618,7 +618,9 @@ static int64_t zxc_stream_engine_run(FILE* f_in, FILE* f_out, const int n_thread
     const size_t raw_alloc_in = (size_t)(((mode) ? runtime_chunk_sz : max_out) + ZXC_PAD_SIZE);
     const size_t alloc_in = (raw_alloc_in + ZXC_ALIGNMENT_MASK) & ~ZXC_ALIGNMENT_MASK;
 
-    const size_t raw_alloc_out = (size_t)(((mode) ? max_out : runtime_chunk_sz) + ZXC_PAD_SIZE);
+    const size_t raw_alloc_out =
+        (size_t)((mode) ? (max_out + ZXC_PAD_SIZE)
+                        : (runtime_chunk_sz + ZXC_DECOMPRESS_TAIL_PAD + ZXC_PAD_SIZE));
     const size_t alloc_out = (raw_alloc_out + ZXC_ALIGNMENT_MASK) & ~ZXC_ALIGNMENT_MASK;
 
     const size_t per_job_sz = sizeof(zxc_stream_job_t) + sizeof(int) + alloc_in + alloc_out;

--- a/src/lib/zxc_pstream.c
+++ b/src/lib/zxc_pstream.c
@@ -659,7 +659,7 @@ typedef enum {
  *      (= header size + comp_size + checksum size).
  * @var zxc_dstream_s::decoded
  *      Heap buffer holding the decoded output of one block (sized for the
- *      wild-copy fast path: @c block_size + @ref ZXC_PAD_SIZE).
+ *      wild-copy fast path: @c block_size + @ref ZXC_DECOMPRESS_TAIL_PAD).
  * @var zxc_dstream_s::decoded_cap
  *      Allocated capacity of @c decoded.
  * @var zxc_dstream_s::decoded_size
@@ -888,8 +888,9 @@ static int ds_drain_decoded(zxc_dstream* ds, zxc_outbuf_t* out, size_t* produced
  * Pulls the 16-byte file header into @c scratch, parses it via
  * @ref zxc_read_file_header, and lazily allocates the @c payload and
  * @c decoded buffers (sized from the negotiated @c block_size).  The
- * @c decoded buffer is over-allocated by @ref ZXC_PAD_SIZE bytes to absorb
- * wild-copy overflow from the inner decoder.  Initialises the underlying
+ * @c decoded buffer is over-allocated by @ref ZXC_DECOMPRESS_TAIL_PAD bytes to
+ * absorb wild-copy overflow and give the decoder's 4x ML bounds checks their
+ * required tail headroom.  Initialises the underlying
  * decompression context and transitions to @c DS_NEED_BLOCK_HEADER.
  *
  * @param[in,out] ds Decompression stream.
@@ -915,11 +916,7 @@ static int ds_handle_need_file_header(zxc_dstream* ds, zxc_inbuf_t* in) {
     ds->payload_cap = (size_t)pb;
     ds->payload = (uint8_t*)ZXC_MALLOC(ds->payload_cap);
 
-    /* Decoded buffer is sized for the wild-copy fast path: block_size +
-     * ZXC_PAD_SIZE; same pattern as the buffer API uses internally.  Real
-     * decoded payload lives in [0..decoded_size); the trailing PAD bytes
-     * hold wild-copy overflow we never emit. */
-    ds->decoded_cap = ds->block_size + ZXC_PAD_SIZE;
+    ds->decoded_cap = ds->block_size + ZXC_DECOMPRESS_TAIL_PAD;
     ds->decoded = (uint8_t*)ZXC_MALLOC(ds->decoded_cap);
     // LCOV_EXCL_START
     if (UNLIKELY(!ds->payload || !ds->decoded)) return ds_set_error(ds, ZXC_ERROR_MEMORY);


### PR DESCRIPTION
Replaces `ZXC_PAD_SIZE` with `ZXC_DECOMPRESS_TAIL_PAD` for decompression output buffers. This ensures sufficient tail headroom for wild-copy operations and the decoder's 4x ML bounds checks, enhancing robustness.

Closes issue #248
