### PR TITLE
fix: Addresses code scan findings and improves robustness

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,4 +1,13 @@
 # Snyk (https://snyk.io) policy file
+ignore:
+  # CWE-23 false positive — CLI tool, path is user intent
+  cpp/PT:
+    - 'src/cli/main.c':
+        reason: >-
+          CLI arg path traversal is intended behavior; input is canonicalized
+          (realpath/_fullpath), restricted to regular files, and bounded to the
+          invoking user's own privileges. CWE-23.
+        expires: 2027-06-09T00:00:00.000Z
 exclude:
   code:
     - tests/**

--- a/src/cli/main.c
+++ b/src/cli/main.c
@@ -1340,6 +1340,14 @@ int main(int argc, char** argv) {
             free(zxd_buf);
             return 1;
         }
+        /* content_size is a file-derived length; zxc_dict_load already
+         * validates it, but re-check the untrusted size at the alloc/copy
+         * boundary so the bound governing memcpy is explicit at the sink. */
+        if (content_size == 0 || content_size > ZXC_DICT_SIZE_MAX) {
+            fprintf(stderr, "Error: invalid dictionary '%s'\n", dict_path);
+            free(zxd_buf);
+            return 1;
+        }
         dict = malloc(content_size);
         if (!dict) {
             free(zxd_buf);

--- a/src/cli/main.c
+++ b/src/cli/main.c
@@ -1023,7 +1023,7 @@ static int process_single_file(const char* in_path, const char* out_path_overrid
     else
         setvbuf(stdin, NULL, _IONBF, 0);
 
-    if (f_out && f_out != stdout)
+    if (created_out_file)
         fclose(f_out);
     else if (use_stdout) {
         fflush(stdout);

--- a/src/cli/main.c
+++ b/src/cli/main.c
@@ -189,6 +189,11 @@ static double zxc_now(void) {
  * @param[out] resolved_buffer Buffer to store resolved path (needs sufficient size).
  * @param[in] buffer_size Size of the resolved_buffer.
  * @return 0 on success, -1 on error.
+ *
+ * Security note (CWE-23): paths come from the CLI at the user's own privileges,
+ * not from archive content, so traversal is intended (suppressed in .snyk).
+ * True only while the format stores no path; an archive mode restoring embedded paths
+ * would be a real zip slip risk: re-evaluate the ignore then.
  */
 static int zxc_validate_input_path(const char* path, char* resolved_buffer, size_t buffer_size) {
 #ifdef _WIN32

--- a/src/cli/main.c
+++ b/src/cli/main.c
@@ -917,8 +917,7 @@ static int process_single_file(const char* in_path, const char* out_path_overrid
         zxc_log(
             "Refusing to write compressed data to terminal.\n"
             "For help, type: zxc -h\n");
-        if (f_in) fclose(f_in);
-        if (f_out) fclose(f_out);
+        if (!use_stdin) fclose(f_in);
         return 1;
     }
 

--- a/src/lib/zxc_dict.c
+++ b/src/lib/zxc_dict.c
@@ -88,7 +88,7 @@ int zxc_dict_load(const void* buf, const size_t buf_size, const void** content_o
     if (UNLIKELY(buf_size < ZXC_DICT_HEADER_SIZE + content_size)) return ZXC_ERROR_SRC_TOO_SMALL;
 
     uint8_t temp[ZXC_DICT_HEADER_SIZE];
-    ZXC_MEMCPY(temp, src, ZXC_DICT_HEADER_SIZE);
+    ZXC_MEMCPY(temp, src, sizeof(temp));
     zxc_store_le32(temp + 12, 0); /* reserved (0x0C) + CRC16 (0x0E), zeroed before CRC */
     const uint16_t expected_crc = zxc_hash16(temp);
     if (UNLIKELY(zxc_le16(src + 14) != expected_crc)) return ZXC_ERROR_BAD_HEADER;

--- a/wrappers/python/src/zxc/_zxc.c
+++ b/wrappers/python/src/zxc/_zxc.c
@@ -643,12 +643,12 @@ static PyObject* pyzxc_train_dict(PyObject* self, PyObject* args, PyObject* kwar
     PyMem_Free(views);
     Py_DECREF(seq);
 
+    PyObject* out = NULL;
     if (dict_size < 0) {
-        free(dict_buf);
-        Py_Return_Err(PyExc_RuntimeError, zxc_error_name((int)dict_size));
+        PyErr_SetString(PyExc_RuntimeError, zxc_error_name((int)dict_size));
+    } else {
+        out = PyBytes_FromStringAndSize((const char*)dict_buf, (Py_ssize_t)dict_size);
     }
-
-    PyObject* out = PyBytes_FromStringAndSize((const char*)dict_buf, (Py_ssize_t)dict_size);
     free(dict_buf);
     return out;
 }


### PR DESCRIPTION
Implements several fixes identified by static code analysis tools, enhancing the overall reliability and security of the application.

*   **Enhances security and clarity:** Suppresses a CWE-23 (path traversal) false positive in the Snyk policy for CLI argument handling, clarifying that such behavior is intended for user-specified paths. Adds a detailed security note in the code to document this exception and guide future considerations.
*   **Improves resource management:** Prevents accidental closure of standard input and output streams (`stdin`, `stdout`) when an error occurs or when handling file output in the CLI, ensuring proper resource handling.
*   **Strengthens memory safety:** Adds an explicit bounds check for dictionary allocation size to guard against potential issues with untrusted input. Utilizes `sizeof()` for `memcpy` operations, making buffer boundaries more explicit and robust.
*   **Ensures proper cleanup:** Guarantees consistent memory deallocation for dictionary buffers in the Python wrapper's training function, preventing memory leaks on all exit paths.