### PR TITLE
Refines code quality and addresses warnings

### DIFF
--- a/src/cli/main.c
+++ b/src/cli/main.c
@@ -77,6 +77,7 @@ int optopt = 0;
  */
 static int getopt_long(int argc, char* const argv[], const char* optstring,
                        const struct option* longopts, int* longindex) {
+    (void)longindex;
     if (optind >= argc) return -1;
     char* curr = argv[optind];
     if (curr[0] == '-' && curr[1] == '-') {
@@ -532,6 +533,7 @@ typedef struct {
  */
 static void cli_progress_callback(uint64_t bytes_processed, uint64_t bytes_total,
                                   const void* user_data) {
+    (void)bytes_total; /* required by zxc_progress_callback_t */
     const progress_ctx_t* pctx = (const progress_ctx_t*)user_data;
 
     if (!pctx) return;
@@ -930,12 +932,10 @@ static int process_single_file(const char* in_path, const char* out_path_overrid
         if (mode == MODE_COMPRESS) {
             // Compression: get input file size
             const long long saved_pos = ftello(f_in);
-            if (saved_pos >= 0) {
-                if (fseeko(f_in, 0, SEEK_END) == 0) {
-                    const long long size = ftello(f_in);
-                    if (size > 0) total_size = (uint64_t)size;
-                    fseeko(f_in, saved_pos, SEEK_SET);
-                }
+            if (saved_pos >= 0 && fseeko(f_in, 0, SEEK_END) == 0) {
+                const long long size = ftello(f_in);
+                if (size > 0) total_size = (uint64_t)size;
+                fseeko(f_in, saved_pos, SEEK_SET);
             }
         } else {
             // Decompression: get decompressed size from footer (BEFORE starting decompression)

--- a/src/lib/zxc_compress.c
+++ b/src/lib/zxc_compress.c
@@ -1623,8 +1623,7 @@ parse_done:;
                 streams_bytes += (size_t)((bits + 7) / 8);
             }
             huf_total_size = ZXC_HUF_HEADER_SIZE + streams_bytes;
-            const size_t baseline =
-                (enc_lit == ZXC_SECTION_ENCODING_RLE) ? rle_size : (size_t)lit_c;
+            const size_t baseline = (enc_lit == ZXC_SECTION_ENCODING_RLE) ? rle_size : lit_c;
             /* Threshold: 3% savings (1/32) over the chosen RAW/RLE baseline.
              * Same heuristic as the RAW/RLE switch above. */
             if (huf_total_size < baseline - (baseline >> 5)) {
@@ -1667,8 +1666,7 @@ parse_done:;
                 if (huf_dict_total_size < huf_total_size)
                     enc_lit = ZXC_SECTION_ENCODING_HUFFMAN_DICT;
             } else {
-                const size_t baseline =
-                    (enc_lit == ZXC_SECTION_ENCODING_RLE) ? rle_size : (size_t)lit_c;
+                const size_t baseline = (enc_lit == ZXC_SECTION_ENCODING_RLE) ? rle_size : lit_c;
                 /* Same 3% (1/32) margin as the other encoding switches. */
                 if (huf_dict_total_size < baseline - (baseline >> 5))
                     enc_lit = ZXC_SECTION_ENCODING_HUFFMAN_DICT;
@@ -1696,7 +1694,7 @@ parse_done:;
                                     : (enc_lit == ZXC_SECTION_ENCODING_HUFFMAN) ? huf_total_size
                                     : (enc_lit == ZXC_SECTION_ENCODING_HUFFMAN_DICT)
                                         ? huf_dict_total_size
-                                        : (size_t)lit_c;
+                                        : lit_c;
     desc[0].sizes = (uint64_t)lit_section_size | ((uint64_t)lit_c << 32);
     desc[1].sizes = (uint64_t)seq_c | ((uint64_t)seq_c << 32);
     desc[2].sizes = (uint64_t)off_stream_size | ((uint64_t)off_stream_size << 32);
@@ -1717,14 +1715,13 @@ parse_done:;
     if (UNLIKELY(rem < sz_lit)) return ZXC_ERROR_DST_TOO_SMALL;
 
     if (enc_lit == ZXC_SECTION_ENCODING_HUFFMAN) {
-        const int written =
-            zxc_huf_encode_section(literals, (size_t)lit_c, huf_code_len, p_curr, rem);
+        const int written = zxc_huf_encode_section(literals, lit_c, huf_code_len, p_curr, rem);
         if (UNLIKELY(written < 0)) return written;
         if (UNLIKELY((size_t)written != huf_total_size)) return ZXC_ERROR_DST_TOO_SMALL;
         p_curr += written;
     } else if (enc_lit == ZXC_SECTION_ENCODING_HUFFMAN_DICT) {
         const int written =
-            zxc_huf_encode_section_dict(literals, (size_t)lit_c, dict_code_len, p_curr, rem);
+            zxc_huf_encode_section_dict(literals, lit_c, dict_code_len, p_curr, rem);
         if (UNLIKELY(written < 0)) return written;
         if (UNLIKELY((size_t)written != huf_dict_total_size)) return ZXC_ERROR_DST_TOO_SMALL;
         p_curr += written;

--- a/src/lib/zxc_decompress.c
+++ b/src/lib/zxc_decompress.c
@@ -1290,7 +1290,7 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(const zxc_cctx_t* RESTRIC
             uint32_t s4 = zxc_le32(seq_ptr + 3 * sizeof(uint32_t));
             seq_ptr += 4 * sizeof(uint32_t);
 
-            uint64_t ll1 = (uint32_t)(s1 >> 24);
+            uint64_t ll1 = s1 >> 24;
             if (UNLIKELY(ll1 == ZXC_SEQ_LL_MASK)) {
                 ll1 += zxc_read_varint(&extras_ptr, extras_end);
                 const uint64_t reserve = (s2 >> 24) + (s3 >> 24) + (s4 >> 24);
@@ -1298,7 +1298,7 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(const zxc_cctx_t* RESTRIC
                              ll1 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
                     goto rollback_safe_4x;
             }
-            uint32_t m1b = (uint32_t)((s1 >> 16) & 0xFF);
+            uint32_t m1b = (s1 >> 16) & 0xFF;
             uint64_t ml1 = m1b + ZXC_LZ_MIN_MATCH_LEN;
             if (UNLIKELY(m1b == ZXC_SEQ_ML_MASK)) {
                 ml1 += zxc_read_varint(&extras_ptr, extras_end);
@@ -1306,10 +1306,10 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(const zxc_cctx_t* RESTRIC
                              (size_t)(d_end - d_ptr)))
                     goto rollback_safe_4x;
             }
-            uint32_t off1 = (uint32_t)(s1 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
+            uint32_t off1 = (s1 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
             DECODE_SEQ_SAFE(ll1, ml1, off1);
 
-            uint64_t ll2 = (uint32_t)(s2 >> 24);
+            uint64_t ll2 = s2 >> 24;
             if (UNLIKELY(ll2 == ZXC_SEQ_LL_MASK)) {
                 ll2 += zxc_read_varint(&extras_ptr, extras_end);
                 const uint64_t reserve = (s3 >> 24) + (s4 >> 24);
@@ -1317,7 +1317,7 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(const zxc_cctx_t* RESTRIC
                              ll2 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
                     goto rollback_safe_4x;
             }
-            uint32_t m2b = (uint32_t)((s2 >> 16) & 0xFF);
+            uint32_t m2b = (s2 >> 16) & 0xFF;
             uint64_t ml2 = m2b + ZXC_LZ_MIN_MATCH_LEN;
             if (UNLIKELY(m2b == ZXC_SEQ_ML_MASK)) {
                 ml2 += zxc_read_varint(&extras_ptr, extras_end);
@@ -1325,10 +1325,10 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(const zxc_cctx_t* RESTRIC
                              (size_t)(d_end - d_ptr)))
                     goto rollback_safe_4x;
             }
-            uint32_t off2 = (uint32_t)(s2 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
+            uint32_t off2 = (s2 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
             DECODE_SEQ_SAFE(ll2, ml2, off2);
 
-            uint64_t ll3 = (uint32_t)(s3 >> 24);
+            uint64_t ll3 = s3 >> 24;
             if (UNLIKELY(ll3 == ZXC_SEQ_LL_MASK)) {
                 ll3 += zxc_read_varint(&extras_ptr, extras_end);
                 const uint64_t reserve = (s4 >> 24);
@@ -1336,7 +1336,7 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(const zxc_cctx_t* RESTRIC
                              ll3 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
                     goto rollback_safe_4x;
             }
-            uint32_t m3b = (uint32_t)((s3 >> 16) & 0xFF);
+            uint32_t m3b = (s3 >> 16) & 0xFF;
             uint64_t ml3 = m3b + ZXC_LZ_MIN_MATCH_LEN;
             if (UNLIKELY(m3b == ZXC_SEQ_ML_MASK)) {
                 ml3 += zxc_read_varint(&extras_ptr, extras_end);
@@ -1344,24 +1344,24 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(const zxc_cctx_t* RESTRIC
                              (size_t)(d_end - d_ptr)))
                     goto rollback_safe_4x;
             }
-            uint32_t off3 = (uint32_t)(s3 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
+            uint32_t off3 = (s3 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
             DECODE_SEQ_SAFE(ll3, ml3, off3);
 
-            uint64_t ll4 = (uint32_t)(s4 >> 24);
+            uint64_t ll4 = s4 >> 24;
             if (UNLIKELY(ll4 == ZXC_SEQ_LL_MASK)) {
                 ll4 += zxc_read_varint(&extras_ptr, extras_end);
                 if (UNLIKELY(ll4 > (size_t)(l_end - l_ptr) ||
                              ll4 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
                     goto rollback_safe_4x;
             }
-            uint32_t m4b = (uint32_t)((s4 >> 16) & 0xFF);
+            uint32_t m4b = (s4 >> 16) & 0xFF;
             uint64_t ml4 = m4b + ZXC_LZ_MIN_MATCH_LEN;
             if (UNLIKELY(m4b == ZXC_SEQ_ML_MASK)) {
                 ml4 += zxc_read_varint(&extras_ptr, extras_end);
                 if (UNLIKELY(ll4 + ml4 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
                     goto rollback_safe_4x;
             }
-            uint32_t off4 = (uint32_t)(s4 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
+            uint32_t off4 = (s4 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
             DECODE_SEQ_SAFE(ll4, ml4, off4);
 
             n_seq -= 4;
@@ -1384,7 +1384,7 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(const zxc_cctx_t* RESTRIC
             uint32_t s4 = zxc_le32(seq_ptr + 3 * sizeof(uint32_t));
             seq_ptr += 4 * sizeof(uint32_t);
 
-            uint64_t ll1 = (uint32_t)(s1 >> 24);
+            uint64_t ll1 = s1 >> 24;
             if (UNLIKELY(ll1 == ZXC_SEQ_LL_MASK)) {
                 ll1 += zxc_read_varint(&extras_ptr, extras_end);
                 const uint64_t reserve = (s2 >> 24) + (s3 >> 24) + (s4 >> 24);
@@ -1392,7 +1392,7 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(const zxc_cctx_t* RESTRIC
                              ll1 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
-            uint32_t m1b = (uint32_t)((s1 >> 16) & 0xFF);
+            uint32_t m1b = (s1 >> 16) & 0xFF;
             uint64_t ml1 = m1b + ZXC_LZ_MIN_MATCH_LEN;
             if (UNLIKELY(m1b == ZXC_SEQ_ML_MASK)) {
                 ml1 += zxc_read_varint(&extras_ptr, extras_end);
@@ -1400,10 +1400,10 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(const zxc_cctx_t* RESTRIC
                              (size_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
-            uint32_t off1 = (uint32_t)(s1 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
+            uint32_t off1 = (s1 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
             DECODE_SEQ_SAFE(ll1, ml1, off1);
 
-            uint64_t ll2 = (uint32_t)(s2 >> 24);
+            uint64_t ll2 = s2 >> 24;
             if (UNLIKELY(ll2 == ZXC_SEQ_LL_MASK)) {
                 ll2 += zxc_read_varint(&extras_ptr, extras_end);
                 const uint64_t reserve = (s3 >> 24) + (s4 >> 24);
@@ -1411,7 +1411,7 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(const zxc_cctx_t* RESTRIC
                              ll2 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
-            uint32_t m2b = (uint32_t)((s2 >> 16) & 0xFF);
+            uint32_t m2b = (s2 >> 16) & 0xFF;
             uint64_t ml2 = m2b + ZXC_LZ_MIN_MATCH_LEN;
             if (UNLIKELY(m2b == ZXC_SEQ_ML_MASK)) {
                 ml2 += zxc_read_varint(&extras_ptr, extras_end);
@@ -1419,10 +1419,10 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(const zxc_cctx_t* RESTRIC
                              (size_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
-            uint32_t off2 = (uint32_t)(s2 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
+            uint32_t off2 = (s2 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
             DECODE_SEQ_SAFE(ll2, ml2, off2);
 
-            uint64_t ll3 = (uint32_t)(s3 >> 24);
+            uint64_t ll3 = s3 >> 24;
             if (UNLIKELY(ll3 == ZXC_SEQ_LL_MASK)) {
                 ll3 += zxc_read_varint(&extras_ptr, extras_end);
                 const uint64_t reserve = (s4 >> 24);
@@ -1430,7 +1430,7 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(const zxc_cctx_t* RESTRIC
                              ll3 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
-            uint32_t m3b = (uint32_t)((s3 >> 16) & 0xFF);
+            uint32_t m3b = (s3 >> 16) & 0xFF;
             uint64_t ml3 = m3b + ZXC_LZ_MIN_MATCH_LEN;
             if (UNLIKELY(m3b == ZXC_SEQ_ML_MASK)) {
                 ml3 += zxc_read_varint(&extras_ptr, extras_end);
@@ -1438,24 +1438,24 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(const zxc_cctx_t* RESTRIC
                              (size_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
-            uint32_t off3 = (uint32_t)(s3 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
+            uint32_t off3 = (s3 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
             DECODE_SEQ_SAFE(ll3, ml3, off3);
 
-            uint64_t ll4 = (uint32_t)(s4 >> 24);
+            uint64_t ll4 = s4 >> 24;
             if (UNLIKELY(ll4 == ZXC_SEQ_LL_MASK)) {
                 ll4 += zxc_read_varint(&extras_ptr, extras_end);
                 if (UNLIKELY(ll4 > (size_t)(l_end - l_ptr) ||
                              ll4 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
-            uint32_t m4b = (uint32_t)((s4 >> 16) & 0xFF);
+            uint32_t m4b = (s4 >> 16) & 0xFF;
             uint64_t ml4 = m4b + ZXC_LZ_MIN_MATCH_LEN;
             if (UNLIKELY(m4b == ZXC_SEQ_ML_MASK)) {
                 ml4 += zxc_read_varint(&extras_ptr, extras_end);
                 if (UNLIKELY(ll4 + ml4 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
-            uint32_t off4 = (uint32_t)(s4 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
+            uint32_t off4 = (s4 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
             DECODE_SEQ_SAFE(ll4, ml4, off4);
 
             n_seq -= 4;
@@ -1520,7 +1520,7 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(const zxc_cctx_t* RESTRIC
             // Prefetch ahead in literal and extras streams to hide memory latency
             ZXC_PREFETCH_READ(l_ptr + ZXC_CACHE_LINE_SIZE);
 
-            uint64_t ll1 = (uint32_t)(s1 >> 24);
+            uint64_t ll1 = s1 >> 24;
             if (UNLIKELY(ll1 == ZXC_SEQ_LL_MASK)) {
                 ll1 += zxc_read_varint(&extras_ptr, extras_end);
                 const uint64_t reserve = (s2 >> 24) + (s3 >> 24) + (s4 >> 24);
@@ -1528,7 +1528,7 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(const zxc_cctx_t* RESTRIC
                              ll1 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
                     goto rollback_fast_4x;
             }
-            uint32_t m1b = (uint32_t)((s1 >> 16) & 0xFF);
+            uint32_t m1b = (s1 >> 16) & 0xFF;
             uint64_t ml1 = m1b + ZXC_LZ_MIN_MATCH_LEN;
             if (UNLIKELY(m1b == ZXC_SEQ_ML_MASK)) {
                 ml1 += zxc_read_varint(&extras_ptr, extras_end);
@@ -1536,10 +1536,10 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(const zxc_cctx_t* RESTRIC
                              (size_t)(d_end - d_ptr)))
                     goto rollback_fast_4x;
             }
-            uint32_t off1 = (uint32_t)(s1 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
+            uint32_t off1 = (s1 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
             DECODE_SEQ_FAST(ll1, ml1, off1);
 
-            uint64_t ll2 = (uint32_t)(s2 >> 24);
+            uint64_t ll2 = s2 >> 24;
             if (UNLIKELY(ll2 == ZXC_SEQ_LL_MASK)) {
                 ll2 += zxc_read_varint(&extras_ptr, extras_end);
                 const uint64_t reserve = (s3 >> 24) + (s4 >> 24);
@@ -1547,7 +1547,7 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(const zxc_cctx_t* RESTRIC
                              ll2 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
                     goto rollback_fast_4x;
             }
-            uint32_t m2b = (uint32_t)((s2 >> 16) & 0xFF);
+            uint32_t m2b = (s2 >> 16) & 0xFF;
             uint64_t ml2 = m2b + ZXC_LZ_MIN_MATCH_LEN;
             if (UNLIKELY(m2b == ZXC_SEQ_ML_MASK)) {
                 ml2 += zxc_read_varint(&extras_ptr, extras_end);
@@ -1555,10 +1555,10 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(const zxc_cctx_t* RESTRIC
                              (size_t)(d_end - d_ptr)))
                     goto rollback_fast_4x;
             }
-            uint32_t off2 = (uint32_t)(s2 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
+            uint32_t off2 = (s2 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
             DECODE_SEQ_FAST(ll2, ml2, off2);
 
-            uint64_t ll3 = (uint32_t)(s3 >> 24);
+            uint64_t ll3 = s3 >> 24;
             if (UNLIKELY(ll3 == ZXC_SEQ_LL_MASK)) {
                 ll3 += zxc_read_varint(&extras_ptr, extras_end);
                 const uint64_t reserve = (s4 >> 24);
@@ -1566,7 +1566,7 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(const zxc_cctx_t* RESTRIC
                              ll3 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
                     goto rollback_fast_4x;
             }
-            uint32_t m3b = (uint32_t)((s3 >> 16) & 0xFF);
+            uint32_t m3b = (s3 >> 16) & 0xFF;
             uint64_t ml3 = m3b + ZXC_LZ_MIN_MATCH_LEN;
             if (UNLIKELY(m3b == ZXC_SEQ_ML_MASK)) {
                 ml3 += zxc_read_varint(&extras_ptr, extras_end);
@@ -1574,24 +1574,24 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(const zxc_cctx_t* RESTRIC
                              (size_t)(d_end - d_ptr)))
                     goto rollback_fast_4x;
             }
-            uint32_t off3 = (uint32_t)(s3 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
+            uint32_t off3 = (s3 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
             DECODE_SEQ_FAST(ll3, ml3, off3);
 
-            uint64_t ll4 = (uint32_t)(s4 >> 24);
+            uint64_t ll4 = s4 >> 24;
             if (UNLIKELY(ll4 == ZXC_SEQ_LL_MASK)) {
                 ll4 += zxc_read_varint(&extras_ptr, extras_end);
                 if (UNLIKELY(ll4 > (size_t)(l_end - l_ptr) ||
                              ll4 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
                     goto rollback_fast_4x;
             }
-            uint32_t m4b = (uint32_t)((s4 >> 16) & 0xFF);
+            uint32_t m4b = (s4 >> 16) & 0xFF;
             uint64_t ml4 = m4b + ZXC_LZ_MIN_MATCH_LEN;
             if (UNLIKELY(m4b == ZXC_SEQ_ML_MASK)) {
                 ml4 += zxc_read_varint(&extras_ptr, extras_end);
                 if (UNLIKELY(ll4 + ml4 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
                     goto rollback_fast_4x;
             }
-            uint32_t off4 = (uint32_t)(s4 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
+            uint32_t off4 = (s4 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
             DECODE_SEQ_FAST(ll4, ml4, off4);
 
             n_seq -= 4;
@@ -1615,7 +1615,7 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(const zxc_cctx_t* RESTRIC
             // Prefetch ahead in literal and extras streams to hide memory latency
             ZXC_PREFETCH_READ(l_ptr + ZXC_CACHE_LINE_SIZE);
 
-            uint64_t ll1 = (uint32_t)(s1 >> 24);
+            uint64_t ll1 = s1 >> 24;
             if (UNLIKELY(ll1 == ZXC_SEQ_LL_MASK)) {
                 ll1 += zxc_read_varint(&extras_ptr, extras_end);
                 const uint64_t reserve = (s2 >> 24) + (s3 >> 24) + (s4 >> 24);
@@ -1623,7 +1623,7 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(const zxc_cctx_t* RESTRIC
                              ll1 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
-            uint32_t m1b = (uint32_t)((s1 >> 16) & 0xFF);
+            uint32_t m1b = (s1 >> 16) & 0xFF;
             uint64_t ml1 = m1b + ZXC_LZ_MIN_MATCH_LEN;
             if (UNLIKELY(m1b == ZXC_SEQ_ML_MASK)) {
                 ml1 += zxc_read_varint(&extras_ptr, extras_end);
@@ -1631,10 +1631,10 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(const zxc_cctx_t* RESTRIC
                              (size_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
-            uint32_t off1 = (uint32_t)(s1 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
+            uint32_t off1 = (s1 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
             DECODE_SEQ_FAST(ll1, ml1, off1);
 
-            uint64_t ll2 = (uint32_t)(s2 >> 24);
+            uint64_t ll2 = s2 >> 24;
             if (UNLIKELY(ll2 == ZXC_SEQ_LL_MASK)) {
                 ll2 += zxc_read_varint(&extras_ptr, extras_end);
                 const uint64_t reserve = (s3 >> 24) + (s4 >> 24);
@@ -1642,7 +1642,7 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(const zxc_cctx_t* RESTRIC
                              ll2 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
-            uint32_t m2b = (uint32_t)((s2 >> 16) & 0xFF);
+            uint32_t m2b = (s2 >> 16) & 0xFF;
             uint64_t ml2 = m2b + ZXC_LZ_MIN_MATCH_LEN;
             if (UNLIKELY(m2b == ZXC_SEQ_ML_MASK)) {
                 ml2 += zxc_read_varint(&extras_ptr, extras_end);
@@ -1650,10 +1650,10 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(const zxc_cctx_t* RESTRIC
                              (size_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
-            uint32_t off2 = (uint32_t)(s2 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
+            uint32_t off2 = (s2 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
             DECODE_SEQ_FAST(ll2, ml2, off2);
 
-            uint64_t ll3 = (uint32_t)(s3 >> 24);
+            uint64_t ll3 = s3 >> 24;
             if (UNLIKELY(ll3 == ZXC_SEQ_LL_MASK)) {
                 ll3 += zxc_read_varint(&extras_ptr, extras_end);
                 const uint64_t reserve = (s4 >> 24);
@@ -1661,7 +1661,7 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(const zxc_cctx_t* RESTRIC
                              ll3 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
-            uint32_t m3b = (uint32_t)((s3 >> 16) & 0xFF);
+            uint32_t m3b = (s3 >> 16) & 0xFF;
             uint64_t ml3 = m3b + ZXC_LZ_MIN_MATCH_LEN;
             if (UNLIKELY(m3b == ZXC_SEQ_ML_MASK)) {
                 ml3 += zxc_read_varint(&extras_ptr, extras_end);
@@ -1669,24 +1669,24 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(const zxc_cctx_t* RESTRIC
                              (size_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
-            uint32_t off3 = (uint32_t)(s3 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
+            uint32_t off3 = (s3 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
             DECODE_SEQ_FAST(ll3, ml3, off3);
 
-            uint64_t ll4 = (uint32_t)(s4 >> 24);
+            uint64_t ll4 = s4 >> 24;
             if (UNLIKELY(ll4 == ZXC_SEQ_LL_MASK)) {
                 ll4 += zxc_read_varint(&extras_ptr, extras_end);
                 if (UNLIKELY(ll4 > (size_t)(l_end - l_ptr) ||
                              ll4 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
-            uint32_t m4b = (uint32_t)((s4 >> 16) & 0xFF);
+            uint32_t m4b = (s4 >> 16) & 0xFF;
             uint64_t ml4 = m4b + ZXC_LZ_MIN_MATCH_LEN;
             if (UNLIKELY(m4b == ZXC_SEQ_ML_MASK)) {
                 ml4 += zxc_read_varint(&extras_ptr, extras_end);
                 if (UNLIKELY(ll4 + ml4 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
                     return ZXC_ERROR_OVERFLOW;
             }
-            uint32_t off4 = (uint32_t)(s4 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
+            uint32_t off4 = (s4 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
             DECODE_SEQ_FAST(ll4, ml4, off4);
 
             n_seq -= 4;

--- a/src/lib/zxc_dispatch.c
+++ b/src/lib/zxc_dispatch.c
@@ -832,7 +832,7 @@ int64_t zxc_compress(const void* RESTRICT src, const size_t src_size, void* REST
         const size_t st_cap = (size_t)(op_end - op);
         const int64_t st_val = zxc_write_seek_table(op, st_cap, seek_comp, seek_count);
         ZXC_FREE(seek_comp);
-        if (UNLIKELY(st_val < 0)) return (int64_t)st_val;  // LCOV_EXCL_LINE
+        if (UNLIKELY(st_val < 0)) return st_val;  // LCOV_EXCL_LINE
         op += st_val;
     } else {
         ZXC_FREE(seek_comp);

--- a/src/lib/zxc_driver.c
+++ b/src/lib/zxc_driver.c
@@ -641,12 +641,10 @@ static int64_t zxc_stream_engine_run(FILE* f_in, FILE* f_out, const int n_thread
     if (mode == 1 && progress_cb) {
         // LCOV_EXCL_START
         const long long saved_pos = ftello(f_in);
-        if (saved_pos >= 0) {
-            if (fseeko(f_in, 0, SEEK_END) == 0) {
-                const long long size = ftello(f_in);
-                if (size > 0) total_file_size = (uint64_t)size;
-                fseeko(f_in, saved_pos, SEEK_SET);
-            }
+        if (saved_pos >= 0 && fseeko(f_in, 0, SEEK_END) == 0) {
+            const long long size = ftello(f_in);
+            if (size > 0) total_file_size = (uint64_t)size;
+            fseeko(f_in, saved_pos, SEEK_SET);
         }
         // LCOV_EXCL_STOP
     }
@@ -690,12 +688,11 @@ static int64_t zxc_stream_engine_run(FILE* f_in, FILE* f_out, const int n_thread
     uint32_t d_global_hash = 0;
 
     const uint64_t max_out = zxc_compress_bound(runtime_chunk_sz);
-    const size_t raw_alloc_in = (size_t)(((mode) ? runtime_chunk_sz : max_out) + ZXC_PAD_SIZE);
+    const size_t raw_alloc_in = (size_t)((mode ? runtime_chunk_sz : max_out) + ZXC_PAD_SIZE);
     const size_t alloc_in = (raw_alloc_in + ZXC_ALIGNMENT_MASK) & ~ZXC_ALIGNMENT_MASK;
 
     const size_t raw_alloc_out =
-        (size_t)((mode) ? (max_out + ZXC_PAD_SIZE)
-                        : (runtime_chunk_sz + ZXC_DECOMPRESS_TAIL_PAD + ZXC_PAD_SIZE));
+        (size_t)((mode ? max_out : runtime_chunk_sz + ZXC_DECOMPRESS_TAIL_PAD) + ZXC_PAD_SIZE);
     const size_t alloc_out = (raw_alloc_out + ZXC_ALIGNMENT_MASK) & ~ZXC_ALIGNMENT_MASK;
 
     const size_t per_job_sz = sizeof(zxc_stream_job_t) + sizeof(int) + alloc_in + alloc_out;

--- a/src/lib/zxc_huffman.c
+++ b/src/lib/zxc_huffman.c
@@ -527,7 +527,7 @@ static int zxc_huf_encode_streams(const uint8_t* RESTRICT literals, const size_t
         size_t stop = start + Q;
         if (stop > n_literals) stop = n_literals;
 
-        uint8_t* const stream_start = p;
+        const uint8_t* const stream_start = p;
         bw_init(&bw, p, (size_t)(stream_end - p));
         for (size_t i = start; i < stop; i++) {
             const uint8_t sym = literals[i];

--- a/src/lib/zxc_pstream.c
+++ b/src/lib/zxc_pstream.c
@@ -432,12 +432,7 @@ int64_t zxc_cstream_compress(zxc_cstream* cs, zxc_outbuf_t* out, zxc_inbuf_t* in
                 break;
             }
 
-            case CS_DRAIN_HEADER: {
-                if (!cs_drain_pending(cs, out)) return (int64_t)(cs->pending_len - cs->pending_pos);
-                cs->state = CS_ACCUMULATE;
-                break;
-            }
-
+            case CS_DRAIN_HEADER:
             case CS_DRAIN_BLOCK: {
                 if (!cs_drain_pending(cs, out)) return (int64_t)(cs->pending_len - cs->pending_pos);
                 cs->state = CS_ACCUMULATE;

--- a/wrappers/nodejs/src/zxc_addon.cc
+++ b/wrappers/nodejs/src/zxc_addon.cc
@@ -7,6 +7,7 @@
 
 #include <napi.h>
 
+#include <array>
 #include <cstring>
 #include <vector>
 
@@ -102,7 +103,7 @@ static Napi::Value Compress(const Napi::CallbackInfo& info) {
         zxc_compress(src, src_size, dst_buf.Data(), static_cast<size_t>(bound), &opts);
 
     if (nwritten < 0) {
-        int err_code = static_cast<int>(nwritten);
+        auto err_code = static_cast<int>(nwritten);
         Napi::Error err = Napi::Error::New(env, zxc_error_name(err_code));
         err.Set("code", Napi::Number::New(env, err_code));
         err.ThrowAsJavaScriptException();
@@ -176,7 +177,7 @@ static Napi::Value Decompress(const Napi::CallbackInfo& info) {
     int64_t nwritten = zxc_decompress(src, src_size, dst, decompress_size, &dopts);
 
     if (nwritten < 0) {
-        int err_code = static_cast<int>(nwritten);
+        auto err_code = static_cast<int>(nwritten);
         Napi::Error err = Napi::Error::New(env, zxc_error_name(err_code));
         err.Set("code", Napi::Number::New(env, err_code));
         err.ThrowAsJavaScriptException();
@@ -347,12 +348,13 @@ static Napi::Value TrainDictHuf(const Napi::CallbackInfo& info) {
     }
 
     Napi::Buffer<uint8_t> dict = info[1].As<Napi::Buffer<uint8_t>>();
-    uint8_t huf[ZXC_HUF_TABLE_SIZE];
-    int r = zxc_train_dict_huf(samples.data(), sizes.data(), n, dict.Data(), dict.Length(), huf);
+    std::array<uint8_t, ZXC_HUF_TABLE_SIZE> huf;
+    int r = zxc_train_dict_huf(samples.data(), sizes.data(), n, dict.Data(), dict.Length(),
+                               huf.data());
     if (r < 0) {
         return ThrowZxcError(env, r);
     }
-    return Napi::Buffer<uint8_t>::Copy(env, huf, ZXC_HUF_TABLE_SIZE);
+    return Napi::Buffer<uint8_t>::Copy(env, huf.data(), huf.size());
 }
 
 // dictHuf(zxd: Buffer): Buffer | null  (128-byte shared Huffman table)
@@ -849,7 +851,7 @@ class SeekableWrap : public Napi::ObjectWrap<SeekableWrap> {
     // as ZXC_ERROR_IO so it doesn't unwind through C.
     static int64_t ReadAtTrampoline(void* ctx, void* dst, size_t len, uint64_t offset) {
         constexpr int64_t kZxcErrorIo = -11;
-        SeekableWrap* self = static_cast<SeekableWrap*>(ctx);
+        auto* self = static_cast<SeekableWrap*>(ctx);
         if (!self || self->read_at_ref_.IsEmpty()) return kZxcErrorIo;
         Napi::Env env = self->env_;
         Napi::HandleScope scope(env);

--- a/wrappers/python/src/zxc/_zxc.c
+++ b/wrappers/python/src/zxc/_zxc.c
@@ -241,6 +241,7 @@ PyMODINIT_FUNC PyInit__zxc(void) {
 // =============================================================================
 
 static PyObject* pyzxc_compress(PyObject* self, PyObject* args, PyObject* kwargs) {
+    (void)self;
     Py_buffer view;
     int level = ZXC_LEVEL_DEFAULT;
     int checksum = 0;
@@ -342,6 +343,8 @@ static PyObject* pyzxc_compress(PyObject* self, PyObject* args, PyObject* kwargs
 }
 
 static PyObject* pyzxc_get_decompressed_size(PyObject* self, PyObject* args, PyObject* kwargs) {
+    (void)self;
+    (void)kwargs;
     Py_buffer view;
 
     if (!PyArg_ParseTuple(args, "y*", &view)) {
@@ -356,6 +359,7 @@ static PyObject* pyzxc_get_decompressed_size(PyObject* self, PyObject* args, PyO
 }
 
 static PyObject* pyzxc_decompress(PyObject* self, PyObject* args, PyObject* kwargs) {
+    (void)self;
     Py_buffer view;
     int checksum = 0;
     Py_buffer dict_view = {0};
@@ -446,6 +450,7 @@ static PyObject* pyzxc_decompress(PyObject* self, PyObject* args, PyObject* kwar
 }
 
 static PyObject* pyzxc_stream_compress(PyObject* self, PyObject* args, PyObject* kwargs) {
+    (void)self;
     PyObject *src, *dst;
     int nthreads = 0;
     int level = ZXC_LEVEL_DEFAULT;
@@ -550,6 +555,7 @@ static PyObject* pyzxc_stream_compress(PyObject* self, PyObject* args, PyObject*
 }
 
 static PyObject* pyzxc_stream_decompress(PyObject* self, PyObject* args, PyObject* kwargs) {
+    (void)self;
     PyObject *src, *dst;
     int nthreads = 0;
     int checksum = 0;
@@ -1610,9 +1616,7 @@ static PyObject* pyzxc_seekable_decompress_range(PyObject* self, PyObject* args,
         Py_Return_Err(PyExc_RuntimeError, zxc_error_name((int)r));
     }
 
-    if (r != (int64_t)length) {
-        if (_PyBytes_Resize(&out, (Py_ssize_t)r) < 0) return NULL;
-    }
+    if (r != (int64_t)length && _PyBytes_Resize(&out, (Py_ssize_t)r) < 0) return NULL;
     return out;
 }
 
@@ -1716,8 +1720,6 @@ static PyObject* pyzxc_write_seek_table(PyObject* self, PyObject* arg) {
         Py_DECREF(out);
         Py_Return_Err(PyExc_RuntimeError, zxc_error_name((int)written));
     }
-    if ((size_t)written != cap) {
-        if (_PyBytes_Resize(&out, (Py_ssize_t)written) < 0) return NULL;
-    }
+    if ((size_t)written != cap && _PyBytes_Resize(&out, (Py_ssize_t)written) < 0) return NULL;
     return out;
 }


### PR DESCRIPTION
This pull request improves code quality and readability by addressing various static analysis findings and compiler warnings across the codebase.

Key changes include:
*   Silences unused function parameters using `(void)` casts in CLI and Python wrapper functions.
*   Eliminates redundant type casts (e.g., `(size_t)`, `(uint32_t)`, `(int64_t)`), simplifying expressions in compression, decompression, and dispatch logic.
*   Simplifies conditional logic and expression syntax, such as combining `fseeko` checks and cleaning up ternary operators.
*   Enforces `const` correctness for a stream pointer in the Huffman encoding module.
*   Updates the Node.js wrapper to adopt modern C++ practices, including `std::array` for fixed-size buffers and `auto` for type deduction.
*   Streamlines state handling in the `zxc_pstream.c` by removing a redundant `CS_DRAIN_HEADER` case.

Relates to SonarQube findings.