### PR TITLE
doc: Refines documentation and API option descriptions

### DIFF
--- a/include/zxc_buffer.h
+++ b/include/zxc_buffer.h
@@ -18,13 +18,13 @@
  * // Compress
  * size_t bound = zxc_compress_bound(src_size);
  * void *dst    = malloc(bound);
- * zxc_compress_opts_t opts = { .level = ZXC_LEVEL_DEFAULT, .checksum = 1 };
+ * zxc_compress_opts_t opts = { .level = ZXC_LEVEL_DEFAULT, .checksum_enabled = 1 };
  * int64_t csize = zxc_compress(src, src_size, dst, bound, &opts);
  *
  * // Decompress
  * uint64_t orig = zxc_get_decompressed_size(dst, csize);
  * void *out     = malloc(orig);
- * zxc_decompress_opts_t dopts = { .checksum = 1 };
+ * zxc_decompress_opts_t dopts = { .checksum_enabled = 1 };
  * int64_t dsize = zxc_decompress(dst, csize, out, orig, &dopts);
  * @endcode
  *
@@ -86,7 +86,7 @@ ZXC_EXPORT int zxc_default_level(void);
  * @brief Returns the human-readable library version string.
  *
  * The returned pointer is a compile-time constant and must not be freed.
- * Example: "0.9.1".
+ * Format: "MAJOR.MINOR.PATCH" (e.g. "0.12.0").
  *
  * @return Null-terminated version string.
  */
@@ -125,7 +125,8 @@ ZXC_EXPORT uint64_t zxc_compress_bound(const size_t input_size);
  * @param[out] dst          Pointer to the destination buffer.
  * @param[in] dst_capacity Maximum capacity of the destination buffer.
  * @param[in] opts         Compression options (NULL uses all defaults).
- *                         Only @c level, @c block_size, and @c checksum are used.
+ *                         @c n_threads and the progress callback are ignored
+ *                         (this call is single-threaded and blocking).
  *
  * @note @p src and @p dst must not overlap (same contract as memcpy).
  *
