### PR TITLE
test: Overhauls dictionary fuzzer for robust testing

### DIFF
--- a/tests/fuzz_decompress.c
+++ b/tests/fuzz_decompress.c
@@ -5,6 +5,23 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+/**
+ * @file fuzz_decompress.c
+ * @brief Fuzzer for the one-shot decompressor on untrusted input.
+ *
+ * The decoder is the security-critical surface: it parses attacker-controlled
+ * frames, so it must never crash, over-read, or over-write regardless of how
+ * malformed the input is. This is a one-way target -- the fuzzer bytes are fed
+ * straight to zxc_decompress() with no preceding compression step.
+ *
+ * Strategy: query zxc_get_decompressed_size() to size the output buffer when
+ * the header advertises a plausible length (clamped to the static cap), then
+ * call zxc_decompress() on the raw bytes. Correctness is enforced by the
+ * sanitizers (ASan/UBSan) catching any out-of-bounds access; truncated,
+ * corrupt, and adversarial frames are all expected to return an error rather
+ * than misbehave.
+ */
+
 #include <stddef.h>
 #include <stdint.h>
 #include <stdlib.h>

--- a/tests/fuzz_dict.c
+++ b/tests/fuzz_dict.c
@@ -5,13 +5,24 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-/*
- * Fuzz target: dictionary roundtrip.
+/**
+ * @file fuzz_dict.c
+ * @brief Fuzzer for the dictionary API in zxc_dict.c.
  *
- * The fuzzer input is split into a dictionary prefix and block data.
- * The first 2 bytes encode the dict size (u16 LE, capped at 32 KB).
- * The remainder is the block data to compress with that dictionary.
- * The roundtrip (compress -> decompress) must produce identical output.
+ * Strategy (exercises the .zxd format and the trainer, not just the in-memory
+ * dict bounce path):
+ *
+ *  Phase 0 -- Raw .zxd parser. Feed the untrusted bytes straight to
+ *             zxc_dict_load() / zxc_dict_get_id(). Must never crash on garbage.
+ *  Phase 1 -- Train. Split the input into samples and call zxc_train_dict().
+ *  Phase 2 -- Serialize roundtrip. Save the trained dict to .zxd, load it back,
+ *             and verify content / dict_id agree across save/load/get_id/id.
+ *             Also drives the DST_TOO_SMALL path and single-byte corruption.
+ *  Phase 3 -- Use the trained dict for a real compress -> decompress roundtrip.
+ *
+ * The control header carries level, sample count, dict capacity, and the
+ * corruption position/mask, so the same input deterministically reaches the
+ * deep validation branches that random bytes (which lack the .zxd magic) miss.
  */
 
 #include <assert.h>
@@ -21,34 +32,140 @@
 #include <string.h>
 
 #include "../include/zxc_buffer.h"
+#include "../include/zxc_constants.h"
+#include "../include/zxc_dict.h"
+#include "../include/zxc_error.h"
 
 #define FUZZ_DICT_MAX_INPUT (256 << 10) /* 256 KiB */
-#define FUZZ_DICT_MAX_DICT (32 << 10)   /* 32 KiB */
+#define FUZZ_DICT_CTRL 8                /* control-header bytes consumed below */
+#define FUZZ_DICT_MAX_SAMPLES 8
 
 int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
+    static uint8_t* dict_buf = NULL;  /* trained dict content (<= ZXC_DICT_SIZE_MAX) */
+    static uint8_t* zxd_buf = NULL;   /* serialized .zxd (header + content)          */
     static void* comp_buf = NULL;
     static size_t comp_cap = 0;
     static void* decomp_buf = NULL;
     static size_t decomp_cap = 0;
 
-    if (size < 4) return 0;
     if (size > FUZZ_DICT_MAX_INPUT) return 0;
 
-    /* First 2 bytes: dict_size (u16 LE, capped). Byte 2: level. */
-    size_t dict_size = (size_t)(data[0] | (data[1] << 8));
-    if (dict_size > FUZZ_DICT_MAX_DICT) dict_size = FUZZ_DICT_MAX_DICT;
-    const int level = (data[2] % 6) + 1;
-    data += 3;
-    size -= 3;
+    /* ------------------------------------------------------------------ */
+    /* Phase 0: raw .zxd parser on untrusted bytes (must not crash).      */
+    /* zxc_dict_load tolerates buf_size < header, so any size is safe.    */
+    /* ------------------------------------------------------------------ */
+    {
+        const void* content = NULL;
+        size_t content_size = 0;
+        uint32_t id = 0;
+        const int rc = zxc_dict_load(data, size, &content, &content_size, &id);
+        if (rc == ZXC_OK) {
+            assert(content != NULL);
+            assert(content_size > 0 && content_size <= ZXC_DICT_SIZE_MAX);
+            /* A validated header round-trips through both ID accessors. */
+            assert(zxc_dict_get_id(data, size) == id);
+            assert(zxc_dict_id(content, content_size) == id);
+        }
+        (void)zxc_dict_get_id(data, size);
+    }
 
