### PR TITLE
feat: Adds `unzxc` alias and renames dictionary training option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -574,6 +574,14 @@ if(ZXC_BUILD_CLI)
     install(TARGETS zxc
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
     )
+    # "unzxc" alias: a symlink to zxc that defaults to decompression. 
+    # Symbolic links are POSIX-only; skipped on Windows.
+    if(NOT WIN32)
+        install(CODE "
+            execute_process(COMMAND \"${CMAKE_COMMAND}\" -E create_symlink
+                zxc \"\$ENV{DESTDIR}${CMAKE_INSTALL_FULL_BINDIR}/unzxc\")
+        ")
+    endif()
 endif()
 
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/libzxc.pc

--- a/README.md
+++ b/README.md
@@ -469,12 +469,16 @@ For workloads compressed in **small blocks** (4 KB–128 KB), a pre-trained dict
 ### Training a dictionary
 
 ```bash
-# Train a dictionary from a corpus of similar files
-zxc --train corpus.zxd samples/*.json
+# Train a dictionary from a corpus of similar files.
+# Without -o the dictionary is written as ./dictionary_<dict_id>.zxd.
+zxc --train samples/*.json
 
-# Or pass a directory: the dictionary is saved as dictionary_<dict_id>.zxd inside it
-# (the dict_id embeds in the name), e.g. dicts/dictionary_bc46eec1.zxd
-zxc --train dicts/ samples/*.json
+# Choose the output file explicitly with -o:
+zxc --train -o corpus.zxd samples/*.json
+
+# Or point -o at a directory: the dictionary is saved as dictionary_<dict_id>.zxd
+# inside it (the dict_id embeds in the name), e.g. dicts/dictionary_bc46eec1.zxd
+zxc --train -o dicts/ samples/*.json
 ```
 
 ```c
@@ -539,7 +543,7 @@ zxc input_file
 # Decompression
 zxc -d compressed_file output_file
 
-# When installed, "unzxc" is an alias for "zxc -d" (like unzstd / gunzip)
+# When installed, "unzxc" is an alias for "zxc -d"
 unzxc compressed_file output_file
 
 # Benchmark Mode (Testing speed on your machine)

--- a/README.md
+++ b/README.md
@@ -470,11 +470,11 @@ For workloads compressed in **small blocks** (4 KB–128 KB), a pre-trained dict
 
 ```bash
 # Train a dictionary from a corpus of similar files
-zxc --train-dict corpus.zxd samples/*.json
+zxc --train corpus.zxd samples/*.json
 
 # Or pass a directory: the dictionary is saved as dictionary_<dict_id>.zxd inside it
 # (the dict_id embeds in the name), e.g. dicts/dictionary_bc46eec1.zxd
-zxc --train-dict dicts/ samples/*.json
+zxc --train dicts/ samples/*.json
 ```
 
 ```c

--- a/README.md
+++ b/README.md
@@ -539,6 +539,9 @@ zxc input_file
 # Decompression
 zxc -d compressed_file output_file
 
+# When installed, "unzxc" is an alias for "zxc -d" (like unzstd / gunzip)
+unzxc compressed_file output_file
+
 # Benchmark Mode (Testing speed on your machine)
 zxc -b input_file
 ```

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -546,7 +546,7 @@ How it ties together:
 
 ```sh
 # Train from a corpus directory -> writes dictionary_<dict_id>.zxd in it.
-zxc --train-dict ./corpus/
+zxc --train ./corpus/
 
 # Compress / decompress with the dictionary (required at both ends).
 zxc -D dictionary_1a2b3c4d.zxd -z record.json

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -545,8 +545,9 @@ How it ties together:
 ### CLI quickstart
 
 ```sh
-# Train from a corpus directory -> writes dictionary_<dict_id>.zxd in it.
-zxc --train ./corpus/
+# Train from a corpus of files -> writes dictionary_<dict_id>.zxd in the
+# current directory (use -o DIR/ or -o FILE to choose the destination).
+zxc --train ./corpus/*
 
 # Compress / decompress with the dictionary (required at both ends).
 zxc -D dictionary_1a2b3c4d.zxd -z record.json

--- a/docs/FORMAT.md
+++ b/docs/FORMAT.md
@@ -594,7 +594,7 @@ offset `0x00`, never by extension. This is a tooling convention, not a format
 requirement; it does not affect bytes on the wire. The reference CLI applies it
 as follows:
 
-- `zxc --train-dict <dir>/` writes the trained dictionary as
+- `zxc --train <dir>/` writes the trained dictionary as
   `<dir>/dictionary_<dict_id>.zxd`, where `<dict_id>` is the lowercase 8-digit
   hex of the dictionary id (e.g. `dictionary_bc46eec1.zxd`). Embedding the id
   keeps the name unique per dictionary and easy to match against the `Dict ID`

--- a/docs/FORMAT.md
+++ b/docs/FORMAT.md
@@ -594,11 +594,12 @@ offset `0x00`, never by extension. This is a tooling convention, not a format
 requirement; it does not affect bytes on the wire. The reference CLI applies it
 as follows:
 
-- `zxc --train <dir>/` writes the trained dictionary as
+- `zxc --train -o <dir>/ <files>` writes the trained dictionary as
   `<dir>/dictionary_<dict_id>.zxd`, where `<dict_id>` is the lowercase 8-digit
   hex of the dictionary id (e.g. `dictionary_bc46eec1.zxd`). Embedding the id
   keeps the name unique per dictionary and easy to match against the `Dict ID`
-  reported by `zxc -l`.
+  reported by `zxc -l`. With no `-o`, the file is written to the current
+  directory; with `-o <file>` it is written there verbatim.
 - On **decompression**, a dictionary is **not** auto-located: an archive that
   was compressed with a dictionary must be decompressed by passing that
   dictionary explicitly with `-D`. Without it, decompression fails with

--- a/docs/man/zxc.1.md
+++ b/docs/man/zxc.1.md
@@ -30,7 +30,7 @@ By default, **zxc** compresses a single *INPUT-FILE*. If no *OUTPUT-FILE* is pro
 **-l**, **--list**
 : List archive information, including compressed size, uncompressed size, compression ratio, checksum method, and dictionary ID (if any). Also accepts a `.zxd` dictionary file, in which case it prints the dictionary's `dict_id`.
 
-**--train-dict** *PATH*
+**--train** *PATH*
 : Train a dictionary from the input files given as training samples and write it to *PATH*. If *PATH* is a directory (or ends with a path separator), the dictionary is saved inside it as `dictionary_<dict_id>.zxd`; otherwise *PATH* is used verbatim. See **DICTIONARIES**.
 
 **-t**, **--test**
@@ -104,7 +104,7 @@ For workloads compressed in small blocks (4K–128K), a pre-trained dictionary c
 
 Dictionaries are external `.zxd` files referenced from the archive header by a 32-bit `dict_id` (a hash of the dictionary content). The `.zxd` extension is cosmetic; a `.zxd` file is identified by its magic word, not its name.
 
-When **--train-dict** targets a directory, **zxc** names the file `dictionary_<dict_id>.zxd` (the `dict_id` is the lowercase 8-digit hex reported by `zxc -l`). On decompression the dictionary is **not** auto-located: an archive compressed with a dictionary must be decompressed by supplying that dictionary with **-D**, otherwise decompression fails with a dictionary-required error.
+When **--train** targets a directory, **zxc** names the file `dictionary_<dict_id>.zxd` (the `dict_id` is the lowercase 8-digit hex reported by `zxc -l`). On decompression the dictionary is **not** auto-located: an archive compressed with a dictionary must be decompressed by supplying that dictionary with **-D**, otherwise decompression fails with a dictionary-required error.
 
 If no matching dictionary can be found (or supplied), decompression fails with a dictionary-required error rather than producing corrupt output.
 
@@ -147,7 +147,7 @@ If no matching dictionary can be found (or supplied), decompression fails with a
   zxc -b 10 data.txt
 
 **Train a dictionary into a directory (saved as `dictionary_<dict_id>.zxd`):**
-  zxc --train-dict dicts/ samples/*.json
+  zxc --train dicts/ samples/*.json
 
 **Compress with a dictionary using small blocks:**
   zxc -B 4K -D dicts/dictionary_bc46eec1.zxd input.json

--- a/docs/man/zxc.1.md
+++ b/docs/man/zxc.1.md
@@ -1,12 +1,10 @@
 # zxc(1)
 
 ## NAME
-**zxc** - High-performance asymmetric lossless compression
+**zxc** - zxc, unzxc - Compress or decompress .zxc files
 
 ## SYNOPSIS
 **zxc** [*OPTIONS*] [*INPUT-FILE*] [*OUTPUT-FILE*]
-
-**unzxc** [*OPTIONS*] [*INPUT-FILE*] [*OUTPUT-FILE*]
 
 **unzxc** is equivalent to **zxc -d**.
 
@@ -25,7 +23,7 @@ By default, **zxc** compresses a single *INPUT-FILE*. If no *OUTPUT-FILE* is pro
 : Compress FILE. This is the default mode if no mode is specified.
 
 **-d**, **--decompress**
-: Decompress FILE. This is the default mode when **zxc** is invoked under the name **unzxc** (typically an installed symlink), mirroring **unzstd**(1) and **gunzip**(1). An explicit mode flag still takes precedence.
+: Decompress FILE. This is the default mode when **zxc** is invoked under the name **unzxc** (typically an installed symlink). An explicit mode flag still takes precedence.
 
 **-l**, **--list**
 : List archive information, including compressed size, uncompressed size, compression ratio, checksum method, and dictionary ID (if any). Also accepts a `.zxd` dictionary file, in which case it prints the dictionary's `dict_id`.

--- a/docs/man/zxc.1.md
+++ b/docs/man/zxc.1.md
@@ -1,7 +1,7 @@
 # zxc(1)
 
 ## NAME
-**zxc** - zxc, unzxc - Compress or decompress .zxc files
+**zxc**, **unzxc** - Compress or decompress .zxc files
 
 ## SYNOPSIS
 **zxc** [*OPTIONS*] [*INPUT-FILE*] [*OUTPUT-FILE*]

--- a/docs/man/zxc.1.md
+++ b/docs/man/zxc.1.md
@@ -74,7 +74,7 @@ By default, **zxc** compresses a single *INPUT-FILE*. If no *OUTPUT-FILE* is pro
 : Append a seek table to the archive during compression. This transforms the file into a random-access format (Seekable Archive), allowing the decoder to instantly locate and decompress specific blocks in `O(1)` time without reading the entire file. Ideal for compressed filesystems, game assets, and log analysis.
 
 **-k**, **--keep**
-: Keep the input file after compression or decompression. (Currently, the input file is preserved by default, but this flag ensures compatibility with future changes).
+: Keep the input file after an in-place compression or decompression. By default the input is removed **only** when its output name is auto-derived (e.g. `file` → `file.zxc`). When the output is named explicitly — with **-o** or a positional *OUTPUT-FILE* — the input is always kept, so this flag is only needed for the in-place case.
 
 **-f**, **--force**
 : Force overwrite of the *OUTPUT-FILE* if it already exists.

--- a/docs/man/zxc.1.md
+++ b/docs/man/zxc.1.md
@@ -28,8 +28,8 @@ By default, **zxc** compresses a single *INPUT-FILE*. If no *OUTPUT-FILE* is pro
 **-l**, **--list**
 : List archive information, including compressed size, uncompressed size, compression ratio, checksum method, and dictionary ID (if any). Also accepts a `.zxd` dictionary file, in which case it prints the dictionary's `dict_id`.
 
-**--train** *PATH*
-: Train a dictionary from the input files given as training samples and write it to *PATH*. If *PATH* is a directory (or ends with a path separator), the dictionary is saved inside it as `dictionary_<dict_id>.zxd`; otherwise *PATH* is used verbatim. See **DICTIONARIES**.
+**--train**
+: Train a dictionary from the input *FILE*s given as training samples. The output path is set with **-o** (see **--output**); when **-o** is omitted, the dictionary is written to `dictionary_<dict_id>.zxd` in the current directory. See **DICTIONARIES**.
 
 **-t**, **--test**
 : Test the integrity of a compressed FILE. It decodes the file and verifies its checksum (if present) without writing any output.
@@ -67,6 +67,9 @@ By default, **zxc** compresses a single *INPUT-FILE*. If no *OUTPUT-FILE* is pro
 **-D**, **--dict** *FILE*
 : Use a pre-trained dictionary (`.zxd`) for compression or decompression. On compression, the archive records the dictionary's `dict_id` in its header. On decompression, **-D** is **required** for any archive that was compressed with a dictionary — there is no auto-lookup; without it, decompression fails with a dictionary-required error (see **DICTIONARIES**).
 
+**-o**, **--output** *FILE*
+: Write output to *FILE*. For compression/decompression this overrides the positional *OUTPUT-FILE* (single-file mode only); when omitted the output name is derived from the input. For **--train** it sets the dictionary path: if *FILE* is a directory (or ends with a path separator) the dictionary is saved inside it as `dictionary_<dict_id>.zxd`, otherwise *FILE* is used verbatim; when omitted the dictionary is written to `dictionary_<dict_id>.zxd` in the current directory.
+
 **-S**, **--seekable**
 : Append a seek table to the archive during compression. This transforms the file into a random-access format (Seekable Archive), allowing the decoder to instantly locate and decompress specific blocks in `O(1)` time without reading the entire file. Ideal for compressed filesystems, game assets, and log analysis.
 
@@ -102,7 +105,7 @@ For workloads compressed in small blocks (4K–128K), a pre-trained dictionary c
 
 Dictionaries are external `.zxd` files referenced from the archive header by a 32-bit `dict_id` (a hash of the dictionary content). The `.zxd` extension is cosmetic; a `.zxd` file is identified by its magic word, not its name.
 
-When **--train** targets a directory, **zxc** names the file `dictionary_<dict_id>.zxd` (the `dict_id` is the lowercase 8-digit hex reported by `zxc -l`). On decompression the dictionary is **not** auto-located: an archive compressed with a dictionary must be decompressed by supplying that dictionary with **-D**, otherwise decompression fails with a dictionary-required error.
+When **--train**'s **-o** targets a directory (or is omitted, defaulting to the current directory), **zxc** names the file `dictionary_<dict_id>.zxd` (the `dict_id` is the lowercase 8-digit hex reported by `zxc -l`). On decompression the dictionary is **not** auto-located: an archive compressed with a dictionary must be decompressed by supplying that dictionary with **-D**, otherwise decompression fails with a dictionary-required error.
 
 If no matching dictionary can be found (or supplied), decompression fails with a dictionary-required error rather than producing corrupt output.
 
@@ -145,7 +148,7 @@ If no matching dictionary can be found (or supplied), decompression fails with a
   zxc -b 10 data.txt
 
 **Train a dictionary into a directory (saved as `dictionary_<dict_id>.zxd`):**
-  zxc --train dicts/ samples/*.json
+  zxc --train -o dicts/ samples/*.json
 
 **Compress with a dictionary using small blocks:**
   zxc -B 4K -D dicts/dictionary_bc46eec1.zxd input.json

--- a/docs/man/zxc.1.md
+++ b/docs/man/zxc.1.md
@@ -155,8 +155,11 @@ If no matching dictionary can be found (or supplied), decompression fails with a
 **Decompress (the dictionary is required, pass it with -D):**
   zxc -d -D dicts/dictionary_bc46eec1.zxd input.json.zxc
 
+## BUGS
+Report bugs at <https://github.com/hellobertrand/zxc/issues>.
+
 ## AUTHORS
-Written by Bertrand Lebonnois & contributors.
+Bertrand Lebonnois
 
 ## LICENSE
 BSD 3-Clause License.

--- a/docs/man/zxc.1.md
+++ b/docs/man/zxc.1.md
@@ -6,6 +6,10 @@
 ## SYNOPSIS
 **zxc** [*OPTIONS*] [*INPUT-FILE*] [*OUTPUT-FILE*]
 
+**unzxc** [*OPTIONS*] [*INPUT-FILE*] [*OUTPUT-FILE*]
+
+**unzxc** is equivalent to **zxc -d**.
+
 ## DESCRIPTION
 **zxc** is a command-line interface for the ZXC compression library, a high-performance lossless compression algorithm optimized for maximum decompression throughput.
 
@@ -21,7 +25,7 @@ By default, **zxc** compresses a single *INPUT-FILE*. If no *OUTPUT-FILE* is pro
 : Compress FILE. This is the default mode if no mode is specified.
 
 **-d**, **--decompress**
-: Decompress FILE.
+: Decompress FILE. This is the default mode when **zxc** is invoked under the name **unzxc** (typically an installed symlink), mirroring **unzstd**(1) and **gunzip**(1). An explicit mode flag still takes precedence.
 
 **-l**, **--list**
 : List archive information, including compressed size, uncompressed size, compression ratio, checksum method, and dictionary ID (if any). Also accepts a `.zxd` dictionary file, in which case it prints the dictionary's `dict_id`.
@@ -114,6 +118,9 @@ If no matching dictionary can be found (or supplied), decompression fails with a
 
 **Decompress a file:**
   zxc -d data.txt.zxc
+
+**Decompress a file using the unzxc alias:**
+  unzxc data.txt.zxc
 
 **Compress multiple files independently:**
   zxc -m file1.txt file2.txt file3.txt

--- a/src/cli/main.c
+++ b/src/cli/main.c
@@ -457,8 +457,8 @@ void print_help(const char* app) {
         "  -l, --list        List archive or dictionary info\n"
         "  -t, --test        Test compressed FILE integrity\n"
         "  -b, --bench [N]   Benchmark in-memory (N=seconds, default 5)\n"
-        "  --train PATH      Train a dictionary from input files. PATH may be a\n"
-        "                    directory (saved as dictionary_<dict_id>.zxd inside it) or a file\n\n"
+        "  --train           Train a dictionary from input FILEs (training samples).\n"
+        "                    Output via -o (default: ./dictionary_<dict_id>.zxd)\n\n"
         "Batch Processing:\n"
         "  -m, --multiple    Multiple input files\n"
         "  -r, --recursive   Operate recursively on directories\n\n"
@@ -474,6 +474,8 @@ void print_help(const char* app) {
         "  -D, --dict FILE   Use pre-trained dictionary (.zxd). Required to decompress\n"
         "                    an archive that was compressed with a dictionary\n"
         "  -S, --seekable    Append seek table for random-access decompression\n"
+        "  -o, --output FILE Write output to FILE (else derived from input;\n"
+        "                    for --train: ./dictionary_<dict_id>.zxd, or a directory)\n"
         "  -k, --keep        Keep input file\n"
         "  -f, --force       Force overwrite\n"
         "  -c, --stdout      Write to stdout\n"
@@ -1097,9 +1099,10 @@ int main(int argc, char** argv) {
     size_t block_size = 0;
     int seekable = 0;
     const char* dict_path = NULL;
-    const char* train_dict_path = NULL;
+    const char* output_path = NULL;
 
-    static const struct option long_options[] = {{"train", required_argument, 0, OPT_TRAIN_DICT},
+    static const struct option long_options[] = {{"train", no_argument, 0, OPT_TRAIN_DICT},
+                                                 {"output", required_argument, 0, 'o'},
                                                  {"dict", required_argument, 0, 'D'},
                                                  {"compress", no_argument, 0, 'z'},
                                                  {"decompress", no_argument, 0, 'd'},
@@ -1126,7 +1129,7 @@ int main(int argc, char** argv) {
     int opt;
     int multiple_mode = 0;
     int recursive_mode = 0;
-    while ((opt = getopt_long(argc, argv, "123456b::B:cCdD:fhjklmrNqST:tvVz", long_options, NULL)) !=
+    while ((opt = getopt_long(argc, argv, "123456b::B:cCdD:fho:jklmrNqST:tvVz", long_options, NULL)) !=
            -1) {
         switch (opt) {
             case 'z':
@@ -1215,7 +1218,9 @@ int main(int argc, char** argv) {
                 break;
             case OPT_TRAIN_DICT:
                 mode = MODE_TRAIN_DICT;
-                train_dict_path = optarg;
+                break;
+            case 'o':
+                output_path = optarg;
                 break;
             case 'r':
                 recursive_mode = 1;
@@ -1441,25 +1446,30 @@ int main(int argc, char** argv) {
         }
 
         /*
-         * Resolve the output path. If train_dict_path names a directory (or ends
-         * with a separator), use the content-addressable name {dict_id:08x}.zxd
-         * inside it; otherwise write to train_dict_path verbatim. The id must be
+         * Resolve the output path (from -o, optional). With no -o, write the
+         * content-addressable name dictionary_{dict_id:08x}.zxd in the current
+         * directory. If -o names a directory (or ends with a separator), use that
+         * name inside it; otherwise write to the -o path verbatim. The id must be
          * computed before opening the file so it can name it.
          */
         const uint32_t trained_id = zxc_dict_get_id(zxd, (size_t)zxd_sz);
         char final_path[4096];
-        const size_t tdp_len = strlen(train_dict_path);
-        const int is_dir_target =
-            zxc_is_directory(train_dict_path) ||
-            (tdp_len > 0 && (train_dict_path[tdp_len - 1] == '/' ||
-                             train_dict_path[tdp_len - 1] == '\\'));
-        if (is_dir_target) {
-            const int has_sep = tdp_len > 0 && (train_dict_path[tdp_len - 1] == '/' ||
-                                                train_dict_path[tdp_len - 1] == '\\');
-            snprintf(final_path, sizeof(final_path), "%s%sdictionary_%08x.zxd", train_dict_path,
-                     has_sep ? "" : "/", trained_id);
+        if (!output_path) {
+            snprintf(final_path, sizeof(final_path), "dictionary_%08x.zxd", trained_id);
         } else {
-            snprintf(final_path, sizeof(final_path), "%s", train_dict_path);
+            const size_t op_len = strlen(output_path);
+            const int is_dir_target =
+                zxc_is_directory(output_path) ||
+                (op_len > 0 &&
+                 (output_path[op_len - 1] == '/' || output_path[op_len - 1] == '\\'));
+            if (is_dir_target) {
+                const int has_sep = op_len > 0 && (output_path[op_len - 1] == '/' ||
+                                                   output_path[op_len - 1] == '\\');
+                snprintf(final_path, sizeof(final_path), "%s%sdictionary_%08x.zxd", output_path,
+                         has_sep ? "" : "/", trained_id);
+            } else {
+                snprintf(final_path, sizeof(final_path), "%s", output_path);
+            }
         }
 
         FILE* out;
@@ -1765,10 +1775,13 @@ int main(int argc, char** argv) {
                                              to_stdout, checksum, level, block_size, json_output,
                                              seekable, dict, dict_size);
         } else {
-            const char* explicit_out_path = (!multiple_mode && optind + 1 < argc && current_arg &&
-                                             strcmp(current_arg, "-") != 0 && !to_stdout)
-                                                ? argv[start_optind + 1]
-                                                : NULL;
+            // -o takes precedence over a positional OUTPUT-FILE (single-file mode only).
+            const char* explicit_out_path =
+                (output_path && !multiple_mode && !to_stdout) ? output_path
+                : (!multiple_mode && optind + 1 < argc && current_arg &&
+                   strcmp(current_arg, "-") != 0 && !to_stdout)
+                    ? argv[start_optind + 1]
+                    : NULL;
 
             overall_ret |=
                 process_single_file(current_arg, explicit_out_path, mode, num_threads, keep_input,

--- a/src/cli/main.c
+++ b/src/cli/main.c
@@ -1776,13 +1776,14 @@ int main(int argc, char** argv) {
                                              to_stdout, checksum, level, block_size, json_output,
                                              seekable, dict, dict_size);
         } else {
-            // -o takes precedence over a positional OUTPUT-FILE (single-file mode only).
-            const char* explicit_out_path =
-                (output_path && !multiple_mode && !to_stdout) ? output_path
-                : (!multiple_mode && optind + 1 < argc && current_arg &&
-                   strcmp(current_arg, "-") != 0 && !to_stdout)
-                    ? argv[start_optind + 1]
-                    : NULL;
+            // -o takes precedence over a positional OUTPUT-FILE.
+            const char* explicit_out_path = NULL;
+            if (!multiple_mode && !to_stdout) {
+                if (output_path)
+                    explicit_out_path = output_path;
+                else if (optind + 1 < argc && current_arg && strcmp(current_arg, "-") != 0)
+                    explicit_out_path = argv[start_optind + 1];
+            }
 
             overall_ret |=
                 process_single_file(current_arg, explicit_out_path, mode, num_threads, keep_input,

--- a/src/cli/main.c
+++ b/src/cli/main.c
@@ -1034,7 +1034,8 @@ static int process_single_file(const char* in_path, const char* out_path_overrid
         } else {
             zxc_log_v("Processed %lld bytes in %.3fs\n", (long long)bytes, dt);
         }
-        if (!use_stdin && !use_stdout && !keep_input && mode != MODE_INTEGRITY)
+        if (!use_stdin && !use_stdout && !keep_input && !out_path_override &&
+            mode != MODE_INTEGRITY)
             unlink(resolved_in_path);
     } else {
         if (mode == MODE_INTEGRITY) {

--- a/src/cli/main.c
+++ b/src/cli/main.c
@@ -1101,6 +1101,21 @@ static int process_single_file(const char* in_path, const char* out_path_overrid
  */
 int main(int argc, char** argv) {
     zxc_mode_t mode = MODE_COMPRESS;
+
+    /* When invoked as "unzxc" (typically a symlink to zxc), default to
+     * decompression -- like unzstd / gunzip. An explicit -z/-d/-l/-t/-b below
+     * still overrides this default. */
+    {
+        const char* prog = (argc > 0 && argv[0]) ? argv[0] : "zxc";
+        const char* slash = strrchr(prog, '/');
+#ifdef _WIN32
+        const char* bslash = strrchr(prog, '\\');
+        if (bslash && (!slash || bslash > slash)) slash = bslash;
+#endif
+        const char* base = slash ? slash + 1 : prog;
+        if (strstr(base, "unzxc")) mode = MODE_DECOMPRESS;
+    }
+
     int num_threads = 0;
     int keep_input = 0;
     int force = 0;

--- a/src/cli/main.c
+++ b/src/cli/main.c
@@ -476,7 +476,7 @@ void print_help(const char* app) {
         "  -l, --list        List archive or dictionary info\n"
         "  -t, --test        Test compressed FILE integrity\n"
         "  -b, --bench [N]   Benchmark in-memory (N=seconds, default 5)\n"
-        "  --train-dict PATH Train a dictionary from input files. PATH may be a\n"
+        "  --train PATH      Train a dictionary from input files. PATH may be a\n"
         "                    directory (saved as dictionary_<dict_id>.zxd inside it) or a file\n\n"
         "Batch Processing:\n"
         "  -m, --multiple    Multiple input files\n"
@@ -1129,7 +1129,7 @@ int main(int argc, char** argv) {
     const char* dict_path = NULL;
     const char* train_dict_path = NULL;
 
-    static const struct option long_options[] = {{"train-dict", required_argument, 0, OPT_TRAIN_DICT},
+    static const struct option long_options[] = {{"train", required_argument, 0, OPT_TRAIN_DICT},
                                                  {"dict", required_argument, 0, 'D'},
                                                  {"compress", no_argument, 0, 'z'},
                                                  {"decompress", no_argument, 0, 'd'},
@@ -1383,7 +1383,7 @@ int main(int argc, char** argv) {
      */
     if (mode == MODE_TRAIN_DICT) {
         if (optind >= argc) {
-            fprintf(stderr, "Error: --train-dict requires input files as training samples.\n");
+            fprintf(stderr, "Error: --train requires input files as training samples.\n");
             free(dict);
             return 1;
         }

--- a/src/cli/main.c
+++ b/src/cli/main.c
@@ -513,7 +513,7 @@ void print_version(void) {
         snprintf(sys_info, sizeof(sys_info), "%s-%s", ZXC_ARCH, ZXC_OS);
 
 #endif
-    printf("zxc v%s (%s) by Bertrand Lebonnois & al.\nBSD 3-Clause License\n", ZXC_LIB_VERSION_STR,
+    printf("zxc v%s (%s) by Bertrand Lebonnois\nBSD 3-Clause License\n", ZXC_LIB_VERSION_STR,
            sys_info);
 }
 

--- a/src/cli/main.c
+++ b/src/cli/main.c
@@ -28,24 +28,6 @@
 
 #define ZXC_STDIO_BUFFER_SIZE (1024 * 1024)
 
-#if defined(_WIN32)
-#define ZXC_OS "windows"
-#elif defined(__APPLE__)
-#define ZXC_OS "darwin"
-#elif defined(__linux__)
-#define ZXC_OS "linux"
-#else
-#define ZXC_OS "unknown"
-#endif
-
-#if defined(__x86_64__) || defined(_M_AMD64)
-#define ZXC_ARCH "x86_64"
-#elif defined(__aarch64__) || defined(_M_ARM64)
-#define ZXC_ARCH "arm64"
-#else
-#define ZXC_ARCH "unknown"
-#endif
-
 #ifdef _WIN32
 // Windows Implementation
 #include <direct.h>
@@ -166,7 +148,6 @@ static int getopt_long(int argc, char* const argv[], const char* optstring,
 #include <string.h>
 #include <sys/stat.h>
 #include <sys/types.h>
-#include <sys/utsname.h>
 #include <time.h>
 #include <unistd.h>
 
@@ -502,19 +483,8 @@ void print_help(const char* app) {
 }
 
 void print_version(void) {
-    char sys_info[256];
-#ifdef _WIN32
-    snprintf(sys_info, sizeof(sys_info), "%s-%s", ZXC_ARCH, ZXC_OS);
-#else
-    struct utsname buffer;
-    if (uname(&buffer) == 0)
-        snprintf(sys_info, sizeof(sys_info), "%s-%s-%s", ZXC_ARCH, ZXC_OS, buffer.release);
-    else
-        snprintf(sys_info, sizeof(sys_info), "%s-%s", ZXC_ARCH, ZXC_OS);
-
-#endif
-    printf("zxc v%s (%s) by Bertrand Lebonnois\nBSD 3-Clause License\n", ZXC_LIB_VERSION_STR,
-           sys_info);
+    printf("ZXC CLI (%zu-bit) v%s, by Bertrand Lebonnois\nBSD 3-Clause License\n",
+           sizeof(void*) * CHAR_BIT, ZXC_LIB_VERSION_STR);
 }
 
 /**

--- a/tests/test_cli.sh
+++ b/tests/test_cli.sh
@@ -893,18 +893,18 @@ fi
 # 25. Dictionary Tests (-D)
 echo "Testing Dictionary (-D)..."
 
-# 25.1 Train a dictionary using --train-dict
+# 25.1 Train a dictionary using --train
 echo "  Training dictionary from test data..."
 # Create a few sample files for training
 for i in 1 2 3 4 5; do
     cp "$TEST_FILE" "$TEST_DIR/sample_${i}.txt"
 done
 DICT_FILE="$TEST_DIR/test.zxd"
-"$ZXC_BIN" --train-dict "$DICT_FILE" "$TEST_DIR"/sample_*.txt 2>/dev/null
+"$ZXC_BIN" --train "$DICT_FILE" "$TEST_DIR"/sample_*.txt 2>/dev/null
 if [ ! -f "$DICT_FILE" ]; then
     log_fail "Dictionary training failed"
 fi
-log_pass "Dictionary trained via --train-dict"
+log_pass "Dictionary trained via --train"
 
 # 25.2 Round-trip with dictionary
 echo "  Testing dict round-trip..."
@@ -1001,7 +1001,7 @@ fi
 echo "  Testing train-to-directory naming..."
 AUTO_DIR="$TEST_DIR/auto"
 mkdir -p "$AUTO_DIR"
-"$ZXC_BIN" --train-dict "$AUTO_DIR/" "$TEST_DIR"/sample_*.txt 2>/dev/null
+"$ZXC_BIN" --train "$AUTO_DIR/" "$TEST_DIR"/sample_*.txt 2>/dev/null
 ZXD_NAME=$(ls "$AUTO_DIR" | grep -E '^dictionary_[0-9a-f]{8}\.zxd$' || true)
 if [ -n "$ZXD_NAME" ]; then
     log_pass "Train to directory names dict dictionary_<dict_id>.zxd ($ZXD_NAME)"

--- a/tests/test_cli.sh
+++ b/tests/test_cli.sh
@@ -220,7 +220,7 @@ fi
 # 7. Version
 echo "Testing Version..."
 OUT_VER=$("$ZXC_BIN" -V)
-if [[ "$OUT_VER" == *"zxc"* ]]; then
+if [[ "$OUT_VER" == *"ZXC CLI"* && "$OUT_VER" =~ v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
     log_pass "Version flag"
 else
     log_fail "Version flag failed"

--- a/tests/test_cli.sh
+++ b/tests/test_cli.sh
@@ -1029,5 +1029,42 @@ else
     log_fail "Decompress with -D failed to recreate original"
 fi
 
+# 26. unzxc Alias (argv[0]-based mode detection)
+echo "Testing unzxc alias..."
+
+# "unzxc" is a symlink to zxc that defaults to decompression (like unzstd /
+# gunzip). Create a local symlink to the binary under test and exercise it.
+# Symlinks are POSIX-only; skip gracefully where they are unsupported.
+ZXC_ABS=$(cd "$(dirname "$ZXC_BIN")" && pwd)/$(basename "$ZXC_BIN")
+UNZXC_BIN="$TEST_DIR/unzxc"
+
+if ln -sf "$ZXC_ABS" "$UNZXC_BIN" 2>/dev/null && [ -L "$UNZXC_BIN" ]; then
+    # A known archive to decode through the alias.
+    "$ZXC_BIN" -z -c -k "$TEST_FILE_ARG" > "$TEST_DIR/alias.zxc"
+
+    # 26.1 unzxc with no mode flag must decompress (equivalent to zxc -d).
+    if "$UNZXC_BIN" -c "$TEST_DIR/alias.zxc" > "$TEST_DIR/alias.dec" 2>/dev/null \
+       && cmp -s "$TEST_FILE" "$TEST_DIR/alias.dec"; then
+        log_pass "unzxc defaults to decompression"
+    else
+        log_fail "unzxc should decompress by default (like zxc -d)"
+    fi
+
+    # 26.2 An explicit -z on the unzxc-named binary overrides back to compression.
+    # If the override were broken, unzxc would try to *decode* the plaintext input
+    # and fail, so the round-trip below would not match.
+    set +e
+    "$UNZXC_BIN" -z -c "$TEST_FILE_ARG" > "$TEST_DIR/alias_z.zxc" 2>/dev/null
+    "$ZXC_BIN" -d -c "$TEST_DIR/alias_z.zxc" > "$TEST_DIR/alias_z.dec" 2>/dev/null
+    set -e
+    if cmp -s "$TEST_FILE" "$TEST_DIR/alias_z.dec"; then
+        log_pass "unzxc -z overrides back to compression"
+    else
+        log_fail "unzxc -z should compress (explicit flag must win)"
+    fi
+else
+    echo "  [SKIP] symlinks unsupported here, skipping unzxc alias test"
+fi
+
 echo "All tests passed!"
 exit 0

--- a/tests/test_cli.sh
+++ b/tests/test_cli.sh
@@ -900,7 +900,7 @@ for i in 1 2 3 4 5; do
     cp "$TEST_FILE" "$TEST_DIR/sample_${i}.txt"
 done
 DICT_FILE="$TEST_DIR/test.zxd"
-"$ZXC_BIN" --train "$DICT_FILE" "$TEST_DIR"/sample_*.txt 2>/dev/null
+"$ZXC_BIN" --train -o "$DICT_FILE" "$TEST_DIR"/sample_*.txt 2>/dev/null
 if [ ! -f "$DICT_FILE" ]; then
     log_fail "Dictionary training failed"
 fi
@@ -1001,7 +1001,7 @@ fi
 echo "  Testing train-to-directory naming..."
 AUTO_DIR="$TEST_DIR/auto"
 mkdir -p "$AUTO_DIR"
-"$ZXC_BIN" --train "$AUTO_DIR/" "$TEST_DIR"/sample_*.txt 2>/dev/null
+"$ZXC_BIN" --train -o "$AUTO_DIR/" "$TEST_DIR"/sample_*.txt 2>/dev/null
 ZXD_NAME=$(ls "$AUTO_DIR" | grep -E '^dictionary_[0-9a-f]{8}\.zxd$' || true)
 if [ -n "$ZXD_NAME" ]; then
     log_pass "Train to directory names dict dictionary_<dict_id>.zxd ($ZXD_NAME)"


### PR DESCRIPTION
Introduces an `unzxc` alias for the CLI, which acts as a symlink to `zxc` and defaults to decompression. This improves convenience for users.

Also renames the dictionary training option from `--train-dict` to the more concise `--train`.

Enhances documentation with a new section on using pre-trained dictionaries, including CLI and C API examples, and details the error contract for dictionary-related operations. Updates the `man` page to reflect these changes, clarify `unzxc` usage, and include bug reporting instructions.