### PR TITLE
fix: Refines code style, type safety, and modernizes JS/Go wrappers

### DIFF
--- a/src/cli/main.c
+++ b/src/cli/main.c
@@ -578,7 +578,8 @@ static void cli_progress_callback(uint64_t bytes_processed, uint64_t bytes_total
         }
         fprintf(stderr, "] %d%% | ", percent);
 
-        char proc_str[32], total_str[32];
+        char proc_str[32];
+        char total_str[32];
         format_size_decimal(bytes_processed, proc_str, sizeof(proc_str));
         format_size_decimal(total, total_str, sizeof(total_str));
         fprintf(stderr, "%s/%s | %.1f MB/s", proc_str, total_str, speed_mbps);
@@ -736,11 +737,13 @@ static int zxc_list_archive(const char* path, int json_output) {
     const double ratio = (file_size > 0) ? ((double)uncompressed_size / (double)file_size) : 0.0;
 
     // Format sizes
-    char comp_str[32], uncomp_str[32];
+    char comp_str[32];
+    char uncomp_str[32];
+    char dict_id_str[16];
+
     format_size_decimal((uint64_t)file_size, comp_str, sizeof(comp_str));
     format_size_decimal((uint64_t)uncompressed_size, uncomp_str, sizeof(uncomp_str));
-
-    char dict_id_str[16];
+    
     if (dict_id)
         snprintf(dict_id_str, sizeof(dict_id_str), "0x%08X", dict_id);
     else
@@ -801,9 +804,9 @@ static int process_single_file(const char* in_path, const char* out_path_overrid
     char resolved_in_path[4096] = {0};
     char out_path[4096] = {0};
     char resolved_out_path[4096] = {0};
-    int use_stdin = 1, use_stdout = 0;
+    int use_stdin = 1;
+    int use_stdout = 0;
     int created_out_file = 0;
-
     int overall_ret = 0;
 
     if (in_path && strcmp(in_path, "-") != 0) {
@@ -957,13 +960,13 @@ static int process_single_file(const char* in_path, const char* out_path_overrid
     }
 
     // Set large buffers for I/O performance (AFTER file size detection)
-    char *b1 = malloc(ZXC_STDIO_BUFFER_SIZE), *b2 = malloc(ZXC_STDIO_BUFFER_SIZE);
+    char *b1 = malloc(ZXC_STDIO_BUFFER_SIZE);
+    char *b2 = malloc(ZXC_STDIO_BUFFER_SIZE);
     if (b1) setvbuf(f_in, b1, _IOFBF, ZXC_STDIO_BUFFER_SIZE);
     if (f_out && b2) setvbuf(f_out, b2, _IOFBF, ZXC_STDIO_BUFFER_SIZE);
 
-    if (in_path && !g_quiet) {
+    if (in_path && !g_quiet)
         zxc_log_v("Processing %s... (Compression Level %d)\n", in_path, level);
-    }
     if (g_verbose) zxc_log("Checksum: %s\n", checksum_enabled ? "enabled" : "disabled");
     if (g_verbose && seekable) zxc_log("Seekable: enabled\n");
 

--- a/src/cli/main.c
+++ b/src/cli/main.c
@@ -76,7 +76,7 @@ int optopt = 0;
  * Handles long options (--option) and short options (-o).
  */
 static int getopt_long(int argc, char* const argv[], const char* optstring,
-                       const struct option* longopts, int* longindex) {
+                       const struct option* longopts, const int* longindex) {
     (void)longindex;
     if (optind >= argc) return -1;
     char* curr = argv[optind];
@@ -743,7 +743,7 @@ static int zxc_list_archive(const char* path, int json_output) {
 
     format_size_decimal((uint64_t)file_size, comp_str, sizeof(comp_str));
     format_size_decimal((uint64_t)uncompressed_size, uncomp_str, sizeof(uncomp_str));
-    
+
     if (dict_id)
         snprintf(dict_id_str, sizeof(dict_id_str), "0x%08X", dict_id);
     else
@@ -762,9 +762,9 @@ static int zxc_list_archive(const char* path, int json_output) {
             "  \"checksum_value\": \"0x%08X\",\n"
             "  \"dict_id\": %s%s%s\n"
             "}\n",
-            path, (long long)file_size, (long long)uncompressed_size, ratio, format_version,
-            block_size_kb, (stored_checksum != 0) ? "RapidHash" : "none", stored_checksum,
-            dict_id ? "\"" : "", dict_id ? dict_id_str : "null", dict_id ? "\"" : "");
+            path, file_size, (long long)uncompressed_size, ratio, format_version, block_size_kb,
+            (stored_checksum != 0) ? "RapidHash" : "none", stored_checksum, dict_id ? "\"" : "",
+            dict_id ? dict_id_str : "null", dict_id ? "\"" : "");
     } else if (g_verbose) {
         // Verbose mode: detailed vertical layout
         printf(
@@ -960,13 +960,12 @@ static int process_single_file(const char* in_path, const char* out_path_overrid
     }
 
     // Set large buffers for I/O performance (AFTER file size detection)
-    char *b1 = malloc(ZXC_STDIO_BUFFER_SIZE);
-    char *b2 = malloc(ZXC_STDIO_BUFFER_SIZE);
+    char* b1 = malloc(ZXC_STDIO_BUFFER_SIZE);
+    char* b2 = malloc(ZXC_STDIO_BUFFER_SIZE);
     if (b1) setvbuf(f_in, b1, _IOFBF, ZXC_STDIO_BUFFER_SIZE);
     if (f_out && b2) setvbuf(f_out, b2, _IOFBF, ZXC_STDIO_BUFFER_SIZE);
 
-    if (in_path && !g_quiet)
-        zxc_log_v("Processing %s... (Compression Level %d)\n", in_path, level);
+    if (in_path && !g_quiet) zxc_log_v("Processing %s... (Compression Level %d)\n", in_path, level);
     if (g_verbose) zxc_log("Checksum: %s\n", checksum_enabled ? "enabled" : "disabled");
     if (g_verbose && seekable) zxc_log("Seekable: enabled\n");
 

--- a/src/lib/zxc_common.c
+++ b/src/lib/zxc_common.c
@@ -294,13 +294,13 @@ int zxc_cctx_init_in_workspace(zxc_cctx_t* RESTRICT ctx, void* RESTRICT workspac
     }
 
     ctx->hash_table = (uint32_t*)(mem + layout.off_hash_pos);
-    ctx->hash_tags = (uint8_t*)(mem + layout.off_hash_tags);
+    ctx->hash_tags = mem + layout.off_hash_tags;
     ctx->chain_table = (uint16_t*)(mem + layout.off_chain);
     ctx->buf_sequences = (uint32_t*)(mem + layout.off_seq_union);
     ctx->buf_offsets = (uint16_t*)(mem + layout.off_seq_union);
-    ctx->buf_tokens = (uint8_t*)(mem + layout.off_seq_union) + layout.max_seq * sizeof(uint16_t);
-    ctx->buf_extras = (uint8_t*)(mem + layout.off_extras);
-    ctx->literals = (uint8_t*)(mem + layout.off_lit_cctx);
+    ctx->buf_tokens = mem + layout.off_seq_union + layout.max_seq * sizeof(uint16_t);
+    ctx->buf_extras = mem + layout.off_extras;
+    ctx->literals = mem + layout.off_lit_cctx;
     if (layout.sz_opt) {
         ctx->opt_scratch = mem + layout.off_opt;
         ctx->opt_scratch_cap = layout.sz_opt;

--- a/src/lib/zxc_compress.c
+++ b/src/lib/zxc_compress.c
@@ -1262,7 +1262,7 @@ static int zxc_encode_block_glo(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRIC
         if (m.ref) {
             ip -= m.backtrack;
             const uint32_t ll = (uint32_t)(ip - anchor);
-            const uint32_t ml = (uint32_t)(m.len - ZXC_LZ_MIN_MATCH_LEN);
+            const uint32_t ml = m.len - ZXC_LZ_MIN_MATCH_LEN;
             const uint32_t off = (uint32_t)(ip - m.ref);
 
             if (ll > 0) {
@@ -1934,7 +1934,7 @@ static int zxc_encode_block_ghi(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRIC
         if (m.ref) {
             ip -= m.backtrack;
             const uint32_t ll = (uint32_t)(ip - anchor);
-            const uint32_t ml = (uint32_t)(m.len - ZXC_LZ_MIN_MATCH_LEN);
+            const uint32_t ml = m.len - ZXC_LZ_MIN_MATCH_LEN;
             const uint32_t off = (uint32_t)(ip - m.ref);
 
             if (ll > 0) {

--- a/src/lib/zxc_compress.c
+++ b/src/lib/zxc_compress.c
@@ -1213,8 +1213,10 @@ static int zxc_encode_block_glo(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRIC
         zxc_lz_seed_dict(src, dict_sz, ctx->hash_table, ctx->hash_tags, ctx->chain_table,
                          epoch_mark, offset_mask, level);
 
-    const uint8_t *ip = src + dict_sz, *iend = src + src_sz, *anchor = ip,
-                  *search_limit = iend - ZXC_LZ_SEARCH_MARGIN;
+    const uint8_t* ip = src + dict_sz;
+    const uint8_t* iend = src + src_sz;
+    const uint8_t* anchor = ip;
+    const uint8_t* search_limit = iend - ZXC_LZ_SEARCH_MARGIN;
 
     uint32_t* const hash_table = ctx->hash_table;
     uint8_t* const hash_tags = ctx->hash_tags;
@@ -1609,7 +1611,10 @@ parse_done:;
                 size_t stop = start + Q;
                 if (start > lit_c) start = lit_c;
                 if (stop > lit_c) stop = lit_c;
-                uint64_t b0 = 0, b1 = 0, b2 = 0, b3 = 0;
+                uint64_t b0 = 0;
+                uint64_t b1 = 0;
+                uint64_t b2 = 0;
+                uint64_t b3 = 0;
                 size_t i = start;
 
                 for (; i + 4 <= stop; i += 4) {
@@ -1889,8 +1894,10 @@ static int zxc_encode_block_ghi(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRIC
         zxc_lz_seed_dict(src, dict_sz, ctx->hash_table, ctx->hash_tags, ctx->chain_table,
                          epoch_mark, offset_mask, level);
 
-    const uint8_t *ip = src + dict_sz, *iend = src + src_sz, *anchor = ip,
-                  *search_limit = iend - ZXC_LZ_SEARCH_MARGIN;
+    const uint8_t* ip = src + dict_sz;
+    const uint8_t* iend = src + src_sz;
+    const uint8_t* anchor = ip;
+    const uint8_t* search_limit = iend - ZXC_LZ_SEARCH_MARGIN;
 
     uint32_t* const hash_table = ctx->hash_table;
     uint8_t* const hash_tags = ctx->hash_tags;

--- a/src/lib/zxc_decompress.c
+++ b/src/lib/zxc_decompress.c
@@ -1475,14 +1475,14 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(const zxc_cctx_t* RESTRIC
         uint32_t seq = zxc_le32(seq_ptr);
         seq_ptr += sizeof(uint32_t);
 
-        uint64_t ll = (uint32_t)(seq >> 24);
+        uint64_t ll = seq >> 24;
         if (UNLIKELY(ll == ZXC_SEQ_LL_MASK)) ll += zxc_read_varint(&extras_ptr, extras_end);
 
-        uint32_t m_bits = (uint32_t)((seq >> 16) & 0xFF);
+        uint32_t m_bits = (seq >> 16) & 0xFF;
         uint64_t ml = m_bits + ZXC_LZ_MIN_MATCH_LEN;
         if (UNLIKELY(m_bits == ZXC_SEQ_ML_MASK)) ml += zxc_read_varint(&extras_ptr, extras_end);
 
-        uint32_t offset = (uint32_t)(seq & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
+        uint32_t offset = (seq & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
 
         // Strict bounds check: sequence must fit, AND wild copies must not overshoot
         // Check both destination (d_ptr) and source literal stream (l_ptr)
@@ -1710,7 +1710,7 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(const zxc_cctx_t* RESTRIC
         const uint32_t seq = zxc_le32(seq_ptr);
         seq_ptr += sizeof(uint32_t);
 
-        uint64_t ll = (uint32_t)(seq >> 24);
+        uint64_t ll = seq >> 24;
         if (UNLIKELY(ll == ZXC_SEQ_LL_MASK)) {
             ll += zxc_read_varint(&extras_ptr, extras_end);
             if (UNLIKELY(l_ptr + ll > l_end)) {
@@ -1720,7 +1720,7 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(const zxc_cctx_t* RESTRIC
             }
         }
 
-        uint32_t m_bits = (uint32_t)((seq >> 16) & 0xFF);
+        uint32_t m_bits = (seq >> 16) & 0xFF;
         uint64_t ml = m_bits + ZXC_LZ_MIN_MATCH_LEN;
         if (UNLIKELY(m_bits == ZXC_SEQ_ML_MASK)) ml += zxc_read_varint(&extras_ptr, extras_end);
 
@@ -1732,7 +1732,7 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(const zxc_cctx_t* RESTRIC
             extras_ptr = ext_save;
             break;
         }
-        uint32_t offset = (uint32_t)(seq & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
+        uint32_t offset = (seq & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
 
         {
             const uint8_t* src_lit = l_ptr;
@@ -1774,13 +1774,13 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(const zxc_cctx_t* RESTRIC
         uint32_t seq = zxc_le32(seq_ptr);
         seq_ptr += sizeof(uint32_t);
 
-        uint64_t ll = (uint32_t)(seq >> 24);
+        uint64_t ll = seq >> 24;
         if (UNLIKELY(ll == ZXC_SEQ_LL_MASK)) ll += zxc_read_varint(&extras_ptr, extras_end);
 
-        uint32_t m_bits = (uint32_t)((seq >> 16) & 0xFF);
+        uint32_t m_bits = (seq >> 16) & 0xFF;
         uint64_t ml = m_bits + ZXC_LZ_MIN_MATCH_LEN;
         if (UNLIKELY(m_bits == ZXC_SEQ_ML_MASK)) ml += zxc_read_varint(&extras_ptr, extras_end);
-        uint32_t offset = (uint32_t)(seq & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
+        uint32_t offset = (seq & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
 
         if (UNLIKELY(ll + ml > (size_t)(d_end - d_ptr) || l_ptr + ll > l_end))
             return ZXC_ERROR_OVERFLOW;

--- a/src/lib/zxc_decompress.c
+++ b/src/lib/zxc_decompress.c
@@ -743,8 +743,11 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(const zxc_cctx_t* RESTRIC
             uint32_t tokens = zxc_le32(t_ptr);
             t_ptr += sizeof(uint32_t);
 
-            uint32_t off1 = ZXC_LZ_OFFSET_BIAS, off2 = ZXC_LZ_OFFSET_BIAS,
-                     off3 = ZXC_LZ_OFFSET_BIAS, off4 = ZXC_LZ_OFFSET_BIAS;
+            uint32_t off1 = ZXC_LZ_OFFSET_BIAS;
+            uint32_t off2 = ZXC_LZ_OFFSET_BIAS;
+            uint32_t off3 = ZXC_LZ_OFFSET_BIAS;
+            uint32_t off4 = ZXC_LZ_OFFSET_BIAS;
+
             if (gh.enc_off == 1) {
                 // Read 4 x 1-byte offsets
                 uint32_t offsets = zxc_le32(o_ptr);
@@ -853,8 +856,11 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(const zxc_cctx_t* RESTRIC
             uint32_t tokens = zxc_le32(t_ptr);
             t_ptr += sizeof(uint32_t);
 
-            uint32_t off1 = ZXC_LZ_OFFSET_BIAS, off2 = ZXC_LZ_OFFSET_BIAS,
-                     off3 = ZXC_LZ_OFFSET_BIAS, off4 = ZXC_LZ_OFFSET_BIAS;
+            uint32_t off1 = ZXC_LZ_OFFSET_BIAS;
+            uint32_t off2 = ZXC_LZ_OFFSET_BIAS;
+            uint32_t off3 = ZXC_LZ_OFFSET_BIAS;
+            uint32_t off4 = ZXC_LZ_OFFSET_BIAS;
+
             if (gh.enc_off == 1) {
                 uint32_t offsets = zxc_le32(o_ptr);
                 o_ptr += sizeof(uint32_t);
@@ -962,8 +968,10 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(const zxc_cctx_t* RESTRIC
             uint32_t tokens = zxc_le32(t_ptr);
             t_ptr += sizeof(uint32_t);
 
-            uint32_t off1 = ZXC_LZ_OFFSET_BIAS, off2 = ZXC_LZ_OFFSET_BIAS,
-                     off3 = ZXC_LZ_OFFSET_BIAS, off4 = ZXC_LZ_OFFSET_BIAS;
+            uint32_t off1 = ZXC_LZ_OFFSET_BIAS;
+            uint32_t off2 = ZXC_LZ_OFFSET_BIAS;
+            uint32_t off3 = ZXC_LZ_OFFSET_BIAS;
+            uint32_t off4 = ZXC_LZ_OFFSET_BIAS;
             if (gh.enc_off == 1) {
                 // Read 4 x 1-byte offsets
                 uint32_t offsets = zxc_le32(o_ptr);

--- a/src/lib/zxc_driver.c
+++ b/src/lib/zxc_driver.c
@@ -216,9 +216,11 @@ typedef enum { JOB_STATUS_FREE, JOB_STATUS_FILLED, JOB_STATUS_PROCESSED } job_st
  */
 typedef struct {
     uint8_t* in_buf;
-    size_t in_cap, in_sz;
+    size_t in_cap;
+    size_t in_sz;
     uint8_t* out_buf;
-    size_t out_cap, result_sz;
+    size_t out_cap;
+    size_t result_sz;
     int job_id;
     ZXC_ATOMIC job_status_t status;  // Atomic for lock-free status updates
     char pad[ZXC_CACHE_LINE_SIZE];   // Prevent False Sharing
@@ -310,9 +312,13 @@ typedef struct {
     zxc_stream_job_t* jobs;
     size_t ring_size;
     int* worker_queue;
-    int wq_head, wq_tail, wq_count;
+    int wq_head;
+    int wq_tail;
+    int wq_count;
     pthread_mutex_t lock;
-    pthread_cond_t cond_reader, cond_worker, cond_writer;
+    pthread_cond_t cond_reader;
+    pthread_cond_t cond_worker;
+    pthread_cond_t cond_writer;
     int shutdown_workers;
     int compression_mode;
     ZXC_ATOMIC int io_error;

--- a/src/lib/zxc_huffman.c
+++ b/src/lib/zxc_huffman.c
@@ -228,7 +228,9 @@ int zxc_huf_build_code_lengths(const uint32_t* RESTRICT freq, uint8_t* RESTRICT 
     for (int k = 1; k < ZXC_HUF_MAX_CODE_LEN; k++) {
         const int prev = counts[k - 1];
         const int packs = prev / 2;
-        int li = 0, pi = 0, n_lvl = 0;
+        int li = 0;
+        int pi = 0;
+        int n_lvl = 0;
         while (li < n || pi < packs) {
             const uint32_t wl = (li < n) ? leaves[li].w : UINT32_MAX;
             const uint32_t wp =
@@ -797,9 +799,18 @@ static int zxc_huf_decode_streams(const uint8_t* RESTRICT payload, const size_t 
 
     /* Hoist all four bit-reader hot fields into locals. They live in
      * registers for the full duration of the batched loop. */
-    uint64_t a0 = br[0].accum, a1 = br[1].accum, a2 = br[2].accum, a3 = br[3].accum;
-    int bb0 = br[0].bits, bb1 = br[1].bits, bb2 = br[2].bits, bb3 = br[3].bits;
-    const uint8_t *p0 = br[0].ptr, *p1 = br[1].ptr, *p2 = br[2].ptr, *p3 = br[3].ptr;
+    uint64_t a0 = br[0].accum;
+    uint64_t a1 = br[1].accum;
+    uint64_t a2 = br[2].accum;
+    uint64_t a3 = br[3].accum;
+    int bb0 = br[0].bits;
+    int bb1 = br[1].bits;
+    int bb2 = br[2].bits;
+    int bb3 = br[3].bits;
+    const uint8_t* p0 = br[0].ptr;
+    const uint8_t* p1 = br[1].ptr;
+    const uint8_t* p2 = br[2].ptr;
+    const uint8_t* p3 = br[3].ptr;
     const uint8_t* const e0 = br[0].end;
     const uint8_t* const e1 = br[1].end;
     const uint8_t* const e2 = br[2].end;
@@ -864,7 +875,10 @@ static int zxc_huf_decode_streams(const uint8_t* RESTRICT payload, const size_t 
         REFILL(a2, bb2, p2, e2);
         REFILL(a3, bb3, p3, e3);
 
-        int sl0 = 0, sl1 = 0, sl2 = 0, sl3 = 0;
+        int sl0 = 0;
+        int sl1 = 0;
+        int sl2 = 0;
+        int sl3 = 0;
         DECODE_ONE();
         DECODE_ONE();
         DECODE_ONE();

--- a/wrappers/go/zxc_block.go
+++ b/wrappers/go/zxc_block.go
@@ -11,7 +11,9 @@ package zxc
 #include "zxc.h"
 */
 import "C"
-import "unsafe"
+import (
+	"unsafe"
+)
 
 // ============================================================================
 // Block API (single block, no file framing)

--- a/wrappers/nodejs/lib/index.js
+++ b/wrappers/nodejs/lib/index.js
@@ -315,9 +315,9 @@ function compress(data, options = {}) {
         throw new TypeError('data must be a Buffer');
     }
 
-    const level = options.level !== undefined ? options.level : LEVEL_DEFAULT;
-    const checksum = options.checksum !== undefined ? options.checksum : false;
-    const seekable = options.seekable !== undefined ? options.seekable : false;
+    const level = options.level ?? LEVEL_DEFAULT;
+    const checksum = options.checksum ?? false;
+    const seekable = options.seekable ?? false;
     const { dict, dictHuf } = _splitDictOption(options);
 
     return native.compress(data, level, checksum, seekable, dict, dictHuf);
@@ -352,7 +352,7 @@ function decompress(data, options = {}) {
         throw new TypeError('data must be a Buffer');
     }
 
-    const checksum = options.checksum !== undefined ? options.checksum : false;
+    const checksum = options.checksum ?? false;
     const { dict, dictHuf } = _splitDictOption(options);
 
     let size = options.size;
@@ -480,9 +480,9 @@ class CompressStream extends Transform {
         const { level, checksum, blockSize, ...transformOpts } = options;
         super(transformOpts);
         this._cs = new CStream({
-            ...(level !== undefined ? { level } : {}),
-            ...(checksum !== undefined ? { checksum } : {}),
-            ...(blockSize !== undefined ? { blockSize } : {}),
+            ...(level === undefined ? {} : { level }),
+            ...(checksum === undefined ? {} : { checksum }),
+            ...(blockSize === undefined ? {} : { blockSize }),
         });
     }
 
@@ -511,7 +511,7 @@ class CompressStream extends Transform {
     }
 
     _destroy(err, callback) {
-        try { this._cs.close(); } catch (_) { /* idempotent */ }
+        this._cs.close();
         callback(err);
     }
 }
@@ -536,7 +536,7 @@ class DecompressStream extends Transform {
         const { checksum, ...transformOpts } = options;
         super(transformOpts);
         this._ds = new DStream({
-            ...(checksum !== undefined ? { checksum } : {}),
+            ...(checksum === undefined ? {} : { checksum }),
         });
     }
 
@@ -570,7 +570,7 @@ class DecompressStream extends Transform {
     }
 
     _destroy(err, callback) {
-        try { this._ds.close(); } catch (_) { /* idempotent */ }
+        this._ds.close();
         callback(err);
     }
 }

--- a/wrappers/python/src/zxc/_zxc.c
+++ b/wrappers/python/src/zxc/_zxc.c
@@ -451,7 +451,8 @@ static PyObject* pyzxc_decompress(PyObject* self, PyObject* args, PyObject* kwar
 
 static PyObject* pyzxc_stream_compress(PyObject* self, PyObject* args, PyObject* kwargs) {
     (void)self;
-    PyObject *src, *dst;
+    PyObject *src;
+    PyObject *dst;
     int nthreads = 0;
     int level = ZXC_LEVEL_DEFAULT;
     int checksum = 0;
@@ -556,7 +557,8 @@ static PyObject* pyzxc_stream_compress(PyObject* self, PyObject* args, PyObject*
 
 static PyObject* pyzxc_stream_decompress(PyObject* self, PyObject* args, PyObject* kwargs) {
     (void)self;
-    PyObject *src, *dst;
+    PyObject *src;
+    PyObject *dst;
     int nthreads = 0;
     int checksum = 0;
 


### PR DESCRIPTION
Addresses various code quality improvements identified by static analysis, enhancing readability and maintainability across the codebase.

*   Separates multi-variable declarations onto individual lines for improved clarity in C code.
*   Enforces `const` correctness for function parameters in C, improving type safety and signaling intent.
*   Eliminates redundant explicit type casts in C, simplifying expressions where types are already compatible or implicitly convertible.
*   Modernizes JavaScript option handling by adopting nullish coalescing and refined spread syntax.
*   Standardizes Go import statement grouping for better code consistency.
*   Performs minor C code style adjustments, including simplifying `if` statements and removing unnecessary `try/catch` blocks for idempotent operations.

Relates to SonarQube findings