-    if (dict_size >= size) dict_size = size / 2;
-    const uint8_t* dict = data;
-    const uint8_t* src = data + dict_size;
-    const size_t src_size = size - dict_size;
+    /* ------------------------------------------------------------------ */
+    /* Parse the control header.                                          */
+    /* ------------------------------------------------------------------ */
+    if (size < FUZZ_DICT_CTRL) return 0;
 
-    if (src_size == 0) return 0;
+    const int level = (int)(data[0] % 6) + 1;
+    const size_t n_samples = (size_t)(data[1] % FUZZ_DICT_MAX_SAMPLES) + 1;
+    size_t dict_cap = (size_t)(data[2] | (data[3] << 8));
+    const size_t corrupt_pos = (size_t)(data[4] | (data[5] << 8));
+    const uint8_t corrupt_mask = data[6];
+    const int use_checksum = data[7] & 1;
+    data += FUZZ_DICT_CTRL;
+    size -= FUZZ_DICT_CTRL;
 
-    const uint64_t bound64 = zxc_compress_bound(src_size);
+    if (size == 0) return 0;
+
+    if (dict_cap == 0) dict_cap = 1;
+    if (dict_cap > ZXC_DICT_SIZE_MAX) dict_cap = ZXC_DICT_SIZE_MAX;
+
+    /* ------------------------------------------------------------------ */
+    /* Phase 1: split input into samples and train.                       */
+    /* ------------------------------------------------------------------ */
+    const void* samples[FUZZ_DICT_MAX_SAMPLES];
+    size_t sample_sizes[FUZZ_DICT_MAX_SAMPLES];
+    const size_t chunk = size / n_samples;
+    for (size_t i = 0; i < n_samples; i++) {
+        samples[i] = data + chunk * i;
+        sample_sizes[i] = (i + 1 < n_samples) ? chunk : (size - chunk * (n_samples - 1));
+    }
+
+    if (!dict_buf) {
+        dict_buf = (uint8_t*)malloc(ZXC_DICT_SIZE_MAX);
+        if (!dict_buf) return 0;
+    }
+
+    const int64_t dict_sz = zxc_train_dict(samples, sample_sizes, n_samples, dict_buf, dict_cap);
+    if (dict_sz <= 0) return 0; /* corpus too small / no patterns: nothing to serialize */
+    assert((size_t)dict_sz <= dict_cap);
+
+    /* ------------------------------------------------------------------ */
+    /* Phase 2: .zxd save / load roundtrip + corruption.                  */
+    /* ------------------------------------------------------------------ */
+    const size_t zxd_bound = zxc_dict_save_bound((size_t)dict_sz);
+    if (!zxd_buf) {
+        zxd_buf = (uint8_t*)malloc(ZXC_DICT_HEADER_SIZE + ZXC_DICT_SIZE_MAX);
+        if (!zxd_buf) return 0;
+    }
+
+    const int64_t zxd_sz = zxc_dict_save(dict_buf, (size_t)dict_sz, zxd_buf, zxd_bound);
+    assert(zxd_sz == (int64_t)zxd_bound);
+
+    {
+        const void* lc = NULL;
+        size_t lcs = 0;
+        uint32_t lid = 0;
+        const int rc = zxc_dict_load(zxd_buf, (size_t)zxd_sz, &lc, &lcs, &lid);
+        assert(rc == ZXC_OK);
+        assert(lcs == (size_t)dict_sz);
+        assert(memcmp(lc, dict_buf, (size_t)dict_sz) == 0);
+        assert(lid == zxc_dict_id(dict_buf, (size_t)dict_sz));
+        assert(zxc_dict_get_id(zxd_buf, (size_t)zxd_sz) == lid);
+    }
+
+    /* DST_TOO_SMALL: any capacity below the full file must be rejected. */
+    {
+        const size_t small_cap = corrupt_pos % (size_t)zxd_sz; /* in [0, zxd_sz) */
+        const int64_t r = zxc_dict_save(dict_buf, (size_t)dict_sz, zxd_buf, small_cap);
+        assert(r < 0);
+    }
+
+    /* Re-save (the DST_TOO_SMALL attempt left zxd_buf untouched, but be safe). */
+    assert(zxc_dict_save(dict_buf, (size_t)dict_sz, zxd_buf, zxd_bound) == (int64_t)zxd_sz);
+
+    /* Flip one byte and re-load: must not crash. A surviving ZXC_OK can only
+     * come from a reserved-byte flip (offsets 12-13, zeroed before the CRC),
+     * which cannot change the recovered content. */
+    {
+        const size_t pos = corrupt_pos % (size_t)zxd_sz;
+        const uint8_t saved = zxd_buf[pos];
+        zxd_buf[pos] ^= (uint8_t)(corrupt_mask | 1u); /* guaranteed to differ */
+
+        const void* cc = NULL;
+        size_t ccs = 0;
+        uint32_t cid = 0;
+        const int rc = zxc_dict_load(zxd_buf, (size_t)zxd_sz, &cc, &ccs, &cid);
+        if (rc == ZXC_OK) {
+            assert(ccs == (size_t)dict_sz);
+            assert(memcmp(cc, dict_buf, (size_t)dict_sz) == 0);
+        }
+        zxd_buf[pos] = saved;
+    }
+
+    /* ------------------------------------------------------------------ */
+    /* Phase 3: real compress -> decompress roundtrip with the trained    */
+    /* dict (also keeps the in-memory dict bounce path covered).          */
+    /* ------------------------------------------------------------------ */
+    const uint64_t bound64 = zxc_compress_bound(size);
     if (bound64 == 0 || bound64 > SIZE_MAX) return 0;
     const size_t bound = (size_t)bound64;
     if (bound > comp_cap) {
@@ -60,30 +177,30 @@ int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
 
     zxc_compress_opts_t copts = {
         .level = level,
-        .checksum_enabled = 1,
-        .dict = dict_size > 0 ? dict : NULL,
-        .dict_size = dict_size,
+        .checksum_enabled = use_checksum,
+        .dict = dict_buf,
+        .dict_size = (size_t)dict_sz,
     };
-    const int64_t csize = zxc_compress(src, src_size, comp_buf, bound, &copts);
+    const int64_t csize = zxc_compress(data, size, comp_buf, bound, &copts);
     if (csize < 0) return 0;
 
-    if (src_size > decomp_cap) {
-        void* nb = realloc(decomp_buf, src_size);
+    if (size > decomp_cap) {
+        void* nb = realloc(decomp_buf, size);
         if (!nb) return 0;
         decomp_buf = nb;
-        decomp_cap = src_size;
+        decomp_cap = size;
     }
 
     zxc_decompress_opts_t dopts = {
-        .checksum_enabled = 1,
-        .dict = dict_size > 0 ? dict : NULL,
-        .dict_size = dict_size,
+        .checksum_enabled = use_checksum,
+        .dict = dict_buf,
+        .dict_size = (size_t)dict_sz,
     };
-    const int64_t dsize = zxc_decompress(comp_buf, (size_t)csize, decomp_buf, src_size, &dopts);
+    const int64_t dsize = zxc_decompress(comp_buf, (size_t)csize, decomp_buf, size, &dopts);
 
     if (dsize >= 0) {
-        assert((size_t)dsize == src_size);
-        assert(memcmp(src, decomp_buf, src_size) == 0);
+        assert((size_t)dsize == size);
+        assert(memcmp(data, decomp_buf, size) == 0);
     }
 
     return 0;

--- a/tests/fuzz_roundtrip.c
+++ b/tests/fuzz_roundtrip.c
@@ -5,6 +5,22 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+/**
+ * @file fuzz_roundtrip.c
+ * @brief Fuzzer for the one-shot compress -> decompress roundtrip.
+ *
+ * Asserts the core invariant of a lossless codec: decompressing what the
+ * compressor produced must reproduce the original bytes exactly. The fuzzer
+ * data is the payload to compress (never untrusted decoder input -- that is
+ * fuzz_decompress.c's job), so this target hunts for encoder/decoder
+ * mismatches rather than malformed-frame handling.
+ *
+ * Strategy: derive the compression level from the first byte so libFuzzer
+ * explores every level, compress the fuzzed bytes, then decompress into an
+ * exact-size buffer and assert a bit-exact roundtrip. Buffers are reused
+ * across iterations to keep allocator pressure low.
+ */
+
 #include <assert.h>
 #include <stddef.h>
 #include <stdint.h>


### PR DESCRIPTION
Refactors the dictionary fuzzer to significantly enhance testing coverage and robustness for the dictionary API and `.zxd` format.

*   **Expands dictionary API testing:** Includes new phases for validating raw `.zxd` parsing, dictionary training, serialization, and roundtrip verification.
*   **Improves `.zxd` format validation:** Adds explicit tests for loading malformed or corrupted `.zxd` files to ensure crash resilience and proper error handling.
*   **Introduces fuzzer control header:** Enables deterministic exploration of specific code paths by controlling parameters like compression level, sample count, dictionary capacity, corruption position, and checksum usage.
*   **Integrates trained dictionaries:** Ensures the compress-decompress roundtrip uses the dynamically trained dictionary for comprehensive validation.

Also documents the purpose and strategy for all fuzzer targets (`fuzz_decompress.c`, `fuzz_dict.c`, `fuzz_roundtrip.c`) with detailed comments.