### PR TITLE
docs: Enhance API documentation with full Doxygen comments

### DIFF
--- a/src/lib/zxc_common.c
+++ b/src/lib/zxc_common.c
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-/*
+/**
  * @file zxc_common.c
  * @brief Shared library utilities: context management, header I/O,
  *        compress-bound calculation, and error-code name lookup.
@@ -24,7 +24,7 @@
  * ============================================================================
  */
 
-/*
+/**
  * @brief Allocates memory aligned to the specified boundary.
  *
  * Uses `_aligned_malloc` on Windows and `posix_memalign` elsewhere.
@@ -43,7 +43,7 @@ void* zxc_aligned_malloc(const size_t size, const size_t alignment) {
 #endif
 }
 
-/*
+/**
  * @brief Frees memory previously allocated by zxc_aligned_malloc().
  *
  * @param[in] ptr Pointer returned by zxc_aligned_malloc() (may be @c NULL).
@@ -56,13 +56,23 @@ void zxc_aligned_free(void* ptr) {
 #endif
 }
 
-/*
- * @copydoc zxc_compress_opts_size
+/**
+ * @brief Returns @c sizeof(zxc_compress_opts_t) for ABI-safe allocation.
+ *
+ * Public API; see @c zxc_buffer.h. Lets callers (other languages, or a
+ * different library version) size the options struct without knowing its layout.
+ *
+ * @return Size of @ref zxc_compress_opts_t in bytes.
  */
 size_t zxc_compress_opts_size(void) { return sizeof(zxc_compress_opts_t); }
 
-/*
- * @copydoc zxc_decompress_opts_size
+/**
+ * @brief Returns @c sizeof(zxc_decompress_opts_t) for ABI-safe allocation.
+ *
+ * Public API; see @c zxc_buffer.h. Lets callers (other languages, or a
+ * different library version) size the options struct without knowing its layout.
+ *
+ * @return Size of @ref zxc_decompress_opts_t in bytes.
  */
 size_t zxc_decompress_opts_size(void) { return sizeof(zxc_decompress_opts_t); }
 
@@ -97,6 +107,32 @@ typedef struct {
     size_t max_seq;
 } zxc_cctx_layout_t;
 