@@ -147,7 +148,8 @@ ZXC_EXPORT int64_t zxc_compress(const void* src, const size_t src_size, void* ds
  * @param[out] dst          Pointer to the destination buffer.
  * @param[in] dst_capacity  Capacity of the destination buffer.
  * @param[in] opts          Decompression options (NULL uses all defaults).
- *                          Only @c checksum is used.
+ *                          @c n_threads and the progress callback are ignored
+ *                          (this call is single-threaded and blocking).
  *
  * @note @p src and @p dst must not overlap (same contract as memcpy).
  *

--- a/include/zxc_constants.h
+++ b/include/zxc_constants.h
@@ -35,7 +35,7 @@
 /** @endcond */
 
 /**
- * @brief Human-readable version string (e.g. "0.7.2").
+ * @brief Human-readable version string in "MAJOR.MINOR.PATCH" form (e.g. "0.12.0").
  */
 #define ZXC_LIB_VERSION_STR    \
     ZXC_STR(ZXC_VERSION_MAJOR) \
@@ -89,8 +89,8 @@
  * @brief Bounds on thread-count parameters accepted by the streaming APIs.
  * @{
  */
-/** @brief Maximum value accepted for `num_threads` in `zxc_stream_compress`
- *  / `zxc_stream_decompress`. Passing a higher value returns `ZXC_ERROR_INVALID_OPTION`. */
+/** @brief Maximum value accepted for `n_threads` in `zxc_stream_compress`
+ *  / `zxc_stream_decompress`. Higher values are clamped to `ZXC_MAX_THREADS`. */
 #define ZXC_MAX_THREADS 512
 /** @} */ /* end of threading */
 

--- a/include/zxc_opts.h
+++ b/include/zxc_opts.h
@@ -60,7 +60,7 @@ typedef void (*zxc_progress_callback_t)(uint64_t bytes_processed, uint64_t bytes
  */
 typedef struct {
     int n_threads;     /**< Worker thread count (0 = auto-detect CPU cores). */
-    int level;         /**< Compression level 1-5 (0 = default, ZXC_LEVEL_DEFAULT). */
+    int level;         /**< Compression level 1-6 (0 = default, ZXC_LEVEL_DEFAULT). */
     size_t block_size; /**< Block size in bytes (0 = default ZXC_BLOCK_SIZE_DEFAULT). Must be power
                           of 2, [4KB - 2MB]. */
     int checksum_enabled; /**< 1 to enable per-block and global checksums, 0 to disable. */
@@ -81,7 +81,7 @@ typedef struct {
  * Zero-initialise for safe defaults.
  *
  * @code
- * zxc_decompress_opts_t opts = { .checksum = 1 };
+ * zxc_decompress_opts_t opts = { .checksum_enabled = 1 };
  * zxc_stream_decompress(f_in, f_out, &opts);
  * @endcode
  */

--- a/src/lib/zxc_common.c
+++ b/src/lib/zxc_common.c
@@ -926,6 +926,6 @@ int zxc_default_level(void) { return ZXC_LEVEL_DEFAULT; }
  * @brief Returns the human-readable library version string.
  *
  * The returned pointer is a compile-time constant and must not be freed.
- * Example: "0.9.1".
+ * Format: "MAJOR.MINOR.PATCH" (e.g. "0.12.0").
  */
 const char* zxc_version_string(void) { return ZXC_LIB_VERSION_STR; }

--- a/src/lib/zxc_compress.c
+++ b/src/lib/zxc_compress.c
@@ -2050,17 +2050,15 @@ static int zxc_encode_block_ghi(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRIC
  * @brief Encodes a raw data block (uncompressed).
  *
  * This function prepares and writes a "RAW" type block into the destination
- * buffer. It handles the block header, copying of source data, and optionally
- * the calculation and storage of a checksum.
+ * buffer. It handles the block header and copying of source data; any checksum
+ * is appended separately by the wrapper.
  *
  * @param[in] src Pointer to the source data to encode.
  * @param[in] src_sz Size of the source data in bytes.
  * @param[out] dst Pointer to the destination buffer.
  * @param[in] dst_cap Maximum capacity of the destination buffer.
  * @param[out] out_sz Pointer to a variable receiving the total written size
- * (header
- * + data + checksum).
- * @param[in] chk Boolean flag: if non-zero, a checksum is calculated and added.
+ * (header + data).
  *
  * @return ZXC_OK on success, or a negative zxc_error_t code (e.g., ZXC_ERROR_DST_TOO_SMALL) if the
  * destination buffer capacity is insufficient.

--- a/src/lib/zxc_deps.h
+++ b/src/lib/zxc_deps.h
@@ -34,8 +34,8 @@
 /**
  * @name Standard Headers
  * @brief Pulled in by the stock libzxc build to provide @c size_t,
- * @c uintN_t / @c intN_t, @c INT_MAX / @c UINT_MAX, @c malloc / @c calloc /
- * @c realloc / @c free / @c qsort, and @c memcpy / @c memset / @c memmove /
+ * @c uintN_t / @c intN_t, @c CHAR_BIT, @c malloc / @c calloc /
+ * @c realloc / @c free, and @c memcpy / @c memset / @c memmove /
  * @c memcmp.
  *
  * Vendored overrides of this file typically substitute @c <linux/limits.h>,

--- a/src/lib/zxc_dispatch.c
+++ b/src/lib/zxc_dispatch.c
@@ -683,8 +683,8 @@ int zxc_huf_unpack_lengths(const uint8_t* RESTRICT in, uint8_t* RESTRICT code_le
  * @param[in]  src_size         Size of @p src in bytes.
  * @param[out] dst              Destination buffer (use zxc_compress_bound() to size).
  * @param[in]  dst_capacity     Capacity of @p dst.
- * @param[in]  level            Compression level (1-5).
- * @param[in]  checksum_enabled Non-zero to enable per-block and global checksums.
+ * @param[in]  opts             Compression options (level, block size, checksum,
+ *                              dictionary, seekable, threads), or NULL for defaults.
  * @return Total compressed size in bytes, or a negative @ref zxc_error_t code.
  */
 // cppcheck-suppress unusedFunction
@@ -860,7 +860,8 @@ int64_t zxc_compress(const void* RESTRICT src, const size_t src_size, void* REST
  * @param[in]  src_size         Size of @p src in bytes.
  * @param[out] dst              Destination buffer for decompressed data.
  * @param[in]  dst_capacity     Capacity of @p dst.
- * @param[in]  checksum_enabled Non-zero to verify per-block and global checksums.
+ * @param[in]  opts             Decompression options (checksum verification,
+ *                              dictionary, threads), or NULL for defaults.
  * @return Total decompressed size in bytes, or a negative @ref zxc_error_t code.
  */
 // cppcheck-suppress unusedFunction

--- a/src/lib/zxc_driver.c
+++ b/src/lib/zxc_driver.c
@@ -210,9 +210,9 @@ typedef enum { JOB_STATUS_FREE, JOB_STATUS_FILLED, JOB_STATUS_PROCESSED } job_st
  * @var zxc_stream_job_t::status
  *      The current state of this job (Free, Filled, or Processed).
  * @var zxc_stream_job_t::pad
- *      Padding bytes to ensure the structure size aligns with typical cache
- * lines (64 bytes), minimizing cache contention between threads accessing
- * adjacent jobs.
+ *      Padding bytes to ensure the structure size aligns with the cache line
+ * size (@c ZXC_CACHE_LINE_SIZE), minimizing cache contention between threads
+ * accessing adjacent jobs.
  */
 typedef struct {
     uint8_t* in_buf;
@@ -307,6 +307,14 @@ typedef int (*zxc_chunk_processor_t)(zxc_cctx_t* RESTRICT ctx, const uint8_t* RE
  *    User data pointer to be passed to the progress callback function.
  * @var zxc_stream_ctx_t::total_input_bytes
  *     Total size of the input data in bytes, used for progress tracking.
+ * @var zxc_stream_ctx_t::dict
+ *     Pointer to the optional dictionary buffer used to prime
+ *     compression/decompression, NULL when no dictionary is in use.
+ * @var zxc_stream_ctx_t::dict_size
+ *     Size of the dictionary in bytes, 0 when no dictionary is in use.
+ * @var zxc_stream_ctx_t::dict_huf
+ *     Shared dictionary literal Huffman table (128-byte packed code-lengths
+ *     header), NULL when absent.
  */
 typedef struct {
     zxc_stream_job_t* jobs;

--- a/src/lib/zxc_internal.h
+++ b/src/lib/zxc_internal.h
@@ -473,10 +473,10 @@ extern "C" {
  *  @brief Hash table geometry, sliding window, and match parameters.
  *
  *  The hash table uses a split layout with 15-bit addressing (32 768 buckets):
- *  - `hash_positions[]`: uint32_t, stores `(epoch << offset_bits) | position` (128 KB).
+ *  - `hash_table[]`: uint32_t, stores `(epoch << offset_bits) | position` (128 KB).
  *  - `hash_tags[]`:      uint8_t, stores an 8-bit tag for fast rejection (32 KB).
  *  Total: 160 KB.  The tag table fits in L1 cache, enabling a
- *  "filter-first" access pattern that avoids cold loads into hash_positions
+ *  "filter-first" access pattern that avoids cold loads into hash_table
  *  on the ~60-75% of lookups where the tag mismatches.
  *  The 64 KB sliding window allows `chain_table` to use `uint16_t`.
  *  @{ */
@@ -815,7 +815,7 @@ typedef enum {
  * - `ZXC_SECTION_ENCODING_RAW`: Data is stored uncompressed.
  * - `ZXC_SECTION_ENCODING_RLE`: Run-Length Encoding.
  * - `ZXC_SECTION_ENCODING_HUFFMAN`: Canonical Huffman, 4-way interleaved
- *   sub-streams, max 11-bit codes, LSB-first. Only valid for the literal
+ *   sub-streams, max 8-bit codes, LSB-first. Only valid for the literal
  *   stream (`enc_lit`) of GLO blocks. Produced exclusively at level >= 6.
  * - `ZXC_SECTION_ENCODING_HUFFMAN_DICT`: same bitstream layout as HUFFMAN but
  *   the 128-byte code-lengths header is omitted: codes come from the shared
@@ -1508,7 +1508,7 @@ int zxc_huf_unpack_lengths(const uint8_t* RESTRICT in, uint8_t* RESTRICT code_le
  * - @c chain_table: collision chain storing the *previous* occurrence of a
  *   hash, forming a linked list per bucket and enabling history traversal.
  * - @c epoch: drives "lazy hash table invalidation". Instead of memset-ing
- *   the hash table for every block, we store `(epoch << 16) | offset`; an
+ *   the hash table for every block, we store `(epoch << offset_bits) | offset`; an
  *   entry whose stored epoch differs from `ctx->epoch` is treated as empty.
  */
 typedef struct {

--- a/src/lib/zxc_pstream.c
+++ b/src/lib/zxc_pstream.c
@@ -636,8 +636,8 @@ typedef enum {
  * @var zxc_dstream_s::file_has_checksum
  *      File-level checksum flag declared by the file header.
  * @var zxc_dstream_s::scratch
- *      Generic accumulator for fixed-size frames; sized for the largest
- *      (file header = 16 bytes).
+ *      Generic 32-byte accumulator for fixed-size frames (file header, block
+ *      header, footer); comfortably holds the largest (16-byte file header).
  * @var zxc_dstream_s::scratch_used
  *      Number of bytes currently held in @c scratch.
  * @var zxc_dstream_s::scratch_need


### PR DESCRIPTION
Enhances clarity and accuracy across various documentation aspects:
*   Updates example code and descriptions for compression and decompression options, standardizing the `checksum_enabled` option name and clarifying which options are utilized by single-threaded calls.
*   Refines the description of the library version string format to "MAJOR.MINOR.PATCH".
*   Clarifies the behavior of `ZXC_MAX_THREADS` by indicating that higher values are clamped, rather than resulting in an error.
*   Increases the maximum compression level from 5 to 6 in the options structure.
*   Improves internal comments regarding checksum handling in block encoding, hash table structure, Huffman encoding details, and scratch buffer usage.
*   Adds documentation for dictionary-related fields in the streaming context, hinting at dictionary support for streaming APIs.
*   Adjusts the list of standard header functions pulled in by the library.