+/**
+ * @brief Computes the single-allocation memory layout for a compression /
+ *        decompression context.
+ *
+ * Walks the same partition order used by @ref zxc_cctx_init_in_workspace and
+ * records each sub-buffer's offset plus the running @c total, so the sizing
+ * query and the partitioning step share one source of truth and can never
+ * disagree.
+ *
+ * Decompress (@p mode == 0) reserves @c work_buf and @c lit_buffer (both padded
+ * for wild-copy overshoot) and, when @p dict_size > 0, the shared-dictionary
+ * Huffman decode table. Compress (@p mode == 1) reserves the LZ match-finder
+ * tables (hash positions, tags, chain), the sequence / extras / literal buffers
+ * and - only at @c level >= ZXC_LEVEL_DENSITY - the optimal-parser scratch. A
+ * @p dict_size > 0 appends the [dict | data] concat scratch in both modes.
+ *
+ * Every offset is cache-line aligned via @c ZXC_ALIGN_CL.
+ *
+ * @param[in] chunk_size  Block size in bytes.
+ * @param[in] mode        1 = compression, 0 = decompression.
+ * @param[in] level       Compression level (only consulted when @p mode == 1).
+ * @param[in] dict_size   Dictionary prefill size; when > 0 the layout includes
+ *                        the [dict | data] concat buffer (and, on decompress,
+ *                        the dictionary Huffman decode table).
+ * @return Fully populated layout; @c .total is the required workspace size.
+ */
 static zxc_cctx_layout_t compute_cctx_layout(const size_t chunk_size, const int mode,
                                              const int level, const size_t dict_size) {
     zxc_cctx_layout_t layout = {0};
@@ -180,12 +216,44 @@ static zxc_cctx_layout_t compute_cctx_layout(const size_t chunk_size, const int 
     return layout;
 }
 
+/**
+ * @brief Returns the workspace byte count required for the given parameters.
+ *
+ * Public contract documented at the declaration in @c zxc_internal.h. Thin
+ * wrapper that returns @c compute_cctx_layout(...).total, or 0 when
+ * @p chunk_size is 0.
+ *
+ * @param[in] chunk_size  Block size in bytes.
+ * @param[in] mode        1 = compression, 0 = decompression.
+ * @param[in] level       Compression level (only consulted when @p mode == 1).
+ * @param[in] dict_size   Dictionary prefill size; > 0 includes the concat buffer.
+ * @return Workspace size in bytes, or 0 if @p chunk_size is 0.
+ */
 size_t zxc_cctx_compute_workspace_size(const size_t chunk_size, const int mode, const int level,
                                        const size_t dict_size) {
     if (UNLIKELY(chunk_size == 0)) return 0;
     return compute_cctx_layout(chunk_size, mode, level, dict_size).total;
 }
 
+/**
+ * @brief Partitions a caller-supplied workspace into a ready-to-use context.
+ *
+ * Public contract (alignment, lifetime, return codes) documented at the
+ * declaration in @c zxc_internal.h. Computes the layout via
+ * @ref compute_cctx_layout, rejects an undersized @p workspace, then carves the
+ * sub-buffers out of it. @c ctx->memory_block stays NULL so @ref zxc_cctx_free
+ * leaves the caller-owned workspace untouched.
+ *
+ * @param[out] ctx               Context to initialise.
+ * @param[in]  workspace         Caller-allocated, cache-line-aligned buffer.
+ * @param[in]  workspace_size    Capacity of @p workspace in bytes.
+ * @param[in]  chunk_size        Block size in bytes.
+ * @param[in]  mode              1 = compression, 0 = decompression.
+ * @param[in]  level             Compression level (ignored when @p mode == 0).
+ * @param[in]  checksum_enabled  Non-zero to enable checksum computation.
+ * @param[in]  dict_size         Dictionary prefill size; > 0 carves the concat buffer.
+ * @return @ref ZXC_OK, @ref ZXC_ERROR_NULL_INPUT, or @ref ZXC_ERROR_DST_TOO_SMALL.
+ */
 int zxc_cctx_init_in_workspace(zxc_cctx_t* RESTRICT ctx, void* RESTRICT workspace,
                                const size_t workspace_size, const size_t chunk_size, const int mode,
                                const int level, const int checksum_enabled,
@@ -246,7 +314,7 @@ int zxc_cctx_init_in_workspace(zxc_cctx_t* RESTRICT ctx, void* RESTRICT workspac
     return ZXC_OK;
 }
 
-/*
+/**
  * @brief Initialises a compression / decompression context, allocating the
  *        persistent buffer with @c ZXC_ALIGNED_MALLOC.
  *
@@ -256,6 +324,12 @@ int zxc_cctx_init_in_workspace(zxc_cctx_t* RESTRICT ctx, void* RESTRICT workspac
  * release it.  The static-cctx public API (see @c zxc_buffer.h) bypasses
  * this wrapper and partitions a caller-supplied workspace directly.
  *
+ * @param[out] ctx               Context to initialise.
+ * @param[in]  chunk_size        Block size in bytes.
+ * @param[in]  mode              1 = compression, 0 = decompression.
+ * @param[in]  level             Compression level (ignored when @p mode == 0).
+ * @param[in]  checksum_enabled  Non-zero to enable checksum computation.
+ * @param[in]  dict_size         Dictionary prefill size.
  * @return @ref ZXC_OK on success, @ref ZXC_ERROR_MEMORY on allocation failure.
  */
 int zxc_cctx_init(zxc_cctx_t* RESTRICT ctx, const size_t chunk_size, const int mode,
@@ -279,7 +353,7 @@ int zxc_cctx_init(zxc_cctx_t* RESTRICT ctx, const size_t chunk_size, const int m
     return ZXC_OK;
 }
 
-/*
+/**
  * @brief Releases all resources owned by a compression context.
  *
  * After this call every pointer inside @p ctx is @c NULL and the context
@@ -317,8 +391,18 @@ void zxc_cctx_free(zxc_cctx_t* ctx) {
     ctx->lit_freq_acc = NULL;
 }
 
-/*
- * @copydoc zxc_cctx_attach_dict_huf
+/**
+ * @brief Attach the shared dictionary literal Huffman table to a context.
+ *
+ * Stores @p lengths (128-byte packed code-lengths header, caller-owned, must
+ * outlive the context) and, on decompression contexts created with
+ * @c dict_size > 0, builds the decode table once into the workspace-carved
+ * @c dict_huf_table. A NULL @p lengths is a no-op.
+ *
+ * @param[in,out] ctx      Initialised context to attach the table to.
+ * @param[in]     lengths  128-byte packed code lengths, or NULL for a no-op.
+ * @return @ref ZXC_OK on success, @ref ZXC_ERROR_CORRUPT_DATA if @p lengths is
+ *         structurally invalid (bad nibble, Kraft inequality).
  */
 int zxc_cctx_attach_dict_huf(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRICT lengths) {
     if (UNLIKELY(!ctx)) return ZXC_ERROR_NULL_INPUT;
@@ -352,7 +436,7 @@ int zxc_cctx_attach_dict_huf(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRICT l
  * ============================================================================
  */
 
-/*
+/**
  * @brief Serialises a ZXC file header into @p dst.
  *
  * Layout (16 bytes): Magic (4) | Version (1) | Chunk (1) | Flags (1) |
@@ -360,7 +444,10 @@ int zxc_cctx_attach_dict_huf(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRICT l
  *
  * @param[out] dst          Destination buffer (>= @ref ZXC_FILE_HEADER_SIZE bytes).
  * @param[in]  dst_capacity Capacity of @p dst.
+ * @param[in]  chunk_size   Block size (stored as its log2 exponent).
  * @param[in]  has_checksum Non-zero to set the checksum flag.
+ * @param[in]  dict_id      Dictionary id; when non-zero, sets the dictionary flag
+ *                          and is stored in the header.
  * @return Number of bytes written (@ref ZXC_FILE_HEADER_SIZE) on success,
  *         or a negative @ref zxc_error_t code.
  */
@@ -391,7 +478,7 @@ int zxc_write_file_header(uint8_t* RESTRICT dst, const size_t dst_capacity, cons
     return ZXC_FILE_HEADER_SIZE;
 }
 
-/*
+/**
  * @brief Parses and validates a ZXC file header from @p src.
  *
  * Checks the magic word, format version, and CRC-16.
@@ -400,6 +487,8 @@ int zxc_write_file_header(uint8_t* RESTRICT dst, const size_t dst_capacity, cons
  * @param[in]  src_size         Size of @p src.
  * @param[out] out_block_size   Receives the decoded block size (may be @c NULL).
  * @param[out] out_has_checksum Receives 1 if checksums are present, 0 otherwise
+ *                              (may be @c NULL).
+ * @param[out] out_dict_id      Receives the dictionary id, or 0 if none
  *                              (may be @c NULL).
  * @return @ref ZXC_OK on success, or a negative @ref zxc_error_t code.
  */
@@ -435,7 +524,7 @@ int zxc_read_file_header(const uint8_t* RESTRICT src, const size_t src_size,
     return ZXC_OK;
 }
 
-/*
+/**
  * @brief Serialises a block header (8 bytes) into @p dst.
  *
  * @param[out] dst          Destination buffer (>= @ref ZXC_BLOCK_HEADER_SIZE bytes).
@@ -458,7 +547,7 @@ int zxc_write_block_header(uint8_t* RESTRICT dst, const size_t dst_capacity,
     return ZXC_BLOCK_HEADER_SIZE;
 }
 
-/*
+/**
  * @brief Parses and validates a block header from @p src.
  *
  * Validates the 8-bit CRC embedded in the header.
@@ -486,7 +575,7 @@ int zxc_read_block_header(const uint8_t* RESTRICT src, const size_t src_size,
     return ZXC_OK;
 }
 
-/*
+/**
  * @brief Writes the 12-byte file footer (source size + global checksum).
  *
  * @param[out] dst              Destination buffer (>= @ref ZXC_FILE_FOOTER_SIZE bytes).
@@ -512,7 +601,7 @@ int zxc_write_file_footer(uint8_t* RESTRICT dst, const size_t dst_capacity, cons
     return ZXC_FILE_FOOTER_SIZE;
 }
 
-/*
+/**
  * @brief Serialises a GLO block header followed by its section descriptors.
  *
  * @param[out] dst  Destination buffer.
@@ -548,7 +637,7 @@ int zxc_write_glo_header_and_desc(uint8_t* RESTRICT dst, const size_t rem,
     return (int)needed;
 }
 
-/*
+/**
  * @brief Parses a GLO block header and its section descriptors from @p src.
  *
  * @param[in]  src  Source buffer.
@@ -581,7 +670,7 @@ int zxc_read_glo_header_and_desc(const uint8_t* RESTRICT src, const size_t len,
     return ZXC_OK;
 }
 
-/*
+/**
  * @brief Serialises a GHI block header followed by its section descriptors.
  *
  * @param[out] dst  Destination buffer.
@@ -617,7 +706,7 @@ int zxc_write_ghi_header_and_desc(uint8_t* RESTRICT dst, const size_t rem,
     return (int)needed;
 }
 
-/*
+/**
  * @brief Parses a GHI block header and its section descriptors from @p src.
  *
  * @param[in]  src  Source buffer.
@@ -655,7 +744,7 @@ int zxc_read_ghi_header_and_desc(const uint8_t* RESTRICT src, const size_t len,
  * COMPRESS BOUND CALCULATION
  * ============================================================================
  */
-/*
+/**
  * @brief Returns the maximum compressed size for a given input size.
  *
  * The result accounts for the file header, per-block headers, block
@@ -682,7 +771,7 @@ uint64_t zxc_compress_bound(const size_t input_size) {
            ZXC_FILE_FOOTER_SIZE;
 }
 
-/*
+/**
  * @brief Returns the maximum compressed size for a single block (no file framing).
  *
  * @param[in] input_size Uncompressed block size in bytes
@@ -704,7 +793,7 @@ uint64_t zxc_compress_block_bound(const size_t input_size) {
            ZXC_BLOCK_CHECKSUM_SIZE;
 }
 
-/*
+/**
  * @brief Returns the minimum dst_capacity required by zxc_decompress_block().
  *
  * The decoder uses speculative wild-copy writes on its fast path.
@@ -714,13 +803,17 @@ uint64_t zxc_compress_block_bound(const size_t input_size) {
  *
  * Returns 0 if @p uncompressed_size exceeds ZXC_BLOCK_SIZE_MAX (the Block API
  * limit), or if the arithmetic would overflow.
+ *
+ * @param[in] uncompressed_size  Exact decompressed size of the block.
+ * @return Minimum @c dst_capacity in bytes, or 0 if @p uncompressed_size exceeds
+ *         @c ZXC_BLOCK_SIZE_MAX.
  */
 uint64_t zxc_decompress_block_bound(const size_t uncompressed_size) {
     if (UNLIKELY(uncompressed_size > ZXC_BLOCK_SIZE_MAX)) return 0;
     return (uint64_t)uncompressed_size + ZXC_DECOMPRESS_TAIL_PAD;
 }
 
-/*
+/**
  * @brief Estimates the total buffer bytes allocated inside a cctx for a block.
  *
  * Thin wrapper around @ref zxc_cctx_compute_workspace_size for @c mode == 1
@@ -733,6 +826,10 @@ uint64_t zxc_decompress_block_bound(const size_t uncompressed_size) {
  * (@c opt_scratch, ~8.125 bytes per chunk_size byte) used by the optimal
  * parser and reused as transient package-merge scratch for the Huffman
  * code-length builder.
+ *
+ * @param[in] src_size  Input size; rounded up to a valid block size.
+ * @param[in] level     Compression level (>= 6 includes the optimal-parser scratch).
+ * @return Estimated context buffer size in bytes, or 0 if @p src_size is 0.
  */
 uint64_t zxc_estimate_cctx_size(const size_t src_size, const int level) {
     if (UNLIKELY(src_size == 0)) return 0;
@@ -746,7 +843,7 @@ uint64_t zxc_estimate_cctx_size(const size_t src_size, const int level) {
  * ============================================================================
  */
 
-/*
+/**
  * @brief Returns a human-readable string for the given error code.
  *
  * @param[in] code An error code from @ref zxc_error_t (or @ref ZXC_OK).
@@ -802,7 +899,7 @@ const char* zxc_error_name(const int code) {
  * ============================================================================
  */
 
-/*
+/**
  * @brief Returns the minimum supported compression level.
  *
  * Returns the value of ZXC_LEVEL_FASTEST (currently 1).
@@ -811,21 +908,21 @@ const char* zxc_error_name(const int code) {
  */
 int zxc_min_level(void) { return ZXC_LEVEL_FASTEST; }
 
-/*
+/**
  * @brief Returns the maximum supported compression level.
  *
  * Returns the value of ZXC_LEVEL_DENSITY (currently 6).
  */
 int zxc_max_level(void) { return ZXC_LEVEL_DENSITY; }
 
-/*
+/**
  * @brief Returns the default compression level.
  *
  * Returns the value of ZXC_LEVEL_DEFAULT (currently 3).
  */
 int zxc_default_level(void) { return ZXC_LEVEL_DEFAULT; }
 
-/*
+/**
  * @brief Returns the human-readable library version string.
  *
  * The returned pointer is a compile-time constant and must not be freed.

--- a/src/lib/zxc_compress.c
+++ b/src/lib/zxc_compress.c
@@ -85,6 +85,11 @@ static ZXC_ALWAYS_INLINE uint32_t zxc_mm256_reduce_max_epu32(__m256i v) {
  * Selects bytes from @p b where the corresponding @p mask byte has its high bit
  * set, else from @p a. In every call site the mask lanes are full-width compare
  * results (all-ones or all-zero per element), so a plain bitwise select is exact.
+ *
+ * @param[in] a     Lanes chosen where @p mask is clear.
+ * @param[in] b     Lanes chosen where @p mask is set.
+ * @param[in] mask  Per-byte selector (a full-width compare result).
+ * @return The blended 128-bit vector.
  */
 // codeql[cpp/unused-static-function] : Used conditionally when ZXC_USE_SSE2 is defined
 static ZXC_ALWAYS_INLINE __m128i zxc_mm_blendv_epi8_sse2(__m128i a, __m128i b, __m128i mask) {
@@ -98,6 +103,10 @@ static ZXC_ALWAYS_INLINE __m128i zxc_mm_blendv_epi8_sse2(__m128i a, __m128i b, _
  * by -0x8000 so values in [0, 0xFFFF] land in the signed int16 range with no
  * saturation, pack, then add 0x8000 back per 16-bit lane. Exact for inputs in
  * [0, 0xFFFF] (all call sites pass match lengths < 2^16).
+ *
+ * @param[in] a  Four u32 lanes forming the low half of the result.
+ * @param[in] b  Four u32 lanes forming the high half of the result.
+ * @return The eight u16 lanes packed from @p a then @p b.
  */
 // codeql[cpp/unused-static-function] : Used conditionally when ZXC_USE_SSE2 is defined
 static ZXC_ALWAYS_INLINE __m128i zxc_mm_packus_epi32_sse2(__m128i a, __m128i b) {
@@ -191,6 +200,8 @@ typedef struct {
  * @param[in,out] hash_tags Pointer to the tag table for fast rejection.
  * @param[in,out] chain_table Pointer to the chain table for collision handling.
  * @param[in] epoch_mark Current epoch marker for hash table invalidation.
+ * @param[in] offset_mask Mask isolating the position bits in chain/table entries.
+ * @param[in] level Compression level (selects search depth and matcher behaviour).
  * @param[in] p LZ77 parameters controlling search depth, lazy matching, and stepping.
  * @param[in] last_off Most recently accepted match offset, used as a repeat-offset
  *            seed probed before the hash-chain walk. Pass 0 to disable (all callers
@@ -808,6 +819,7 @@ static uint32_t zxc_opt_estimate_lit_bits(const uint8_t* RESTRICT src, const siz
  * @param[out] extras_sz_out    Number of bytes written into @p buf_extras.
  * @param[out] max_offset_out   Largest biased offset emitted (used by the caller
  *                              to choose 1-byte vs 2-byte offset encoding).
+ * @return @c ZXC_OK on success, or a negative @ref zxc_error_t.
  */
 static int zxc_lz77_optimal_parse_glo(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRICT src,
                                       const size_t src_sz, uint32_t* RESTRICT hash_table,
@@ -2069,6 +2081,21 @@ static int zxc_encode_block_raw(const uint8_t* RESTRICT src, const size_t src_sz
     return ZXC_OK;
 }
 
+/**
+ * @brief Compresses one chunk into a single ZXC block (the compression hot path).
+ *
+ * Selects the GHI encoder at level <= 2, otherwise GLO; falls back to a RAW
+ * block when the coded form would not shrink the data. When @c ctx->dict_size
+ * is > 0, @p chunk is the [dict | block] concat and only the block tail counts
+ * toward the expansion check. Appends the per-block checksum when enabled.
+ *
+ * @param[in,out] ctx     Compression context (level, dict_size, checksum, buffers).
+ * @param[in]     chunk   Source bytes ([dict | block] when a dictionary is active).
+ * @param[in]     src_sz  Length of @p chunk in bytes (includes any dict prefix).
+ * @param[out]    dst     Destination block buffer.
+ * @param[in]     dst_cap Capacity of @p dst in bytes.
+ * @return Compressed block size in bytes on success, or a negative @ref zxc_error_t.
+ */
 // cppcheck-suppress unusedFunction
 int zxc_compress_chunk_wrapper(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRICT chunk,
                                const size_t src_sz, uint8_t* RESTRICT dst, const size_t dst_cap) {

--- a/src/lib/zxc_decompress.c
+++ b/src/lib/zxc_decompress.c
@@ -302,30 +302,24 @@ static ZXC_ALWAYS_INLINE void zxc_decode_copy_match(uint8_t* RESTRICT d_ptr, con
     } while (0)
 
 /**
- * @brief Decodes a General Low (GLO) format compressed block.
+ * @brief Unified GLO (General Low) block decoder body, shared by the fast, safe
+ *        and dictionary variants.
  *
- * This function handles the decoding of a compressed block formatted with the
- * internal GLO structure. The decompressed size is derived from Section
- * Descriptors within the compressed payload.
+ * Decodes a block in the internal GLO format; the decompressed size is derived
+ * from the Section Descriptors in the payload. @p safe and @p has_dict must be
+ * compile-time constants (0 or 1): the 4x-unrolled loops are duplicated inside
+ * @c if(safe)/else branches so each variant keeps single-assignment @c const
+ * save pointers, and after constant propagation only one branch survives per
+ * wrapper (codegen equivalent to a hand-written pair).
  *
- * @param[in,out] ctx Pointer to the compression context (`zxc_cctx_t`) containing
- * @param[in] src Pointer to the source buffer containing compressed data.
- * @param[in] src_size Size of the source buffer in bytes.
- * @param[out] dst Pointer to the destination buffer for decompressed data.
- * @param[in] dst_capacity Maximum capacity of the destination buffer.
- *
- * @return The number of bytes written to the destination buffer on success, or
- * a negative zxc_error_t code on failure (e.g., invalid header, buffer overflow, or corrupted
- * data).
- */
-/**
- * @brief Unified GLO decoder body shared by the fast and safe variants.
- *
- * @p safe must be a compile-time constant (0 or 1). The two 4x-unrolled loops
- * are duplicated verbatim inside @c if(safe)/else branches so each variant
- * keeps single-assignment @c const save pointers. After constant propagation
- * only one branch survives per wrapper, yielding codegen equivalent to the
- * hand-written pair.
+ * @param[in,out] ctx          Decompression context (dict buffer, tables).
+ * @param[in]     src          Compressed block payload.
+ * @param[in]     src_size     Size of @p src in bytes.
+ * @param[out]    dst          Destination buffer for decoded bytes.
+ * @param[in]     dst_capacity Capacity of @p dst in bytes.
+ * @param[in]     safe         Compile-time flag: 1 = strict bounds-checked loop.
+ * @param[in]     has_dict     Compile-time flag: 1 = resolve matches against a dict prefix.
+ * @return Bytes written to @p dst on success, or a negative @ref zxc_error_t.
  */
 static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(const zxc_cctx_t* RESTRICT ctx,
                                                        const uint8_t* RESTRICT src,
@@ -1122,26 +1116,24 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(const zxc_cctx_t* RESTRIC
 }
 
 /**
- * @brief Decodes a GHI (General High) format compressed block.
+ * @brief Unified GHI (General High) block decoder body, shared by the fast, safe
+ *        and dictionary variants.
  *
- * This function handles the decoding of a compressed block formatted with the
- * internal GHI structure. The decompressed size is derived from Section
- * Descriptors within the compressed payload.
+ * Decodes a block in the internal GHI format; the decompressed size is derived
+ * from the Section Descriptors in the payload. @p safe and @p has_dict must be
+ * compile-time constants (0 or 1): the 4x-unrolled loops are duplicated inside
+ * @c if(safe)/else branches so each variant keeps single-assignment @c const
+ * save pointers, and after constant propagation only one branch survives per
+ * wrapper.
  *
- * @param[in] ctx Pointer to the decompression context (unused in current implementation).
- * @param[in] src Pointer to the source buffer containing compressed data.
- * @param[in] src_size Size of the source buffer in bytes.
- * @param[out] dst Pointer to the destination buffer for decompressed data.
- * @param[in] dst_capacity Capacity of the destination buffer in bytes.
- * @return int Returns the number of bytes written on success, or a negative zxc_error_t code on
- * failure.
- */
-/**
- * @brief Unified GHI decoder body shared by the fast and safe variants.
- *
- * @p safe must be a compile-time constant (0 or 1). The two 4x-unrolled loops
- * are duplicated verbatim inside @c if(safe)/else branches so that each
- * variant keeps its own single-assignment @c const save pointers.
+ * @param[in,out] ctx          Decompression context (dict buffer, tables).
+ * @param[in]     src          Compressed block payload.
+ * @param[in]     src_size     Size of @p src in bytes.
+ * @param[out]    dst          Destination buffer for decoded bytes.
+ * @param[in]     dst_capacity Capacity of @p dst in bytes.
+ * @param[in]     safe         Compile-time flag: 1 = strict bounds-checked loop.
+ * @param[in]     has_dict     Compile-time flag: 1 = resolve matches against a dict prefix.
+ * @return Bytes written to @p dst on success, or a negative @ref zxc_error_t.
  */
 static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(const zxc_cctx_t* RESTRICT ctx,
                                                        const uint8_t* RESTRICT src,
@@ -1763,22 +1755,57 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(const zxc_cctx_t* RESTRIC
     return (int)(d_ptr - dst);
 }
 
-// No-dict decoders: plain (inlinable) so the no-dict chunk wrapper inlines them
-// exactly like main. has_dict=0 folds the dict_size handling away.
+/**
+ * @brief Decode a no-dict GLO block (plain, inlinable path).
+ *
+ * Wrapper over @ref zxc_decode_block_glo_impl with @c safe=0, @c has_dict=0, so
+ * the no-dict chunk wrapper inlines it exactly like the dict-free build.
+ *
+ * @param[in,out] ctx          Decompression context.
+ * @param[in]     src          Compressed GLO block payload.
+ * @param[in]     src_size     Size of @p src in bytes.
+ * @param[out]    dst          Destination buffer.
+ * @param[in]     dst_capacity Capacity of @p dst in bytes.
+ * @return Bytes written on success, or a negative @ref zxc_error_t.
+ */
 static int zxc_decode_block_glo(const zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRICT src,
                                 const size_t src_size, uint8_t* RESTRICT dst,
                                 const size_t dst_capacity) {
     return zxc_decode_block_glo_impl(ctx, src, src_size, dst, dst_capacity, 0, 0);
 }
 
+/**
+ * @brief Decode a no-dict GHI block (plain, inlinable path).
+ *
+ * Wrapper over @ref zxc_decode_block_ghi_impl with @c safe=0, @c has_dict=0.
+ *
+ * @param[in,out] ctx          Decompression context.
+ * @param[in]     src          Compressed GHI block payload.
+ * @param[in]     src_size     Size of @p src in bytes.
+ * @param[out]    dst          Destination buffer.
+ * @param[in]     dst_capacity Capacity of @p dst in bytes.
+ * @return Bytes written on success, or a negative @ref zxc_error_t.
+ */
 static int zxc_decode_block_ghi(const zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRICT src,
                                 const size_t src_size, uint8_t* RESTRICT dst,
                                 const size_t dst_capacity) {
     return zxc_decode_block_ghi_impl(ctx, src, src_size, dst, dst_capacity, 0, 0);
 }
 
-// Dict decoders: NOINLINE, only reached on the cold dict path (chunk_wrapper_dict),
-// so they never load into I-cache on a no-dict stream.
+/**
+ * @brief Decode a GLO block against a dictionary prefix (cold path).
+ *
+ * Wrapper over @ref zxc_decode_block_glo_impl with @c safe=0, @c has_dict=1.
+ * NOINLINE: only reached on the cold dict path (@ref zxc_decompress_chunk_wrapper_dict),
+ * so it never loads into I-cache on a no-dict stream.
+ *
+ * @param[in,out] ctx          Decompression context (dict prefix in its buffer).
+ * @param[in]     src          Compressed GLO block payload.
+ * @param[in]     src_size     Size of @p src in bytes.
+ * @param[out]    dst          Destination buffer.
+ * @param[in]     dst_capacity Capacity of @p dst in bytes.
+ * @return Bytes written on success, or a negative @ref zxc_error_t.
+ */
 static ZXC_NOINLINE int zxc_decode_block_glo_dict(const zxc_cctx_t* RESTRICT ctx,
                                                   const uint8_t* RESTRICT src,
                                                   const size_t src_size, uint8_t* RESTRICT dst,
@@ -1786,6 +1813,19 @@ static ZXC_NOINLINE int zxc_decode_block_glo_dict(const zxc_cctx_t* RESTRICT ctx
     return zxc_decode_block_glo_impl(ctx, src, src_size, dst, dst_capacity, 0, 1);
 }
 
+/**
+ * @brief Decode a GHI block against a dictionary prefix (cold path).
+ *
+ * Wrapper over @ref zxc_decode_block_ghi_impl with @c safe=0, @c has_dict=1
+ * (NOINLINE; see @ref zxc_decode_block_glo_dict).
+ *
+ * @param[in,out] ctx          Decompression context (dict prefix in its buffer).
+ * @param[in]     src          Compressed GHI block payload.
+ * @param[in]     src_size     Size of @p src in bytes.
+ * @param[out]    dst          Destination buffer.
+ * @param[in]     dst_capacity Capacity of @p dst in bytes.
+ * @return Bytes written on success, or a negative @ref zxc_error_t.
+ */
 static ZXC_NOINLINE int zxc_decode_block_ghi_dict(const zxc_cctx_t* RESTRICT ctx,
                                                   const uint8_t* RESTRICT src,
                                                   const size_t src_size, uint8_t* RESTRICT dst,
@@ -1793,8 +1833,20 @@ static ZXC_NOINLINE int zxc_decode_block_ghi_dict(const zxc_cctx_t* RESTRICT ctx
     return zxc_decode_block_ghi_impl(ctx, src, src_size, dst, dst_capacity, 0, 1);
 }
 
-// Safe path never carries a dict (block_safe routes dict to the bounce path), so
-// has_dict=0 folds the dead dict_size handling.
+/**
+ * @brief Decode a GLO block with the strict-tail safe loop (no wild copies).
+ *
+ * Wrapper over @ref zxc_decode_block_glo_impl with @c safe=1, @c has_dict=0.
+ * The safe path never carries a dict (block_safe routes dict inputs to the
+ * bounce path), so @c has_dict=0 folds the dead dict handling.
+ *
+ * @param[in,out] ctx          Decompression context.
+ * @param[in]     src          Compressed GLO block payload.
+ * @param[in]     src_size     Size of @p src in bytes.
+ * @param[out]    dst          Destination buffer (capacity == exact decoded size).
+ * @param[in]     dst_capacity Capacity of @p dst in bytes.
+ * @return Bytes written on success, or a negative @ref zxc_error_t.
+ */
 static ZXC_NOINLINE int zxc_decode_block_glo_safe(const zxc_cctx_t* RESTRICT ctx,
                                                   const uint8_t* RESTRICT src,
                                                   const size_t src_size, uint8_t* RESTRICT dst,
@@ -1802,7 +1854,20 @@ static ZXC_NOINLINE int zxc_decode_block_glo_safe(const zxc_cctx_t* RESTRICT ctx
     return zxc_decode_block_glo_impl(ctx, src, src_size, dst, dst_capacity, 1, 0);
 }
 
-// Strict-tail safe path never carries a dict (see zxc_decode_block_glo_safe).
+/**
+ * @brief Decode a GHI block with the strict-tail safe loop (no wild copies).
+ *
+ * Wrapper over @ref zxc_decode_block_ghi_impl with @c safe=1, @c has_dict=0
+ * (the strict-tail safe path never carries a dict; see
+ * @ref zxc_decode_block_glo_safe).
+ *
+ * @param[in,out] ctx          Decompression context.
+ * @param[in]     src          Compressed GHI block payload.
+ * @param[in]     src_size     Size of @p src in bytes.
+ * @param[out]    dst          Destination buffer (capacity == exact decoded size).
+ * @param[in]     dst_capacity Capacity of @p dst in bytes.
+ * @return Bytes written on success, or a negative @ref zxc_error_t.
+ */
 static ZXC_NOINLINE int zxc_decode_block_ghi_safe(const zxc_cctx_t* RESTRICT ctx,
                                                   const uint8_t* RESTRICT src,
                                                   const size_t src_size, uint8_t* RESTRICT dst,
@@ -1813,10 +1878,23 @@ static ZXC_NOINLINE int zxc_decode_block_ghi_safe(const zxc_cctx_t* RESTRICT ctx
 #undef DECODE_SEQ_FAST
 #undef DECODE_SEQ_SAFE
 
-/* Shared chunk-decode body. @p has_dict is a compile-time constant: the no-dict
- * instantiation folds the GLO/GHI selection to the plain (inlinable) decoders, so
- * zxc_decompress_chunk_wrapper carries no dict code and matches main; the dict
- * instantiation calls the NOINLINE _dict decoders. */
+/**
+ * @brief Shared chunk-decode body: validates the block header, verifies the
+ *        optional checksum, then dispatches on block type.
+ *
+ * @p has_dict is a compile-time constant: the no-dict instantiation folds the
+ * GLO/GHI selection to the plain (inlinable) decoders, so
+ * @ref zxc_decompress_chunk_wrapper carries no dict code and matches the
+ * dict-free build; the dict instantiation calls the NOINLINE @c _dict decoders.
+ *
+ * @param[in,out] ctx       Decompression context.
+ * @param[in]     src       Compressed block (header + payload + optional checksum).
+ * @param[in]     src_sz    Size of @p src in bytes.
+ * @param[out]    dst       Destination buffer for the decoded block.
+ * @param[in]     dst_cap   Capacity of @p dst in bytes.
+ * @param[in]     has_dict  Compile-time flag: 1 = dictionary-aware decoders.
+ * @return Bytes written on success, or a negative @ref zxc_error_t.
+ */
 static ZXC_ALWAYS_INLINE int zxc_decompress_chunk_wrapper_body(
     const zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRICT src, const size_t src_sz,
     uint8_t* RESTRICT dst, const size_t dst_cap, const int has_dict) {
@@ -1866,15 +1944,39 @@ static ZXC_ALWAYS_INLINE int zxc_decompress_chunk_wrapper_body(
     return decoded_sz;
 }
 
-// No-dict chunk decoder: inlines the plain GLO/GHI decoders -> identical to main.
+/**
+ * @brief Public no-dict chunk decoder (decompression hot path).
+ *
+ * Inlines the plain GLO/GHI decoders via @ref zxc_decompress_chunk_wrapper_body
+ * with @c has_dict=0, so it carries no dict code and matches the dict-free build.
+ *
+ * @param[in,out] ctx     Decompression context.
+ * @param[in]     src     Compressed block bytes.
+ * @param[in]     src_sz  Size of @p src in bytes.
+ * @param[out]    dst     Destination buffer for the decoded block.
+ * @param[in]     dst_cap Capacity of @p dst in bytes.
+ * @return Bytes written on success, or a negative @ref zxc_error_t.
+ */
 // cppcheck-suppress unusedFunction
 int zxc_decompress_chunk_wrapper(const zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRICT src,
                                  const size_t src_sz, uint8_t* RESTRICT dst, const size_t dst_cap) {
     return zxc_decompress_chunk_wrapper_body(ctx, src, src_sz, dst, dst_cap, 0);
 }
 
-// Dict chunk decoder: calls the NOINLINE _dict decoders. Slower (dict back-refs read
-// the prepended dict); only used when ctx->dict_size != 0.
+/**
+ * @brief Public dictionary chunk decoder.
+ *
+ * Routes through @ref zxc_decompress_chunk_wrapper_body with @c has_dict=1,
+ * which calls the NOINLINE @c _dict decoders (slower: dict back-refs read the
+ * prepended dictionary). Used only when @c ctx->dict_size != 0.
+ *
+ * @param[in,out] ctx     Decompression context (dict prefix in its buffer).
+ * @param[in]     src     Compressed block bytes.
+ * @param[in]     src_sz  Size of @p src in bytes.
+ * @param[out]    dst     Destination buffer for the decoded block.
+ * @param[in]     dst_cap Capacity of @p dst in bytes.
+ * @return Bytes written on success, or a negative @ref zxc_error_t.
+ */
 // cppcheck-suppress unusedFunction
 int zxc_decompress_chunk_wrapper_dict(const zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRICT src,
                                       const size_t src_sz, uint8_t* RESTRICT dst,
@@ -1882,6 +1984,21 @@ int zxc_decompress_chunk_wrapper_dict(const zxc_cctx_t* RESTRICT ctx, const uint
     return zxc_decompress_chunk_wrapper_body(ctx, src, src_sz, dst, dst_cap, 1);
 }
 
+/**
+ * @brief Public strict-tail safe chunk decoder (dst_cap == exact decoded size).
+ *
+ * Validates the block header and optional checksum, then decodes via the
+ * @c _safe decoders (no bounce buffer, no tail padding); RAW blocks are copied
+ * directly. Dict inputs are not handled here (the caller routes them to the
+ * bounce-capable path).
+ *
+ * @param[in,out] ctx     Decompression context.
+ * @param[in]     src     Compressed block bytes.
+ * @param[in]     src_sz  Size of @p src in bytes.
+ * @param[out]    dst     Destination buffer (capacity == exact decoded size).
+ * @param[in]     dst_cap Capacity of @p dst in bytes.
+ * @return Bytes written on success, or a negative @ref zxc_error_t.
+ */
 // cppcheck-suppress unusedFunction
 int zxc_decompress_chunk_wrapper_safe(const zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRICT src,
                                       const size_t src_sz, uint8_t* RESTRICT dst,

--- a/src/lib/zxc_dict.c
+++ b/src/lib/zxc_dict.c
@@ -19,6 +19,19 @@
  *  Dictionary ID
  * ------------------------------------------------------------------------- */
 
+/**
+ * @brief Computes the dictionary identifier for @p dict (and optional table).
+ *
+ * Public API; see @c zxc_dict.h. One logical checksum over the content bytes,
+ * optionally chained with the packed Huffman lengths so a single id covers
+ * both. Stored in the archive header and re-checked on decode.
+ *
+ * @param[in] dict         Dictionary content bytes.
+ * @param[in] dict_size    Content length in bytes.
+ * @param[in] huf_lengths  Optional packed Huffman lengths (@c ZXC_HUF_TABLE_SIZE
+ *                         bytes), or NULL to hash the content alone.
+ * @return The 32-bit dictionary id, or 0 if @p dict is NULL or empty.
+ */
 uint32_t zxc_dict_id(const void* RESTRICT dict, const size_t dict_size,
                      const void* RESTRICT huf_lengths) {
     if (UNLIKELY(!dict || dict_size == 0)) return 0;
@@ -46,6 +59,16 @@ uint32_t zxc_dict_id(const void* RESTRICT dict, const size_t dict_size,
  *    +N    128 Packed Huffman code lengths (always present)
  * ------------------------------------------------------------------------- */
 
+/**
+ * @brief Extracts the stored @c dict_id from a serialized .zxd buffer.
+ *
+ * Public API; see @c zxc_dict.h. Validates the magic, then reads the id field
+ * straight from the header without recomputing it.
+ *
+ * @param[in] buf       Serialized .zxd bytes.
+ * @param[in] buf_size  Size of @p buf in bytes.
+ * @return The stored dictionary id, or 0 if @p buf is too small or not a .zxd.
+ */
 uint32_t zxc_dict_get_id(const void* buf, const size_t buf_size) {
     if (UNLIKELY(!buf || buf_size < ZXC_DICT_HEADER_SIZE)) return 0;
     const uint8_t* p = (const uint8_t*)buf;
@@ -53,10 +76,35 @@ uint32_t zxc_dict_get_id(const void* buf, const size_t buf_size) {
     return zxc_le32(p + 8);
 }
 
+/**
+ * @brief Worst-case .zxd byte size for a dictionary of @p content_size bytes.
+ *
+ * Public API; see @c zxc_dict.h. Use it to size the buffer passed to
+ * @ref zxc_dict_save.
+ *
+ * @param[in] content_size  Dictionary content length in bytes.
+ * @return Required buffer size: header + content + Huffman table.
+ */
 size_t zxc_dict_save_bound(const size_t content_size) {
     return ZXC_DICT_HEADER_SIZE + content_size + ZXC_HUF_TABLE_SIZE;
 }
 
+/**
+ * @brief Serializes dictionary content + Huffman table into the .zxd format.
+ *
+ * Public API; full contract in @c zxc_dict.h. Writes the 16-byte header (magic,
+ * version, sizes, dict_id, header CRC), then the content bytes, then the packed
+ * Huffman lengths. See the on-disk layout note above.
+ *
+ * @param[in]  content       Dictionary content bytes.
+ * @param[in]  content_size  Content length (<= @c ZXC_DICT_SIZE_MAX).
+ * @param[in]  huf_lengths   Packed Huffman lengths (@c ZXC_HUF_TABLE_SIZE bytes).
+ * @param[out] buf           Destination .zxd buffer.
+ * @param[in]  buf_capacity  Capacity of @p buf (>= @ref zxc_dict_save_bound).
+ * @return Bytes written on success, or a negative @ref zxc_error_t
+ *         (@ref ZXC_ERROR_NULL_INPUT, @ref ZXC_ERROR_DICT_TOO_LARGE,
+ *         @ref ZXC_ERROR_DST_TOO_SMALL).
+ */
 int64_t zxc_dict_save(const void* RESTRICT content, const size_t content_size,
                       const void* RESTRICT huf_lengths, void* RESTRICT buf,
                       const size_t buf_capacity) {
@@ -83,6 +131,23 @@ int64_t zxc_dict_save(const void* RESTRICT content, const size_t content_size,
     return (int64_t)total;
 }
 
+/**
+ * @brief Parses a .zxd buffer, returning in-buffer views of content and table.
+ *
+ * Public API; full contract in @c zxc_dict.h. Validates magic, version, header
+ * CRC and dict_id, then points the out-params at the content and Huffman table
+ * inside @p buf (no copy). The returned pointers alias @p buf and stay valid
+ * only while it does.
+ *
+ * @param[in]  buf               Serialized .zxd bytes.
+ * @param[in]  buf_size          Size of @p buf in bytes.
+ * @param[out] content_out       Receives a pointer to the content bytes.
+ * @param[out] content_size_out  Receives the content length.
+ * @param[out] huf_out           Receives a pointer to the Huffman table (optional).
+ * @param[out] dict_id_out       Receives the validated dict_id (optional).
+ * @return @ref ZXC_OK, or a negative @ref zxc_error_t (bad magic / version /
+ *         header / checksum, or too small).
+ */
 int zxc_dict_load(const void* RESTRICT buf, const size_t buf_size,
                   const void** RESTRICT content_out, size_t* RESTRICT content_size_out,
                   const void** RESTRICT huf_out, uint32_t* RESTRICT dict_id_out) {
@@ -121,6 +186,18 @@ int zxc_dict_load(const void* RESTRICT buf, const size_t buf_size,
     return ZXC_OK;
 }
 
+/**
+ * @brief Returns a pointer to the packed Huffman table inside a .zxd buffer.
+ *
+ * Public API; see @c zxc_dict.h. Lightweight accessor (checks magic, version
+ * and sizes) that locates the table without the full validation of
+ * @ref zxc_dict_load. The returned pointer aliases @p buf.
+ *
+ * @param[in] buf       Serialized .zxd bytes.
+ * @param[in] buf_size  Size of @p buf in bytes.
+ * @return Pointer to the @c ZXC_HUF_TABLE_SIZE-byte table, or NULL if @p buf is
+ *         too small or not a valid .zxd.
+ */
 const void* zxc_dict_huf(const void* buf, const size_t buf_size) {
     if (UNLIKELY(!buf || buf_size < ZXC_DICT_HEADER_SIZE)) return NULL;
     const uint8_t* src = (const uint8_t*)buf;
@@ -150,6 +227,15 @@ const void* zxc_dict_huf(const void* buf, const size_t buf_size) {
  *     skipped, so capacity goes to NEW patterns instead of redundant copies.
  * ------------------------------------------------------------------------- */
 
+/**
+ * @brief Hashes the k-gram at @p p into a frequency-table bucket index.
+ *
+ * Training-internal: a multiplicative hash of the @c ZXC_DICT_KGRAM_LEN-byte
+ * k-gram, folded down to @c ZXC_DICT_HASH_BITS.
+ *
+ * @param[in] p  Pointer to at least @c ZXC_DICT_KGRAM_LEN readable bytes.
+ * @return Bucket index in [0, @c ZXC_DICT_HASH_SIZE).
+ */
 static uint32_t zxc_dict_hash(const uint8_t* p) {
     uint32_t v = zxc_le32(p);
     v ^= (uint32_t)p[4];
@@ -231,6 +317,23 @@ static void zxc_dict_sort_segs_desc(zxc_dict_seg_t* RESTRICT a, const size_t n) 
     }
 }
 
+/**
+ * @brief Trains a raw dictionary from sample buffers by k-gram coverage.
+ *
+ * Public API; full contract in @c zxc_dict.h, algorithm in the note above.
+ * Concatenates the samples, counts sampled k-gram frequencies, builds
+ * coverage-scored candidate segments, then greedily fills @p dict_buf in
+ * descending coverage while zeroing each pick's k-grams (so overlapping
+ * patterns aren't copied twice). Picks are emitted in reverse so the
+ * highest-coverage bytes land at the dict's end (smallest match offsets).
+ *
+ * @param[in]  samples        Array of @p n_samples sample buffers.
+ * @param[in]  sample_sizes   Array of @p n_samples sample lengths.
+ * @param[in]  n_samples      Number of samples.
+ * @param[out] dict_buf       Destination for the trained content.
+ * @param[in]  dict_capacity  Capacity of @p dict_buf (<= @c ZXC_DICT_SIZE_MAX).
+ * @return Trained content length in bytes, or a negative @ref zxc_error_t.
+ */
 int64_t zxc_train_dict(const void* const* RESTRICT samples, const size_t* RESTRICT sample_sizes,
                        const size_t n_samples, void* RESTRICT dict_buf,
                        const size_t dict_capacity) {
@@ -406,6 +509,23 @@ int64_t zxc_train_dict(const void* const* RESTRICT samples, const size_t* RESTRI
  *  unaffordable there) and literal density is highest.
  * ------------------------------------------------------------------------- */
 
+/**
+ * @brief Trains the shared literal Huffman table for a dictionary (Tier-2).
+ *
+ * Public API; see @c zxc_dict.h and the algorithm note above. Compresses the
+ * samples with @p dict at @c ZXC_LEVEL_DENSITY, accumulating the frequencies of
+ * the REAL post-LZ literals (raw bytes are a poor proxy), then builds and packs
+ * length-limited code lengths. Samples are sliced into
+ * @c ZXC_DICT_HUF_TRAIN_BLOCK blocks, sub-sampled to a fixed budget.
+ *
+ * @param[in]  samples          Array of @p n_samples sample buffers.
+ * @param[in]  sample_sizes     Array of @p n_samples sample lengths.
+ * @param[in]  n_samples        Number of samples.
+ * @param[in]  dict             Trained dictionary content.
+ * @param[in]  dict_size        Dictionary length (<= @c ZXC_DICT_SIZE_MAX).
+ * @param[out] huf_lengths_out  Receives the @c ZXC_HUF_TABLE_SIZE packed lengths.
+ * @return @ref ZXC_OK, or a negative @ref zxc_error_t.
+ */
 int zxc_train_dict_huf(const void* const* RESTRICT samples, const size_t* RESTRICT sample_sizes,
                        const size_t n_samples, const void* RESTRICT dict, const size_t dict_size,
                        uint8_t* RESTRICT huf_lengths_out) {
@@ -498,6 +618,21 @@ int zxc_train_dict_huf(const void* const* RESTRICT samples, const size_t* RESTRI
  *  All-in-one convenience: samples -> ready-to-write .zxd bytes
  * ------------------------------------------------------------------------- */
 
+/**
+ * @brief One-shot training: sample buffers in, ready-to-write .zxd bytes out.
+ *
+ * Public API; see @c zxc_dict.h. Convenience wrapper that trains the content
+ * (@ref zxc_train_dict), then the shared Huffman table from that content
+ * (@ref zxc_train_dict_huf), then serializes both via @ref zxc_dict_save. The
+ * two phases are a real data dependency, hidden behind one call.
+ *
+ * @param[in]  samples       Array of @p n_samples sample buffers.
+ * @param[in]  sample_sizes  Array of @p n_samples sample lengths.
+ * @param[in]  n_samples     Number of samples.
+ * @param[out] zxd_buf       Destination .zxd buffer.
+ * @param[in]  zxd_capacity  Capacity of @p zxd_buf in bytes.
+ * @return Bytes written to @p zxd_buf, or a negative @ref zxc_error_t.
+ */
 int64_t zxc_dict_train(const void* const* RESTRICT samples, const size_t* RESTRICT sample_sizes,
                        const size_t n_samples, void* RESTRICT zxd_buf, const size_t zxd_capacity) {
     if (UNLIKELY(!samples || !sample_sizes || n_samples == 0 || !zxd_buf || zxd_capacity == 0))

--- a/src/lib/zxc_dispatch.c
+++ b/src/lib/zxc_dispatch.c
@@ -268,6 +268,14 @@ static ZXC_ATOMIC zxc_compress_func_t zxc_compress_ptr = (zxc_compress_func_t)0;
  *
  * Detects CPU features, selects the best implementation, stores the
  * pointer atomically, then tail-calls into it.
+ *
+ * @param[in]  ctx      Decompression context (its @c dict_size picks the dict variant).
+ * @param[in]  src      Compressed input chunk.
+ * @param[in]  src_sz   Size of @p src in bytes.
+ * @param[out] dst      Destination buffer for decompressed data.
+ * @param[in]  dst_cap  Capacity of @p dst in bytes.
+ * @return Result of the selected variant: decompressed size, or negative
+ *         @ref zxc_error_t.
  */
 // LCOV_EXCL_START
 static int zxc_decompress_dispatch_init(const zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRICT src,
@@ -330,6 +338,14 @@ static int zxc_decompress_dispatch_init(const zxc_cctx_t* RESTRICT ctx, const ui
  *
  * Mirrors @ref zxc_decompress_dispatch_init but selects the `_safe_*`
  * decoder variants used by @ref zxc_decompress_block_safe.
+ *
+ * @param[in]  ctx      Decompression context.
+ * @param[in]  src      Compressed input chunk.
+ * @param[in]  src_sz   Size of @p src in bytes.
+ * @param[out] dst      Destination buffer (strict: exact uncompressed size).
+ * @param[in]  dst_cap  Capacity of @p dst in bytes.
+ * @return Result of the selected variant: decompressed size, or negative
+ *         @ref zxc_error_t.
  */
 // LCOV_EXCL_START
 static int zxc_decompress_safe_dispatch_init(const zxc_cctx_t* RESTRICT ctx,
@@ -378,6 +394,14 @@ static int zxc_decompress_safe_dispatch_init(const zxc_cctx_t* RESTRICT ctx,
  *
  * Detects CPU features, selects the best implementation, stores the
  * pointer atomically, then tail-calls into it.
+ *
+ * @param[in,out] ctx      Compression context.
+ * @param[in]     src      Uncompressed input chunk.
+ * @param[in]     src_sz   Size of @p src in bytes.
+ * @param[out]    dst      Destination buffer for the compressed chunk.
+ * @param[in]     dst_cap  Capacity of @p dst in bytes.
+ * @return Result of the selected variant: compressed size, or negative
+ *         @ref zxc_error_t.
  */
 // LCOV_EXCL_START
 static int zxc_compress_dispatch_init(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRICT src,
@@ -448,6 +472,15 @@ int zxc_decompress_chunk_wrapper(const zxc_cctx_t* RESTRICT ctx, const uint8_t* 
 
 /**
  * @brief Internal safe-decompression dispatcher (strict dst_capacity == uncompressed_size).
+ *
+ * Calls the lazily-resolved `_safe_*` variant, running first-call init if needed.
+ *
+ * @param[in]  ctx      Decompression context.
+ * @param[in]  src      Compressed input chunk.
+ * @param[in]  src_sz   Size of @p src in bytes.
+ * @param[out] dst      Destination buffer (capacity == exact uncompressed size).
+ * @param[in]  dst_cap  Capacity of @p dst in bytes.
+ * @return Decompressed size in bytes, or a negative @ref zxc_error_t.
  */
 static int zxc_decompress_chunk_wrapper_safe_public(const zxc_cctx_t* RESTRICT ctx,
                                                     const uint8_t* RESTRICT src,
@@ -498,42 +531,133 @@ int zxc_compress_chunk_wrapper(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRICT
  * These thin wrappers exist only for tests and external callers that link
  * against the un-suffixed names. They forward to the default (scalar) variant.
  */
+/**
+ * @brief Build length-limited per-symbol Huffman code lengths from frequencies.
+ *
+ * Un-suffixed entry forwarding to @ref zxc_huf_build_code_lengths_default; full
+ * contract in @c zxc_internal.h.
+ *
+ * @param[in]  freq      Per-symbol frequency counts.
+ * @param[out] code_len  Per-symbol code lengths.
+ * @param[in]  scratch   Caller-provided build scratch buffer.
+ * @return `ZXC_OK` on success, negative `zxc_error_t` on failure.
+ */
 int zxc_huf_build_code_lengths(const uint32_t* RESTRICT freq, uint8_t* RESTRICT code_len,
                                void* RESTRICT scratch) {
     return zxc_huf_build_code_lengths_default(freq, code_len, scratch);
 }
 
+/**
+ * @brief Encode a full Huffman literal section (lengths header + streams).
+ *
+ * Un-suffixed entry forwarding to @ref zxc_huf_encode_section_default; full
+ * contract in @c zxc_internal.h.
+ *
+ * @param[in]  literals    Source literal bytes.
+ * @param[in]  n_literals  Number of source bytes.
+ * @param[in]  code_len    Per-symbol code lengths.
+ * @param[out] dst         Destination section buffer.
+ * @param[in]  dst_cap     Capacity of @p dst in bytes.
+ * @return Bytes written on success, negative `zxc_error_t` on failure.
+ */
 int zxc_huf_encode_section(const uint8_t* RESTRICT literals, const size_t n_literals,
                            const uint8_t* RESTRICT code_len, uint8_t* RESTRICT dst,
                            const size_t dst_cap) {
     return zxc_huf_encode_section_default(literals, n_literals, code_len, dst, dst_cap);
 }
 
+/**
+ * @brief Decode a full Huffman literal section.
+ *
+ * Un-suffixed entry forwarding to @ref zxc_huf_decode_section_default; full
+ * contract in @c zxc_internal.h.
+ *
+ * @param[in]  payload       Section payload.
+ * @param[in]  payload_size  Payload length in bytes.
+ * @param[out] dst           Destination buffer.
+ * @param[in]  n_literals    Expected number of decoded bytes.
+ * @return `ZXC_OK` on success, negative `zxc_error_t` on failure.
+ */
 int zxc_huf_decode_section(const uint8_t* RESTRICT payload, const size_t payload_size,
                            uint8_t* RESTRICT dst, const size_t n_literals) {
     return zxc_huf_decode_section_default(payload, payload_size, dst, n_literals);
 }
 
+/**
+ * @brief Encode a Huffman literal section without lengths header (shared dict table).
+ *
+ * Un-suffixed entry forwarding to @ref zxc_huf_encode_section_dict_default; full
+ * contract in @c zxc_internal.h.
+ *
+ * @param[in]  literals    Source literal bytes.
+ * @param[in]  n_literals  Number of source bytes.
+ * @param[in]  code_len    Per-symbol code lengths (from the shared dict table).
+ * @param[out] dst         Destination section buffer.
+ * @param[in]  dst_cap     Capacity of @p dst in bytes.
+ * @return Bytes written on success, negative `zxc_error_t` on failure.
+ */
 int zxc_huf_encode_section_dict(const uint8_t* RESTRICT literals, const size_t n_literals,
                                 const uint8_t* RESTRICT code_len, uint8_t* RESTRICT dst,
                                 const size_t dst_cap) {
     return zxc_huf_encode_section_dict_default(literals, n_literals, code_len, dst, dst_cap);
 }
 
+/**
+ * @brief Decode a Huffman literal section using a prebuilt shared-dict table.
+ *
+ * Un-suffixed entry forwarding to @ref zxc_huf_decode_section_dict_default; full
+ * contract in @c zxc_internal.h.
+ *
+ * @param[in]  payload       Section payload.
+ * @param[in]  payload_size  Payload length in bytes.
+ * @param[out] dst           Destination buffer.
+ * @param[in]  n_literals    Expected number of decoded bytes.
+ * @param[in]  table         Prebuilt shared-dict decode table.
+ * @return `ZXC_OK` on success, negative `zxc_error_t` on failure.
+ */
 int zxc_huf_decode_section_dict(const uint8_t* RESTRICT payload, const size_t payload_size,
                                 uint8_t* RESTRICT dst, const size_t n_literals,
                                 const zxc_huf_dec_entry_t* RESTRICT table) {
     return zxc_huf_decode_section_dict_default(payload, payload_size, dst, n_literals, table);
 }
 
+/**
+ * @brief Build the multi-symbol Huffman decode table from code lengths.
+ *
+ * Un-suffixed entry forwarding to @ref zxc_huf_build_dec_table_default; full
+ * contract in @c zxc_internal.h.
+ *
+ * @param[in]  code_len  Per-symbol code lengths.
+ * @param[out] table     Destination decode table.
+ * @return `ZXC_OK` on success, `ZXC_ERROR_CORRUPT_DATA` on invalid lengths.
+ */
 int zxc_huf_build_dec_table(const uint8_t* RESTRICT code_len, zxc_huf_dec_entry_t* RESTRICT table) {
     return zxc_huf_build_dec_table_default(code_len, table);
 }
 
+/**
+ * @brief Pack per-symbol code lengths into the 128-byte nibble header.
+ *
+ * Un-suffixed entry forwarding to @ref zxc_huf_pack_lengths_default; full
+ * contract in @c zxc_internal.h.
+ *
+ * @param[in]  code_len  Per-symbol code lengths (one byte each).
+ * @param[out] out       Destination 128-byte packed header.
+ */
 void zxc_huf_pack_lengths(const uint8_t* RESTRICT code_len, uint8_t* RESTRICT out) {
     zxc_huf_pack_lengths_default(code_len, out);
 }
 
+/**
+ * @brief Unpack and validate a 128-byte packed lengths header.
+ *
+ * Un-suffixed entry forwarding to @ref zxc_huf_unpack_lengths_default; full
+ * contract in @c zxc_internal.h.
+ *
+ * @param[in]  in        128-byte packed lengths header.
+ * @param[out] code_len  Destination per-symbol code lengths.
+ * @return `ZXC_OK` on success, `ZXC_ERROR_CORRUPT_DATA` on invalid lengths.
+ */
 int zxc_huf_unpack_lengths(const uint8_t* RESTRICT in, uint8_t* RESTRICT code_len) {
     return zxc_huf_unpack_lengths_default(in, code_len);
 }
@@ -916,6 +1040,17 @@ uint64_t zxc_get_decompressed_size(const void* src, const size_t src_size) {
     return zxc_le64(footer);
 }
 
+/**
+ * @brief Reads the dictionary id from a compressed archive's file header.
+ *
+ * Public API; see @c zxc_buffer.h. Validates the magic, then returns the
+ * header's @c dict_id field when the dictionary flag is set. Does not decompress.
+ *
+ * @param[in] src       Start of the compressed archive (>= @c ZXC_FILE_HEADER_SIZE).
+ * @param[in] src_size  Size of @p src in bytes.
+ * @return The dictionary id, or 0 if @p src is invalid or the archive uses no
+ *         dictionary.
+ */
 // cppcheck-suppress unusedFunction
 uint32_t zxc_get_dict_id(const void* src, const size_t src_size) {
     if (UNLIKELY(!src || src_size < ZXC_FILE_HEADER_SIZE)) return 0;
@@ -938,6 +1073,13 @@ uint32_t zxc_get_dict_id(const void* src, const size_t src_size) {
 
 /* --- Compression --------------------------------------------------------- */
 
+/**
+ * @brief Opaque reusable compression context (public handle @ref zxc_cctx).
+ *
+ * Wraps one internal @ref zxc_cctx_t plus the sticky options and bookkeeping
+ * needed to reuse buffers across calls and re-init only when the block size
+ * changes.
+ */
 struct zxc_cctx_s {
     zxc_cctx_t inner;       /* existing internal context */
     int initialized;        /* 1 if inner has live allocations */
@@ -951,6 +1093,18 @@ struct zxc_cctx_s {
     size_t stored_block_size;
 };
 
+/**
+ * @brief Creates a reusable compression context.
+ *
+ * Public API; full contract in @c zxc_buffer.h. With non-NULL @p opts the
+ * internal buffers are pre-allocated for the given level / block size /
+ * checksum; with NULL @p opts allocation is deferred to the first
+ * @ref zxc_compress_cctx call. The resolved settings become sticky defaults.
+ *
+ * @param[in] opts  Initial compression options, or NULL to defer allocation.
+ * @return A context to release with @ref zxc_free_cctx, or NULL on allocation
+ *         failure or invalid @p opts.
+ */
 zxc_cctx* zxc_create_cctx(const zxc_compress_opts_t* opts) {
     zxc_cctx* const cctx = (zxc_cctx*)ZXC_CALLOC(1, sizeof(zxc_cctx));
     if (UNLIKELY(!cctx)) return NULL;  // LCOV_EXCL_LINE
@@ -977,6 +1131,15 @@ zxc_cctx* zxc_create_cctx(const zxc_compress_opts_t* opts) {
     return cctx;
 }
 
+/**
+ * @brief Releases a reusable compression context.
+ *
+ * Public API; see @c zxc_buffer.h. Frees the inner buffers and the handle.
+ * NULL-safe. For a static (caller-workspace) context this is a no-op, since the
+ * caller owns the workspace.
+ *
+ * @param[in] cctx  Context from @ref zxc_create_cctx (may be NULL).
+ */
 void zxc_free_cctx(zxc_cctx* cctx) {
     if (UNLIKELY(!cctx)) return;
     /* Static cctx: handle + inner buffers live inside the caller's workspace,
@@ -986,6 +1149,23 @@ void zxc_free_cctx(zxc_cctx* cctx) {
     ZXC_FREE(cctx);
 }
 
+/**
+ * @brief Compresses a whole buffer into a framed archive, reusing @p cctx.
+ *
+ * Public API; full contract in @c zxc_buffer.h. Resolves per-call options over
+ * the context's sticky defaults, re-initialises the inner buffers only when the
+ * block size changes (level / checksum update in place), then writes the file
+ * header, the compressed blocks, the EOF block and the footer.
+ *
+ * @param[in,out] cctx          Reusable compression context.
+ * @param[in]     src           Source bytes.
+ * @param[in]     src_size      Number of source bytes (must be > 0).
+ * @param[out]    dst           Destination buffer for the archive.
+ * @param[in]     dst_capacity  Capacity of @p dst in bytes.
+ * @param[in]     opts          Per-call option overrides, or NULL for the
+ *                              context defaults.
+ * @return Archive size in bytes on success, or a negative @ref zxc_error_t.
+ */
 int64_t zxc_compress_cctx(zxc_cctx* cctx, const void* RESTRICT src, const size_t src_size,
                           void* RESTRICT dst, const size_t dst_capacity,
                           const zxc_compress_opts_t* opts) {
@@ -1083,6 +1263,12 @@ int64_t zxc_compress_cctx(zxc_cctx* cctx, const void* RESTRICT src, const size_t
 
 /* --- Decompression ------------------------------------------------------- */
 
+/**
+ * @brief Opaque reusable decompression context (public handle @ref zxc_dctx).
+ *
+ * Reuses the internal @ref zxc_cctx_t type for decode, tracking the last block
+ * and dict sizes so the inner buffers are re-carved only when they change.
+ */
 struct zxc_dctx_s {
     zxc_cctx_t inner;       /* reuses the same internal context type */
     size_t last_block_size; /* block size from last header parse */
@@ -1093,11 +1279,29 @@ struct zxc_dctx_s {
                                block_size pinned at init) */
 };
 
+/**
+ * @brief Creates a reusable decompression context.
+ *
+ * Public API; see @c zxc_buffer.h. The inner buffers are allocated lazily on
+ * the first decode (sized from the archive header), so this only allocates the
+ * handle itself.
+ *
+ * @return A context to release with @ref zxc_free_dctx, or NULL on allocation
+ *         failure.
+ */
 zxc_dctx* zxc_create_dctx(void) {
     zxc_dctx* const dctx = (zxc_dctx*)ZXC_CALLOC(1, sizeof(zxc_dctx));
     return dctx;
 }
 
+/**
+ * @brief Releases a reusable decompression context.
+ *
+ * Public API; see @c zxc_buffer.h. Frees the inner buffers and the handle.
+ * NULL-safe; a no-op for a static (caller-workspace) context.
+ *
+ * @param[in] dctx  Context from @ref zxc_create_dctx (may be NULL).
+ */
 void zxc_free_dctx(zxc_dctx* dctx) {
     if (UNLIKELY(!dctx)) return;
     /* Static dctx: handle + inner buffers live inside the caller's workspace,
@@ -1107,6 +1311,23 @@ void zxc_free_dctx(zxc_dctx* dctx) {
     ZXC_FREE(dctx);
 }
 
+/**
+ * @brief Decompresses a framed archive into @p dst, reusing @p dctx.
+ *
+ * Public API; full contract in @c zxc_buffer.h. Parses the file header,
+ * re-initialises the inner buffers only when the block size changes (or a prior
+ * dict call left a prefix), then decodes each block - straight into @p dst when
+ * the tail padding fits, otherwise through a bounce buffer - and verifies the
+ * footer size and optional checksum.
+ *
+ * @param[in,out] dctx          Reusable decompression context.
+ * @param[in]     src           Compressed archive bytes.
+ * @param[in]     src_size      Archive size (>= @c ZXC_FILE_HEADER_SIZE).
+ * @param[out]    dst           Destination for the decompressed output.
+ * @param[in]     dst_capacity  Capacity of @p dst in bytes.
+ * @param[in]     opts          Per-call options (e.g. checksum), or NULL.
+ * @return Decompressed size in bytes on success, or a negative @ref zxc_error_t.
+ */
 int64_t zxc_decompress_dctx(zxc_dctx* dctx, const void* RESTRICT src, const size_t src_size,
                             void* RESTRICT dst, const size_t dst_capacity,
                             const zxc_decompress_opts_t* opts) {
@@ -1218,6 +1439,24 @@ int64_t zxc_decompress_dctx(zxc_dctx* dctx, const void* RESTRICT src, const size
 /*  Block-Level API (no file framing)                                        */
 /* ========================================================================= */
 
+/**
+ * @brief Compresses a single block (no file framing), reusing @p cctx.
+ *
+ * Public API; full contract in @c zxc_buffer.h. Produces one format-conformant
+ * block with no header / EOF / footer, so @p src_size must not exceed
+ * @c ZXC_BLOCK_SIZE_MAX (use the frame or streaming APIs for larger inputs).
+ * With a dictionary in @p opts, [dict | block] is assembled in the cctx-owned
+ * bounce buffer before encoding. Inner buffers are re-initialised only when the
+ * effective block size changes.
+ *
+ * @param[in,out] cctx          Reusable compression context.
+ * @param[in]     src           Source block bytes.
+ * @param[in]     src_size      Source length (0 < @p src_size <= @c ZXC_BLOCK_SIZE_MAX).
+ * @param[out]    dst           Destination buffer for the block payload.
+ * @param[in]     dst_capacity  Capacity of @p dst in bytes.
+ * @param[in]     opts          Per-call options (level, dict, ...), or NULL.
+ * @return Block payload size in bytes on success, or a negative @ref zxc_error_t.
+ */
 int64_t zxc_compress_block(zxc_cctx* cctx, const void* RESTRICT src, const size_t src_size,
                            void* RESTRICT dst, const size_t dst_capacity,
                            const zxc_compress_opts_t* opts) {
@@ -1286,6 +1525,24 @@ int64_t zxc_compress_block(zxc_cctx* cctx, const void* RESTRICT src, const size_
     return (int64_t)res;
 }
 
+/**
+ * @brief Decompresses a single block (no file framing), reusing @p dctx.
+ *
+ * Public API; full contract in @c zxc_buffer.h. Decodes one format-conformant
+ * block; the decoded payload cannot exceed @c ZXC_BLOCK_SIZE_MAX, so
+ * @p dst_capacity is bounded by @c ZXC_BLOCK_SIZE_MAX + @c ZXC_DECOMPRESS_TAIL_PAD.
+ * With a dictionary in @p opts the decode runs through the [dict | decode]
+ * bounce buffer; otherwise it goes straight into @p dst when the tail padding
+ * fits, or via @c work_buf when it doesn't.
+ *
+ * @param[in,out] dctx          Reusable decompression context.
+ * @param[in]     src           Compressed block bytes.
+ * @param[in]     src_size      Source length (>= @c ZXC_BLOCK_HEADER_SIZE).
+ * @param[out]    dst           Destination for the decoded payload.
+ * @param[in]     dst_capacity  Capacity of @p dst in bytes.
+ * @param[in]     opts          Per-call options (dict, checksum), or NULL.
+ * @return Decoded payload size in bytes on success, or a negative @ref zxc_error_t.
+ */
 int64_t zxc_decompress_block(zxc_dctx* dctx, const void* RESTRICT src, const size_t src_size,
                              void* RESTRICT dst, const size_t dst_capacity,
                              const zxc_decompress_opts_t* opts) {
@@ -1363,6 +1620,16 @@ int64_t zxc_decompress_block(zxc_dctx* dctx, const void* RESTRICT src, const siz
  *
  * Dict inputs and RAW blocks route to @ref zxc_decompress_block; plain GLO/GHI
  * use the strict safe decoder (no bounce buffer, no +ZXC_DECOMPRESS_TAIL_PAD).
+ *
+ * Public API; full contract in @c zxc_buffer.h.
+ *
+ * @param[in,out] dctx          Reusable decompression context.
+ * @param[in]     src           Compressed block bytes.
+ * @param[in]     src_size      Source length (>= @c ZXC_BLOCK_HEADER_SIZE).
+ * @param[out]    dst           Destination for the decoded payload.
+ * @param[in]     dst_capacity  Exact uncompressed size (<= @c ZXC_BLOCK_SIZE_MAX).
+ * @param[in]     opts          Per-call options (dict, checksum), or NULL.
+ * @return Decoded payload size in bytes on success, or a negative @ref zxc_error_t.
  */
 int64_t zxc_decompress_block_safe(zxc_dctx* dctx, const void* RESTRICT src, const size_t src_size,
                                   void* RESTRICT dst, const size_t dst_capacity,
@@ -1427,6 +1694,17 @@ int64_t zxc_decompress_block_safe(zxc_dctx* dctx, const void* RESTRICT src, cons
 #define ZXC_STATIC_CCTX_HDR_SIZE ZXC_ALIGN_CL(sizeof(struct zxc_cctx_s))
 #define ZXC_STATIC_DCTX_HDR_SIZE ZXC_ALIGN_CL(sizeof(struct zxc_dctx_s))
 
+/**
+ * @brief Workspace size needed for a static compression context.
+ *
+ * Public API; see @c zxc_buffer.h. Sum of the cache-line-aligned handle header
+ * and the persistent buffer that @ref zxc_init_static_cctx carves for the given
+ * @p block_size / @p level. Performs no allocation.
+ *
+ * @param[in] block_size  Block size the context will be pinned to.
+ * @param[in] level       Compression level.
+ * @return Required workspace size in bytes, or 0 if the parameters are invalid.
+ */
 size_t zxc_static_cctx_workspace_size(const size_t block_size, const int level) {
     if (UNLIKELY(!zxc_validate_block_size(block_size))) return 0;
     if (UNLIKELY(level < ZXC_LEVEL_FASTEST || level > ZXC_LEVEL_DENSITY)) return 0;
@@ -1435,6 +1713,21 @@ size_t zxc_static_cctx_workspace_size(const size_t block_size, const int level) 
     return ZXC_STATIC_CCTX_HDR_SIZE + inner_sz;
 }
 
+/**
+ * @brief Initialises a compression context inside a caller-supplied workspace.
+ *
+ * Public API; full contract in @c zxc_buffer.h. Places the opaque handle at the
+ * start of @p workspace and carves the persistent buffer in the aligned tail -
+ * no heap allocation. The block size is pinned for the context's lifetime, and
+ * @ref zxc_free_cctx becomes a no-op (the caller owns @p workspace).
+ *
+ * @param[in] workspace       Caller buffer (>= @ref zxc_static_cctx_workspace_size).
+ * @param[in] workspace_size  Capacity of @p workspace in bytes.
+ * @param[in] opts            Compression options (non-NULL: level, block_size,
+ *                            checksum).
+ * @return A ready context owned by @p workspace, or NULL on invalid input or an
+ *         undersized workspace.
+ */
 zxc_cctx* zxc_init_static_cctx(void* RESTRICT workspace, const size_t workspace_size,
                                const zxc_compress_opts_t* RESTRICT opts) {
     if (UNLIKELY(!workspace || !opts)) return NULL;
@@ -1467,6 +1760,16 @@ zxc_cctx* zxc_init_static_cctx(void* RESTRICT workspace, const size_t workspace_
     return cctx;
 }
 
+/**
+ * @brief Workspace size needed for a static decompression context.
+ *
+ * Public API; see @c zxc_buffer.h. Sum of the cache-line-aligned handle header
+ * and the persistent buffer that @ref zxc_init_static_dctx carves for the given
+ * @p block_size. Performs no allocation.
+ *
+ * @param[in] block_size  Block size the context will be pinned to.
+ * @return Required workspace size in bytes, or 0 if @p block_size is invalid.
+ */
 size_t zxc_static_dctx_workspace_size(const size_t block_size) {
     if (UNLIKELY(!zxc_validate_block_size(block_size))) return 0;
     const size_t inner_sz = zxc_cctx_compute_workspace_size(block_size, 0, 0, 0);
@@ -1474,6 +1777,20 @@ size_t zxc_static_dctx_workspace_size(const size_t block_size) {
     return ZXC_STATIC_DCTX_HDR_SIZE + inner_sz;
 }
 
+/**
+ * @brief Initialises a decompression context inside a caller-supplied workspace.
+ *
+ * Public API; full contract in @c zxc_buffer.h. Places the opaque handle at the
+ * start of @p workspace and carves the persistent buffer in the aligned tail -
+ * no heap allocation. The block size is pinned, so decoded archives must match
+ * it; @ref zxc_free_dctx becomes a no-op (the caller owns @p workspace).
+ *
+ * @param[in] workspace       Caller buffer (>= @ref zxc_static_dctx_workspace_size).
+ * @param[in] workspace_size  Capacity of @p workspace in bytes.
+ * @param[in] block_size      Block size to pin the context to.
+ * @return A ready context owned by @p workspace, or NULL on invalid input or an
+ *         undersized workspace.
+ */
 zxc_dctx* zxc_init_static_dctx(void* RESTRICT workspace, const size_t workspace_size,
                                const size_t block_size) {
     if (UNLIKELY(!workspace)) return NULL;

--- a/src/lib/zxc_driver.c
+++ b/src/lib/zxc_driver.c
@@ -57,7 +57,10 @@
 #define fseeko _fseeki64
 #define ftello _ftelli64
 
-// Simple sysconf emulation to get core count
+/**
+ * @brief Returns the logical-processor count (backs the @c sysconf shim below).
+ * @return Number of processors reported by @c GetSystemInfo.
+ */
 static int zxc_get_num_procs(void) {
     SYSTEM_INFO sysinfo;
     GetSystemInfo(&sysinfo);
@@ -79,11 +82,26 @@ typedef HANDLE pthread_t;
 #define pthread_cond_signal(c) WakeConditionVariable(c)
 #define pthread_cond_broadcast(c) WakeAllConditionVariable(c)
 
+/**
+ * @brief Trampoline payload bridging the POSIX @c void*(*)(void*) worker
+ *        signature to the @c _beginthreadex entry point.
+ *
+ * Heap-allocated by the @c pthread_create shim and freed by
+ * @ref zxc_win_thread_entry once the captured worker has started.
+ */
 typedef struct {
-    void* (*func)(void*);
-    void* arg;
+    void* (*func)(void*); /* worker to invoke */
+    void* arg;            /* argument forwarded to @c func */
 } zxc_win_thread_arg_t;
 
+/**
+ * @brief @c _beginthreadex entry point: unpacks the trampoline payload, frees
+ *        it, then runs the captured POSIX-style worker.
+ *
+ * @param[in] p  Heap @ref zxc_win_thread_arg_t handed over by the creator;
+ *               ownership transfers to this function.
+ * @return Always 0 (the worker's @c void* result is discarded, as on POSIX).
+ */
 static unsigned __stdcall zxc_win_thread_entry(void* p) {
     zxc_win_thread_arg_t* a = (zxc_win_thread_arg_t*)p;
     void* (*f)(void*) = a->func;
@@ -93,6 +111,16 @@ static unsigned __stdcall zxc_win_thread_entry(void* p) {
     return 0;
 }
 
+/**
+ * @brief @c pthread_create shim: spawns @p start_routine(@p arg) via
+ *        @c _beginthreadex, matching the POSIX prototype.
+ *
+ * @param[out] thread        Receives the thread handle on success.
+ * @param[in]  attr          Unused (POSIX attribute object); ignored.
+ * @param[in]  start_routine Worker to run on the new thread.
+ * @param[in]  arg           Opaque argument forwarded to @p start_routine.
+ * @return 0 on success, @ref ZXC_ERROR_MEMORY on allocation or spawn failure.
+ */
 static int pthread_create(pthread_t* thread, const void* attr, void* (*start_routine)(void*),
                           void* arg) {
     (void)attr;
@@ -109,6 +137,14 @@ static int pthread_create(pthread_t* thread, const void* attr, void* (*start_rou
     return 0;
 }
 
+/**
+ * @brief @c pthread_join shim: blocks until @p thread finishes, then closes its
+ *        handle.
+ *
+ * @param[in] thread  Handle from a successful @c pthread_create.
+ * @param[in] retval  Unused (POSIX exit-value out-param); ignored.
+ * @return Always 0.
+ */
 static int pthread_join(pthread_t thread, void** retval) {
     (void)retval;
     WaitForSingleObject(thread, INFINITE);
@@ -568,20 +604,23 @@ static void* zxc_async_writer(void* arg) {
  * directly into `in_buf`, and the writer writes directly from `out_buf`,
  * minimizing memory copies.
  *
- * @param[in] f_in      Pointer to the input file stream (source).
- * @param[out] f_out     Pointer to the output file stream (destination).
- * @param[in] n_threads Number of worker threads to spawn. If set to 0 or less, the
- * function automatically detects the number of online processors.
- * @param[in] mode      Operation mode: 1 for compression, 0 for decompression.
- * @param[in] level     Compression level to be applied (relevant for compression
- * mode).
- * @param[in] checksum_enabled  Flag indicating whether to enable checksum
- * generation/verification.
- * @param[in] func      Function pointer to the chunk processor (compression or
- * decompression logic).
- *
- * @return The total number of bytes written to the output stream on success, or
- * -1 if an initialization or I/O error occurred.
+ * @param[in]  f_in             Input file stream (source).
+ * @param[out] f_out            Output file stream (destination).
+ * @param[in]  n_threads        Worker thread count; 0 or less auto-detects the
+ *                              number of online processors.
+ * @param[in]  mode             1 for compression, 0 for decompression.
+ * @param[in]  level            Compression level (compression mode only).
+ * @param[in]  block_size       Block size in bytes (compression mode).
+ * @param[in]  checksum_enabled Non-zero to generate / verify checksums.
+ * @param[in]  seekable         Non-zero to emit a seek table (compression mode).
+ * @param[in]  func             Chunk processor (compression or decompression).
+ * @param[in]  progress_cb      Optional progress callback, or NULL.
+ * @param[in]  user_data        Opaque pointer passed to @p progress_cb.
+ * @param[in]  dict             Optional dictionary content, or NULL.
+ * @param[in]  dict_size        Dictionary length in bytes (0 if none).
+ * @param[in]  dict_huf         Optional shared literal Huffman table, or NULL.
+ * @return Total bytes written to the output on success, or a negative
+ *         @ref zxc_error_t code.
  */
 static int64_t zxc_stream_engine_run(FILE* f_in, FILE* f_out, const int n_threads, const int mode,
                                      const int level, const size_t block_size,
@@ -971,6 +1010,19 @@ static int64_t zxc_stream_engine_run(FILE* f_in, FILE* f_out, const int n_thread
     return w_args.total_bytes;
 }
 
+/**
+ * @brief Compresses a @c FILE* stream to another @c FILE* stream.
+ *
+ * Public API; full contract in @c zxc_stream.h. Resolves the options (threads,
+ * level, block size, checksums, seekable, dictionary) with their defaults, then
+ * drives @ref zxc_stream_engine_run in compression mode with the
+ * compress chunk processor.
+ *
+ * @param[in]  f_in   Input stream (must be non-NULL).
+ * @param[out] f_out  Output stream (NULL performs a dry run / size estimate).
+ * @param[in]  opts   Compression options, or NULL for all defaults.
+ * @return Total bytes written on success, or a negative @ref zxc_error_t.
+ */
 int64_t zxc_stream_compress(FILE* f_in, FILE* f_out, const zxc_compress_opts_t* opts) {
     if (UNLIKELY(!f_in)) return ZXC_ERROR_NULL_INPUT;
 
@@ -994,6 +1046,19 @@ int64_t zxc_stream_compress(FILE* f_in, FILE* f_out, const zxc_compress_opts_t* 
                                  dict_huf);
 }
 
+/**
+ * @brief Decompresses a @c FILE* stream to another @c FILE* stream.
+ *
+ * Public API; full contract in @c zxc_stream.h. Resolves the options (threads,
+ * checksums, dictionary), then drives @ref zxc_stream_engine_run in
+ * decompression mode with the decompress chunk processor. The block size and
+ * level are recovered from the archive header, not from @p opts.
+ *
+ * @param[in]  f_in   Input (compressed) stream (must be non-NULL).
+ * @param[out] f_out  Output (decompressed) stream.
+ * @param[in]  opts   Decompression options, or NULL for all defaults.
+ * @return Total bytes written on success, or a negative @ref zxc_error_t.
+ */
 int64_t zxc_stream_decompress(FILE* f_in, FILE* f_out, const zxc_decompress_opts_t* opts) {
     if (UNLIKELY(!f_in)) return ZXC_ERROR_NULL_INPUT;
 
@@ -1010,6 +1075,18 @@ int64_t zxc_stream_decompress(FILE* f_in, FILE* f_out, const zxc_decompress_opts
                                  dict_size, dict_huf);
 }
 
+/**
+ * @brief Reads the total decompressed size from an archive's footer.
+ *
+ * Public API; see @c zxc_stream.h. Validates the file magic, reads the 64-bit
+ * decompressed-size field from the footer, and restores the caller's original
+ * stream position before returning. Does not decompress any data.
+ *
+ * @param[in] f_in  Compressed stream (must be non-NULL and seekable).
+ * @return Decompressed size in bytes, or a negative @ref zxc_error_t
+ *         (@ref ZXC_ERROR_BAD_MAGIC, @ref ZXC_ERROR_SRC_TOO_SMALL,
+ *         @ref ZXC_ERROR_IO).
+ */
 int64_t zxc_stream_get_decompressed_size(FILE* f_in) {
     if (UNLIKELY(!f_in)) return ZXC_ERROR_NULL_INPUT;
 
@@ -1059,11 +1136,24 @@ int64_t zxc_stream_get_decompressed_size(FILE* f_in) {
  */
 
 #if defined(_WIN32)
+/** @brief Reader context for the Win32 @c FILE* adapter (OS file handle + size). */
 typedef struct {
-    HANDLE handle;
-    uint64_t size;
+    HANDLE handle; /* OS handle from _get_osfhandle(_fileno(f)) */
+    uint64_t size; /* total file size in bytes */
 } zxc_stdio_ctx_t;
 
+/**
+ * @brief Thread-safe positioned read backing the seekable @c FILE* reader.
+ *
+ * Win32 implementation: a positioned @c ReadFile via @c OVERLAPPED, so
+ * concurrent worker threads never race on a shared file cursor.
+ *
+ * @param[in]  vctx    @ref zxc_stdio_ctx_t carrying the file handle.
+ * @param[out] dst     Destination buffer (at least @p len bytes).
+ * @param[in]  len     Number of bytes to read.
+ * @param[in]  offset  Absolute byte offset to read from.
+ * @return @p len on a full read, otherwise @ref ZXC_ERROR_IO.
+ */
 // LCOV_EXCL_START - Windows I/O path, not reachable on POSIX CI
 static int64_t zxc_stdio_read_at(void* vctx, void* dst, size_t len, uint64_t offset) {
     zxc_stdio_ctx_t* const ctx = (zxc_stdio_ctx_t*)vctx;
@@ -1078,11 +1168,24 @@ static int64_t zxc_stdio_read_at(void* vctx, void* dst, size_t len, uint64_t off
 // LCOV_EXCL_STOP
 
 #else  /* POSIX */
+/** @brief Reader context for the POSIX @c FILE* adapter (file descriptor + size). */
 typedef struct {
-    int fd;
-    uint64_t size;
+    int fd;        /* descriptor from fileno(f) */
+    uint64_t size; /* total file size in bytes */
 } zxc_stdio_ctx_t;
 
+/**
+ * @brief Thread-safe positioned read backing the seekable @c FILE* reader.
+ *
+ * POSIX implementation: a single @c pread, which carries its own offset and so
+ * is safe to call concurrently from multiple worker threads on one descriptor.
+ *
+ * @param[in]  vctx    @ref zxc_stdio_ctx_t carrying the file descriptor.
+ * @param[out] dst     Destination buffer (at least @p len bytes).
+ * @param[in]  len     Number of bytes to read.
+ * @param[in]  offset  Absolute byte offset to read from.
+ * @return @p len on a full read, otherwise @ref ZXC_ERROR_IO.
+ */
 static int64_t zxc_stdio_read_at(void* vctx, void* dst, size_t len, uint64_t offset) {
     zxc_stdio_ctx_t* const ctx = (zxc_stdio_ctx_t*)vctx;
     const ssize_t r = pread(ctx->fd, dst, len, (off_t)offset);
@@ -1090,6 +1193,20 @@ static int64_t zxc_stdio_read_at(void* vctx, void* dst, size_t len, uint64_t off
 }
 #endif /* _WIN32 */
 
+/**
+ * @brief Opens a seekable archive backed by an open @c FILE*.
+ *
+ * Public API; full contract in @c zxc_stream.h. Snapshots and restores the
+ * file position, measures the file, wraps it in a thread-safe positioned
+ * reader (@c pread on POSIX, @c ReadFile + @c OVERLAPPED on Windows), and
+ * delegates to @ref zxc_seekable_open_reader. The reader context is heap-owned
+ * and handed to the returned handle via @ref zxc_seekable_attach_owned_ctx, so
+ * @ref zxc_seekable_free releases it.
+ *
+ * @param[in] f  Open, seekable file handle.
+ * @return A handle to release with @ref zxc_seekable_free, or NULL on bad input,
+ *         an I/O error, or a missing / malformed seek table.
+ */
 zxc_seekable* zxc_seekable_open_file(FILE* f) {
     if (UNLIKELY(!f)) return NULL;
 

--- a/src/lib/zxc_huffman.c
+++ b/src/lib/zxc_huffman.c
@@ -85,6 +85,10 @@ typedef zxc_huf_pm_frame_t frame_t;
  *
  * Precondition: all weights are > 0 (zero-frequency symbols are filtered
  * by the caller before this runs).
+ *
+ * @param[in,out] leaves  Leaf array, sorted in place (ascending weight, then
+ *                        ascending @c sym on ties).
+ * @param[in]     n       Number of leaves; @c n < 2 is effectively a no-op.
  */
 static void pm_leaves_sort(pm_leaf_t* RESTRICT leaves, const int n) {
     /* One bucket per possible value of floor(log2(weight)) for a 32-bit
@@ -488,6 +492,11 @@ static ZXC_ALWAYS_INLINE int bw_finish(bit_writer_t* RESTRICT bw) {
  *        sub-streams, written at @p dst. The 128-byte lengths header, when
  *        wanted, is the caller's business (see the two public wrappers).
  *
+ * @param[in]  literals    Source literal bytes (must not alias @p dst).
+ * @param[in]  n_literals  Number of source bytes (must be > 0).
+ * @param[in]  code_len    Per-symbol code lengths for the canonical codes.
+ * @param[out] dst         Destination for the sizes header + sub-streams.
+ * @param[in]  dst_cap     Capacity of @p dst in bytes.
  * @return Bytes written (>= ZXC_HUF_STREAM_SIZES_HEADER_SIZE) on success,
  *         negative `zxc_error_t` code on failure.
  */
@@ -542,7 +551,18 @@ static int zxc_huf_encode_streams(const uint8_t* RESTRICT literals, const size_t
 }
 
 /**
- * @copydoc zxc_huf_encode_section
+ * @brief Encode the literal stream into a full Huffman section payload.
+ *
+ * Packs the 128-byte lengths header, then delegates to
+ * @ref zxc_huf_encode_streams for the 6-byte sub-stream sizes and the 4
+ * interleaved LSB-first bit-streams.
+ *
+ * @param[in]  literals    Source literal bytes (must not alias @p dst).
+ * @param[in]  n_literals  Number of source bytes (must be > 0).
+ * @param[in]  code_len    Per-symbol code lengths (see @ref zxc_huf_build_code_lengths).
+ * @param[out] dst         Destination buffer for the section payload.
+ * @param[in]  dst_cap     Capacity of @p dst in bytes.
+ * @return Total bytes written on success, negative `zxc_error_t` on failure.
  */
 int zxc_huf_encode_section(const uint8_t* RESTRICT literals, const size_t n_literals,
                            const uint8_t* RESTRICT code_len, uint8_t* RESTRICT dst,
@@ -558,7 +578,19 @@ int zxc_huf_encode_section(const uint8_t* RESTRICT literals, const size_t n_lite
 }
 
 /**
- * @copydoc zxc_huf_encode_section_dict
+ * @brief Encode a literal section using supplied code lengths, WITHOUT the
+ *        128-byte lengths header (shared dictionary table).
+ *
+ * Emits only the 6-byte sub-stream sizes header + 4 sub-streams (a thin pass
+ * through @ref zxc_huf_encode_streams); the lengths live in the dictionary.
+ *
+ * @param[in]  literals    Source literal bytes (must not alias @p dst).
+ * @param[in]  n_literals  Number of source bytes (must be > 0).
+ * @param[in]  code_len    Per-symbol code lengths from the shared dict table.
+ * @param[out] dst         Destination buffer for the section payload.
+ * @param[in]  dst_cap     Capacity of @p dst in bytes.
+ * @return Bytes written on success, negative `zxc_error_t` on failure
+ *         (incl. `ZXC_ERROR_CORRUPT_DATA` if a literal has no code).
  */
 int zxc_huf_encode_section_dict(const uint8_t* RESTRICT literals, const size_t n_literals,
                                 const uint8_t* RESTRICT code_len, uint8_t* RESTRICT dst,
@@ -692,6 +724,13 @@ static int build_decode_table(const uint8_t* RESTRICT code_len,
  *        @p payload and runs the 4-way interleaved decode with @p table.
  *        The 128-byte lengths header, when present, has already been consumed
  *        by the caller (see the two public wrappers).
+ *
+ * @param[in]  payload       Sizes header followed by the 4 sub-streams.
+ * @param[in]  payload_size  Size of @p payload in bytes.
+ * @param[out] dst           Destination for the decoded literals.
+ * @param[in]  n_literals    Number of literals to decode (must be > 0).
+ * @param[in]  table         Multi-symbol decode table built for this section.
+ * @return @c ZXC_OK on success, @c ZXC_ERROR_CORRUPT_DATA on a malformed stream.
  */
 static int zxc_huf_decode_streams(const uint8_t* RESTRICT payload, const size_t payload_size,
                                   uint8_t* RESTRICT dst, const size_t n_literals,
@@ -862,7 +901,16 @@ static int zxc_huf_decode_streams(const uint8_t* RESTRICT payload, const size_t 
 }
 
 /**
- * @copydoc zxc_huf_decode_section
+ * @brief Decode a full Huffman literal section payload.
+ *
+ * Unpacks the 128-byte lengths header, builds the multi-symbol decode table,
+ * then runs the 4-way interleaved decode, writing exactly @p n_literals bytes.
+ *
+ * @param[in]  payload       Section payload (lengths header + sizes + 4 sub-streams).
+ * @param[in]  payload_size  Total payload length in bytes.
+ * @param[out] dst           Destination buffer (must not alias @p payload).
+ * @param[in]  n_literals    Expected number of decoded bytes.
+ * @return `ZXC_OK` on success, negative `zxc_error_t` on failure.
  */
 int zxc_huf_decode_section(const uint8_t* RESTRICT payload, const size_t payload_size,
                            uint8_t* RESTRICT dst, const size_t n_literals) {
@@ -892,7 +940,16 @@ int zxc_huf_decode_section(const uint8_t* RESTRICT payload, const size_t payload
 }
 
 /**
- * @copydoc zxc_huf_decode_section_dict
+ * @brief Decode a literal section that carries no lengths header, using a
+ *        prebuilt decode table (shared dictionary table).
+ *
+ * @param[in]  payload       Section payload (6-byte sizes header + 4 sub-streams).
+ * @param[in]  payload_size  Total payload length in bytes.
+ * @param[out] dst           Destination buffer (must not alias @p payload).
+ * @param[in]  n_literals    Expected number of decoded bytes.
+ * @param[in]  table         Prebuilt @ref ZXC_HUF_DEC_TABLE_SIZE-entry decode table.
+ * @return `ZXC_OK` on success, `ZXC_ERROR_CORRUPT_DATA` if @p table is NULL or
+ *         the stream is malformed.
  */
 int zxc_huf_decode_section_dict(const uint8_t* RESTRICT payload, const size_t payload_size,
                                 uint8_t* RESTRICT dst, const size_t n_literals,
@@ -902,21 +959,35 @@ int zxc_huf_decode_section_dict(const uint8_t* RESTRICT payload, const size_t pa
 }
 
 /**
- * @copydoc zxc_huf_build_dec_table
+ * @brief Build the @ref ZXC_HUF_DEC_TABLE_SIZE-entry decode table from
+ *        per-symbol code lengths. Validates Kraft equality.
+ *
+ * Public wrapper around @ref build_decode_table.
+ *
+ * @param[in]  code_len  Per-symbol code lengths.
+ * @param[out] table     Destination decode table (caller-aligned).
+ * @return `ZXC_OK` on success, `ZXC_ERROR_CORRUPT_DATA` on invalid lengths.
  */
 int zxc_huf_build_dec_table(const uint8_t* RESTRICT code_len, zxc_huf_dec_entry_t* RESTRICT table) {
     return build_decode_table(code_len, table);
 }
 
 /**
- * @copydoc zxc_huf_pack_lengths
+ * @brief Pack per-symbol code lengths into the 128-byte (4-bit nibble) header.
+ *
+ * @param[in]  code_len  Per-symbol code lengths (one byte each).
+ * @param[out] out       Destination 128-byte packed header.
  */
 void zxc_huf_pack_lengths(const uint8_t* RESTRICT code_len, uint8_t* RESTRICT out) {
     pack_lengths_header(code_len, out);
 }
 
 /**
- * @copydoc zxc_huf_unpack_lengths
+ * @brief Unpack and structurally validate a 128-byte packed lengths header.
+ *
+ * @param[in]  in        128-byte packed lengths header.
+ * @param[out] code_len  Destination per-symbol code lengths.
+ * @return `ZXC_OK` on success, `ZXC_ERROR_CORRUPT_DATA` on invalid lengths.
  */
 int zxc_huf_unpack_lengths(const uint8_t* RESTRICT in, uint8_t* RESTRICT code_len) {
     return unpack_lengths_header(in, code_len);

--- a/src/lib/zxc_seekable.c
+++ b/src/lib/zxc_seekable.c
@@ -45,11 +45,27 @@
 /* Map POSIX threading primitives to Windows equivalents */
 typedef HANDLE zxc_thread_t;
 
+/**
+ * @brief Trampoline payload bridging the POSIX-style @c void*(*)(void*) worker
+ *        signature to the Win32 @c _beginthreadex entry point.
+ *
+ * Heap-allocated by @ref zxc_seek_thread_create and freed by
+ * @ref zxc_seek_thread_entry once the captured callback has started.
+ */
 typedef struct {
-    void* (*func)(void*);
-    void* arg;
+    void* (*func)(void*); /* worker to invoke */
+    void* arg;            /* argument forwarded to @c func */
 } zxc_seek_thread_arg_t;
 
+/**
+ * @brief @c _beginthreadex entry point: unpacks the trampoline payload, frees
+ *        it, then runs the captured POSIX-style worker.
+ *
+ * @param[in] p  Heap @ref zxc_seek_thread_arg_t handed over by the creator;
+ *               ownership transfers to this function.
+ * @return Always 0 (the worker's @c void* result is discarded, matching the
+ *         POSIX path which also ignores it).
+ */
 static unsigned __stdcall zxc_seek_thread_entry(void* p) {
     zxc_seek_thread_arg_t* a = (zxc_seek_thread_arg_t*)p;
     void* (*f)(void*) = a->func;
@@ -59,6 +75,18 @@ static unsigned __stdcall zxc_seek_thread_entry(void* p) {
     return 0;
 }
 
+/**
+ * @brief Spawns a thread running @p fn(@p arg), abstracting @c _beginthreadex.
+ *
+ * Allocates a @ref zxc_seek_thread_arg_t trampoline so the Win32 entry-point
+ * signature can carry a POSIX-style worker; the trampoline is freed by the
+ * thread itself (or here, on a launch failure).
+ *
+ * @param[out] t    Receives the created thread handle on success.
+ * @param[in]  fn   Worker to run on the new thread.
+ * @param[in]  arg  Opaque argument forwarded to @p fn.
+ * @return 0 on success, @ref ZXC_ERROR_MEMORY on allocation or spawn failure.
+ */
 static int zxc_seek_thread_create(zxc_thread_t* t, void* (*fn)(void*), void* arg) {
     zxc_seek_thread_arg_t* wrapper = ZXC_MALLOC(sizeof(zxc_seek_thread_arg_t));
     if (UNLIKELY(!wrapper)) return ZXC_ERROR_MEMORY;
@@ -73,11 +101,19 @@ static int zxc_seek_thread_create(zxc_thread_t* t, void* (*fn)(void*), void* arg
     return 0;
 }
 
+/**
+ * @brief Blocks until thread @p t finishes, then releases its handle.
+ * @param[in] t  Handle from a successful @ref zxc_seek_thread_create.
+ */
 static void zxc_seek_thread_join(zxc_thread_t t) {
     WaitForSingleObject(t, INFINITE);
     CloseHandle(t);
 }
 
+/**
+ * @brief Returns the number of logical processors reported by the OS.
+ * @return Online processor count (always >= 1 in practice).
+ */
 static int zxc_seek_get_num_procs(void) {
     SYSTEM_INFO si;
     GetSystemInfo(&si);
@@ -91,12 +127,27 @@ static int zxc_seek_get_num_procs(void) {
 
 typedef pthread_t zxc_thread_t;
 
+/**
+ * @brief Spawns a thread running @p fn(@p arg) via @c pthread_create.
+ * @param[out] t    Receives the created thread handle on success.
+ * @param[in]  fn   Worker to run on the new thread.
+ * @param[in]  arg  Opaque argument forwarded to @p fn.
+ * @return 0 on success, @ref ZXC_ERROR_MEMORY if the thread cannot be created.
+ */
 static int zxc_seek_thread_create(zxc_thread_t* t, void* (*fn)(void*), void* arg) {
     return pthread_create(t, NULL, fn, arg) == 0 ? 0 : ZXC_ERROR_MEMORY;
 }
 
+/**
+ * @brief Blocks until thread @p t finishes (its @c void* result is discarded).
+ * @param[in] t  Handle from a successful @ref zxc_seek_thread_create.
+ */
 static void zxc_seek_thread_join(zxc_thread_t t) { pthread_join(t, NULL); }
 
+/**
+ * @brief Returns the number of online logical processors.
+ * @return @c _SC_NPROCESSORS_ONLN, clamped to a minimum of 1 if the query fails.
+ */
 static int zxc_seek_get_num_procs(void) {
     const long n = sysconf(_SC_NPROCESSORS_ONLN);
     return (n > 0) ? (int)n : 1;
@@ -108,10 +159,34 @@ static int zxc_seek_get_num_procs(void) {
 /*  Seek Table Writer                                                        */
 /* ========================================================================= */
 
+/**
+ * @brief Byte size of a seek table holding @p num_blocks entries.
+ *
+ * Public API (declared in @c zxc_seekable.h): one block header plus
+ * @p num_blocks fixed-size entries. Use it to size the destination buffer
+ * before @ref zxc_write_seek_table.
+ *
+ * @param[in] num_blocks  Number of block entries the table will hold.
+ * @return Total table size in bytes (block header + entries).
+ */
 size_t zxc_seek_table_size(const uint32_t num_blocks) {
     return ZXC_BLOCK_HEADER_SIZE + (size_t)num_blocks * ZXC_SEEK_ENTRY_SIZE;
 }
 
+/**
+ * @brief Serialises a seek table (a @c ZXC_BLOCK_SEK block) into @p dst.
+ *
+ * Public API; full contract in @c zxc_seekable.h. Emits the standard ZXC block
+ * header followed by one little-endian @c u32 compressed-size entry per block.
+ *
+ * @param[out] dst           Destination buffer.
+ * @param[in]  dst_capacity  Capacity of @p dst in bytes.
+ * @param[in]  comp_sizes    Array of @p num_blocks compressed block sizes.
+ * @param[in]  num_blocks    Number of blocks (and entries) to write.
+ * @return Bytes written on success, or a negative @ref zxc_error_t
+ *         (@ref ZXC_ERROR_OVERFLOW, @ref ZXC_ERROR_DST_TOO_SMALL,
+ *         @ref ZXC_ERROR_NULL_INPUT).
+ */
 int64_t zxc_write_seek_table(uint8_t* dst, const size_t dst_capacity, const uint32_t* comp_sizes,
                              const uint32_t num_blocks) {
     if (UNLIKELY(num_blocks > UINT32_MAX / ZXC_SEEK_ENTRY_SIZE)) return ZXC_ERROR_OVERFLOW;
@@ -190,6 +265,11 @@ struct zxc_seekable_s {
  *   3. Derive num_blocks = ceil(total_decomp_size / block_size)
  *   4. Compute expected seek block position, validate block_type == SEK
  *   5. Read comp_sizes; derive decomp_sizes from block_size
+ *
+ * @param[in] data       Pointer to the whole in-memory archive.
+ * @param[in] data_size  Archive size in bytes.
+ * @return A newly allocated handle (free via @ref zxc_seekable_free), or NULL
+ *         if the buffer is too small or the seek table is missing / malformed.
  */
 static zxc_seekable* zxc_seekable_parse(const uint8_t* data, const size_t data_size) {
     /* Minimum: file_header(16) + eof_block(8) + seek_block_header(8)
@@ -311,6 +391,17 @@ static zxc_seekable* zxc_seekable_parse(const uint8_t* data, const size_t data_s
     return s;
 }
 
+/**
+ * @brief Opens a seekable archive held entirely in a memory buffer.
+ *
+ * Public API; see @c zxc_seekable.h. Thin guard around
+ * @ref zxc_seekable_parse, which detects and validates the trailing seek table.
+ *
+ * @param[in] src       Pointer to the whole compressed archive.
+ * @param[in] src_size  Archive size in bytes.
+ * @return A handle to release with @ref zxc_seekable_free, or NULL on bad input
+ *         or a missing / malformed seek table.
+ */
 zxc_seekable* zxc_seekable_open(const void* src, const size_t src_size) {
     if (UNLIKELY(!src || src_size == 0)) return NULL;
     return zxc_seekable_parse((const uint8_t*)src, src_size);
@@ -321,6 +412,19 @@ zxc_seekable* zxc_seekable_open(const void* src, const size_t src_size) {
  * zxc_seekable_open_reader below, keeping this translation unit free of any
  * <stdio.h> dependency. */
 
+/**
+ * @brief Opens a seekable archive over a caller-supplied random-access reader.
+ *
+ * Public API; see @c zxc_seekable.h. Reads the file header, footer and seek
+ * block through @p r->read_at (the FILE* variant wraps @c pread this way),
+ * validates the SEK block, and builds the per-block compressed-offset prefix
+ * sums. Unlike @ref zxc_seekable_open the archive is never mapped whole; only
+ * the metadata is read up front.
+ *
+ * @param[in] r  Reader descriptor (@c read_at and @c size must be set).
+ * @return A handle to release with @ref zxc_seekable_free, or NULL on bad input,
+ *         a short read, or a malformed seek table.
+ */
 zxc_seekable* zxc_seekable_open_reader(const zxc_reader_t* r) {
     if (UNLIKELY(!r || !r->read_at || r->size == 0)) return NULL;
 
@@ -445,17 +549,45 @@ zxc_seekable* zxc_seekable_open_reader(const zxc_reader_t* r) {
     return s;
 }
 
+/**
+ * @brief Number of blocks in the archive.
+ * @param[in] s  Seekable handle (may be NULL).
+ * @return Block count, or 0 if @p s is NULL.
+ */
 uint32_t zxc_seekable_get_num_blocks(const zxc_seekable* s) { return s ? s->num_blocks : 0; }
 
+/**
+ * @brief Total decompressed size of the archive.
+ * @param[in] s  Seekable handle (may be NULL).
+ * @return Decompressed size in bytes, or 0 if @p s is NULL.
+ */
 uint64_t zxc_seekable_get_decompressed_size(const zxc_seekable* s) {
     return s ? s->total_decomp : 0;
 }
 
+/**
+ * @brief Compressed byte size of a given block.
+ * @param[in] s          Seekable handle (may be NULL).
+ * @param[in] block_idx  Zero-based block index.
+ * @return Compressed size in bytes, or 0 if @p s is NULL or @p block_idx is
+ *         out of range.
+ */
 uint32_t zxc_seekable_get_block_comp_size(const zxc_seekable* s, const uint32_t block_idx) {
     if (UNLIKELY(!s || block_idx >= s->num_blocks)) return 0;
     return s->comp_sizes[block_idx];
 }
 
+/**
+ * @brief Decompressed byte size of a given block.
+ *
+ * Every block decompresses to @c block_size except the last, which holds the
+ * remainder of @c total_decomp.
+ *
+ * @param[in] s          Seekable handle (may be NULL).
+ * @param[in] block_idx  Zero-based block index.
+ * @return Decompressed size in bytes, or 0 if @p s is NULL or @p block_idx is
+ *         out of range.
+ */
 uint32_t zxc_seekable_get_block_decomp_size(const zxc_seekable* s, const uint32_t block_idx) {
     if (UNLIKELY(!s || block_idx >= s->num_blocks)) return 0;
     const uint64_t start = (uint64_t)block_idx * (uint64_t)s->block_size;
@@ -467,17 +599,37 @@ uint32_t zxc_seekable_get_block_decomp_size(const zxc_seekable* s, const uint32_
 /*  Random-Access Decompression                                              */
 /* ========================================================================= */
 
-/** @brief O(1) block lookup: block_index = offset / block_size. */
+/**
+ * @brief Maps a decompressed @p offset to its containing block index (O(1)).
+ * @param[in] block_size  Fixed decompressed block size (a power of two).
+ * @param[in] offset      Absolute decompressed byte offset.
+ * @return Zero-based index of the block that holds @p offset.
+ */
 static uint32_t zxc_seek_find_block(const uint32_t block_size, const uint64_t offset) {
     return (uint32_t)(offset / (uint64_t)block_size);
 }
 
-/** @brief O(1) decompressed offset for block @p idx. */
+/**
+ * @brief Decompressed start offset of block @p idx (O(1)).
+ * @param[in] block_size  Fixed decompressed block size.
+ * @param[in] idx         Zero-based block index.
+ * @return Absolute decompressed byte offset where block @p idx begins.
+ */
 static uint64_t zxc_seek_decomp_offset(const uint32_t block_size, const uint32_t idx) {
     return (uint64_t)idx * (uint64_t)block_size;
 }
 
-/** @brief O(1) decompressed size for block @p idx. */
+/**
+ * @brief Decompressed size of block @p idx (O(1)).
+ *
+ * Returns @p block_size for every block except the last, which holds the
+ * remainder of @p total_decomp.
+ *
+ * @param[in] block_size    Fixed decompressed block size.
+ * @param[in] total_decomp  Total decompressed archive size.
+ * @param[in] idx           Zero-based block index.
+ * @return Decompressed byte size of block @p idx.
+ */
 static uint32_t zxc_seek_decomp_size(const uint32_t block_size, const uint64_t total_decomp,
                                      const uint32_t idx) {
     const uint64_t start = (uint64_t)idx * (uint64_t)block_size;
@@ -486,7 +638,18 @@ static uint32_t zxc_seek_decomp_size(const uint32_t block_size, const uint64_t t
 }
 
 /**
- * @brief Reads a compressed block from buffer or file.
+ * @brief Reads a compressed block into @p buf from the memory buffer or reader.
+ *
+ * Single-threaded path: copies from @c s->src in buffer mode, otherwise calls
+ * @c s->reader.read_at (which also backs the FILE* variant).
+ *
+ * @param[in]  s          Seekable handle.
+ * @param[in]  block_idx  Zero-based block index to read.
+ * @param[out] buf        Destination buffer.
+ * @param[in]  buf_cap    Capacity of @p buf in bytes.
+ * @return The block's compressed byte count on success, or a negative
+ *         @ref zxc_error_t (@ref ZXC_ERROR_DST_TOO_SMALL,
+ *         @ref ZXC_ERROR_SRC_TOO_SMALL, @ref ZXC_ERROR_IO).
  */
 static int zxc_seek_read_block(const zxc_seekable* s, const uint32_t block_idx, uint8_t* buf,
                                const size_t buf_cap) {
@@ -509,6 +672,22 @@ static int zxc_seek_read_block(const zxc_seekable* s, const uint32_t block_idx, 
     return (int)csz;
 }
 
+/**
+ * @brief Decompresses the byte range [@p offset, @p offset + @p len) into @p dst.
+ *
+ * Public API; full contract in @c zxc_seekable.h. Maps the range to its block
+ * span via O(1) division, decodes each covered block through a reusable,
+ * lazily-initialised, dictionary-aware context, and copies out only the
+ * requested sub-range. Single-threaded; see @ref zxc_seekable_decompress_range_mt
+ * for the parallel variant.
+ *
+ * @param[in,out] s             Seekable handle (carries the reusable context).
+ * @param[out]    dst           Destination buffer.
+ * @param[in]     dst_capacity  Capacity of @p dst (must be >= @p len).
+ * @param[in]     offset        Absolute decompressed start offset.
+ * @param[in]     len           Number of decompressed bytes to produce.
+ * @return @p len on success, or a negative @ref zxc_error_t.
+ */
 int64_t zxc_seekable_decompress_range(zxc_seekable* s, void* dst, const size_t dst_capacity,
                                       const uint64_t offset, const size_t len) {
     if (UNLIKELY(len == 0)) return 0;
@@ -622,7 +801,18 @@ typedef struct {
 } zxc_seek_mt_job_t;
 
 /**
- * @brief Thread-safe block read using pread (for file mode) or memcpy (buffer mode).
+ * @brief Thread-safe block read backing the multi-threaded path.
+ *
+ * Like @ref zxc_seek_read_block but safe to call concurrently: buffer mode uses
+ * @c memcpy on const data, reader mode relies on a positioned (pread-style)
+ * callback that carries its own offset.
+ *
+ * @param[in]  s          Seekable handle (read-only).
+ * @param[in]  block_idx  Zero-based block index to read.
+ * @param[out] buf        Destination buffer.
+ * @param[in]  buf_cap    Capacity of @p buf in bytes.
+ * @return The block's compressed byte count on success, or a negative
+ *         @ref zxc_error_t.
  */
 static int zxc_seek_read_block_mt(const zxc_seekable* s, const uint32_t block_idx, uint8_t* buf,
                                   const size_t buf_cap) {
@@ -654,6 +844,12 @@ static int zxc_seek_read_block_mt(const zxc_seekable* s, const uint32_t block_id
  *   2. Reads the compressed block via pread (thread-safe).
  *   3. Decompresses into a local work buffer.
  *   4. Copies the requested sub-range into the caller's output buffer.
+ *
+ * The outcome is written into @c job->result; the main thread reads it after
+ * join.
+ *
+ * @param[in,out] arg  Pointer to this worker's @ref zxc_seek_mt_job_t.
+ * @return Always NULL (the result code is reported via @c job->result).
  */
 static void* zxc_seek_mt_worker(void* arg) {
     zxc_seek_mt_job_t* const job = (zxc_seek_mt_job_t*)arg;
@@ -728,6 +924,22 @@ static void* zxc_seek_mt_worker(void* arg) {
     return NULL;
 }
 
+/**
+ * @brief Multi-threaded variant of @ref zxc_seekable_decompress_range.
+ *
+ * Public API; full contract in @c zxc_seekable.h. Plans one job per covered
+ * block (each with its own thread-local context and read buffer) and runs them
+ * fork-join in waves of up to @p n_threads. Falls back to the single-threaded
+ * path for trivial spans. @p n_threads == 0 auto-detects the core count.
+ *
+ * @param[in,out] s             Seekable handle (read-only during the parallel phase).
+ * @param[out]    dst           Destination buffer.
+ * @param[in]     dst_capacity  Capacity of @p dst (must be >= @p len).
+ * @param[in]     offset        Absolute decompressed start offset.
+ * @param[in]     len           Number of decompressed bytes to produce.
+ * @param[in]     n_threads     Worker thread count; 0 = auto-detect.
+ * @return @p len on success, or the first negative @ref zxc_error_t observed.
+ */
 int64_t zxc_seekable_decompress_range_mt(zxc_seekable* s, void* dst, const size_t dst_capacity,
                                          const uint64_t offset, const size_t len, int n_threads) {
     if (UNLIKELY(len == 0)) return 0;
@@ -849,6 +1061,15 @@ int64_t zxc_seekable_decompress_range_mt(zxc_seekable* s, void* dst, const size_
     return result;
 }
 
+/**
+ * @brief Releases a seekable handle and every resource it owns.
+ *
+ * Public API; see @c zxc_seekable.h. Tears down the reusable context, the seek
+ * arrays (comp sizes / offsets), the owned dictionary copy and any attached
+ * reader context. NULL-safe.
+ *
+ * @param[in] s  Seekable handle to release (may be NULL).
+ */
 void zxc_seekable_free(zxc_seekable* s) {
     if (!s) return;
     if (s->dctx_initialized) zxc_cctx_free(&s->dctx);
@@ -859,6 +1080,21 @@ void zxc_seekable_free(zxc_seekable* s) {
     ZXC_FREE(s);
 }
 
+/**
+ * @brief Installs the dictionary needed to decode a dict-compressed archive.
+ *
+ * Public API; full contract in @c zxc_seekable.h. Validates the dict_id against
+ * the file header, then takes an owned copy of @p dict (and the optional shared
+ * literal Huffman table @p dict_huf). Drops any context already built so the
+ * [dict | decode] bounce buffer is re-carved on the next decompress.
+ *
+ * @param[in,out] s          Seekable handle.
+ * @param[in]     dict       Dictionary bytes.
+ * @param[in]     dict_size  Dictionary length (<= @c ZXC_DICT_SIZE_MAX).
+ * @param[in]     dict_huf   Optional shared literal Huffman table, or NULL.
+ * @return @ref ZXC_OK, or a negative @ref zxc_error_t
+ *         (@ref ZXC_ERROR_DICT_TOO_LARGE, @ref ZXC_ERROR_DICT_MISMATCH, ...).
+ */
 int zxc_seekable_set_dict(zxc_seekable* s, const void* dict, const size_t dict_size,
                           const void* dict_huf) {
     if (UNLIKELY(!s || !dict || dict_size == 0)) return ZXC_ERROR_NULL_INPUT;
@@ -891,6 +1127,17 @@ int zxc_seekable_set_dict(zxc_seekable* s, const void* dict, const size_t dict_s
     return ZXC_OK;
 }
 
+/**
+ * @brief Transfers ownership of a heap reader context to the handle.
+ *
+ * Cross-TU hook (declared in @c zxc_internal.h): @p ctx is released via
+ * @c ZXC_FREE when @ref zxc_seekable_free runs. Used by
+ * @ref zxc_seekable_open_file so its allocated reader state outlives the open
+ * call. NULL-safe on @p s.
+ *
+ * @param[in,out] s    Seekable handle (may be NULL).
+ * @param[in]     ctx  Heap pointer to hand over; freed by @ref zxc_seekable_free.
+ */
 void zxc_seekable_attach_owned_ctx(zxc_seekable* s, void* ctx) {
     if (s) s->owned_reader_ctx = ctx;
 }


### PR DESCRIPTION
Systematically converts block comments to Doxygen format and expands @copydoc directives into complete @brief, @param, and @return descriptions.
This improves clarity and completeness for both public and internal APIs.
