### PR TITLE
feat: Adds Level 7 (Ultra) compression to wrappers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -758,8 +758,12 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
     )
     target_link_options(zxc_wasm PRIVATE
         "-sEXPORTED_FUNCTIONS=[${ZXC_WASM_EXPORTS_STR}]"
-        "-sEXPORTED_RUNTIME_METHODS=[ccall,cwrap,getValue,setValue,UTF8ToString,HEAPU8,HEAP32,HEAPU32]"
+        "-sEXPORTED_RUNTIME_METHODS=[ccall,cwrap,getValue,setValue,UTF8ToString,getTempRet0,HEAPU8,HEAP32,HEAPU32]"
         "-sMODULARIZE=1"
+        # ES6 output: the npm package is "type": "module", so a CJS zxc.js
+        # would expose no factory through `import` (broken default loading
+        # path of createZXC()).
+        "-sEXPORT_ES6=1"
         "-sEXPORT_NAME=ZXCModule"
         "-sALLOW_MEMORY_GROWTH=1"
         "-sINITIAL_MEMORY=2097152"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -689,7 +689,6 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
         "_zxc_compress"
         "_zxc_decompress"
         "_zxc_compress_bound"
-        "_zxc_compress_block_bound"
         "_zxc_get_decompressed_size"
         "_zxc_decompress_inplace"
         "_zxc_decompress_inplace_bound"
@@ -758,7 +757,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
     )
     target_link_options(zxc_wasm PRIVATE
         "-sEXPORTED_FUNCTIONS=[${ZXC_WASM_EXPORTS_STR}]"
-        "-sEXPORTED_RUNTIME_METHODS=[ccall,cwrap,getValue,setValue,UTF8ToString,getTempRet0,HEAPU8,HEAP32,HEAPU32]"
+        "-sEXPORTED_RUNTIME_METHODS=[ccall,cwrap,UTF8ToString,getTempRet0,HEAPU8,HEAP32,HEAPU32]"
         "-sMODULARIZE=1"
         # ES6 output: the npm package is "type": "module", so a CJS zxc.js
         # would expose no factory through `import` (broken default loading

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -759,9 +759,6 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
         "-sEXPORTED_FUNCTIONS=[${ZXC_WASM_EXPORTS_STR}]"
         "-sEXPORTED_RUNTIME_METHODS=[ccall,cwrap,UTF8ToString,getTempRet0,HEAPU8,HEAP32,HEAPU32]"
         "-sMODULARIZE=1"
-        # ES6 output: the npm package is "type": "module", so a CJS zxc.js
-        # would expose no factory through `import` (broken default loading
-        # path of createZXC()).
         "-sEXPORT_ES6=1"
         "-sEXPORT_NAME=ZXCModule"
         "-sALLOW_MEMORY_GROWTH=1"

--- a/include/zxc_buffer.h
+++ b/include/zxc_buffer.h
@@ -67,7 +67,7 @@ ZXC_EXPORT int zxc_min_level(void);
 /**
  * @brief Returns the maximum supported compression level.
  *
- * Currently returns @ref ZXC_LEVEL_DENSITY (6).
+ * Currently returns @ref ZXC_LEVEL_ULTRA (7).
  *
  * @return Maximum compression level value.
  */
@@ -421,8 +421,8 @@ ZXC_EXPORT int64_t zxc_decompress_block_safe(zxc_dctx* dctx, const void* src, co
  * Intended for integrators that need an accurate memory-budget figure.
  *
  * @param[in] src_size Uncompressed block size in bytes.
- * @param[in] level    Compression level (1..6). Levels <= 5 share the same
- *                     persistent cctx footprint; level 6 adds the optimal-
+ * @param[in] level    Compression level (1..7). Levels <= 5 share the same
+ *                     persistent cctx footprint; levels >= 6 add the optimal-
  *                     parser scratch.
  * @return Estimated peak cctx memory usage in bytes, or 0 if @p src_size is 0.
  */
@@ -587,7 +587,7 @@ ZXC_EXPORT int64_t zxc_decompress_dctx(zxc_dctx* dctx, const void* src, size_t s
  * @param[in] block_size  Block size in bytes (must satisfy the regular
  *                        block-size constraints: power of two in
  *                        [@ref ZXC_BLOCK_SIZE_MIN, @ref ZXC_BLOCK_SIZE_MAX]).
- * @param[in] level       Compression level (1..6); higher levels at
+ * @param[in] level       Compression level (1..7); levels at or above
  *                        @ref ZXC_LEVEL_DENSITY add the optimal-parser
  *                        scratch (~8.125 x block_size).
  * @return Workspace size in bytes, or 0 if either argument is invalid.

--- a/include/zxc_opts.h
+++ b/include/zxc_opts.h
@@ -60,7 +60,7 @@ typedef void (*zxc_progress_callback_t)(uint64_t bytes_processed, uint64_t bytes
  */
 typedef struct {
     int n_threads;     /**< Worker thread count (0 = auto-detect CPU cores). */
-    int level;         /**< Compression level 1-6 (0 = default, ZXC_LEVEL_DEFAULT). */
+    int level;         /**< Compression level 1-7 (0 = default, ZXC_LEVEL_DEFAULT). */
     size_t block_size; /**< Block size in bytes (0 = default ZXC_BLOCK_SIZE_DEFAULT). Must be power
                           of 2, [4KB - 2MB]. */
     int checksum_enabled; /**< 1 to enable per-block and global checksums, 0 to disable. */

--- a/src/lib/zxc_dispatch.c
+++ b/src/lib/zxc_dispatch.c
@@ -1543,8 +1543,11 @@ int64_t zxc_compress_block(zxc_cctx* cctx, const void* RESTRICT src, const size_
     cctx->stored_block_size = effective_block_size;
     cctx->stored_checksum = checksum_enabled;
 
-    /* Re-init only when block_size changed. */
-    if (UNLIKELY(!cctx->initialized || cctx->last_block_size != effective_block_size)) {
+    /* Re-init when block_size changed, or when a per-call level raise into
+     * the optimal-parser tier requires the opt_scratch region that inits at
+     * level < ZXC_LEVEL_DENSITY do not allocate (using it NULL would crash). */
+    if (UNLIKELY(!cctx->initialized || cctx->last_block_size != effective_block_size ||
+                 (level >= ZXC_LEVEL_DENSITY && !cctx->inner.opt_scratch))) {
         if (cctx->initialized) {
             // LCOV_EXCL_START
             zxc_cctx_free(&cctx->inner);

--- a/src/lib/zxc_pstream.c
+++ b/src/lib/zxc_pstream.c
@@ -231,8 +231,9 @@ static int cs_drain_pending(zxc_cstream* cs, zxc_outbuf_t* out) {
  * Copies @p opts into the new context, applying defaults for any zero-valued
  * field (@c level -> @ref ZXC_LEVEL_DEFAULT, @c block_size ->
  * @ref ZXC_BLOCK_SIZE_DEFAULT).  Forces single-threaded operation
- * (@c n_threads = 0), disables progress callbacks and seekable framing
- * (those modes belong to the @c FILE*-based pipeline).  Pre-sizes the
+ * (@c n_threads = 0), disables progress callbacks, seekable framing and
+ * dictionary options (those modes belong to the @c FILE*-based pipeline;
+ * the push-stream format carries no dict_id).  Pre-sizes the
  * @c pending buffer so that the file header / footer paths never need a
  * realloc.
  *
@@ -252,6 +253,9 @@ zxc_cstream* zxc_cstream_create(const zxc_compress_opts_t* opts) {
     cs->opts.progress_cb = NULL;
     cs->opts.user_data = NULL;
     cs->opts.seekable = 0;
+    cs->opts.dict = NULL;
+    cs->opts.dict_size = 0;
+    cs->opts.dict_huf = NULL;
     cs->block_size = cs->opts.block_size;
 
     cs->cctx = zxc_create_cctx(&cs->opts);

--- a/wrappers/go/zxc.go
+++ b/wrappers/go/zxc.go
@@ -67,16 +67,19 @@ const (
 	// (level 5).
 	LevelCompact Level = C.ZXC_LEVEL_COMPACT
 
-	// LevelDensity provides maximum density: Huffman-coded literals on top
-	// of LevelCompact plus a price-based optimal LZ77 parser. Slowest
-	// compression, best ratio (level 6).
+	// LevelDensity provides high density: Huffman-coded literals on top
+	// of LevelCompact plus a price-based optimal LZ77 parser (level 6).
 	LevelDensity Level = C.ZXC_LEVEL_DENSITY
+
+	// LevelUltra provides maximum density: Huffman-coded literals and sequence
+	// tokens with a deep parse. Slowest compression, best ratio (level 7).
+	LevelUltra Level = C.ZXC_LEVEL_ULTRA
 )
 
 // AllLevels returns all available compression levels from fastest to most
 // compact.
 func AllLevels() []Level {
-	return []Level{LevelFastest, LevelFast, LevelDefault, LevelBalanced, LevelCompact, LevelDensity}
+	return []Level{LevelFastest, LevelFast, LevelDefault, LevelBalanced, LevelCompact, LevelDensity, LevelUltra}
 }
 
 // ============================================================================
@@ -119,7 +122,7 @@ func MinLevel() int {
 	return int(C.zxc_min_level())
 }
 
-// MaxLevel returns the maximum supported compression level (currently 6).
+// MaxLevel returns the maximum supported compression level (currently 7).
 func MaxLevel() int {
 	return int(C.zxc_max_level())
 }

--- a/wrappers/go/zxc.go
+++ b/wrappers/go/zxc.go
@@ -162,7 +162,19 @@ var (
 	ErrNullInput    = &Error{Code: int(C.ZXC_ERROR_NULL_INPUT), Name: "null input pointer"}
 	ErrBadBlockType = &Error{Code: int(C.ZXC_ERROR_BAD_BLOCK_TYPE), Name: "unknown block type"}
 	ErrBadBlockSize = &Error{Code: int(C.ZXC_ERROR_BAD_BLOCK_SIZE), Name: "invalid block size"}
+	ErrDictRequired = &Error{Code: int(C.ZXC_ERROR_DICT_REQUIRED), Name: "archive requires a dictionary"}
+	ErrDictMismatch = &Error{Code: int(C.ZXC_ERROR_DICT_MISMATCH), Name: "dictionary ID mismatch"}
+	ErrDictTooLarge = &Error{Code: int(C.ZXC_ERROR_DICT_TOO_LARGE), Name: "dictionary exceeds maximum size"}
 	ErrInvalidData  = errors.New("zxc: invalid compressed data")
+
+	// ErrBadHufTable is returned when a shared literal Huffman table does not
+	// have the required [HufTableSize] length.
+	ErrBadHufTable = errors.New("zxc: shared Huffman table must be HufTableSize bytes")
+
+	// ErrDictUnsupported is returned by the push streaming API when dictionary
+	// options are supplied: the push-stream format carries no dictionary ID, so
+	// dictionary compression would produce undecodable archives.
+	ErrDictUnsupported = errors.New("zxc: dictionaries are not supported by the push streaming API")
 )
 
 // errorFromCode converts a negative C error code to a Go error.
@@ -196,6 +208,12 @@ func errorFromCode(code C.int64_t) error {
 		return ErrBadBlockType
 	case int(C.ZXC_ERROR_BAD_BLOCK_SIZE):
 		return ErrBadBlockSize
+	case int(C.ZXC_ERROR_DICT_REQUIRED):
+		return ErrDictRequired
+	case int(C.ZXC_ERROR_DICT_MISMATCH):
+		return ErrDictMismatch
+	case int(C.ZXC_ERROR_DICT_TOO_LARGE):
+		return ErrDictTooLarge
 	default:
 		return fmt.Errorf("zxc: unknown error (code %d)", int(code))
 	}
@@ -213,6 +231,12 @@ type options struct {
 	threads  int
 	dict     []byte
 	dictHuf  []byte
+
+	// levelSet / checksumSet record whether the caller supplied the option
+	// explicitly, so per-call options can fall back to context-creation values
+	// instead of silently overriding them with defaults (see Cctx).
+	levelSet    bool
+	checksumSet bool
 }
 
 func defaultOptions() options {
@@ -228,12 +252,18 @@ type Option func(*options)
 
 // WithLevel sets the compression level.
 func WithLevel(l Level) Option {
-	return func(o *options) { o.level = l }
+	return func(o *options) {
+		o.level = l
+		o.levelSet = true
+	}
 }
 
 // WithChecksum enables checksum computation and verification.
 func WithChecksum(enabled bool) Option {
-	return func(o *options) { o.checksum = enabled }
+	return func(o *options) {
+		o.checksum = enabled
+		o.checksumSet = true
+	}
 }
 
 // WithThreads sets the number of worker threads for streaming operations.

--- a/wrappers/go/zxc_block.go
+++ b/wrappers/go/zxc_block.go
@@ -29,7 +29,7 @@ func CompressBlockBound(inputSize int) uint64 {
 }
 
 // DecompressBlockBound returns the minimum destination buffer size required
-// by [Cctx.DecompressBlock] for a block of uncompressedSize bytes.
+// by [Dctx.DecompressBlock] for a block of uncompressedSize bytes.
 //
 // The fast decoder uses speculative wild-copy writes and needs a small tail
 // pad beyond the declared uncompressed size. Callers that cannot oversize
@@ -65,13 +65,18 @@ func EstimateCctxSize(srcSize, level int) uint64 {
 // [NewCctx] and always defer a call to Close to release the native memory.
 type Cctx struct {
 	ptr *C.zxc_cctx
+
+	// Creation-time settings, used as the fallback for CompressBlock calls
+	// that do not override them explicitly.
+	level    Level
+	checksum bool
 }
 
 // NewCctx creates a new compression context.
 //
-// Options [WithLevel], [WithChecksum] and [WithBlockSize] are supported at
-// creation time to pre-allocate internal buffers; otherwise allocation is
-// deferred to the first call to [Cctx.CompressBlock].
+// Options [WithLevel] and [WithChecksum] are supported at creation time and
+// become the defaults for every [Cctx.CompressBlock] call that does not
+// override them per call.
 func NewCctx(opts ...Option) (*Cctx, error) {
 	o := applyOptions(opts)
 	var copts C.zxc_compress_opts_t
@@ -85,7 +90,7 @@ func NewCctx(opts ...Option) (*Cctx, error) {
 	if ptr == nil {
 		return nil, ErrMemory
 	}
-	return &Cctx{ptr: ptr}, nil
+	return &Cctx{ptr: ptr, level: o.level, checksum: o.checksum}, nil
 }
 
 // Close releases the native resources held by the context. Safe to call
@@ -102,6 +107,9 @@ func (c *Cctx) Close() error {
 // CompressBlock compresses a single block using the context. Output format
 // is [block_header(8B) + payload (+ optional checksum 4B)]. Use
 // [CompressBlockBound] to size dst.
+//
+// Per-call [WithLevel] / [WithChecksum] override the values given to
+// [NewCctx]; when omitted, the creation-time settings apply.
 func (c *Cctx) CompressBlock(src, dst []byte, opts ...Option) (int, error) {
 	if c == nil || c.ptr == nil {
 		return 0, ErrNullInput
@@ -113,7 +121,16 @@ func (c *Cctx) CompressBlock(src, dst []byte, opts ...Option) (int, error) {
 		return 0, ErrDstTooSmall
 	}
 
+	// Merge per-call options over the creation-time settings: the C side
+	// always receives a non-NULL opts struct, so its own stored-level
+	// fallback never triggers and the merge must happen here.
 	o := applyOptions(opts)
+	if !o.levelSet {
+		o.level = c.level
+	}
+	if !o.checksumSet {
+		o.checksum = c.checksum
+	}
 	var copts C.zxc_compress_opts_t
 	copts.level = C.int(o.level)
 	if o.checksum {

--- a/wrappers/go/zxc_block.go
+++ b/wrappers/go/zxc_block.go
@@ -110,6 +110,8 @@ func (c *Cctx) Close() error {
 //
 // Per-call [WithLevel] / [WithChecksum] override the values given to
 // [NewCctx]; when omitted, the creation-time settings apply.
+// [WithDict]/[WithDictHuf] are not wired to the block API and are ignored;
+// use the buffer API ([Compress]/[Decompress]) for dictionary compression.
 func (c *Cctx) CompressBlock(src, dst []byte, opts ...Option) (int, error) {
 	if c == nil || c.ptr == nil {
 		return 0, ErrNullInput

--- a/wrappers/go/zxc_buffer.go
+++ b/wrappers/go/zxc_buffer.go
@@ -12,6 +12,7 @@ package zxc
 */
 import "C"
 import (
+	"math"
 	"runtime"
 	"unsafe"
 )
@@ -43,7 +44,9 @@ func Compress(data []byte, opts ...Option) ([]byte, error) {
 	}
 	var pinner runtime.Pinner
 	defer pinner.Unpin()
-	setCompressDict(&copts, o, &pinner)
+	if err := setCompressDict(&copts, o, &pinner); err != nil {
+		return nil, err
+	}
 
 	// &data[0] panics on an empty slice; pass a valid non-nil pointer instead
 	// (the C side reads 0 bytes) so empty input yields a minimal 36-byte frame.
@@ -90,7 +93,9 @@ func CompressTo(data []byte, output []byte, opts ...Option) (int, error) {
 	}
 	var pinner runtime.Pinner
 	defer pinner.Unpin()
-	setCompressDict(&copts, o, &pinner)
+	if err := setCompressDict(&copts, o, &pinner); err != nil {
+		return 0, err
+	}
 
 	written := C.zxc_compress(
 		unsafe.Pointer(&data[0]),
@@ -147,12 +152,23 @@ func Decompress(data []byte, opts ...Option) ([]byte, error) {
 	}
 	var pinner runtime.Pinner
 	defer pinner.Unpin()
-	setDecompressDict(&dopts, o, &pinner)
+	if err := setDecompressDict(&dopts, o, &pinner); err != nil {
+		return nil, err
+	}
 
 	size := uint64(C.zxc_get_decompressed_size(
 		unsafe.Pointer(&data[0]),
 		C.size_t(len(data)),
 	))
+
+	// The size comes from the (untrusted) footer with no plausibility check in
+	// C. Reject values that cannot be allocated or that exceed the format's
+	// maximum expansion (a block header is 8 bytes and decodes to at most
+	// ZXC_BLOCK_SIZE_MAX bytes) instead of panicking in make().
+	const maxRatio = uint64(C.ZXC_BLOCK_SIZE_MAX) / 8
+	if size > math.MaxInt || size/maxRatio > uint64(len(data)) {
+		return nil, ErrInvalidData
+	}
 
 	if size == 0 {
 		// Either a valid empty-payload archive or invalid input. Let the C
@@ -212,7 +228,9 @@ func DecompressTo(data []byte, output []byte, opts ...Option) (int, error) {
 	}
 	var pinner runtime.Pinner
 	defer pinner.Unpin()
-	setDecompressDict(&dopts, o, &pinner)
+	if err := setDecompressDict(&dopts, o, &pinner); err != nil {
+		return 0, err
+	}
 
 	written := C.zxc_decompress(
 		unsafe.Pointer(&data[0]),

--- a/wrappers/go/zxc_dict.go
+++ b/wrappers/go/zxc_dict.go
@@ -34,31 +34,43 @@ const HufTableSize = int(C.ZXC_HUF_TABLE_SIZE)
 // the Go pointer stored inside the (Go-allocated) opts struct satisfies the
 // cgo pointer-passing rules; callers must keep pinner alive until the C call
 // returns.
-func setCompressDict(copts *C.zxc_compress_opts_t, o options, pinner *runtime.Pinner) {
+//
+// The shared Huffman table length is validated here: the C library reads a
+// fixed ZXC_HUF_TABLE_SIZE bytes from dict_huf, so a shorter slice would be
+// read out of bounds.
+func setCompressDict(copts *C.zxc_compress_opts_t, o options, pinner *runtime.Pinner) error {
 	if len(o.dict) == 0 {
-		return
+		return nil
 	}
 	pinner.Pin(&o.dict[0])
 	copts.dict = unsafe.Pointer(&o.dict[0])
 	copts.dict_size = C.size_t(len(o.dict))
 	if len(o.dictHuf) > 0 {
+		if len(o.dictHuf) != HufTableSize {
+			return ErrBadHufTable
+		}
 		pinner.Pin(&o.dictHuf[0])
 		copts.dict_huf = unsafe.Pointer(&o.dictHuf[0])
 	}
+	return nil
 }
 
 // setDecompressDict mirrors setCompressDict for decompression options.
-func setDecompressDict(dopts *C.zxc_decompress_opts_t, o options, pinner *runtime.Pinner) {
+func setDecompressDict(dopts *C.zxc_decompress_opts_t, o options, pinner *runtime.Pinner) error {
 	if len(o.dict) == 0 {
-		return
+		return nil
 	}
 	pinner.Pin(&o.dict[0])
 	dopts.dict = unsafe.Pointer(&o.dict[0])
 	dopts.dict_size = C.size_t(len(o.dict))
 	if len(o.dictHuf) > 0 {
+		if len(o.dictHuf) != HufTableSize {
+			return ErrBadHufTable
+		}
 		pinner.Pin(&o.dictHuf[0])
 		dopts.dict_huf = unsafe.Pointer(&o.dictHuf[0])
 	}
+	return nil
 }
 
 // TrainDict trains a dictionary from a corpus of samples.

--- a/wrappers/go/zxc_dict.go
+++ b/wrappers/go/zxc_dict.go
@@ -9,7 +9,6 @@ package zxc
 
 /*
 #include <stdlib.h>
-#include <string.h>
 #include "zxc.h"
 */
 import "C"
@@ -73,6 +72,34 @@ func setDecompressDict(dopts *C.zxc_decompress_opts_t, o options, pinner *runtim
 	return nil
 }
 
+// pinSamples builds C-allocated pointer/size arrays that reference the
+// sample buffers directly: each sample is pinned via pinner, which makes it
+// legal (Go >= 1.21) to store its address in C memory for the duration of
+// the call — training never copies the corpus. Empty samples point at a
+// pinned placeholder byte so the C side never sees NULL. The returned
+// arrays must be freed with C.free; the pins are released by the caller's
+// pinner.Unpin.
+func pinSamples(samples [][]byte, pinner *runtime.Pinner) (cptrs, csizes unsafe.Pointer) {
+	n := len(samples)
+	cptrs = C.malloc(C.size_t(n) * C.size_t(unsafe.Sizeof(uintptr(0))))
+	csizes = C.malloc(C.size_t(n) * C.size_t(unsafe.Sizeof(C.size_t(0))))
+	ptrSlice := unsafe.Slice((*unsafe.Pointer)(cptrs), n)
+	sizeSlice := unsafe.Slice((*C.size_t)(csizes), n)
+
+	placeholder := new(byte)
+	pinner.Pin(placeholder)
+	for i, s := range samples {
+		sizeSlice[i] = C.size_t(len(s))
+		if len(s) == 0 {
+			ptrSlice[i] = unsafe.Pointer(placeholder)
+			continue
+		}
+		pinner.Pin(&s[0])
+		ptrSlice[i] = unsafe.Pointer(&s[0])
+	}
+	return cptrs, csizes
+}
+
 // TrainDict trains a dictionary from a corpus of samples.
 //
 // It analyses the samples to select byte sequences that maximise LZ77 match
@@ -89,53 +116,17 @@ func TrainDict(samples [][]byte, maxSize int) ([]byte, error) {
 		maxSize = DictSizeMax
 	}
 
-	// cgo forbids passing a Go pointer to memory that itself contains Go
-	// pointers, so the sample buffers, the pointer array, and the size array
-	// are all built in C-allocated memory. Each sample is copied into C memory
-	// for the duration of the call.
-	n := len(samples)
-	cptrs := C.malloc(C.size_t(n) * C.size_t(unsafe.Sizeof(uintptr(0))))
-	if cptrs == nil {
-		return nil, ErrMemory
-	}
+	var pinner runtime.Pinner
+	defer pinner.Unpin()
+	cptrs, csizes := pinSamples(samples, &pinner)
 	defer C.free(cptrs)
-	csizes := C.malloc(C.size_t(n) * C.size_t(unsafe.Sizeof(C.size_t(0))))
-	if csizes == nil {
-		return nil, ErrMemory
-	}
 	defer C.free(csizes)
-
-	ptrSlice := unsafe.Slice((*unsafe.Pointer)(cptrs), n)
-	sizeSlice := unsafe.Slice((*C.size_t)(csizes), n)
-	// Free each copied sample buffer on return.
-	defer func() {
-		for _, p := range ptrSlice {
-			if p != nil {
-				C.free(p)
-			}
-		}
-	}()
-
-	for i, s := range samples {
-		sizeSlice[i] = C.size_t(len(s))
-		if len(s) == 0 {
-			// Allocate a 1-byte placeholder so the pointer is non-NULL.
-			ptrSlice[i] = C.malloc(1)
-			continue
-		}
-		buf := C.malloc(C.size_t(len(s)))
-		if buf == nil {
-			return nil, ErrMemory
-		}
-		C.memcpy(buf, unsafe.Pointer(&s[0]), C.size_t(len(s)))
-		ptrSlice[i] = buf
-	}
 
 	dict := make([]byte, DictSizeMax)
 	written := C.zxc_train_dict(
 		(*unsafe.Pointer)(cptrs),
 		(*C.size_t)(csizes),
-		C.size_t(n),
+		C.size_t(len(samples)),
 		unsafe.Pointer(&dict[0]),
 		C.size_t(maxSize),
 	)
@@ -211,47 +202,17 @@ func TrainDictHuf(samples [][]byte, dict []byte) ([]byte, error) {
 		return nil, ErrSrcTooSmall
 	}
 
-	n := len(samples)
-	cptrs := C.malloc(C.size_t(n) * C.size_t(unsafe.Sizeof(uintptr(0))))
-	if cptrs == nil {
-		return nil, ErrMemory
-	}
+	var pinner runtime.Pinner
+	defer pinner.Unpin()
+	cptrs, csizes := pinSamples(samples, &pinner)
 	defer C.free(cptrs)
-	csizes := C.malloc(C.size_t(n) * C.size_t(unsafe.Sizeof(C.size_t(0))))
-	if csizes == nil {
-		return nil, ErrMemory
-	}
 	defer C.free(csizes)
-
-	ptrSlice := unsafe.Slice((*unsafe.Pointer)(cptrs), n)
-	sizeSlice := unsafe.Slice((*C.size_t)(csizes), n)
-	defer func() {
-		for _, p := range ptrSlice {
-			if p != nil {
-				C.free(p)
-			}
-		}
-	}()
-
-	for i, s := range samples {
-		sizeSlice[i] = C.size_t(len(s))
-		if len(s) == 0 {
-			ptrSlice[i] = C.malloc(1)
-			continue
-		}
-		buf := C.malloc(C.size_t(len(s)))
-		if buf == nil {
-			return nil, ErrMemory
-		}
-		C.memcpy(buf, unsafe.Pointer(&s[0]), C.size_t(len(s)))
-		ptrSlice[i] = buf
-	}
 
 	huf := make([]byte, HufTableSize)
 	rc := C.zxc_train_dict_huf(
 		(*unsafe.Pointer)(cptrs),
 		(*C.size_t)(csizes),
-		C.size_t(n),
+		C.size_t(len(samples)),
 		unsafe.Pointer(&dict[0]),
 		C.size_t(len(dict)),
 		(*C.uint8_t)(unsafe.Pointer(&huf[0])),
@@ -304,48 +265,18 @@ func TrainDictionary(samples [][]byte) (*Dictionary, error) {
 		return nil, ErrSrcTooSmall
 	}
 
-	n := len(samples)
-	cptrs := C.malloc(C.size_t(n) * C.size_t(unsafe.Sizeof(uintptr(0))))
-	if cptrs == nil {
-		return nil, ErrMemory
-	}
+	var pinner runtime.Pinner
+	defer pinner.Unpin()
+	cptrs, csizes := pinSamples(samples, &pinner)
 	defer C.free(cptrs)
-	csizes := C.malloc(C.size_t(n) * C.size_t(unsafe.Sizeof(C.size_t(0))))
-	if csizes == nil {
-		return nil, ErrMemory
-	}
 	defer C.free(csizes)
-
-	ptrSlice := unsafe.Slice((*unsafe.Pointer)(cptrs), n)
-	sizeSlice := unsafe.Slice((*C.size_t)(csizes), n)
-	defer func() {
-		for _, p := range ptrSlice {
-			if p != nil {
-				C.free(p)
-			}
-		}
-	}()
-
-	for i, s := range samples {
-		sizeSlice[i] = C.size_t(len(s))
-		if len(s) == 0 {
-			ptrSlice[i] = C.malloc(1)
-			continue
-		}
-		buf := C.malloc(C.size_t(len(s)))
-		if buf == nil {
-			return nil, ErrMemory
-		}
-		C.memcpy(buf, unsafe.Pointer(&s[0]), C.size_t(len(s)))
-		ptrSlice[i] = buf
-	}
 
 	cap := uint64(C.zxc_dict_save_bound(C.size_t(DictSizeMax)))
 	zxd := make([]byte, cap)
 	written := C.zxc_dict_train(
 		(*unsafe.Pointer)(cptrs),
 		(*C.size_t)(csizes),
-		C.size_t(n),
+		C.size_t(len(samples)),
 		unsafe.Pointer(&zxd[0]),
 		C.size_t(cap),
 	)

--- a/wrappers/go/zxc_dup_windows.go
+++ b/wrappers/go/zxc_dup_windows.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"os"
 	"runtime"
+	"syscall"
 )
 
 // C mode strings - allocated once, never freed (intentional; they live for the
@@ -21,56 +22,49 @@ var (
 	cModeWrite = C.CString("wb")
 )
 
-// dupFileRead converts a Go *os.File to a C FILE* for reading on Windows.
+// dupHandleToFile duplicates the Windows HANDLE owned by f, wraps the
+// duplicate as a CRT fd, then opens a C FILE* over it. The FILE* owns the
+// whole chain: fclose() closes the CRT fd, which closes the duplicated
+// HANDLE. Go's *os.File and its HANDLE are never touched.
 //
-// os.File.Fd() returns a Windows HANDLE (not a CRT fd), so we must use
-// _open_osfhandle() to wrap it as a CRT fd, then _dup() to own it
-// independently, since _open_osfhandle() transfers ownership of the HANDLE.
-func dupFileRead(f *os.File) (*C.FILE, error) {
-	handle := C.intptr_t(f.Fd())
+// Duplicating the HANDLE first (rather than _open_osfhandle on Go's HANDLE
+// followed by _dup) matters: _open_osfhandle transfers HANDLE ownership to
+// the CRT fd, which then could never be closed without also closing Go's
+// HANDLE — permanently leaking one slot of the bounded CRT fd table per call.
+func dupHandleToFile(f *os.File, oflag C.int, mode *C.char, what string) (*C.FILE, error) {
+	proc, _ := syscall.GetCurrentProcess()
+	var dup syscall.Handle
+	err := syscall.DuplicateHandle(
+		proc, syscall.Handle(f.Fd()), proc, &dup,
+		0, false, syscall.DUPLICATE_SAME_ACCESS,
+	)
 	runtime.KeepAlive(f)
+	if err != nil {
+		return nil, fmt.Errorf("zxc: DuplicateHandle failed for %s fd: %w", what, err)
+	}
 
-	// Wrap the HANDLE as a read-only CRT fd.
-	crtFd := C._open_osfhandle(handle, C._O_RDONLY)
+	crtFd := C._open_osfhandle(C.intptr_t(dup), oflag)
 	if crtFd < 0 {
-		return nil, fmt.Errorf("zxc: _open_osfhandle failed for read fd")
+		syscall.CloseHandle(dup)
+		return nil, fmt.Errorf("zxc: _open_osfhandle failed for %s fd", what)
 	}
 
-	// Dup so we own this fd independently from Go's *os.File.
-	// Do NOT close crtFd: _open_osfhandle transfers HANDLE ownership to the
-	// CRT; closing it would also close the HANDLE still owned by Go.
-	dupFd := C._dup(crtFd)
-	if dupFd < 0 {
-		return nil, fmt.Errorf("zxc: _dup failed for read fd")
-	}
-
-	cFile := C._fdopen(dupFd, cModeRead)
+	cFile := C._fdopen(crtFd, mode)
 	if cFile == nil {
-		C._close(dupFd)
-		return nil, fmt.Errorf("zxc: _fdopen failed for read fd")
+		C._close(crtFd) // also closes the duplicated HANDLE
+		return nil, fmt.Errorf("zxc: _fdopen failed for %s fd", what)
 	}
 	return cFile, nil
 }
 
-// dupFileWrite converts a Go *os.File to a C FILE* for writing on Windows.
+// dupFileRead converts a Go *os.File to an independently-owned C FILE* for
+// reading on Windows.
+func dupFileRead(f *os.File) (*C.FILE, error) {
+	return dupHandleToFile(f, C._O_RDONLY, cModeRead, "read")
+}
+
+// dupFileWrite converts a Go *os.File to an independently-owned C FILE* for
+// writing on Windows.
 func dupFileWrite(f *os.File) (*C.FILE, error) {
-	handle := C.intptr_t(f.Fd())
-	runtime.KeepAlive(f)
-
-	crtFd := C._open_osfhandle(handle, C._O_WRONLY)
-	if crtFd < 0 {
-		return nil, fmt.Errorf("zxc: _open_osfhandle failed for write fd")
-	}
-
-	dupFd := C._dup(crtFd)
-	if dupFd < 0 {
-		return nil, fmt.Errorf("zxc: _dup failed for write fd")
-	}
-
-	cFile := C._fdopen(dupFd, cModeWrite)
-	if cFile == nil {
-		C._close(dupFd)
-		return nil, fmt.Errorf("zxc: _fdopen failed for write fd")
-	}
-	return cFile, nil
+	return dupHandleToFile(f, C._O_WRONLY, cModeWrite, "write")
 }

--- a/wrappers/go/zxc_file.go
+++ b/wrappers/go/zxc_file.go
@@ -57,7 +57,12 @@ func CompressFile(input, output string, opts ...Option) (int64, error) {
 	if err != nil {
 		return 0, err
 	}
-	defer C.fclose(cOut)
+	outClosed := false
+	defer func() {
+		if !outClosed {
+			C.fclose(cOut)
+		}
+	}()
 
 	var copts C.zxc_compress_opts_t
 	copts.n_threads = C.int(o.threads)
@@ -70,11 +75,22 @@ func CompressFile(input, output string, opts ...Option) (int64, error) {
 	}
 	var pinner runtime.Pinner
 	defer pinner.Unpin()
-	setCompressDict(&copts, o, &pinner)
+	if err := setCompressDict(&copts, o, &pinner); err != nil {
+		return 0, err
+	}
 
 	result := C.zxc_stream_compress(cIn, cOut, &copts)
+
+	// fclose flushes the last stdio buffer of compressed output; a failure
+	// here (ENOSPC, EIO) means the archive tail never reached the OS, so it
+	// must be reported instead of being swallowed by a deferred close.
+	outClosed = true
+	closeRC := C.fclose(cOut)
 	if result < 0 {
 		return 0, errorFromCode(result)
+	}
+	if closeRC != 0 {
+		return 0, ErrIO
 	}
 	return int64(result), nil
 }
@@ -132,7 +148,12 @@ func DecompressFile(input, output string, opts ...Option) (int64, error) {
 	if err != nil {
 		return 0, err
 	}
-	defer C.fclose(cOut)
+	outClosed := false
+	defer func() {
+		if !outClosed {
+			C.fclose(cOut)
+		}
+	}()
 
 	var dopts C.zxc_decompress_opts_t
 	dopts.n_threads = C.int(o.threads)
@@ -141,11 +162,20 @@ func DecompressFile(input, output string, opts ...Option) (int64, error) {
 	}
 	var pinner runtime.Pinner
 	defer pinner.Unpin()
-	setDecompressDict(&dopts, o, &pinner)
+	if err := setDecompressDict(&dopts, o, &pinner); err != nil {
+		return 0, err
+	}
 
 	result := C.zxc_stream_decompress(cIn, cOut, &dopts)
+
+	// See CompressFile: the fclose flush result is part of the success path.
+	outClosed = true
+	closeRC := C.fclose(cOut)
 	if result < 0 {
 		return 0, errorFromCode(result)
+	}
+	if closeRC != 0 {
+		return 0, ErrIO
 	}
 	return int64(result), nil
 }

--- a/wrappers/go/zxc_io.go
+++ b/wrappers/go/zxc_io.go
@@ -101,11 +101,13 @@ func (w *Writer) Write(p []byte) (int, error) {
 		total += consumed
 		p = p[consumed:]
 
-		// If the encoder made no input progress, drain pending output and
-		// retry — this guarantees forward progress even when the caller
-		// supplies a smaller-than-recommended output buffer.
+		// Defensive: the encoder reported no input progress, no output and
+		// nothing pending while input remains. This should be unreachable
+		// with a healthy stream; returning nil here would silently drop the
+		// rest of p, violating the io.Writer contract.
 		if consumed == 0 && produced == 0 && pending == 0 {
-			break
+			w.err = io.ErrShortWrite
+			return total, io.ErrShortWrite
 		}
 	}
 	return total, nil

--- a/wrappers/go/zxc_regression_test.go
+++ b/wrappers/go/zxc_regression_test.go
@@ -1,0 +1,102 @@
+package zxc
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"testing"
+)
+
+// Regression tests for wrapper-review fixes: create-time option inheritance
+// in the block API, footer plausibility validation, pstream dictionary
+// rejection, dictionary error-code mapping, and Huffman-table length checks.
+
+func TestFixCctxStickyLevel(t *testing.T) {
+	src := bytes.Repeat([]byte("the quick brown fox jumps over the lazy dog 0123456789 "), 2000)
+	dst := make([]byte, CompressBlockBound(len(src)))
+
+	cUltra, err := NewCctx(WithLevel(LevelUltra))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cUltra.Close()
+	nDefault := 0
+	{
+		c, _ := NewCctx(WithLevel(LevelDefault))
+		defer c.Close()
+		nDefault, err = c.CompressBlock(src, dst, WithLevel(LevelDefault))
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	nExplicitUltra := 0
+	{
+		c, _ := NewCctx()
+		defer c.Close()
+		nExplicitUltra, err = c.CompressBlock(src, dst, WithLevel(LevelUltra))
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	// No per-call options: must inherit the create-time ULTRA level.
+	nInherited, err := cUltra.CompressBlock(src, dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if nInherited != nExplicitUltra {
+		t.Fatalf("create-time level not inherited: got %d, explicit ultra %d, default %d",
+			nInherited, nExplicitUltra, nDefault)
+	}
+	if nInherited == nDefault && nDefault != nExplicitUltra {
+		t.Fatalf("no-opts call silently used LevelDefault")
+	}
+}
+
+func TestFixDecompressCraftedFooter(t *testing.T) {
+	comp, err := Compress([]byte("hello world hello world"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Footer = original_size(8) + checksum(4); patch original_size to 2^64-1.
+	binary.LittleEndian.PutUint64(comp[len(comp)-12:], ^uint64(0))
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("Decompress panicked on crafted footer: %v", r)
+		}
+	}()
+	if _, err := Decompress(comp); !errors.Is(err, ErrInvalidData) {
+		t.Fatalf("want ErrInvalidData, got %v", err)
+	}
+}
+
+func TestFixPstreamDictRejected(t *testing.T) {
+	if _, err := NewCStream(WithDict([]byte("abc"))); !errors.Is(err, ErrDictUnsupported) {
+		t.Fatalf("NewCStream(WithDict): want ErrDictUnsupported, got %v", err)
+	}
+	if _, err := NewDStream(WithDict([]byte("abc"))); !errors.Is(err, ErrDictUnsupported) {
+		t.Fatalf("NewDStream(WithDict): want ErrDictUnsupported, got %v", err)
+	}
+}
+
+func TestFixDictErrorCodes(t *testing.T) {
+	dict := bytes.Repeat([]byte("sample dictionary content for zxc "), 100)
+	payload := bytes.Repeat([]byte("sample dictionary content for zxc payload"), 50)
+	comp, err := Compress(payload, WithDict(dict))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Decompress(comp); !errors.Is(err, ErrDictRequired) {
+		t.Fatalf("want ErrDictRequired, got %v", err)
+	}
+	wrong := bytes.Repeat([]byte("a completely different dictionary "), 100)
+	if _, err := Decompress(comp, WithDict(wrong)); !errors.Is(err, ErrDictMismatch) {
+		t.Fatalf("want ErrDictMismatch, got %v", err)
+	}
+}
+
+func TestFixHufTableValidation(t *testing.T) {
+	dict := bytes.Repeat([]byte("sample dictionary content for zxc "), 100)
+	if _, err := Compress([]byte("data"), WithDict(dict), WithDictHuf([]byte("short"))); !errors.Is(err, ErrBadHufTable) {
+		t.Fatalf("want ErrBadHufTable, got %v", err)
+	}
+}

--- a/wrappers/go/zxc_seekable.go
+++ b/wrappers/go/zxc_seekable.go
@@ -269,6 +269,10 @@ func (s *Seekable) SetDict(dict, hufLengths []byte) error {
 	if len(dict) == 0 {
 		return ErrSrcTooSmall
 	}
+	if len(hufLengths) > 0 && len(hufLengths) != HufTableSize {
+		// The C library reads a fixed ZXC_HUF_TABLE_SIZE bytes from the table.
+		return ErrBadHufTable
+	}
 
 	// Copy the buffers into C-owned memory for the duration of the call (the
 	// library makes its own internal copies; the cgo pointer-passing rules

--- a/wrappers/go/zxc_seekable.go
+++ b/wrappers/go/zxc_seekable.go
@@ -10,7 +10,6 @@ package zxc
 /*
 #include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
 #include <stdint.h>
 #include "zxc_seekable.h"
 #include "zxc_stream.h"
@@ -34,6 +33,7 @@ import "C"
 
 import (
 	"io"
+	"runtime"
 	"runtime/cgo"
 	"unsafe"
 )
@@ -51,11 +51,11 @@ import (
 // from more than one goroutine concurrently.
 type Seekable struct {
 	ptr     *C.zxc_seekable
-	file    *C.FILE        // set when opened via Open
-	cbuf    unsafe.Pointer // C-owned copy of source bytes (OpenBytes)
-	dbuf    unsafe.Pointer // C-owned copy of the dictionary content (SetDict)
-	rhandle cgo.Handle     // valid when opened via OpenReader; zero otherwise
-	hasRH   bool           // true when rhandle is set (cgo.Handle 0 is itself valid)
+	file    *C.FILE // set when opened via Open
+	srcData []byte  // in-memory source (OpenBytes); pinned for the handle's life
+	pinner  runtime.Pinner
+	rhandle cgo.Handle // valid when opened via OpenReader; zero otherwise
+	hasRH   bool       // true when rhandle is set (cgo.Handle 0 is itself valid)
 }
 
 // Open opens a seekable archive from a file path.
@@ -88,26 +88,27 @@ func Open(path string) (*Seekable, error) {
 // OpenBytes opens a seekable archive from an in-memory buffer.
 //
 // The library requires the source buffer to remain valid for the lifetime
-// of the handle. To satisfy CGO pointer rules and avoid keeping a Go slice
-// pinned, OpenBytes copies the buffer into C-allocated memory. The copy is
-// freed by [Seekable.Close].
+// of the handle, so data is pinned (not copied) until [Seekable.Close] —
+// opening a large archive costs no extra memory. The caller must not
+// modify data while the handle is open.
 func OpenBytes(data []byte) (*Seekable, error) {
 	if len(data) == 0 {
 		return nil, ErrSrcTooSmall
 	}
 
-	cbuf := C.malloc(C.size_t(len(data)))
-	if cbuf == nil {
-		return nil, ErrMemory
-	}
-	C.memcpy(cbuf, unsafe.Pointer(&data[0]), C.size_t(len(data)))
+	// Pinning makes it legal for C to retain the pointer beyond the call
+	// (cgo pointer rules, Go >= 1.21) and keeps the backing array alive.
+	s := &Seekable{}
+	s.pinner.Pin(&data[0])
 
-	ptr := C.zxc_seekable_open(cbuf, C.size_t(len(data)))
+	ptr := C.zxc_seekable_open(unsafe.Pointer(&data[0]), C.size_t(len(data)))
 	if ptr == nil {
-		C.free(cbuf)
+		s.pinner.Unpin()
 		return nil, ErrInvalidData
 	}
-	return &Seekable{ptr: ptr, cbuf: cbuf}, nil
+	s.ptr = ptr
+	s.srcData = data
+	return s, nil
 }
 
 // OpenReader opens a seekable archive backed by a user-supplied
@@ -160,13 +161,9 @@ func (s *Seekable) Close() error {
 		C.fclose(s.file)
 		s.file = nil
 	}
-	if s.cbuf != nil {
-		C.free(s.cbuf)
-		s.cbuf = nil
-	}
-	if s.dbuf != nil {
-		C.free(s.dbuf)
-		s.dbuf = nil
+	if s.srcData != nil {
+		s.pinner.Unpin()
+		s.srcData = nil
 	}
 	if s.hasRH {
 		s.rhandle.Delete()
@@ -274,31 +271,17 @@ func (s *Seekable) SetDict(dict, hufLengths []byte) error {
 		return ErrBadHufTable
 	}
 
-	// Copy the buffers into C-owned memory for the duration of the call (the
-	// library makes its own internal copies; the cgo pointer-passing rules
-	// just forbid handing it Go memory containing Go pointers via the handle).
-	buf := C.malloc(C.size_t(len(dict) + len(hufLengths)))
-	if buf == nil {
-		return ErrMemory
-	}
-	C.memcpy(buf, unsafe.Pointer(&dict[0]), C.size_t(len(dict)))
+	// The library copies both buffers internally, so the Go pointers only
+	// need to stay valid for the duration of the call — passing them as
+	// direct call arguments satisfies the cgo pointer rules with no copy.
 	var huf unsafe.Pointer
 	if len(hufLengths) > 0 {
-		huf = unsafe.Add(buf, len(dict))
-		C.memcpy(huf, unsafe.Pointer(&hufLengths[0]), C.size_t(len(hufLengths)))
+		huf = unsafe.Pointer(&hufLengths[0])
 	}
-
-	rc := C.zxc_seekable_set_dict(s.ptr, buf, C.size_t(len(dict)), huf)
+	rc := C.zxc_seekable_set_dict(s.ptr, unsafe.Pointer(&dict[0]), C.size_t(len(dict)), huf)
 	if rc < 0 {
-		C.free(buf)
 		return errorFromCode(C.int64_t(rc))
 	}
-
-	// Replace any previously-set dictionary buffer.
-	if s.dbuf != nil {
-		C.free(s.dbuf)
-	}
-	s.dbuf = buf
 	return nil
 }
 

--- a/wrappers/go/zxc_seekable_export.go
+++ b/wrappers/go/zxc_seekable_export.go
@@ -15,6 +15,7 @@ package zxc
 import "C"
 
 import (
+	"errors"
 	"io"
 	"runtime/cgo"
 	"unsafe"
@@ -44,7 +45,9 @@ func zxcGoSeekableReadAt(ctx unsafe.Pointer, dst unsafe.Pointer, length C.size_t
 	// Map the C-owned destination region as a Go slice without copying.
 	buf := unsafe.Slice((*byte)(dst), int(length))
 	n, err := reader.ReadAt(buf, int64(offset))
-	if err != nil || n != int(length) {
+	// io.ReaderAt explicitly allows (n == len(buf), io.EOF) when the read
+	// ends exactly at EOF — which the footer and seek-table reads always do.
+	if n != int(length) || (err != nil && !errors.Is(err, io.EOF)) {
 		return C.int64_t(C.ZXC_ERROR_IO)
 	}
 	return C.int64_t(length)

--- a/wrappers/go/zxc_stream.go
+++ b/wrappers/go/zxc_stream.go
@@ -9,7 +9,6 @@ package zxc
 
 /*
 #include <stdlib.h>
-#include <string.h>
 #include "zxc.h"
 */
 import "C"
@@ -17,49 +16,6 @@ import (
 	"runtime"
 	"unsafe"
 )
-
-// cDictCopy copies a dictionary (and its optional shared Huffman table) into
-// a single C-owned allocation laid out as [dict | huf] and points opts at it.
-// The push streams retain the pointers for their whole lifetime, so they must
-// reference native (not Go) memory. Returns the C buffer to free later, or
-// nil when no dictionary is configured.
-func cCompressDictCopy(copts *C.zxc_compress_opts_t, o options) unsafe.Pointer {
-	if len(o.dict) == 0 {
-		return nil
-	}
-	buf := C.malloc(C.size_t(len(o.dict) + len(o.dictHuf)))
-	if buf == nil {
-		return nil
-	}
-	C.memcpy(buf, unsafe.Pointer(&o.dict[0]), C.size_t(len(o.dict)))
-	copts.dict = buf
-	copts.dict_size = C.size_t(len(o.dict))
-	if len(o.dictHuf) > 0 {
-		hufDst := unsafe.Add(buf, len(o.dict))
-		C.memcpy(hufDst, unsafe.Pointer(&o.dictHuf[0]), C.size_t(len(o.dictHuf)))
-		copts.dict_huf = hufDst
-	}
-	return buf
-}
-
-func cDecompressDictCopy(dopts *C.zxc_decompress_opts_t, o options) unsafe.Pointer {
-	if len(o.dict) == 0 {
-		return nil
-	}
-	buf := C.malloc(C.size_t(len(o.dict) + len(o.dictHuf)))
-	if buf == nil {
-		return nil
-	}
-	C.memcpy(buf, unsafe.Pointer(&o.dict[0]), C.size_t(len(o.dict)))
-	dopts.dict = buf
-	dopts.dict_size = C.size_t(len(o.dict))
-	if len(o.dictHuf) > 0 {
-		hufDst := unsafe.Add(buf, len(o.dict))
-		C.memcpy(hufDst, unsafe.Pointer(&o.dictHuf[0]), C.size_t(len(o.dictHuf)))
-		dopts.dict_huf = hufDst
-	}
-	return buf
-}
 
 // ============================================================================
 // Push Streaming API (single-threaded, caller-driven)
@@ -72,34 +28,31 @@ func cDecompressDictCopy(dopts *C.zxc_decompress_opts_t, o options) unsafe.Point
 //
 // CStream is not safe for concurrent use; one goroutine per stream.
 type CStream struct {
-	ptr  *C.zxc_cstream
-	dbuf unsafe.Pointer // C-owned dictionary copy retained for the stream's life
+	ptr *C.zxc_cstream
 }
 
 // NewCStream creates a push compression stream.
 //
-// Honoured options: [WithLevel], [WithChecksum], [WithDict]. [WithThreads] and
+// Honoured options: [WithLevel], [WithChecksum]. [WithThreads] and
 // [WithSeekable] are ignored (the push API is single-threaded and never
-// emits a seek table).
+// emits a seek table). [WithDict]/[WithDictionary] return
+// [ErrDictUnsupported]: the push-stream format carries no dictionary ID, so
+// dictionary compression would produce undecodable archives.
 func NewCStream(opts ...Option) (*CStream, error) {
 	o := applyOptions(opts)
+	if len(o.dict) > 0 || len(o.dictHuf) > 0 {
+		return nil, ErrDictUnsupported
+	}
 	var copts C.zxc_compress_opts_t
 	copts.level = C.int(o.level)
 	if o.checksum {
 		copts.checksum_enabled = 1
 	}
-	dbuf := cCompressDictCopy(&copts, o)
-	if dbuf == nil && len(o.dict) > 0 {
-		return nil, ErrMemory
-	}
 	ptr := C.zxc_cstream_create(&copts)
 	if ptr == nil {
-		if dbuf != nil {
-			C.free(dbuf)
-		}
 		return nil, ErrMemory
 	}
-	return &CStream{ptr: ptr, dbuf: dbuf}, nil
+	return &CStream{ptr: ptr}, nil
 }
 
 // Close releases the stream and all internal buffers. Safe to call multiple
@@ -110,10 +63,6 @@ func (c *CStream) Close() error {
 	}
 	C.zxc_cstream_free(c.ptr)
 	c.ptr = nil
-	if c.dbuf != nil {
-		C.free(c.dbuf)
-		c.dbuf = nil
-	}
 	return nil
 }
 
@@ -206,31 +155,27 @@ func (c *CStream) End(out []byte) (produced int, pending int64, err error) {
 // DStream is a push-based, single-threaded decompression stream — the Go
 // counterpart of the C [zxc_dstream].
 type DStream struct {
-	ptr  *C.zxc_dstream
-	dbuf unsafe.Pointer // C-owned dictionary copy retained for the stream's life
+	ptr *C.zxc_dstream
 }
 
 // NewDStream creates a push decompression stream.
 //
-// Honoured options: [WithChecksum], [WithDict]. [WithThreads] is ignored.
+// Honoured options: [WithChecksum]. [WithThreads] is ignored.
+// [WithDict]/[WithDictionary] return [ErrDictUnsupported] (see [NewCStream]).
 func NewDStream(opts ...Option) (*DStream, error) {
 	o := applyOptions(opts)
+	if len(o.dict) > 0 || len(o.dictHuf) > 0 {
+		return nil, ErrDictUnsupported
+	}
 	var dopts C.zxc_decompress_opts_t
 	if o.checksum {
 		dopts.checksum_enabled = 1
 	}
-	dbuf := cDecompressDictCopy(&dopts, o)
-	if dbuf == nil && len(o.dict) > 0 {
-		return nil, ErrMemory
-	}
 	ptr := C.zxc_dstream_create(&dopts)
 	if ptr == nil {
-		if dbuf != nil {
-			C.free(dbuf)
-		}
 		return nil, ErrMemory
 	}
-	return &DStream{ptr: ptr, dbuf: dbuf}, nil
+	return &DStream{ptr: ptr}, nil
 }
 
 // Close releases the stream and all internal buffers. Safe to call multiple
@@ -241,10 +186,6 @@ func (d *DStream) Close() error {
 	}
 	C.zxc_dstream_free(d.ptr)
 	d.ptr = nil
-	if d.dbuf != nil {
-		C.free(d.dbuf)
-		d.dbuf = nil
-	}
 	return nil
 }
 

--- a/wrappers/nodejs/README.md
+++ b/wrappers/nodejs/README.md
@@ -50,7 +50,7 @@ Compress a Buffer.
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `data` | `Buffer` | - | Input data |
-| `options.level` | `number` | `LEVEL_DEFAULT` | Compression level (1–5) |
+| `options.level` | `number` | `LEVEL_DEFAULT` | Compression level (1–7) |
 | `options.checksum` | `boolean` | `false` | Enable checksum |
 
 Returns: `Buffer` - compressed data.

--- a/wrappers/nodejs/lib/index.d.ts
+++ b/wrappers/nodejs/lib/index.d.ts
@@ -48,6 +48,12 @@ export const ERROR_NULL_INPUT: number;
 export const ERROR_BAD_BLOCK_TYPE: number;
 /** Invalid block size. */
 export const ERROR_BAD_BLOCK_SIZE: number;
+/** File requires a dictionary but none was provided. */
+export const ERROR_DICT_REQUIRED: number;
+/** Provided dictionary ID does not match the file header. */
+export const ERROR_DICT_MISMATCH: number;
+/** Dictionary exceeds maximum allowed size. */
+export const ERROR_DICT_TOO_LARGE: number;
 
 export interface CompressOptions {
     /** Compression level (1-7). Defaults to LEVEL_DEFAULT. */

--- a/wrappers/nodejs/lib/index.d.ts
+++ b/wrappers/nodejs/lib/index.d.ts
@@ -15,8 +15,10 @@ export const LEVEL_DEFAULT: number;
 export const LEVEL_BALANCED: number;
 /** High density. Best for storage/firmware/assets. */
 export const LEVEL_COMPACT: number;
-/** Maximum density: Huffman-coded literals on top of COMPACT. */
+/** High density: Huffman-coded literals on top of COMPACT. */
 export const LEVEL_DENSITY: number;
+/** Maximum density: Huffman-coded literals and sequence tokens (level 7 / ULTRA). */
+export const LEVEL_ULTRA: number;
 
 /** Memory allocation failure. */
 export const ERROR_MEMORY: number;
@@ -48,7 +50,7 @@ export const ERROR_BAD_BLOCK_TYPE: number;
 export const ERROR_BAD_BLOCK_SIZE: number;
 
 export interface CompressOptions {
-    /** Compression level (1-6). Defaults to LEVEL_DEFAULT. */
+    /** Compression level (1-7). Defaults to LEVEL_DEFAULT. */
     level?: number;
     /** Enable checksum verification. Defaults to false. */
     checksum?: boolean;
@@ -188,7 +190,7 @@ export function dictLoad(zxd: Buffer): LoadedDict;
 /** Returns the minimum supported compression level (currently 1). */
 export function minLevel(): number;
 
-/** Returns the maximum supported compression level (currently 6). */
+/** Returns the maximum supported compression level (currently 7). */
 export function maxLevel(): number;
 
 /** Returns the default compression level (currently 3). */
@@ -201,7 +203,7 @@ export function defaultLevel(): number;
 export function libraryVersion(): string;
 
 export interface CStreamOptions {
-    /** Compression level (1-6). Defaults to LEVEL_DEFAULT. */
+    /** Compression level (1-7). Defaults to LEVEL_DEFAULT. */
     level?: number;
     /** Enable per-block and global checksums. Defaults to false. */
     checksum?: boolean;

--- a/wrappers/nodejs/lib/index.js
+++ b/wrappers/nodejs/lib/index.js
@@ -34,6 +34,9 @@ const ERROR_IO             = native.ERROR_IO;
 const ERROR_NULL_INPUT     = native.ERROR_NULL_INPUT;
 const ERROR_BAD_BLOCK_TYPE = native.ERROR_BAD_BLOCK_TYPE;
 const ERROR_BAD_BLOCK_SIZE = native.ERROR_BAD_BLOCK_SIZE;
+const ERROR_DICT_REQUIRED  = native.ERROR_DICT_REQUIRED;
+const ERROR_DICT_MISMATCH  = native.ERROR_DICT_MISMATCH;
+const ERROR_DICT_TOO_LARGE = native.ERROR_DICT_TOO_LARGE;
 
 /**
  * Returns the minimum supported compression level (currently 1).
@@ -659,4 +662,7 @@ module.exports = {
     ERROR_NULL_INPUT,
     ERROR_BAD_BLOCK_TYPE,
     ERROR_BAD_BLOCK_SIZE,
+    ERROR_DICT_REQUIRED,
+    ERROR_DICT_MISMATCH,
+    ERROR_DICT_TOO_LARGE,
 };

--- a/wrappers/nodejs/lib/index.js
+++ b/wrappers/nodejs/lib/index.js
@@ -17,6 +17,7 @@ const LEVEL_DEFAULT  = native.LEVEL_DEFAULT;
 const LEVEL_BALANCED = native.LEVEL_BALANCED;
 const LEVEL_COMPACT  = native.LEVEL_COMPACT;
 const LEVEL_DENSITY  = native.LEVEL_DENSITY;
+const LEVEL_ULTRA    = native.LEVEL_ULTRA;
 
 // Re-export error constants
 const ERROR_MEMORY         = native.ERROR_MEMORY;
@@ -43,7 +44,7 @@ function minLevel() {
 }
 
 /**
- * Returns the maximum supported compression level (currently 6).
+ * Returns the maximum supported compression level (currently 7).
  * @returns {number}
  */
 function maxLevel() {
@@ -304,7 +305,7 @@ function dictLoad(zxd) {
  *
  * @param {Buffer} data - Buffer to compress.
  * @param {object} [options] - Compression options.
- * @param {number} [options.level=LEVEL_DEFAULT] - Compression level (1-6).
+ * @param {number} [options.level=LEVEL_DEFAULT] - Compression level (1-7).
  * @param {boolean} [options.checksum=false] - Enable checksum verification.
  * @param {boolean} [options.seekable=false] - Enable seek table for random-access decompression.
  * @param {Buffer|Uint8Array} [options.dict] - Pre-trained dictionary content (raw bytes).
@@ -640,6 +641,7 @@ module.exports = {
     LEVEL_BALANCED,
     LEVEL_COMPACT,
     LEVEL_DENSITY,
+    LEVEL_ULTRA,
 
     // Error handling
     errorName,

--- a/wrappers/nodejs/src/zxc_addon.cc
+++ b/wrappers/nodejs/src/zxc_addon.cc
@@ -9,6 +9,7 @@
 
 #include <array>
 #include <cstring>
+#include <memory>
 #include <vector>
 
 extern "C" {
@@ -89,7 +90,16 @@ static Napi::Value Compress(const Napi::CallbackInfo& info) {
     }
 
     uint64_t bound = zxc_compress_bound(src_size);
-    Napi::Buffer<uint8_t> dst_buf = Napi::Buffer<uint8_t>::New(env, static_cast<size_t>(bound));
+    // Uninitialised native scratch instead of a bound-size JS Buffer: the
+    // bound is >= src_size, and a JS allocation of that size would be
+    // registered as external GC memory only to be discarded after the
+    // copy-slice below.
+    std::unique_ptr<uint8_t[]> dst(new (std::nothrow) uint8_t[static_cast<size_t>(bound)]);
+    if (!dst) {
+        Napi::Error::New(env, "zxc: allocation failed for compression scratch")
+            .ThrowAsJavaScriptException();
+        return env.Undefined();
+    }
 
     zxc_compress_opts_t opts = {0};
     opts.level = level;
@@ -99,8 +109,7 @@ static Napi::Value Compress(const Napi::CallbackInfo& info) {
     opts.dict_size = dict_size;
     opts.dict_huf = dict_huf;
 
-    int64_t nwritten =
-        zxc_compress(src, src_size, dst_buf.Data(), static_cast<size_t>(bound), &opts);
+    int64_t nwritten = zxc_compress(src, src_size, dst.get(), static_cast<size_t>(bound), &opts);
 
     if (nwritten < 0) {
         auto err_code = static_cast<int>(nwritten);
@@ -111,7 +120,7 @@ static Napi::Value Compress(const Napi::CallbackInfo& info) {
     }
 
     // Return a slice of the buffer with the actual size
-    return Napi::Buffer<uint8_t>::Copy(env, dst_buf.Data(), static_cast<size_t>(nwritten));
+    return Napi::Buffer<uint8_t>::Copy(env, dst.get(), static_cast<size_t>(nwritten));
 }
 
 // =============================================================================
@@ -537,6 +546,10 @@ class CStreamWrap : public Napi::ObjectWrap<CStreamWrap> {
 
    private:
     zxc_cstream* cs_ = nullptr;
+    // Reusable staging buffer: sized on first use and kept across calls, so
+    // the malloc + value-initialising memset of a full block (~512 KB) is
+    // paid once per stream instead of once per streamed chunk.
+    std::vector<uint8_t> stage_;
 
     bool requireOpen(Napi::Env env) {
         if (!cs_) {
@@ -550,46 +563,44 @@ class CStreamWrap : public Napi::ObjectWrap<CStreamWrap> {
      * caller-supplied `step` decides whether one iteration of
      * zxc_cstream_compress / _end has fully drained. */
     Napi::Value DrainCompress(Napi::Env env, const uint8_t* src, size_t srcLen) {
-        std::vector<uint8_t> out;
         size_t cap = zxc_cstream_out_size(cs_);
         if (cap < 4096) cap = 4096;
-        out.resize(cap);
+        if (stage_.size() < cap) stage_.resize(cap);
         size_t out_len = 0;
 
         zxc_inbuf_t in = {src, srcLen, 0};
         for (;;) {
             size_t want = zxc_cstream_out_size(cs_);
             if (want < 4096) want = 4096;
-            if (out.size() - out_len < want) {
-                if (!GrowOutput(env, out, out_len, want)) return env.Undefined();
+            if (stage_.size() - out_len < want) {
+                if (!GrowOutput(env, stage_, out_len, want)) return env.Undefined();
             }
-            zxc_outbuf_t obuf = {out.data() + out_len, out.size() - out_len, 0};
+            zxc_outbuf_t obuf = {stage_.data() + out_len, stage_.size() - out_len, 0};
             int64_t r = zxc_cstream_compress(cs_, &obuf, &in);
             out_len += obuf.pos;
             if (r < 0) return ThrowZxcError(env, static_cast<int>(r));
             if (r == 0 && in.pos == in.size) break;
         }
-        return Napi::Buffer<uint8_t>::Copy(env, out.data(), out_len);
+        return Napi::Buffer<uint8_t>::Copy(env, stage_.data(), out_len);
     }
 
     Napi::Value DrainEnd(Napi::Env env) {
-        std::vector<uint8_t> out;
         size_t cap = zxc_cstream_out_size(cs_);
         if (cap < 4096) cap = 4096;
-        out.resize(cap);
+        if (stage_.size() < cap) stage_.resize(cap);
         size_t out_len = 0;
 
         for (;;) {
-            if (out.size() - out_len < 4096) {
-                if (!GrowOutput(env, out, out_len, 4096)) return env.Undefined();
+            if (stage_.size() - out_len < 4096) {
+                if (!GrowOutput(env, stage_, out_len, 4096)) return env.Undefined();
             }
-            zxc_outbuf_t obuf = {out.data() + out_len, out.size() - out_len, 0};
+            zxc_outbuf_t obuf = {stage_.data() + out_len, stage_.size() - out_len, 0};
             int64_t r = zxc_cstream_end(cs_, &obuf);
             out_len += obuf.pos;
             if (r < 0) return ThrowZxcError(env, static_cast<int>(r));
             if (r == 0) break;
         }
-        return Napi::Buffer<uint8_t>::Copy(env, out.data(), out_len);
+        return Napi::Buffer<uint8_t>::Copy(env, stage_.data(), out_len);
     }
 
     Napi::Value Compress(const Napi::CallbackInfo& info) {
@@ -614,6 +625,9 @@ class CStreamWrap : public Napi::ObjectWrap<CStreamWrap> {
             zxc_cstream_free(cs_);
             cs_ = nullptr;
         }
+        // Release the staging memory too; the JS wrapper object may outlive
+        // the stream by a long time.
+        std::vector<uint8_t>().swap(stage_);
         return info.Env().Undefined();
     }
 
@@ -662,6 +676,8 @@ class DStreamWrap : public Napi::ObjectWrap<DStreamWrap> {
 
    private:
     zxc_dstream* ds_ = nullptr;
+    // Reusable staging buffer; see CStreamWrap::stage_.
+    std::vector<uint8_t> stage_;
 
     bool requireOpen(Napi::Env env) {
         if (!ds_) {
@@ -680,20 +696,19 @@ class DStreamWrap : public Napi::ObjectWrap<DStreamWrap> {
         }
         Napi::Buffer<uint8_t> buf = info[0].As<Napi::Buffer<uint8_t>>();
 
-        std::vector<uint8_t> out;
         size_t cap = zxc_dstream_out_size(ds_);
         if (cap < 4096) cap = 4096;
-        out.resize(cap);
+        if (stage_.size() < cap) stage_.resize(cap);
         size_t out_len = 0;
 
         zxc_inbuf_t in = {buf.Data(), buf.Length(), 0};
         for (;;) {
             size_t want = zxc_dstream_out_size(ds_);
             if (want < 4096) want = 4096;
-            if (out.size() - out_len < want) {
-                if (!GrowOutput(env, out, out_len, want)) return env.Undefined();
+            if (stage_.size() - out_len < want) {
+                if (!GrowOutput(env, stage_, out_len, want)) return env.Undefined();
             }
-            zxc_outbuf_t obuf = {out.data() + out_len, out.size() - out_len, 0};
+            zxc_outbuf_t obuf = {stage_.data() + out_len, stage_.size() - out_len, 0};
             zxc_inbuf_t empty_in = {nullptr, 0, 0};
             zxc_inbuf_t* cur_in = (in.pos < in.size) ? &in : &empty_in;
             const size_t before_in = cur_in->pos;
@@ -705,7 +720,7 @@ class DStreamWrap : public Napi::ObjectWrap<DStreamWrap> {
              * no progress was made (no input consumed AND no output produced). */
             if (cur_in->pos == before_in && obuf.pos == before_out) break;
         }
-        return Napi::Buffer<uint8_t>::Copy(env, out.data(), out_len);
+        return Napi::Buffer<uint8_t>::Copy(env, stage_.data(), out_len);
     }
 
     Napi::Value Finished(const Napi::CallbackInfo& info) {
@@ -717,6 +732,7 @@ class DStreamWrap : public Napi::ObjectWrap<DStreamWrap> {
             zxc_dstream_free(ds_);
             ds_ = nullptr;
         }
+        std::vector<uint8_t>().swap(stage_);
         return info.Env().Undefined();
     }
 
@@ -1012,7 +1028,7 @@ static Napi::Value SeekTableSize(const Napi::CallbackInfo& info) {
 }
 
 // =============================================================================
-// writeSeekTable(compSizes: number[] | Uint32Array): Buffer
+// writeSeekTable(compSizes: number[]): Buffer
 // =============================================================================
 static Napi::Value WriteSeekTable(const Napi::CallbackInfo& info) {
     Napi::Env env = info.Env();
@@ -1046,6 +1062,9 @@ static Napi::Value WriteSeekTable(const Napi::CallbackInfo& info) {
     if (r < 0) {
         return ThrowZxcError(env, static_cast<int>(r));
     }
+    // On success the table fills the buffer exactly; slice only if it ever
+    // came back shorter (napi buffers are uninitialized past r).
+    if (static_cast<size_t>(r) == sz) return out;
     return Napi::Buffer<uint8_t>::Copy(env, out.Data(), static_cast<size_t>(r));
 }
 

--- a/wrappers/nodejs/src/zxc_addon.cc
+++ b/wrappers/nodejs/src/zxc_addon.cc
@@ -110,11 +110,6 @@ static Napi::Value Compress(const Napi::CallbackInfo& info) {
         return env.Undefined();
     }
 
-    if (nwritten == 0) {
-        Napi::Error::New(env, "Input is too small to be compressed").ThrowAsJavaScriptException();
-        return env.Undefined();
-    }
-
     // Return a slice of the buffer with the actual size
     return Napi::Buffer<uint8_t>::Copy(env, dst_buf.Data(), static_cast<size_t>(nwritten));
 }
@@ -184,7 +179,12 @@ static Napi::Value Decompress(const Napi::CallbackInfo& info) {
         return env.Undefined();
     }
 
-    return dst_buf;
+    // decompress_size is an upper bound from the caller: when fewer bytes
+    // were written, slice to the actual size — napi buffers are allocated
+    // uninitialized, so returning the full-length buffer would expose stale
+    // heap contents past nwritten.
+    if (static_cast<size_t>(nwritten) == decompress_size) return dst_buf;
+    return Napi::Buffer<uint8_t>::Copy(env, dst_buf.Data(), static_cast<size_t>(nwritten));
 }
 
 // =============================================================================
@@ -843,29 +843,37 @@ class SeekableWrap : public Napi::ObjectWrap<SeekableWrap> {
     // reader mode.
     Napi::FunctionReference read_at_ref_;
     Napi::Env env_{nullptr};
+    // True while a native call that may re-enter JS (via ReadAtTrampoline)
+    // is on the stack. Guards close()/decompressRange() against reentrant
+    // calls from the readAt callback, which would free or corrupt the
+    // handle the C library is still using.
+    bool in_native_call_ = false;
 
     // C trampoline invoked by the library for every positional read against
     // a user-supplied JS `readAt`. Always called on the V8 main thread —
     // never use this binding with the multi-threaded decompress_range_mt
-    // entry point. Any exception thrown from JS is swallowed and surfaced
-    // as ZXC_ERROR_IO so it doesn't unwind through C.
+    // entry point. The whole body is guarded: any C++ exception (from the
+    // JS callback, buffer allocation, or env teardown) is swallowed and
+    // surfaced as ZXC_ERROR_IO so it never unwinds through the C frames.
     static int64_t ReadAtTrampoline(void* ctx, void* dst, size_t len, uint64_t offset) {
-        constexpr int64_t kZxcErrorIo = -11;
         auto* self = static_cast<SeekableWrap*>(ctx);
-        if (!self || self->read_at_ref_.IsEmpty()) return kZxcErrorIo;
-        Napi::Env env = self->env_;
-        Napi::HandleScope scope(env);
-        // Allocate a fresh JS Buffer of `len` bytes for the callback to fill,
-        // then memcpy back into `dst`. This avoids exposing the C-side
-        // pointer to JS lifetime hazards.
-        Napi::Buffer<uint8_t> jsbuf = Napi::Buffer<uint8_t>::New(env, len);
+        if (!self || self->read_at_ref_.IsEmpty()) return ZXC_ERROR_IO;
         try {
+            Napi::Env env = self->env_;
+            Napi::HandleScope scope(env);
+            // Allocate a fresh JS Buffer of `len` bytes for the callback to
+            // fill, then memcpy back into `dst`. This avoids exposing the
+            // C-side pointer to JS lifetime hazards.
+            Napi::Buffer<uint8_t> jsbuf = Napi::Buffer<uint8_t>::New(env, len);
             self->read_at_ref_.Call({jsbuf, Napi::Number::New(env, static_cast<double>(offset))});
-        } catch (const Napi::Error&) {
-            return kZxcErrorIo;
+            // The callback may have detached/transferred the ArrayBuffer,
+            // in which case Data() is null.
+            if (!jsbuf.Data()) return ZXC_ERROR_IO;
+            std::memcpy(dst, jsbuf.Data(), len);
+            return static_cast<int64_t>(len);
+        } catch (...) {
+            return ZXC_ERROR_IO;
         }
-        std::memcpy(dst, jsbuf.Data(), len);
-        return static_cast<int64_t>(len);
     }
 
     bool requireOpen(Napi::Env env) {
@@ -928,15 +936,25 @@ class SeekableWrap : public Napi::ObjectWrap<SeekableWrap> {
                 .ThrowAsJavaScriptException();
             return env.Undefined();
         }
+        if (in_native_call_) {
+            Napi::Error::New(env, "reentrant decompressRange from readAt callback")
+                .ThrowAsJavaScriptException();
+            return env.Undefined();
+        }
         Napi::Buffer<uint8_t> out =
             Napi::Buffer<uint8_t>::New(env, static_cast<size_t>(length));
         if (length == 0) return out;
 
+        in_native_call_ = true;
         int64_t r = zxc_seekable_decompress_range(s_, out.Data(), static_cast<size_t>(length),
                                                   offset, static_cast<size_t>(length));
+        in_native_call_ = false;
         if (r < 0) {
             return ThrowZxcError(env, static_cast<int>(r));
         }
+        // On success the library fills the whole range; slice defensively if
+        // fewer bytes were produced (napi buffers are uninitialized).
+        if (r == length) return out;
         return Napi::Buffer<uint8_t>::Copy(env, out.Data(), static_cast<size_t>(r));
     }
 
@@ -966,6 +984,11 @@ class SeekableWrap : public Napi::ObjectWrap<SeekableWrap> {
     }
 
     Napi::Value Close(const Napi::CallbackInfo& info) {
+        if (in_native_call_) {
+            Napi::Error::New(info.Env(), "cannot close Seekable from inside its readAt callback")
+                .ThrowAsJavaScriptException();
+            return info.Env().Undefined();
+        }
         if (s_) {
             zxc_seekable_free(s_);
             s_ = nullptr;
@@ -1089,6 +1112,9 @@ static Napi::Object Init(Napi::Env env, Napi::Object exports) {
     exports.Set("ERROR_NULL_INPUT", Napi::Number::New(env, ZXC_ERROR_NULL_INPUT));
     exports.Set("ERROR_BAD_BLOCK_TYPE", Napi::Number::New(env, ZXC_ERROR_BAD_BLOCK_TYPE));
     exports.Set("ERROR_BAD_BLOCK_SIZE", Napi::Number::New(env, ZXC_ERROR_BAD_BLOCK_SIZE));
+    exports.Set("ERROR_DICT_REQUIRED", Napi::Number::New(env, ZXC_ERROR_DICT_REQUIRED));
+    exports.Set("ERROR_DICT_MISMATCH", Napi::Number::New(env, ZXC_ERROR_DICT_MISMATCH));
+    exports.Set("ERROR_DICT_TOO_LARGE", Napi::Number::New(env, ZXC_ERROR_DICT_TOO_LARGE));
 
     return exports;
 }

--- a/wrappers/nodejs/src/zxc_addon.cc
+++ b/wrappers/nodejs/src/zxc_addon.cc
@@ -189,7 +189,7 @@ static Napi::Value Decompress(const Napi::CallbackInfo& info) {
     }
 
     // decompress_size is an upper bound from the caller: when fewer bytes
-    // were written, slice to the actual size — napi buffers are allocated
+    // were written, slice to the actual size; napi buffers are allocated
     // uninitialized, so returning the full-length buffer would expose stale
     // heap contents past nwritten.
     if (static_cast<size_t>(nwritten) == decompress_size) return dst_buf;
@@ -792,7 +792,7 @@ class SeekableWrap : public Napi::ObjectWrap<SeekableWrap> {
         }
 
         // Reader-callback form: { size: number, readAt: (buf, offset) => void }.
-        // Single-threaded only — the JS callback is invoked synchronously on
+        // Single-threaded only: the JS callback is invoked synchronously on
         // the calling thread.
         if (info[0].IsObject() && !info[0].IsBuffer()) {
             Napi::Object opts = info[0].As<Napi::Object>();
@@ -866,7 +866,7 @@ class SeekableWrap : public Napi::ObjectWrap<SeekableWrap> {
     bool in_native_call_ = false;
 
     // C trampoline invoked by the library for every positional read against
-    // a user-supplied JS `readAt`. Always called on the V8 main thread —
+    // a user-supplied JS `readAt`. Always called on the V8 main thread,
     // never use this binding with the multi-threaded decompress_range_mt
     // entry point. The whole body is guarded: any C++ exception (from the
     // JS callback, buffer allocation, or env teardown) is swallowed and
@@ -887,7 +887,7 @@ class SeekableWrap : public Napi::ObjectWrap<SeekableWrap> {
             if (!jsbuf.Data()) return ZXC_ERROR_IO;
             std::memcpy(dst, jsbuf.Data(), len);
             return static_cast<int64_t>(len);
-        } catch (...) {
+        } catch (const std::exception&) {
             return ZXC_ERROR_IO;
         }
     }

--- a/wrappers/nodejs/src/zxc_addon.cc
+++ b/wrappers/nodejs/src/zxc_addon.cc
@@ -1072,6 +1072,7 @@ static Napi::Object Init(Napi::Env env, Napi::Object exports) {
     exports.Set("LEVEL_BALANCED", Napi::Number::New(env, ZXC_LEVEL_BALANCED));
     exports.Set("LEVEL_COMPACT", Napi::Number::New(env, ZXC_LEVEL_COMPACT));
     exports.Set("LEVEL_DENSITY", Napi::Number::New(env, ZXC_LEVEL_DENSITY));
+    exports.Set("LEVEL_ULTRA", Napi::Number::New(env, ZXC_LEVEL_ULTRA));
 
     // Error constants
     exports.Set("ERROR_MEMORY", Napi::Number::New(env, ZXC_ERROR_MEMORY));

--- a/wrappers/nodejs/test/zxc.test.js
+++ b/wrappers/nodejs/test/zxc.test.js
@@ -23,7 +23,7 @@ describe('compress/decompress roundtrip', () => {
 
     for (const { name, data } of testCases) {
         test(`roundtrip: ${name}`, () => {
-            for (let level = zxc.LEVEL_FASTEST; level <= zxc.LEVEL_DENSITY; level++) {
+            for (let level = zxc.LEVEL_FASTEST; level <= zxc.LEVEL_ULTRA; level++) {
                 const compressed = zxc.compress(data, { level });
                 const size = zxc.getDecompressedSize(compressed);
                 const decompressed = zxc.decompress(compressed, { size });
@@ -122,6 +122,7 @@ describe('constants', () => {
         expect(zxc.LEVEL_BALANCED).toBe(4);
         expect(zxc.LEVEL_COMPACT).toBe(5);
         expect(zxc.LEVEL_DENSITY).toBe(6);
+        expect(zxc.LEVEL_ULTRA).toBe(7);
     });
 });
 

--- a/wrappers/nodejs/test/zxc.test.js
+++ b/wrappers/nodejs/test/zxc.test.js
@@ -42,6 +42,17 @@ describe('compress/decompress roundtrip', () => {
         expect(decompressed.length).toBe(data.length);
         expect(Buffer.compare(decompressed, data)).toBe(0);
     });
+
+    test('oversized size hint returns exactly the real payload', () => {
+        // Regression: the full hint-sized buffer used to be returned, with an
+        // uninitialized (allocUnsafe) tail past the real decompressed size.
+        const data = Buffer.from('oversized hint test'.repeat(50));
+        const compressed = zxc.compress(data);
+        const decompressed = zxc.decompress(compressed, { size: data.length + 4096 });
+
+        expect(decompressed.length).toBe(data.length);
+        expect(Buffer.compare(decompressed, data)).toBe(0);
+    });
 });
 
 // =============================================================================

--- a/wrappers/python/src/zxc/__init__.py
+++ b/wrappers/python/src/zxc/__init__.py
@@ -5,6 +5,8 @@ Copyright (c) 2025-2026 Bertrand Lebonnois and contributors.
 SPDX-License-Identifier: BSD-3-Clause
 """
 
+from __future__ import annotations
+
 import io as _io
 
 from ._zxc import (
@@ -70,6 +72,9 @@ from ._zxc import (
     ERROR_NULL_INPUT,
     ERROR_BAD_BLOCK_TYPE,
     ERROR_BAD_BLOCK_SIZE,
+    ERROR_DICT_REQUIRED,
+    ERROR_DICT_MISMATCH,
+    ERROR_DICT_TOO_LARGE,
 )
 
 try:
@@ -140,6 +145,9 @@ __all__ = [
     "ERROR_NULL_INPUT",
     "ERROR_BAD_BLOCK_TYPE",
     "ERROR_BAD_BLOCK_SIZE",
+    "ERROR_DICT_REQUIRED",
+    "ERROR_DICT_MISMATCH",
+    "ERROR_DICT_TOO_LARGE",
 ]
 
 def min_level() -> int:
@@ -327,7 +335,7 @@ def decompress(data, decompress_size=None, checksum=False, dict=None, dict_huf=N
 
     Args:
         data: Compressed bytes.
-        decompress_size: Expected size. If None, read from header (slower/safer).
+        decompress_size: Expected size. If None, read from the archive footer.
         checksum: If True, verify the checksum appended during compression.
         dict: Pre-trained dictionary content (bytes) required if the archive
             was compressed with one. Must match the dictionary ID stored in
@@ -356,6 +364,9 @@ def stream_compress(src, dst, n_threads=0, level=LEVEL_DEFAULT, checksum=False, 
         seekable: If True, append a seek table for random-access decompression.
         dict: Optional pre-trained dictionary content (bytes). The archive
             records its dictionary ID; decompression must supply the same dict.
+        dict_huf: Optional shared literal Huffman table (128 bytes) trained
+            alongside the dictionary; ignored without `dict`. The dictionary
+            ID binds the (dict, table) pair.
 
     Returns:
         Number of bytes written to `dst`.
@@ -735,7 +746,7 @@ class ZxcReader(_io.RawIOBase):
     def readable(self) -> bool:
         return True
 
-    def readinto(self, b) -> int:
+    def readinto(self, b) -> int | None:
         if self.closed:
             raise ValueError("I/O operation on closed reader")
         n_out = len(b)
@@ -747,6 +758,11 @@ class ZxcReader(_io.RawIOBase):
                 return 0
             if not self._inbuf and not self._eof_src:
                 chunk = self._src.read(self._bufsize)
+                if chunk is None:
+                    # Non-blocking source with no data available right now
+                    # (RawIOBase semantics) — not EOF; propagate the "would
+                    # block" condition to the caller.
+                    return None
                 if not chunk:
                     self._eof_src = True
                 else:

--- a/wrappers/python/src/zxc/__init__.py
+++ b/wrappers/python/src/zxc/__init__.py
@@ -55,6 +55,7 @@ from ._zxc import (
     LEVEL_BALANCED,
     LEVEL_COMPACT,
     LEVEL_DENSITY,
+    LEVEL_ULTRA,
     ERROR_MEMORY,
     ERROR_DST_TOO_SMALL,
     ERROR_SRC_TOO_SMALL,
@@ -122,6 +123,7 @@ __all__ = [
     "LEVEL_BALANCED",
     "LEVEL_COMPACT",
     "LEVEL_DENSITY",
+    "LEVEL_ULTRA",
 
     # Error Constants
     "ERROR_MEMORY",
@@ -146,7 +148,7 @@ def min_level() -> int:
 
 
 def max_level() -> int:
-    """Return the maximum supported compression level (currently 5)."""
+    """Return the maximum supported compression level (currently 7)."""
     return pyzxc_max_level()
 
 

--- a/wrappers/python/src/zxc/__init__.py
+++ b/wrappers/python/src/zxc/__init__.py
@@ -437,7 +437,9 @@ class Seekable:
 
     Two construction modes:
 
-    **From bytes** (the buffer is copied internally)::
+    **From bytes** (zero-copy: the buffer is pinned, not copied — do not
+    mutate it while the handle is open; a ``bytearray`` source cannot be
+    resized until :meth:`close`)::
 
         with zxc.Seekable(compressed_bytes) as s:
             chunk = s.decompress_range(offset, length)
@@ -740,7 +742,6 @@ class ZxcReader(_io.RawIOBase):
             buffer_size = self._ds.in_size
         self._bufsize = buffer_size
         self._pending = b""    # decompressed bytes not yet returned
-        self._inbuf = b""      # compressed bytes pulled from src, not yet fed
         self._eof_src = False  # True once src.read() returned empty bytes
 
     def readable(self) -> bool:
@@ -756,7 +757,8 @@ class ZxcReader(_io.RawIOBase):
         while not self._pending:
             if self._ds.finished:
                 return 0
-            if not self._inbuf and not self._eof_src:
+            inbuf = b""
+            if not self._eof_src:
                 chunk = self._src.read(self._bufsize)
                 if chunk is None:
                     # Non-blocking source with no data available right now
@@ -766,10 +768,9 @@ class ZxcReader(_io.RawIOBase):
                 if not chunk:
                     self._eof_src = True
                 else:
-                    self._inbuf = chunk
+                    inbuf = chunk
 
-            produced = self._ds.decompress(self._inbuf)
-            self._inbuf = b""
+            produced = self._ds.decompress(inbuf)
             if produced:
                 self._pending = produced
                 break
@@ -828,7 +829,12 @@ class ZxcWriter(_io.RawIOBase):
         mv = memoryview(b)
         if mv.nbytes == 0:
             return 0
-        chunk = self._cs.compress(bytes(mv))
+        # The C layer accepts any C-contiguous buffer directly and copies it
+        # into its block accumulator, so no intermediate bytes() copy is
+        # needed here.
+        if not mv.c_contiguous:
+            mv = memoryview(bytes(mv))
+        chunk = self._cs.compress(mv)
         if chunk:
             self._dst.write(chunk)
         return mv.nbytes

--- a/wrappers/python/src/zxc/__init__.pyi
+++ b/wrappers/python/src/zxc/__init__.pyi
@@ -13,6 +13,27 @@ LEVEL_FAST: int
 LEVEL_DEFAULT: int
 LEVEL_BALANCED: int
 LEVEL_COMPACT: int
+LEVEL_DENSITY: int
+LEVEL_ULTRA: int
+
+# ---------- error codes ----------
+ERROR_MEMORY: int
+ERROR_DST_TOO_SMALL: int
+ERROR_SRC_TOO_SMALL: int
+ERROR_BAD_MAGIC: int
+ERROR_BAD_VERSION: int
+ERROR_BAD_HEADER: int
+ERROR_BAD_CHECKSUM: int
+ERROR_CORRUPT_DATA: int
+ERROR_BAD_OFFSET: int
+ERROR_OVERFLOW: int
+ERROR_IO: int
+ERROR_NULL_INPUT: int
+ERROR_BAD_BLOCK_TYPE: int
+ERROR_BAD_BLOCK_SIZE: int
+ERROR_DICT_REQUIRED: int
+ERROR_DICT_MISMATCH: int
+ERROR_DICT_TOO_LARGE: int
 
 # ---------- types ----------
 class FileLike(Protocol):
@@ -152,7 +173,7 @@ class ZxcReader(_io.RawIOBase):
         buffer_size: int = 0,
     ) -> None: ...
     def readable(self) -> bool: ...
-    def readinto(self, b: bytearray) -> int: ...
+    def readinto(self, b: bytearray) -> Optional[int]: ...
     def close(self) -> None: ...
 
 class ZxcWriter(_io.RawIOBase):

--- a/wrappers/python/src/zxc/_zxc.c
+++ b/wrappers/python/src/zxc/_zxc.c
@@ -74,7 +74,7 @@ static PyObject* pyzxc_compress(PyObject* self, PyObject* args, PyObject* kwargs
 static PyObject* pyzxc_decompress(PyObject* self, PyObject* args, PyObject* kwargs);
 static PyObject* pyzxc_stream_compress(PyObject* self, PyObject* args, PyObject* kwargs);
 static PyObject* pyzxc_stream_decompress(PyObject* self, PyObject* args, PyObject* kwargs);
-static PyObject* pyzxc_get_decompressed_size(PyObject* self, PyObject* args, PyObject* kwargs);
+static PyObject* pyzxc_get_decompressed_size(PyObject* self, PyObject* arg);
 static PyObject* pyzxc_min_level(PyObject* self, PyObject* args);
 static PyObject* pyzxc_max_level(PyObject* self, PyObject* args);
 static PyObject* pyzxc_default_level(PyObject* self, PyObject* args);
@@ -150,8 +150,7 @@ static PyMethodDef zxc_methods[] = {
      NULL},
     {"pyzxc_stream_decompress", (PyCFunction)pyzxc_stream_decompress, METH_VARARGS | METH_KEYWORDS,
      NULL},
-    {"pyzxc_get_decompressed_size", (PyCFunction)pyzxc_get_decompressed_size,
-     METH_VARARGS | METH_KEYWORDS, NULL},
+    {"pyzxc_get_decompressed_size", (PyCFunction)pyzxc_get_decompressed_size, METH_O, NULL},
     {"pyzxc_min_level", (PyCFunction)pyzxc_min_level, METH_NOARGS, NULL},
     {"pyzxc_max_level", (PyCFunction)pyzxc_max_level, METH_NOARGS, NULL},
     {"pyzxc_default_level", (PyCFunction)pyzxc_default_level, METH_NOARGS, NULL},
@@ -348,16 +347,13 @@ static PyObject* pyzxc_compress(PyObject* self, PyObject* args, PyObject* kwargs
     return out;
 }
 
-static PyObject* pyzxc_get_decompressed_size(PyObject* self, PyObject* args, PyObject* kwargs) {
+static PyObject* pyzxc_get_decompressed_size(PyObject* self, PyObject* arg) {
     (void)self;
-    (void)kwargs;
     Py_buffer view;
 
-    if (!PyArg_ParseTuple(args, "y*", &view)) {
-        return NULL;
-    }
+    if (PyObject_GetBuffer(arg, &view, PyBUF_SIMPLE) < 0) return NULL;
 
-    uint64_t n = zxc_get_decompressed_size(view.buf, view.len);
+    uint64_t n = zxc_get_decompressed_size(view.buf, (size_t)view.len);
 
     PyBuffer_Release(&view);
 
@@ -1421,7 +1417,10 @@ static PyObject* pyzxc_dstream_free(PyObject* self, PyObject* capsule) {
 
 typedef struct {
     zxc_seekable* s;
-    uint8_t* src_copy;    /* owned copy when opened from bytes */
+    Py_buffer src_view;   /* held view on the source when opened from bytes:
+                             pins the exporter for the handle's lifetime so no
+                             copy of the archive is needed */
+    int has_view;         /* 1 when src_view must be released */
     PyObject* reader_obj; /* strong ref to the Python reader when using callback */
     /* First exception raised by the reader callback, stashed under the GIL by
      * the trampoline (which may run on a library worker thread) and re-raised
@@ -1458,7 +1457,7 @@ static void seekable_capsule_destructor(PyObject* capsule) {
         (pyzxc_seekable_holder_t*)PyCapsule_GetPointer(capsule, ZXC_SEEKABLE_CAPSULE);
     if (h) {
         if (h->s) zxc_seekable_free(h->s);
-        free(h->src_copy);
+        if (h->has_view) PyBuffer_Release(&h->src_view);
         Py_XDECREF(h->reader_obj);
         Py_XDECREF(h->exc_type);
         Py_XDECREF(h->exc_value);
@@ -1487,29 +1486,27 @@ static PyObject* pyzxc_seekable_open(PyObject* self, PyObject* arg) {
         Py_Return_Err(PyExc_ValueError, "seekable buffer must be non-empty");
     }
 
-    uint8_t* copy = (uint8_t*)malloc((size_t)view.len);
-    if (!copy) {
-        PyBuffer_Release(&view);
-        return PyErr_NoMemory();
-    }
-    memcpy(copy, view.buf, (size_t)view.len);
-    size_t src_size = (size_t)view.len;
-    PyBuffer_Release(&view);
+    /* The view pins the exporter (and, for a bytearray, blocks resizing)
+     * for the handle's lifetime, so the library can reference the caller's
+     * buffer directly — no copy of the archive. */
+    zxc_seekable* s;
+    Py_BEGIN_ALLOW_THREADS s = zxc_seekable_open(view.buf, (size_t)view.len);
+    Py_END_ALLOW_THREADS
 
-    zxc_seekable* s = zxc_seekable_open(copy, src_size);
     if (!s) {
-        free(copy);
+        PyBuffer_Release(&view);
         Py_Return_Err(PyExc_RuntimeError, "zxc_seekable_open failed (not a valid seekable archive)");
     }
 
     pyzxc_seekable_holder_t* h = (pyzxc_seekable_holder_t*)PyMem_Malloc(sizeof(*h));
     if (!h) {
         zxc_seekable_free(s);
-        free(copy);
+        PyBuffer_Release(&view);
         return PyErr_NoMemory();
     }
     h->s = s;
-    h->src_copy = copy;
+    h->src_view = view;
+    h->has_view = 1;
     h->reader_obj = NULL;
     h->exc_type = NULL;
     h->exc_value = NULL;
@@ -1518,7 +1515,7 @@ static PyObject* pyzxc_seekable_open(PyObject* self, PyObject* arg) {
     PyObject* cap = PyCapsule_New(h, ZXC_SEEKABLE_CAPSULE, seekable_capsule_destructor);
     if (!cap) {
         zxc_seekable_free(s);
-        free(copy);
+        PyBuffer_Release(&h->src_view);
         PyMem_Free(h);
         return NULL;
     }
@@ -1581,7 +1578,7 @@ static PyObject* pyzxc_seekable_open_reader(PyObject* self, PyObject* arg) {
     pyzxc_seekable_holder_t* h = (pyzxc_seekable_holder_t*)PyMem_Malloc(sizeof(*h));
     if (!h) return PyErr_NoMemory();
     h->s = NULL;
-    h->src_copy = NULL;
+    h->has_view = 0;
     Py_INCREF(arg);
     h->reader_obj = arg;
     h->exc_type = NULL;
@@ -1725,9 +1722,9 @@ static PyObject* pyzxc_seekable_free(PyObject* self, PyObject* capsule) {
         zxc_seekable_free(h->s);
         h->s = NULL;
     }
-    if (h && h->src_copy) {
-        free(h->src_copy);
-        h->src_copy = NULL;
+    if (h && h->has_view) {
+        PyBuffer_Release(&h->src_view);
+        h->has_view = 0;
     }
     if (h && h->reader_obj) {
         Py_DECREF(h->reader_obj);

--- a/wrappers/python/src/zxc/_zxc.c
+++ b/wrappers/python/src/zxc/_zxc.c
@@ -347,7 +347,7 @@ static PyObject* pyzxc_compress(PyObject* self, PyObject* args, PyObject* kwargs
     return out;
 }
 
-static PyObject* pyzxc_get_decompressed_size(PyObject* self, PyObject* arg) {
+static PyObject* pyzxc_get_decompressed_size(const PyObject* self, PyObject* arg) {
     (void)self;
     Py_buffer view;
 
@@ -1070,7 +1070,7 @@ static PyObject* pyzxc_cstream_create(PyObject* self, PyObject* args, PyObject* 
         return NULL;
     }
     /* 0 = library default; otherwise must be a power of two in
-     * [ZXC_BLOCK_SIZE_MIN, ZXC_BLOCK_SIZE_MAX] — zxc_cstream_create returns
+     * [ZXC_BLOCK_SIZE_MIN, ZXC_BLOCK_SIZE_MAX]. zxc_cstream_create returns
      * NULL for invalid values, which must not surface as MemoryError. */
     if (block_size != 0 &&
         (block_size < (Py_ssize_t)ZXC_BLOCK_SIZE_MIN || block_size > (Py_ssize_t)ZXC_BLOCK_SIZE_MAX ||
@@ -1488,7 +1488,7 @@ static PyObject* pyzxc_seekable_open(PyObject* self, PyObject* arg) {
 
     /* The view pins the exporter (and, for a bytearray, blocks resizing)
      * for the handle's lifetime, so the library can reference the caller's
-     * buffer directly — no copy of the archive. */
+     * buffer directly: no copy of the archive. */
     zxc_seekable* s;
     Py_BEGIN_ALLOW_THREADS s = zxc_seekable_open(view.buf, (size_t)view.len);
     Py_END_ALLOW_THREADS

--- a/wrappers/python/src/zxc/_zxc.c
+++ b/wrappers/python/src/zxc/_zxc.c
@@ -233,6 +233,9 @@ PyMODINIT_FUNC PyInit__zxc(void) {
     PyModule_AddIntConstant(m, "ERROR_NULL_INPUT", ZXC_ERROR_NULL_INPUT);
     PyModule_AddIntConstant(m, "ERROR_BAD_BLOCK_TYPE", ZXC_ERROR_BAD_BLOCK_TYPE);
     PyModule_AddIntConstant(m, "ERROR_BAD_BLOCK_SIZE", ZXC_ERROR_BAD_BLOCK_SIZE);
+    PyModule_AddIntConstant(m, "ERROR_DICT_REQUIRED", ZXC_ERROR_DICT_REQUIRED);
+    PyModule_AddIntConstant(m, "ERROR_DICT_MISMATCH", ZXC_ERROR_DICT_MISMATCH);
+    PyModule_AddIntConstant(m, "ERROR_DICT_TOO_LARGE", ZXC_ERROR_DICT_TOO_LARGE);
 
     return m;
 }
@@ -263,6 +266,13 @@ static PyObject* pyzxc_compress(PyObject* self, PyObject* args, PyObject* kwargs
     if (view.itemsize != 1) {
         PyBuffer_Release(&view);
         PyErr_SetString(PyExc_TypeError, "expected a byte buffer (itemsize==1)");
+        return NULL;
+    }
+
+    if (level < zxc_min_level() || level > zxc_max_level()) {
+        PyBuffer_Release(&view);
+        PyErr_Format(PyExc_ValueError, "level must be in [%d, %d], got %d", zxc_min_level(),
+                     zxc_max_level(), level);
         return NULL;
     }
 
@@ -332,11 +342,6 @@ static PyObject* pyzxc_compress(PyObject* self, PyObject* args, PyObject* kwargs
         Py_Return_Err(PyExc_RuntimeError, zxc_error_name((int)nwritten));
     }
 
-    if (nwritten == 0) {
-        Py_DECREF(out);
-        Py_Return_Err(PyExc_ValueError, "input is too small to be compressed");
-    }
-
     if (_PyBytes_Resize(&out, (Py_ssize_t)nwritten) < 0)  // Realloc
         return NULL;
 
@@ -381,6 +386,12 @@ static PyObject* pyzxc_decompress(PyObject* self, PyObject* args, PyObject* kwar
     if (view.itemsize != 1) {
         PyBuffer_Release(&view);
         PyErr_SetString(PyExc_TypeError, "expected a byte buffer (itemsize==1)");
+        return NULL;
+    }
+
+    if (decompress_size < 0) {
+        PyBuffer_Release(&view);
+        PyErr_SetString(PyExc_ValueError, "decompress_size must be non-negative");
         return NULL;
     }
 
@@ -447,6 +458,12 @@ static PyObject* pyzxc_decompress(PyObject* self, PyObject* args, PyObject* kwar
         Py_Return_Err(PyExc_RuntimeError, zxc_error_name((int)nwritten));
     }
 
+    /* decompress_size is an upper bound from the caller; shrink to the bytes
+     * actually written so no uninitialized tail is ever exposed. */
+    if (nwritten != (int64_t)decompress_size &&
+        _PyBytes_Resize(&out, (Py_ssize_t)nwritten) < 0)
+        return NULL;
+
     return out;
 }
 
@@ -470,6 +487,12 @@ static PyObject* pyzxc_stream_compress(PyObject* self, PyObject* args, PyObject*
 
     if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OO|iippOO", kwlist, &src, &dst, &nthreads,
                                      &level, &checksum, &seekable, &dict_obj, &dict_huf_obj)) {
+        return NULL;
+    }
+
+    if (level < zxc_min_level() || level > zxc_max_level()) {
+        PyErr_Format(PyExc_ValueError, "level must be in [%d, %d], got %d", zxc_min_level(),
+                     zxc_max_level(), level);
         return NULL;
     }
 
@@ -1050,8 +1073,21 @@ static PyObject* pyzxc_cstream_create(PyObject* self, PyObject* args, PyObject* 
                                      &block_size)) {
         return NULL;
     }
-    if (block_size < 0) {
-        Py_Return_Err(PyExc_ValueError, "block_size must be non-negative");
+    /* 0 = library default; otherwise must be a power of two in
+     * [ZXC_BLOCK_SIZE_MIN, ZXC_BLOCK_SIZE_MAX] — zxc_cstream_create returns
+     * NULL for invalid values, which must not surface as MemoryError. */
+    if (block_size != 0 &&
+        (block_size < (Py_ssize_t)ZXC_BLOCK_SIZE_MIN || block_size > (Py_ssize_t)ZXC_BLOCK_SIZE_MAX ||
+         (block_size & (block_size - 1)) != 0)) {
+        PyErr_Format(PyExc_ValueError,
+                     "block_size must be 0 (default) or a power of two in [%u, %u], got %zd",
+                     ZXC_BLOCK_SIZE_MIN, ZXC_BLOCK_SIZE_MAX, block_size);
+        return NULL;
+    }
+    if (level < zxc_min_level() || level > zxc_max_level()) {
+        PyErr_Format(PyExc_ValueError, "level must be in [%d, %d], got %d", zxc_min_level(),
+                     zxc_max_level(), level);
+        return NULL;
     }
 
     zxc_compress_opts_t copts = {0};
@@ -1387,7 +1423,35 @@ typedef struct {
     zxc_seekable* s;
     uint8_t* src_copy;    /* owned copy when opened from bytes */
     PyObject* reader_obj; /* strong ref to the Python reader when using callback */
+    /* First exception raised by the reader callback, stashed under the GIL by
+     * the trampoline (which may run on a library worker thread) and re-raised
+     * on the calling thread once the C call returns. */
+    PyObject* exc_type;
+    PyObject* exc_value;
+    PyObject* exc_tb;
 } pyzxc_seekable_holder_t;
+
+/* Stores the currently-raised exception into the holder (first one wins) so
+ * the user's traceback survives the round-trip through the C library.
+ * GIL must be held. */
+static void seekable_stash_exception(pyzxc_seekable_holder_t* h) {
+    if (h->exc_type) {
+        PyErr_Clear();
+        return;
+    }
+    PyErr_Fetch(&h->exc_type, &h->exc_value, &h->exc_tb);
+}
+
+/* Re-raises a stashed exception (if any) and clears the slots.
+ * GIL must be held. Returns 1 when an exception was restored. */
+static int seekable_restore_exception(pyzxc_seekable_holder_t* h) {
+    if (!h->exc_type) return 0;
+    PyErr_Restore(h->exc_type, h->exc_value, h->exc_tb);
+    h->exc_type = NULL;
+    h->exc_value = NULL;
+    h->exc_tb = NULL;
+    return 1;
+}
 
 static void seekable_capsule_destructor(PyObject* capsule) {
     pyzxc_seekable_holder_t* h =
@@ -1396,6 +1460,9 @@ static void seekable_capsule_destructor(PyObject* capsule) {
         if (h->s) zxc_seekable_free(h->s);
         free(h->src_copy);
         Py_XDECREF(h->reader_obj);
+        Py_XDECREF(h->exc_type);
+        Py_XDECREF(h->exc_value);
+        Py_XDECREF(h->exc_tb);
         PyMem_Free(h);
     }
 }
@@ -1444,6 +1511,9 @@ static PyObject* pyzxc_seekable_open(PyObject* self, PyObject* arg) {
     h->s = s;
     h->src_copy = copy;
     h->reader_obj = NULL;
+    h->exc_type = NULL;
+    h->exc_value = NULL;
+    h->exc_tb = NULL;
 
     PyObject* cap = PyCapsule_New(h, ZXC_SEEKABLE_CAPSULE, seekable_capsule_destructor);
     if (!cap) {
@@ -1455,29 +1525,42 @@ static PyObject* pyzxc_seekable_open(PyObject* self, PyObject* arg) {
     return cap;
 }
 
-/* C trampoline for the Python reader callback.  Called synchronously on the
- * same thread that drives decompress_range, so the GIL must be held. */
+/* C trampoline for the Python reader callback.  May be invoked from the
+ * calling thread (single-threaded decode, with or without the GIL held) or
+ * from library-spawned worker threads (multi-threaded decode), so it always
+ * attaches to the interpreter with PyGILState_Ensure.  A failing callback
+ * stashes its exception into the holder for re-raise by the caller. */
 static int64_t seekable_read_at_trampoline(void* ctx, void* dst, size_t len, uint64_t offset) {
-    PyObject* reader = (PyObject*)ctx;
-    PyObject* result =
-        PyObject_CallMethod(reader, "read_at", "nK", (Py_ssize_t)len, (unsigned long long)offset);
-    if (!result) return ZXC_ERROR_IO;
+    pyzxc_seekable_holder_t* h = (pyzxc_seekable_holder_t*)ctx;
+    PyGILState_STATE gstate = PyGILState_Ensure();
+    int64_t rc = ZXC_ERROR_IO;
+
+    PyObject* result = PyObject_CallMethod(h->reader_obj, "read_at", "nK", (Py_ssize_t)len,
+                                           (unsigned long long)offset);
+    if (!result) {
+        seekable_stash_exception(h);
+        goto done;
+    }
 
     Py_buffer view;
     if (PyObject_GetBuffer(result, &view, PyBUF_SIMPLE) < 0) {
         Py_DECREF(result);
         PyErr_Clear();
-        return ZXC_ERROR_IO;
+        goto done;
     }
     if ((size_t)view.len < len) {
         PyBuffer_Release(&view);
         Py_DECREF(result);
-        return ZXC_ERROR_IO;
+        goto done;
     }
     memcpy(dst, view.buf, len);
     PyBuffer_Release(&view);
     Py_DECREF(result);
-    return (int64_t)len;
+    rc = (int64_t)len;
+
+done:
+    PyGILState_Release(gstate);
+    return rc;
 }
 
 static PyObject* pyzxc_seekable_open_reader(PyObject* self, PyObject* arg) {
@@ -1493,26 +1576,33 @@ static PyObject* pyzxc_seekable_open_reader(PyObject* self, PyObject* arg) {
     if (sz == -1 && PyErr_Occurred()) return NULL;
     if (sz <= 0) Py_Return_Err(PyExc_ValueError, "reader.size must be > 0");
 
+    /* The holder is created before the open call because it doubles as the
+     * trampoline context (reader object + stashed-exception slots). */
+    pyzxc_seekable_holder_t* h = (pyzxc_seekable_holder_t*)PyMem_Malloc(sizeof(*h));
+    if (!h) return PyErr_NoMemory();
+    h->s = NULL;
+    h->src_copy = NULL;
+    Py_INCREF(arg);
+    h->reader_obj = arg;
+    h->exc_type = NULL;
+    h->exc_value = NULL;
+    h->exc_tb = NULL;
+
     zxc_reader_t r;
     r.read_at = seekable_read_at_trampoline;
-    r.ctx = arg;
+    r.ctx = h;
     r.size = (uint64_t)sz;
 
     zxc_seekable* s = zxc_seekable_open_reader(&r);
     if (!s) {
+        int restored = seekable_restore_exception(h);
+        Py_DECREF(arg);
+        PyMem_Free(h);
+        if (restored) return NULL; /* re-raise the reader's own exception */
         Py_Return_Err(PyExc_RuntimeError,
                       "zxc_seekable_open_reader failed (not a valid seekable archive)");
     }
-
-    pyzxc_seekable_holder_t* h = (pyzxc_seekable_holder_t*)PyMem_Malloc(sizeof(*h));
-    if (!h) {
-        zxc_seekable_free(s);
-        return PyErr_NoMemory();
-    }
     h->s = s;
-    h->src_copy = NULL;
-    Py_INCREF(arg);
-    h->reader_obj = arg;
 
     PyObject* cap = PyCapsule_New(h, ZXC_SEEKABLE_CAPSULE, seekable_capsule_destructor);
     if (!cap) {
@@ -1591,32 +1681,35 @@ static PyObject* pyzxc_seekable_decompress_range(PyObject* self, PyObject* args,
     int64_t r;
     pyzxc_seekable_holder_t* h =
         (pyzxc_seekable_holder_t*)PyCapsule_GetPointer(capsule, ZXC_SEEKABLE_CAPSULE);
-    int has_reader = (h && h->reader_obj != NULL);
 
-    if (has_reader) {
-        /* Reader callback needs the GIL (Python callables). */
-        if (n_threads > 1) {
-            r = zxc_seekable_decompress_range_mt(s, dst, (size_t)length, (uint64_t)offset,
-                                                 (size_t)length, n_threads);
-        } else {
-            r = zxc_seekable_decompress_range(s, dst, (size_t)length, (uint64_t)offset,
-                                              (size_t)length);
-        }
-    } else {
-        Py_BEGIN_ALLOW_THREADS if (n_threads > 1) {
-            r = zxc_seekable_decompress_range_mt(s, dst, (size_t)length, (uint64_t)offset,
-                                                 (size_t)length, n_threads);
-        }
-        else {
-            r = zxc_seekable_decompress_range(s, dst, (size_t)length, (uint64_t)offset,
-                                              (size_t)length);
-        }
-        Py_END_ALLOW_THREADS
+    /* The GIL is released on every path: the reader trampoline re-attaches
+     * with PyGILState_Ensure, which also makes the multi-threaded decode safe
+     * when the library invokes the Python callback from its worker threads
+     * (holding the GIL here would let workers call into Python without it). */
+    Py_BEGIN_ALLOW_THREADS if (n_threads > 1) {
+        r = zxc_seekable_decompress_range_mt(s, dst, (size_t)length, (uint64_t)offset,
+                                             (size_t)length, n_threads);
     }
+    else {
+        r = zxc_seekable_decompress_range(s, dst, (size_t)length, (uint64_t)offset,
+                                          (size_t)length);
+    }
+    Py_END_ALLOW_THREADS
 
     if (r < 0) {
         Py_DECREF(out);
+        /* Prefer the reader's own exception (with traceback) when it caused
+         * the failure; otherwise report the library error code. */
+        if (h && seekable_restore_exception(h)) return NULL;
         Py_Return_Err(PyExc_RuntimeError, zxc_error_name((int)r));
+    }
+    /* A callback may have failed on one worker while another satisfied the
+     * range; drop any stale stashed exception so it cannot leak into an
+     * unrelated later call. */
+    if (h && h->exc_type) {
+        Py_CLEAR(h->exc_type);
+        Py_CLEAR(h->exc_value);
+        Py_CLEAR(h->exc_tb);
     }
 
     if (r != (int64_t)length && _PyBytes_Resize(&out, (Py_ssize_t)r) < 0) return NULL;

--- a/wrappers/python/src/zxc/_zxc.c
+++ b/wrappers/python/src/zxc/_zxc.c
@@ -347,7 +347,7 @@ static PyObject* pyzxc_compress(PyObject* self, PyObject* args, PyObject* kwargs
     return out;
 }
 
-static PyObject* pyzxc_get_decompressed_size(const PyObject* self, PyObject* arg) {
+static PyObject* pyzxc_get_decompressed_size(PyObject* self, PyObject* arg) {
     (void)self;
     Py_buffer view;
 

--- a/wrappers/python/src/zxc/_zxc.c
+++ b/wrappers/python/src/zxc/_zxc.c
@@ -216,6 +216,7 @@ PyMODINIT_FUNC PyInit__zxc(void) {
     PyModule_AddIntConstant(m, "LEVEL_BALANCED", ZXC_LEVEL_BALANCED);
     PyModule_AddIntConstant(m, "LEVEL_COMPACT", ZXC_LEVEL_COMPACT);
     PyModule_AddIntConstant(m, "LEVEL_DENSITY", ZXC_LEVEL_DENSITY);
+    PyModule_AddIntConstant(m, "LEVEL_ULTRA", ZXC_LEVEL_ULTRA);
 
     /* Error Enums */
     PyModule_AddIntConstant(m, "ERROR_MEMORY", ZXC_ERROR_MEMORY);

--- a/wrappers/python/tests/test_buffer.py
+++ b/wrappers/python/tests/test_buffer.py
@@ -54,8 +54,8 @@ def test_compress_corruption(data, corrupt_func, exc):
 )
 
 def test_compress_roundtrip(data):
-    # test all compression levels (1..LEVEL_DENSITY)
-    for level in range(zxc.LEVEL_FASTEST, zxc.LEVEL_DENSITY + 1):
+    # test all compression levels (1..LEVEL_ULTRA)
+    for level in range(zxc.LEVEL_FASTEST, zxc.LEVEL_ULTRA + 1):
         compressed = zxc.compress(data, level)
 
         out_size = zxc.get_decompressed_size(compressed)

--- a/wrappers/python/tests/test_seekable.py
+++ b/wrappers/python/tests/test_seekable.py
@@ -146,7 +146,9 @@ class TestSeekableReader:
             assert chunk == payload[2048:2048 + 1024]
             assert calls[0] - before == 1
 
-    def test_reader_exception_maps_to_error(self, tmp_path):
+    def test_reader_exception_propagates(self, tmp_path):
+        # The reader's own exception (with its message) must reach the caller,
+        # not be shadowed by a generic RuntimeError.
         payload = build_payload(128 * 1024)
         compressed = build_seekable_archive_stream(payload, tmp_path)
         attempted = [0]
@@ -161,8 +163,26 @@ class TestSeekableReader:
                 return compressed[offset:offset + length]
 
         with zxc.Seekable(BadReader()) as s:
-            with pytest.raises(RuntimeError):
+            with pytest.raises(IOError, match="boom"):
                 s.decompress_range(0, len(payload))
+
+    def test_reader_multithreaded_decode(self, tmp_path):
+        # Regression: multi-threaded decode with a Python reader used to
+        # invoke the callback from library worker threads without the GIL,
+        # corrupting the interpreter.
+        payload = build_payload(2 * 1024 * 1024)
+        compressed = build_seekable_archive_stream(payload, tmp_path)
+
+        class Reader:
+            size = len(compressed)
+
+            def read_at(self, length, offset):
+                return compressed[offset:offset + length]
+
+        with zxc.Seekable(Reader()) as s:
+            assert s.num_blocks >= 2
+            out = s.decompress_range(0, len(payload), n_threads=4)
+            assert out == payload
 
     def test_rejects_missing_attrs(self):
         with pytest.raises(TypeError):

--- a/wrappers/python/tests/test_seekable.py
+++ b/wrappers/python/tests/test_seekable.py
@@ -78,7 +78,7 @@ class TestDecompressRange:
 
     def test_all_levels(self, tmp_path):
         payload = build_payload(32 * 1024)
-        for level in range(zxc.LEVEL_FASTEST, zxc.LEVEL_DENSITY + 1):
+        for level in range(zxc.LEVEL_FASTEST, zxc.LEVEL_ULTRA + 1):
             compressed = build_seekable_archive_stream(payload, tmp_path, level=level)
             with zxc.Seekable(compressed) as s:
                 assert s.decompress_range(0, len(payload)) == payload

--- a/wrappers/python/tests/test_stream.py
+++ b/wrappers/python/tests/test_stream.py
@@ -107,7 +107,7 @@ def test_stream_roundtrip(tmp_path, data):
 
     src_file_path.write_bytes(data)
 
-    for level in range(zxc.LEVEL_FASTEST, zxc.LEVEL_DENSITY + 1):
+    for level in range(zxc.LEVEL_FASTEST, zxc.LEVEL_ULTRA + 1):
         with open(src_file_path, "rb") as src, \
             open(compressed_file_path, "wb") as compressed:
             zxc.stream_compress(src, compressed, level=level)

--- a/wrappers/rust/Cargo.lock
+++ b/wrappers/rust/Cargo.lock
@@ -13,48 +13,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "cfg-if"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
-
-[[package]]
-name = "chacha20"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "rand_core",
-]
-
-[[package]]
-name = "cpufeatures"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
-
-[[package]]
-name = "getrandom"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
-dependencies = [
- "cfg-if",
- "libc",
- "r-efi",
- "rand_core",
-]
 
 [[package]]
 name = "libc"
@@ -79,29 +41,6 @@ checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
-
-[[package]]
-name = "r-efi"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
-
-[[package]]
-name = "rand"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
-dependencies = [
- "chacha20",
- "getrandom",
- "rand_core",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "shlex"
@@ -166,7 +105,6 @@ name = "zxc-compress"
 version = "0.12.0"
 dependencies = [
  "libc",
- "rand",
  "thiserror",
  "windows-sys",
  "zxc-compress-sys",

--- a/wrappers/rust/zxc-sys/build.rs
+++ b/wrappers/rust/zxc-sys/build.rs
@@ -52,7 +52,7 @@ fn extract_version(include_dir: &Path) -> (u32, u32, u32) {
 }
 
 /// Extract compression level constants from zxc_constants.h
-fn extract_compression_levels(include_dir: &Path) -> (i32, i32, i32, i32, i32, i32) {
+fn extract_compression_levels(include_dir: &Path) -> (i32, i32, i32, i32, i32, i32, i32) {
     let header_path = include_dir.join("zxc_constants.h");
     let content = fs::read_to_string(&header_path)
         .expect("Failed to read zxc_constants.h");
@@ -63,6 +63,7 @@ fn extract_compression_levels(include_dir: &Path) -> (i32, i32, i32, i32, i32, i
     let mut balanced = None;
     let mut compact = None;
     let mut density = None;
+    let mut ultra = None;
 
     for line in content.lines() {
         let trimmed = line.trim();
@@ -83,6 +84,7 @@ fn extract_compression_levels(include_dir: &Path) -> (i32, i32, i32, i32, i32, i
                     "ZXC_LEVEL_BALANCED" => balanced = value,
                     "ZXC_LEVEL_COMPACT" => compact = value,
                     "ZXC_LEVEL_DENSITY" => density = value,
+                    "ZXC_LEVEL_ULTRA" => ultra = value,
                     _ => {}
                 }
             }
@@ -96,6 +98,7 @@ fn extract_compression_levels(include_dir: &Path) -> (i32, i32, i32, i32, i32, i
         balanced.expect("ZXC_LEVEL_BALANCED not found"),
         compact.expect("ZXC_LEVEL_COMPACT not found"),
         density.expect("ZXC_LEVEL_DENSITY not found"),
+        ultra.expect("ZXC_LEVEL_ULTRA not found"),
     )
 }
 
@@ -144,7 +147,7 @@ fn main() {
     println!("cargo:rustc-env=ZXC_VERSION_PATCH={}", patch);
 
     // Extract compression levels from header and make them available to lib.rs
-    let (fastest, fast, default, balanced, compact, density) =
+    let (fastest, fast, default, balanced, compact, density, ultra) =
         extract_compression_levels(&include_dir);
     println!("cargo:rustc-env=ZXC_LEVEL_FASTEST={}", fastest);
     println!("cargo:rustc-env=ZXC_LEVEL_FAST={}", fast);
@@ -152,6 +155,7 @@ fn main() {
     println!("cargo:rustc-env=ZXC_LEVEL_BALANCED={}", balanced);
     println!("cargo:rustc-env=ZXC_LEVEL_COMPACT={}", compact);
     println!("cargo:rustc-env=ZXC_LEVEL_DENSITY={}", density);
+    println!("cargo:rustc-env=ZXC_LEVEL_ULTRA={}", ultra);
 
     let target = env::var("TARGET").unwrap_or_default();
     let is_arm64 = target.contains("aarch64") || target.contains("arm64");

--- a/wrappers/rust/zxc-sys/build.rs
+++ b/wrappers/rust/zxc-sys/build.rs
@@ -102,16 +102,32 @@ fn extract_compression_levels(include_dir: &Path) -> (i32, i32, i32, i32, i32, i
     )
 }
 
-fn main() {
-    // Check if we should use system library instead of compiling from source
-    if env::var("CARGO_FEATURE_SYSTEM").is_ok() {
-        println!("cargo:rustc-link-lib=zxc");
-        return;
+/// Compiles one FMV variant of the three per-ISA translation units
+/// (zxc_compress.c, zxc_decompress.c, zxc_huffman.c) with the given function
+/// suffix and ISA flags.
+fn compile_variant(include_dir: &Path, src_lib: &Path, suffix: &str, flags: &[&str]) {
+    for unit in ["zxc_compress", "zxc_decompress", "zxc_huffman"] {
+        let mut build = cc::Build::new();
+        build
+            .include(include_dir)
+            .include(src_lib)
+            .include(src_lib.join("vendors"))
+            .define("ZXC_STATIC_DEFINE", None)
+            .file(src_lib.join(format!("{unit}.c")))
+            .define("ZXC_FUNCTION_SUFFIX", suffix)
+            .opt_level(3)
+            .warnings(false);
+        for flag in flags {
+            build.flag_if_supported(flag);
+        }
+        build.compile(&format!("{unit}{suffix}"));
     }
+}
 
+fn main() {
     // Path to ZXC source files
     let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
-    
+
     // We use mirrored symlinks under zxc/ to preserve relative include paths
     // expected by the C source code (../../include/...).
     // During `cargo publish`, these symlinks are followed and real files are packaged.
@@ -128,12 +144,8 @@ fn main() {
         (zxc_root.join("src/lib"), zxc_root.join("include"))
     };
 
-    // Verify paths exist
-    assert!(
-        src_lib.exists(),
-        "ZXC source directory not found: {:?}",
-        src_lib
-    );
+    // Verify the headers exist: even the `system` feature needs them to
+    // extract the version/level constants consumed by lib.rs's env!() calls.
     assert!(
         include_dir.exists(),
         "ZXC include directory not found: {:?}",
@@ -156,6 +168,22 @@ fn main() {
     println!("cargo:rustc-env=ZXC_LEVEL_COMPACT={}", compact);
     println!("cargo:rustc-env=ZXC_LEVEL_DENSITY={}", density);
     println!("cargo:rustc-env=ZXC_LEVEL_ULTRA={}", ultra);
+
+    // Use the system library instead of compiling from source
+    if env::var("CARGO_FEATURE_SYSTEM").is_ok() {
+        println!("cargo:rerun-if-env-changed=ZXC_LIB_DIR");
+        if let Ok(dir) = env::var("ZXC_LIB_DIR") {
+            println!("cargo:rustc-link-search=native={}", dir);
+        }
+        println!("cargo:rustc-link-lib=zxc");
+        return;
+    }
+
+    assert!(
+        src_lib.exists(),
+        "ZXC source directory not found: {:?}",
+        src_lib
+    );
 
     let target = env::var("TARGET").unwrap_or_default();
     let is_arm64 = target.contains("aarch64") || target.contains("arm64");
@@ -185,40 +213,6 @@ fn main() {
     // Function Multi-Versioning: Compile variants with different suffixes
     // =========================================================================
 
-    // --- Default variant (baseline, always compiled) ---
-    let mut default_compress = cc::Build::new();
-    default_compress
-        .include(&include_dir)
-        .include(&src_lib)
-        .include(src_lib.join("vendors"))
-        .define("ZXC_STATIC_DEFINE", None)
-        .file(src_lib.join("zxc_compress.c"))
-        .define("ZXC_FUNCTION_SUFFIX", "_default")
-        .opt_level(3)
-        .warnings(false);
-
-    let mut default_decompress = cc::Build::new();
-    default_decompress
-        .include(&include_dir)
-        .include(&src_lib)
-        .include(src_lib.join("vendors"))
-        .define("ZXC_STATIC_DEFINE", None)
-        .file(src_lib.join("zxc_decompress.c"))
-        .define("ZXC_FUNCTION_SUFFIX", "_default")
-        .opt_level(3)
-        .warnings(false);
-
-    let mut default_huffman = cc::Build::new();
-    default_huffman
-        .include(&include_dir)
-        .include(&src_lib)
-        .include(src_lib.join("vendors"))
-        .define("ZXC_STATIC_DEFINE", None)
-        .file(src_lib.join("zxc_huffman.c"))
-        .define("ZXC_FUNCTION_SUFFIX", "_default")
-        .opt_level(3)
-        .warnings(false);
-
     // Add architecture-specific flags to core build BEFORE compiling
     if is_arm64 {
         core_build.flag_if_supported("-march=armv8-a+crc");
@@ -229,189 +223,55 @@ fn main() {
 
     core_build.compile("zxc_core");
 
-    // Compile defaults
-    default_compress.compile("zxc_compress_default");
-    default_decompress.compile("zxc_decompress_default");
-    default_huffman.compile("zxc_huffman_default");
+    // --- Default variant (baseline, always compiled) ---
+    compile_variant(&include_dir, &src_lib, "_default", &[]);
 
     // --- Architecture-specific variants ---
+    // The per-variant flags mirror zxc_add_variant() in CMakeLists.txt;
+    // keep both in sync. MSVC ignores GCC-style -m flags silently, so it
+    // needs its own /arch spellings plus the __BMI*__/__LZCNT__ macros the
+    // sources test (cl.exe never defines them itself).
+    let is_msvc = target.contains("msvc");
     if is_arm64 {
-        // NEON variant for ARM64
-        let mut neon_compress = cc::Build::new();
-        neon_compress
-            .include(&include_dir)
-            .include(&src_lib)
-            .include(src_lib.join("vendors"))
-            .define("ZXC_STATIC_DEFINE", None)
-            .file(src_lib.join("zxc_compress.c"))
-            .define("ZXC_FUNCTION_SUFFIX", "_neon")
-            .flag_if_supported("-march=armv8-a+simd")
-            .opt_level(3)
-            .warnings(false);
-
-        let mut neon_decompress = cc::Build::new();
-        neon_decompress
-            .include(&include_dir)
-            .include(&src_lib)
-            .include(src_lib.join("vendors"))
-            .define("ZXC_STATIC_DEFINE", None)
-            .file(src_lib.join("zxc_decompress.c"))
-            .define("ZXC_FUNCTION_SUFFIX", "_neon")
-            .flag_if_supported("-march=armv8-a+simd")
-            .opt_level(3)
-            .warnings(false);
-
-        let mut neon_huffman = cc::Build::new();
-        neon_huffman
-            .include(&include_dir)
-            .include(&src_lib)
-            .include(src_lib.join("vendors"))
-            .define("ZXC_STATIC_DEFINE", None)
-            .file(src_lib.join("zxc_huffman.c"))
-            .define("ZXC_FUNCTION_SUFFIX", "_neon")
-            .flag_if_supported("-march=armv8-a+simd")
-            .opt_level(3)
-            .warnings(false);
-
-        neon_compress.compile("zxc_compress_neon");
-        neon_decompress.compile("zxc_decompress_neon");
-        neon_huffman.compile("zxc_huffman_neon");
+        compile_variant(&include_dir, &src_lib, "_neon", &["-march=armv8-a+simd"]);
+    } else if is_x86_64 && is_msvc {
+        compile_variant(&include_dir, &src_lib, "_sse2", &["/D__SSE2__"]);
+        compile_variant(
+            &include_dir,
+            &src_lib,
+            "_avx2",
+            &["/arch:AVX2", "/D__BMI__", "/D__BMI2__", "/D__LZCNT__"],
+        );
+        compile_variant(
+            &include_dir,
+            &src_lib,
+            "_avx512",
+            &["/arch:AVX512", "/D__BMI__", "/D__BMI2__", "/D__LZCNT__"],
+        );
     } else if is_x86_64 {
         // SSE2 variant: the x86-64 baseline (also covers any i686 built with
-        // SSE2). Mirrors the _sse2 variant in CMakeLists.txt / meson.build.
-        let mut sse2_compress = cc::Build::new();
-        sse2_compress
-            .include(&include_dir)
-            .include(&src_lib)
-            .include(src_lib.join("vendors"))
-            .define("ZXC_STATIC_DEFINE", None)
-            .file(src_lib.join("zxc_compress.c"))
-            .define("ZXC_FUNCTION_SUFFIX", "_sse2")
-            .flag_if_supported("-msse2")
-            .opt_level(3)
-            .warnings(false);
-
-        let mut sse2_decompress = cc::Build::new();
-        sse2_decompress
-            .include(&include_dir)
-            .include(&src_lib)
-            .include(src_lib.join("vendors"))
-            .define("ZXC_STATIC_DEFINE", None)
-            .file(src_lib.join("zxc_decompress.c"))
-            .define("ZXC_FUNCTION_SUFFIX", "_sse2")
-            .flag_if_supported("-msse2")
-            .opt_level(3)
-            .warnings(false);
-
-        let mut sse2_huffman = cc::Build::new();
-        sse2_huffman
-            .include(&include_dir)
-            .include(&src_lib)
-            .include(src_lib.join("vendors"))
-            .define("ZXC_STATIC_DEFINE", None)
-            .file(src_lib.join("zxc_huffman.c"))
-            .define("ZXC_FUNCTION_SUFFIX", "_sse2")
-            .flag_if_supported("-msse2")
-            .opt_level(3)
-            .warnings(false);
-
-        sse2_compress.compile("zxc_compress_sse2");
-        sse2_decompress.compile("zxc_decompress_sse2");
-        sse2_huffman.compile("zxc_huffman_sse2");
-
-        // AVX2 variant
-        let mut avx2_compress = cc::Build::new();
-        avx2_compress
-            .include(&include_dir)
-            .include(&src_lib)
-            .include(src_lib.join("vendors"))
-            .define("ZXC_STATIC_DEFINE", None)
-            .file(src_lib.join("zxc_compress.c"))
-            .define("ZXC_FUNCTION_SUFFIX", "_avx2")
-            .flag_if_supported("-mavx2")
-            .flag_if_supported("-mfma")
-            .flag_if_supported("-mbmi2")
-            .opt_level(3)
-            .warnings(false);
-
-        let mut avx2_decompress = cc::Build::new();
-        avx2_decompress
-            .include(&include_dir)
-            .include(&src_lib)
-            .include(src_lib.join("vendors"))
-            .define("ZXC_STATIC_DEFINE", None)
-            .file(src_lib.join("zxc_decompress.c"))
-            .define("ZXC_FUNCTION_SUFFIX", "_avx2")
-            .flag_if_supported("-mavx2")
-            .flag_if_supported("-mfma")
-            .flag_if_supported("-mbmi2")
-            .opt_level(3)
-            .warnings(false);
-
-        let mut avx2_huffman = cc::Build::new();
-        avx2_huffman
-            .include(&include_dir)
-            .include(&src_lib)
-            .include(src_lib.join("vendors"))
-            .define("ZXC_STATIC_DEFINE", None)
-            .file(src_lib.join("zxc_huffman.c"))
-            .define("ZXC_FUNCTION_SUFFIX", "_avx2")
-            .flag_if_supported("-mavx2")
-            .flag_if_supported("-mfma")
-            .flag_if_supported("-mbmi2")
-            .opt_level(3)
-            .warnings(false);
-
-        avx2_compress.compile("zxc_compress_avx2");
-        avx2_decompress.compile("zxc_decompress_avx2");
-        avx2_huffman.compile("zxc_huffman_avx2");
-
-        // AVX512 variant
-        let mut avx512_compress = cc::Build::new();
-        avx512_compress
-            .include(&include_dir)
-            .include(&src_lib)
-            .include(src_lib.join("vendors"))
-            .define("ZXC_STATIC_DEFINE", None)
-            .file(src_lib.join("zxc_compress.c"))
-            .define("ZXC_FUNCTION_SUFFIX", "_avx512")
-            .flag_if_supported("-mavx512f")
-            .flag_if_supported("-mavx512bw")
-            .flag_if_supported("-mbmi2")
-            .opt_level(3)
-            .warnings(false);
-
-        let mut avx512_decompress = cc::Build::new();
-        avx512_decompress
-            .include(&include_dir)
-            .include(&src_lib)
-            .include(src_lib.join("vendors"))
-            .define("ZXC_STATIC_DEFINE", None)
-            .file(src_lib.join("zxc_decompress.c"))
-            .define("ZXC_FUNCTION_SUFFIX", "_avx512")
-            .flag_if_supported("-mavx512f")
-            .flag_if_supported("-mavx512bw")
-            .flag_if_supported("-mbmi2")
-            .opt_level(3)
-            .warnings(false);
-
-        let mut avx512_huffman = cc::Build::new();
-        avx512_huffman
-            .include(&include_dir)
-            .include(&src_lib)
-            .include(src_lib.join("vendors"))
-            .define("ZXC_STATIC_DEFINE", None)
-            .file(src_lib.join("zxc_huffman.c"))
-            .define("ZXC_FUNCTION_SUFFIX", "_avx512")
-            .flag_if_supported("-mavx512f")
-            .flag_if_supported("-mavx512bw")
-            .flag_if_supported("-mbmi2")
-            .opt_level(3)
-            .warnings(false);
-
-        avx512_compress.compile("zxc_compress_avx512");
-        avx512_decompress.compile("zxc_decompress_avx512");
-        avx512_huffman.compile("zxc_huffman_avx512");
+        // SSE2).
+        compile_variant(&include_dir, &src_lib, "_sse2", &["-msse2"]);
+        compile_variant(
+            &include_dir,
+            &src_lib,
+            "_avx2",
+            &["-mavx2", "-mfma", "-mbmi", "-mbmi2", "-mlzcnt"],
+        );
+        compile_variant(
+            &include_dir,
+            &src_lib,
+            "_avx512",
+            &[
+                "-mavx512f",
+                "-mavx512bw",
+                "-mavx512vbmi",
+                "-mavx512vbmi2",
+                "-mbmi",
+                "-mbmi2",
+                "-mlzcnt",
+            ],
+        );
     }
 
     // Threading support (not needed on Windows, which uses kernel32)

--- a/wrappers/rust/zxc-sys/src/lib.rs
+++ b/wrappers/rust/zxc-sys/src/lib.rs
@@ -92,9 +92,13 @@ pub const ZXC_LEVEL_BALANCED: i32 = parse_i32(env!("ZXC_LEVEL_BALANCED"));
 /// High density. Best for storage/firmware/assets.
 pub const ZXC_LEVEL_COMPACT: i32 = parse_i32(env!("ZXC_LEVEL_COMPACT"));
 
-/// Maximum density: Huffman-coded literals on top of COMPACT,
-/// price-based optimal LZ77 parser. Slowest compression, best ratio.
+/// High density: Huffman-coded literals on top of COMPACT,
+/// price-based optimal LZ77 parser.
 pub const ZXC_LEVEL_DENSITY: i32 = parse_i32(env!("ZXC_LEVEL_DENSITY"));
+
+/// Maximum density: Huffman-coded literals *and* sequence tokens, deep parse.
+/// Slowest compression, best ratio (level 7 / ULTRA).
+pub const ZXC_LEVEL_ULTRA: i32 = parse_i32(env!("ZXC_LEVEL_ULTRA"));
 
 // =============================================================================
 // Error Codes
@@ -169,7 +173,7 @@ pub const ZXC_HUF_TABLE_SIZE: usize = 128;
 pub struct zxc_compress_opts_t {
     /// Worker thread count (0 = auto-detect CPU cores).
     pub n_threads: c_int,
-    /// Compression level 1-6 (0 = default).
+    /// Compression level 1-7 (0 = default).
     pub level: c_int,
     /// Block size in bytes (0 = default 512 KB). Must be power of 2, 4 KB – 2 MB.
     pub block_size: usize,
@@ -266,7 +270,7 @@ unsafe extern "C" {
     /// Returns the minimum supported compression level (currently 1).
     pub fn zxc_min_level() -> c_int;
 
-    /// Returns the maximum supported compression level (currently 5).
+    /// Returns the maximum supported compression level (currently 7).
     pub fn zxc_max_level() -> c_int;
 
     /// Returns the default compression level (currently 3).
@@ -646,7 +650,7 @@ unsafe extern "C" {
     /// * `f_in` - Input file stream
     /// * `f_out` - Output file stream  
     /// * `n_threads` - Number of worker threads (0 = auto-detect CPU cores)
-    /// * `level` - Compression level (1-6)
+    /// * `level` - Compression level (1-7)
     /// * `checksum_enabled` - If non-zero, enables checksum verification
     ///
     /// # Returns
@@ -1085,6 +1089,7 @@ mod tests {
             ZXC_LEVEL_BALANCED,
             ZXC_LEVEL_COMPACT,
             ZXC_LEVEL_DENSITY,
+            ZXC_LEVEL_ULTRA,
         ] {
             unsafe {
                 let bound = zxc_compress_bound(input.len()) as usize;

--- a/wrappers/rust/zxc-sys/src/lib.rs
+++ b/wrappers/rust/zxc-sys/src/lib.rs
@@ -149,6 +149,15 @@ pub const ZXC_ERROR_BAD_BLOCK_TYPE: i32 = -13;
 /// Invalid block size
 pub const ZXC_ERROR_BAD_BLOCK_SIZE: i32 = -14;
 
+/// File requires a dictionary but none was provided
+pub const ZXC_ERROR_DICT_REQUIRED: i32 = -15;
+
+/// Provided dictionary ID does not match the file header
+pub const ZXC_ERROR_DICT_MISMATCH: i32 = -16;
+
+/// Dictionary exceeds maximum allowed size
+pub const ZXC_ERROR_DICT_TOO_LARGE: i32 = -17;
+
 // =============================================================================
 // Dictionary Constants
 // =============================================================================

--- a/wrappers/rust/zxc-sys/src/lib.rs
+++ b/wrappers/rust/zxc-sys/src/lib.rs
@@ -347,6 +347,34 @@ unsafe extern "C" {
     /// Original uncompressed size in bytes, or 0 if invalid.
     pub fn zxc_get_decompressed_size(src: *const c_void, src_size: usize) -> u64;
 
+    /// Returns the minimum single-buffer size for an in-place decompression.
+    ///
+    /// Reads `src`'s header and footer (no decoding) and returns the buffer
+    /// size `zxc_decompress_inplace` needs: decompressed size plus a
+    /// one-block and wild-copy safety margin.
+    ///
+    /// # Returns
+    ///
+    /// Required buffer size in bytes, or 0 if `src` is not a valid archive.
+    pub fn zxc_decompress_inplace_bound(src: *const c_void, src_size: usize) -> usize;
+
+    /// Decompresses in place inside a single caller-owned buffer.
+    ///
+    /// The compressed archive must sit flush-right in `buffer` (its last
+    /// `comp_size` bytes); decoding runs left-to-right into `buffer[0..]`.
+    /// `buffer_capacity` must be at least `zxc_decompress_inplace_bound`.
+    ///
+    /// # Returns
+    ///
+    /// Decompressed size (>0), 0 for an empty frame, or a negative error
+    /// code (`ZXC_ERROR_DST_TOO_SMALL` if the margin is missing).
+    pub fn zxc_decompress_inplace(
+        buffer: *mut c_void,
+        buffer_capacity: usize,
+        comp_size: usize,
+        opts: *const zxc_decompress_opts_t,
+    ) -> i64;
+
     /// Returns a human-readable name for the given error code.
     ///
     /// # Arguments
@@ -636,6 +664,49 @@ unsafe extern "C" {
         dst_capacity: usize,
         opts: *const zxc_decompress_opts_t,
     ) -> i64;
+
+    /// Returns the exact byte count required by a static compression
+    /// workspace for the given `block_size` and `level`.
+    ///
+    /// # Returns
+    ///
+    /// Workspace size in bytes, or 0 if either argument is invalid.
+    pub fn zxc_static_cctx_workspace_size(block_size: usize, level: c_int) -> usize;
+
+    /// Initialises a compression context inside a caller-supplied workspace
+    /// (no heap allocation).
+    ///
+    /// # Safety
+    /// - `workspace` must be cache-line (64-byte) aligned, at least
+    ///   `zxc_static_cctx_workspace_size` bytes, and outlive the handle.
+    /// - `opts` must be non-null with `block_size` and `level` set.
+    /// - `zxc_free_cctx` is a no-op on the returned handle.
+    pub fn zxc_init_static_cctx(
+        workspace: *mut c_void,
+        workspace_size: usize,
+        opts: *const zxc_compress_opts_t,
+    ) -> *mut zxc_cctx;
+
+    /// Returns the exact byte count required by a static decompression
+    /// workspace for the given `block_size`.
+    ///
+    /// # Returns
+    ///
+    /// Workspace size in bytes, or 0 if `block_size` is invalid.
+    pub fn zxc_static_dctx_workspace_size(block_size: usize) -> usize;
+
+    /// Initialises a decompression context inside a caller-supplied
+    /// workspace (no heap allocation).
+    ///
+    /// # Safety
+    /// - `workspace` must be cache-line (64-byte) aligned, at least
+    ///   `zxc_static_dctx_workspace_size` bytes, and outlive the handle.
+    /// - `zxc_free_dctx` is a no-op on the returned handle.
+    pub fn zxc_init_static_dctx(
+        workspace: *mut c_void,
+        workspace_size: usize,
+        block_size: usize,
+    ) -> *mut zxc_dctx;
 }
 
 // =============================================================================

--- a/wrappers/rust/zxc/Cargo.toml
+++ b/wrappers/rust/zxc/Cargo.toml
@@ -24,8 +24,5 @@ windows-sys = { version = "0.61.2", features = [
   "Win32_System_Threading",
 ] }
 
-[dev-dependencies]
-rand = "0.10"
-
 [features]
 default = []

--- a/wrappers/rust/zxc/README.md
+++ b/wrappers/rust/zxc/README.md
@@ -35,12 +35,13 @@ fn main() -> Result<(), zxc::Error> {
 | `Level::Default` | ★★★☆☆ | ★★★★☆ | General purpose |
 | `Level::Balanced` | ★★☆☆☆ | ★★★★☆ | Archives |
 | `Level::Compact` | ★☆☆☆☆ | ★★★★★ | Storage, firmware |
-| `Level::Density` | ★☆☆☆☆ | ★★★★★ | Maximum density (Huffman literals + optimal parser) |
+| `Level::Density` | ★☆☆☆☆ | ★★★★★ | High density (Huffman literals + optimal parser) |
+| `Level::Ultra` | ★☆☆☆☆ | ★★★★★ | Maximum density (Huffman literals + tokens, deep parse) |
 
 ## Features
 
 - **Fast decompression**: Optimized for read-heavy workloads
-- **5 compression levels**: Trade off speed vs ratio
+- **7 compression levels**: Trade off speed vs ratio
 - **Optional checksums**: Disabled by default for maximum performance, enable for data integrity
 - **File streaming**: Multi-threaded compression/decompression for large files
 - **Zero-allocation API**: `compress_to` and `decompress_to` for buffer reuse

--- a/wrappers/rust/zxc/README.md
+++ b/wrappers/rust/zxc/README.md
@@ -57,7 +57,7 @@ use zxc::{compress_to, decompress_to, compress_bound, CompressOptions, Decompres
 let data = b"Hello, world!";
 
 // Compression
-let mut output = vec![0u8; compress_bound(data.len())];
+let mut output = vec![0u8; compress_bound(data.len()) as usize];
 let size = compress_to(data, &mut output, &CompressOptions::default())?;
 output.truncate(size);
 
@@ -83,7 +83,7 @@ let decompressed = decompress_with_options(&compressed, &DecompressOptions::skip
 use zxc::decompressed_size;
 
 if let Some(size) = decompressed_size(&compressed) {
-    let mut buffer = vec![0u8; size];
+    let mut buffer = vec![0u8; size as usize];
     // ...
 }
 ```

--- a/wrappers/rust/zxc/src/error.rs
+++ b/wrappers/rust/zxc/src/error.rs
@@ -10,7 +10,8 @@
 use zxc_sys::{
     ZXC_ERROR_BAD_BLOCK_SIZE, ZXC_ERROR_BAD_BLOCK_TYPE, ZXC_ERROR_BAD_CHECKSUM,
     ZXC_ERROR_BAD_HEADER, ZXC_ERROR_BAD_MAGIC, ZXC_ERROR_BAD_OFFSET, ZXC_ERROR_BAD_VERSION,
-    ZXC_ERROR_CORRUPT_DATA, ZXC_ERROR_DST_TOO_SMALL, ZXC_ERROR_IO, ZXC_ERROR_MEMORY,
+    ZXC_ERROR_CORRUPT_DATA, ZXC_ERROR_DICT_MISMATCH, ZXC_ERROR_DICT_REQUIRED,
+    ZXC_ERROR_DICT_TOO_LARGE, ZXC_ERROR_DST_TOO_SMALL, ZXC_ERROR_IO, ZXC_ERROR_MEMORY,
     ZXC_ERROR_NULL_INPUT, ZXC_ERROR_OVERFLOW, ZXC_ERROR_SRC_TOO_SMALL,
 };
 
@@ -73,6 +74,22 @@ pub enum Error {
     #[error("invalid block size")]
     BadBlockSize,
 
+    /// The archive requires a dictionary but none was provided
+    #[error("archive requires a dictionary but none was provided")]
+    DictRequired,
+
+    /// The provided dictionary does not match the archive's dictionary ID
+    #[error("dictionary ID does not match the archive header")]
+    DictMismatch,
+
+    /// The dictionary exceeds the maximum allowed size
+    #[error("dictionary exceeds maximum allowed size")]
+    DictTooLarge,
+
+    /// The requested options are not supported by this API
+    #[error("unsupported option: {0}")]
+    Unsupported(&'static str),
+
     /// The compressed data appears to be invalid or truncated
     #[error("invalid compressed data")]
     InvalidData,
@@ -99,6 +116,9 @@ pub(crate) fn error_from_code(code: i64) -> Error {
         ZXC_ERROR_NULL_INPUT => Error::NullInput,
         ZXC_ERROR_BAD_BLOCK_TYPE => Error::BadBlockType,
         ZXC_ERROR_BAD_BLOCK_SIZE => Error::BadBlockSize,
+        ZXC_ERROR_DICT_REQUIRED => Error::DictRequired,
+        ZXC_ERROR_DICT_MISMATCH => Error::DictMismatch,
+        ZXC_ERROR_DICT_TOO_LARGE => Error::DictTooLarge,
         _ => Error::Unknown(code as i32),
     }
 }

--- a/wrappers/rust/zxc/src/file.rs
+++ b/wrappers/rust/zxc/src/file.rs
@@ -305,11 +305,42 @@ pub fn compress_file<P: AsRef<Path>>(
     threads: Option<usize>,
     checksum: Option<bool>,
 ) -> StreamResult<u64> {
+    compress_file_with_options(
+        input,
+        output,
+        &StreamCompressOptions {
+            level,
+            threads,
+            checksum: checksum.unwrap_or(false),
+            seekable: false,
+        },
+    )
+}
+
+/// Compresses a file using multi-threaded streaming, honouring `opts`.
+///
+/// Unlike [`compress_file`], this exposes every [`StreamCompressOptions`]
+/// field — including `seekable`, which appends a seek table for
+/// random-access decompression via [`crate::seekable::Seekable`].
+///
+/// # Example
+///
+/// ```rust,no_run
+/// use zxc::{compress_file_with_options, Level, StreamCompressOptions};
+///
+/// let opts = StreamCompressOptions::with_level(Level::Compact)
+///     .threads(4)
+///     .with_seekable();
+/// let bytes = compress_file_with_options("input.bin", "output.zxc", &opts)?;
+/// # Ok::<(), zxc::StreamError>(())
+/// ```
+pub fn compress_file_with_options<P: AsRef<Path>>(
+    input: P,
+    output: P,
+    opts: &StreamCompressOptions,
+) -> StreamResult<u64> {
     let f_in = File::open(input)?;
     let f_out = File::create(output)?;
-
-    let n_threads = threads.unwrap_or(0) as i32;
-    let checksum_enabled = if checksum.unwrap_or(false) { 1 } else { 0 };
 
     unsafe {
         let c_in = file_to_c_file_read(&f_in);
@@ -331,9 +362,10 @@ pub fn compress_file<P: AsRef<Path>>(
             c_in,
             c_out,
             &zxc_sys::zxc_compress_opts_t {
-                n_threads,
-                level: level as i32,
-                checksum_enabled,
+                n_threads: opts.threads.unwrap_or(0) as i32,
+                level: opts.level as i32,
+                checksum_enabled: opts.checksum as i32,
+                seekable: opts.seekable as i32,
                 ..Default::default()
             },
         );
@@ -367,11 +399,41 @@ pub fn decompress_file<P: AsRef<Path>>(
     output: P,
     threads: Option<usize>,
 ) -> StreamResult<u64> {
+    decompress_file_with_options(
+        input,
+        output,
+        &StreamDecompressOptions {
+            threads,
+            verify_checksum: true,
+        },
+    )
+}
+
+/// Decompresses a file using multi-threaded streaming, honouring `opts`.
+///
+/// Unlike [`decompress_file`], this exposes every
+/// [`StreamDecompressOptions`] field — including `verify_checksum`, which
+/// can be disabled to skip integrity verification.
+///
+/// # Example
+///
+/// ```rust,no_run
+/// use zxc::{decompress_file_with_options, StreamDecompressOptions};
+///
+/// let opts = StreamDecompressOptions::default().skip_checksum();
+/// let bytes = decompress_file_with_options("compressed.zxc", "output.bin", &opts)?;
+/// # Ok::<(), zxc::StreamError>(())
+/// ```
+pub fn decompress_file_with_options<P: AsRef<Path>>(
+    input: P,
+    output: P,
+    opts: &StreamDecompressOptions,
+) -> StreamResult<u64> {
     let f_in = File::open(input)?;
     let f_out = File::create(output)?;
 
-    let n_threads = threads.unwrap_or(0) as i32;
-    let checksum_enabled = 1; // Default to verify
+    let n_threads = opts.threads.unwrap_or(0) as i32;
+    let checksum_enabled = opts.verify_checksum as i32;
 
     unsafe {
         let c_in = file_to_c_file_read(&f_in);

--- a/wrappers/rust/zxc/src/file.rs
+++ b/wrappers/rust/zxc/src/file.rs
@@ -70,12 +70,21 @@ impl StreamCompressOptions {
 }
 
 /// Options for streaming decompression operations.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct StreamDecompressOptions {
     /// Number of worker threads (default: `None` = auto-detect CPU cores)
     pub threads: Option<usize>,
     /// Verify checksum during decompression (default: `true`)
     pub verify_checksum: bool,
+}
+
+impl Default for StreamDecompressOptions {
+    fn default() -> Self {
+        Self {
+            threads: None,
+            verify_checksum: true,
+        }
+    }
 }
 
 impl StreamDecompressOptions {
@@ -427,6 +436,10 @@ pub fn file_decompressed_size<P: AsRef<Path>>(path: P) -> StreamResult<u64> {
         }
 
         let result = zxc_sys::zxc_stream_get_decompressed_size(c_file);
+
+        // The FILE* owns a dup'd fd; it must be closed here or every call
+        // leaks one file descriptor.
+        libc::fclose(c_file);
 
         if result < 0 {
             Err(StreamError::InvalidFile)

--- a/wrappers/rust/zxc/src/lib.rs
+++ b/wrappers/rust/zxc/src/lib.rs
@@ -289,8 +289,9 @@ pub use oneshot::{
 };
 pub use ctx::{compress_block_bound, decompress_block_bound, Cctx, Dctx};
 pub use file::{
-    compress_file, decompress_file, file_decompressed_size, StreamCompressOptions,
-    StreamDecompressOptions, StreamError, StreamResult,
+    compress_file, compress_file_with_options, decompress_file, decompress_file_with_options,
+    file_decompressed_size, StreamCompressOptions, StreamDecompressOptions, StreamError,
+    StreamResult,
 };
 pub use pstream::{CStream, CStreamProgress, DStream, DStreamProgress};
 pub use seekable::{seek_table_size, write_seek_table, Seekable};

--- a/wrappers/rust/zxc/src/lib.rs
+++ b/wrappers/rust/zxc/src/lib.rs
@@ -205,7 +205,7 @@ impl CompressOptions {
 // =============================================================================
 
 /// Options for decompression operations.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct DecompressOptions {
     /// Verify checksum during decompression (default: `true`)
     pub verify_checksum: bool,
@@ -221,6 +221,16 @@ pub struct DecompressOptions {
     /// Must match the table used at compression time (the archive's dict_id
     /// binds the (dict, table) pair).
     pub dict_huf: Option<Vec<u8>>,
+}
+
+impl Default for DecompressOptions {
+    fn default() -> Self {
+        Self {
+            verify_checksum: true,
+            dict: None,
+            dict_huf: None,
+        }
+    }
 }
 
 impl DecompressOptions {

--- a/wrappers/rust/zxc/src/lib.rs
+++ b/wrappers/rust/zxc/src/lib.rs
@@ -26,7 +26,7 @@
 //!
 //! # Compression Levels
 //!
-//! ZXC provides 6 compression levels trading off speed vs ratio:
+//! ZXC provides 7 compression levels trading off speed vs ratio:
 //!
 //! | Level | Speed | Ratio | Use Case |
 //! |-------|-------|-------|----------|
@@ -35,7 +35,8 @@
 //! | `Default` | ★★★☆☆ | ★★★★☆ | General purpose |
 //! | `Balanced` | ★★☆☆☆ | ★★★★☆ | Archives |
 //! | `Compact` | ★☆☆☆☆ | ★★★★★ | Storage, firmware |
-//! | `Density` | ★☆☆☆☆ | ★★★★★ | Maximum density (Huffman literals + optimal parser) |
+//! | `Density` | ★☆☆☆☆ | ★★★★★ | High density (Huffman literals + optimal parser) |
+//! | `Ultra` | ★☆☆☆☆ | ★★★★★ | Maximum density (Huffman literals + tokens, deep parse) |
 //!
 //! # Features
 //!
@@ -47,7 +48,7 @@
 
 pub use zxc_sys::{
     ZXC_LEVEL_BALANCED, ZXC_LEVEL_COMPACT, ZXC_LEVEL_DEFAULT, ZXC_LEVEL_DENSITY, ZXC_LEVEL_FAST,
-    ZXC_LEVEL_FASTEST, ZXC_VERSION_MAJOR, ZXC_VERSION_MINOR, ZXC_VERSION_PATCH,
+    ZXC_LEVEL_FASTEST, ZXC_LEVEL_ULTRA, ZXC_VERSION_MAJOR, ZXC_VERSION_MINOR, ZXC_VERSION_PATCH,
     // Error codes
     ZXC_OK, ZXC_ERROR_MEMORY, ZXC_ERROR_DST_TOO_SMALL, ZXC_ERROR_SRC_TOO_SMALL,
     ZXC_ERROR_BAD_MAGIC, ZXC_ERROR_BAD_VERSION, ZXC_ERROR_BAD_HEADER,
@@ -63,9 +64,9 @@ pub use zxc_sys::{
 /// Compression level presets.
 ///
 /// Higher levels produce smaller output but compress more slowly.
-/// Decompression speed is similar across most levels; level 6 sits a notch
-/// below the others because Huffman-coded literals add a per-block decode
-/// cost relative to RAW/RLE literals.
+/// Decompression speed is similar across most levels; levels 6-7 sit a notch
+/// below the others because Huffman-coded literals (and, at level 7, tokens)
+/// add a per-block decode cost relative to RAW/RLE literals.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 #[repr(i32)]
 pub enum Level {
@@ -85,10 +86,13 @@ pub enum Level {
     /// High density: storage / firmware / assets (level 5)
     Compact = 5,
 
-    /// Maximum density: Huffman-coded literals on top of COMPACT plus a
-    /// price-based optimal LZ77 parser. Slowest compression, best ratio
-    /// (level 6).
+    /// High density: Huffman-coded literals on top of COMPACT plus a
+    /// price-based optimal LZ77 parser (level 6).
     Density = 6,
+
+    /// Maximum density: Huffman-coded literals *and* sequence tokens with a
+    /// deep parse. Slowest compression, best ratio (level 7 / ULTRA).
+    Ultra = 7,
 }
 
 impl Level {
@@ -101,6 +105,7 @@ impl Level {
             Level::Balanced,
             Level::Compact,
             Level::Density,
+            Level::Ultra,
         ]
     }
 }

--- a/wrappers/rust/zxc/src/oneshot.rs
+++ b/wrappers/rust/zxc/src/oneshot.rs
@@ -333,7 +333,7 @@ pub fn min_level() -> i32 {
 
 /// Returns the maximum supported compression level (currently `5`).
 ///
-/// Equivalent to [`Level::Compact`] as an integer.
+/// Equivalent to [`Level::Ultra`] as an integer.
 pub fn max_level() -> i32 {
     unsafe { zxc_sys::zxc_max_level() }
 }

--- a/wrappers/rust/zxc/src/oneshot.rs
+++ b/wrappers/rust/zxc/src/oneshot.rs
@@ -331,7 +331,7 @@ pub fn min_level() -> i32 {
     unsafe { zxc_sys::zxc_min_level() }
 }
 
-/// Returns the maximum supported compression level (currently `5`).
+/// Returns the maximum supported compression level (currently `7`).
 ///
 /// Equivalent to [`Level::Ultra`] as an integer.
 pub fn max_level() -> i32 {

--- a/wrappers/rust/zxc/src/pstream.rs
+++ b/wrappers/rust/zxc/src/pstream.rs
@@ -86,7 +86,20 @@ impl CStream {
     ///
     /// `opts.seekable` is ignored (the push API is single-threaded and does
     /// not emit a seek table). Pass `None` for all defaults.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Unsupported`] when `opts.dict` or `opts.dict_huf`
+    /// is set: the push-stream format carries no dictionary ID, so
+    /// dictionary compression would produce undecodable archives.
     pub fn new(opts: Option<&CompressOptions>) -> Result<Self> {
+        if let Some(o) = opts {
+            if o.dict.is_some() || o.dict_huf.is_some() {
+                return Err(Error::Unsupported(
+                    "dictionaries are not supported by the push streaming API",
+                ));
+            }
+        }
         let c_opts = opts.map(|o| zxc_sys::zxc_compress_opts_t {
             level: o.level as i32,
             checksum_enabled: o.checksum as i32,
@@ -205,7 +218,20 @@ unsafe impl Send for DStream {}
 
 impl DStream {
     /// Creates a new push decompression stream.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Unsupported`] when `opts.dict` or `opts.dict_huf`
+    /// is set: the push-stream decoder has no dictionary support (see
+    /// [`CStream::new`]).
     pub fn new(opts: Option<&DecompressOptions>) -> Result<Self> {
+        if let Some(o) = opts {
+            if o.dict.is_some() || o.dict_huf.is_some() {
+                return Err(Error::Unsupported(
+                    "dictionaries are not supported by the push streaming API",
+                ));
+            }
+        }
         let c_opts = opts.map(|o| zxc_sys::zxc_decompress_opts_t {
             checksum_enabled: o.verify_checksum as i32,
             ..Default::default()

--- a/wrappers/rust/zxc/src/seekable.rs
+++ b/wrappers/rust/zxc/src/seekable.rs
@@ -60,6 +60,9 @@ pub struct Seekable {
 // SAFETY: the underlying handle is opaque and the library guarantees
 // per-handle thread affinity. `Send` is safe (move the handle to another
 // thread is fine); `Sync` is not (no concurrent calls on the same handle).
+// The reader stored behind `reader_ctx` is `Send` by construction:
+// `open_reader` requires `R: Send`, so moving the handle (and invoking
+// `read_at` from the destination thread) cannot race thread-bound state.
 unsafe impl Send for Seekable {}
 
 impl Seekable {
@@ -125,7 +128,7 @@ impl Seekable {
     ///
     /// Returns [`Error::InvalidData`] if the archive is not a valid
     /// seekable ZXC archive, or if any of the open-time reads fail.
-    pub fn open_reader<R: ReadAt + 'static>(reader: R) -> Result<Self> {
+    pub fn open_reader<R: ReadAt + Send + 'static>(reader: R) -> Result<Self> {
         // Heap-allocate the trait object so its address is stable across
         // the FFI boundary. The outer Box gives us a thin pointer to pass
         // as the C `ctx`.

--- a/wrappers/wasm/README.md
+++ b/wrappers/wasm/README.md
@@ -6,7 +6,7 @@ High-performance lossless compression for the browser and Node.js via WebAssembl
 
 - **Buffer API**: Compress and decompress `Uint8Array` buffers
 - **Reusable Contexts**: Amortise allocation overhead across multiple operations
-- **All Levels**: Compression levels 1–5
+- **All Levels**: Compression levels 1–7
 - **Checksum Support**: Optional integrity verification
 - **Tiny Footprint**: ~60 KB `.wasm` file (scalar build, no SIMD)
 
@@ -51,7 +51,7 @@ Initialise the WASM module. Returns a frozen API object.
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `level` | `number` | `3` | Compression level (1–5) |
+| `level` | `number` | `3` | Compression level (1–7) |
 | `checksum` | `boolean` | `false` | Enable integrity checksums |
 
 ### `zxc.decompress(data, opts?) -> Uint8Array`

--- a/wrappers/wasm/test.mjs
+++ b/wrappers/wasm/test.mjs
@@ -11,9 +11,8 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-import { createRequire } from 'module';
 import { join, dirname, resolve } from 'path';
-import { fileURLToPath } from 'url';
+import { fileURLToPath, pathToFileURL } from 'url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 // Resolve BUILD_DIR relative to CWD (not the test file location)
@@ -21,9 +20,8 @@ const buildDir = process.env.BUILD_DIR
     ? resolve(process.cwd(), process.env.BUILD_DIR)
     : join(__dirname, '..', '..', 'build-wasm');
 
-// Emscripten generates a CJS module; use createRequire to load it.
-const require = createRequire(import.meta.url);
-const ZXCModule = require(join(buildDir, 'zxc.js'));
+// The module is built with -sEXPORT_ES6=1; import it as ESM.
+const ZXCModule = (await import(pathToFileURL(join(buildDir, 'zxc.js')))).default;
 
 let passed = 0;
 let failed = 0;
@@ -73,7 +71,7 @@ async function main() {
     const version = _version_string();
     assert(typeof version === 'string' && version.length > 0, `Version: ${version}`);
     assert(_min_level() === 1, `Min level: ${_min_level()}`);
-    assert(_max_level() === 6, `Max level: ${_max_level()}`);
+    assert(_max_level() === 7, `Max level: ${_max_level()}`);
     assert(_default_level() === 3, `Default level: ${_default_level()}`);
 
     // --- 3. Compress bound ---
@@ -130,27 +128,29 @@ async function main() {
         }
         const bound = _compress_bound(input.length);
 
-        for (let level = 1; level <= 6; level++) {
+        for (let level = 1; level <= 7; level++) {
             const srcPtr = Module._malloc(input.length);
             const dstPtr = Module._malloc(bound);
             Module.HEAPU8.set(input, srcPtr);
 
-            // Build opts struct: {n_threads=0, level, block_size=0, checksum=1, seekable=0, ...}
-            const optsPtr = Module._malloc(28);
-            for (let i = 0; i < 28; i++) Module.HEAPU8[optsPtr + i] = 0;
+            // Build opts struct (full 40-byte zxc_compress_opts_t so the
+            // dict/progress fields the library reads are zeroed, not heap
+            // garbage): {n_threads=0, level, block_size=0, checksum=1, ...}
+            const optsPtr = Module._malloc(40);
+            for (let i = 0; i < 40; i++) Module.HEAPU8[optsPtr + i] = 0;
             Module.HEAP32[(optsPtr >> 2) + 1] = level;  // level
             Module.HEAP32[(optsPtr >> 2) + 3] = 1;      // checksum_enabled
 
             const csize = _compress(srcPtr, input.length, dstPtr, bound, optsPtr);
             assert(csize > 0, `Level ${level}: compressed to ${csize} bytes`);
 
-            // Decompress with checksum verification
+            // Decompress with checksum verification (28-byte zxc_decompress_opts_t)
             const compressed = new Uint8Array(Module.HEAPU8.buffer, dstPtr, csize).slice();
             const csrcPtr = Module._malloc(compressed.length);
             Module.HEAPU8.set(compressed, csrcPtr);
 
-            const dOptsPtr = Module._malloc(16);
-            for (let i = 0; i < 16; i++) Module.HEAPU8[dOptsPtr + i] = 0;
+            const dOptsPtr = Module._malloc(28);
+            for (let i = 0; i < 28; i++) Module.HEAPU8[dOptsPtr + i] = 0;
             Module.HEAP32[(dOptsPtr >> 2) + 1] = 1; // checksum_enabled
 
             const outPtr = Module._malloc(input.length);
@@ -523,6 +523,25 @@ async function main() {
                 'seekable+dict mid-range byte-exact');
         } finally {
             s.free();
+            s.free(); // idempotent: second call must be a no-op
+        }
+
+        // Seekable + Dictionary (content + huf table): regression for setDict
+        // dropping the table argument, which made every (dict, huf)-bound
+        // archive fail range decode with DICT_MISMATCH.
+        const seekArchiveHuf = zxc.compress(bigPayload, { dict: d, seekable: true });
+        const sh = zxc.createSeekable(seekArchiveHuf);
+        try {
+            sh.setDict(d);
+            const full = sh.decompressRange(0, bigPayload.length);
+            assert(arraysEqual(full, bigPayload),
+                'seekable+Dictionary(huf) full-range byte-exact');
+            let hufRejected = false;
+            try { sh.setDict(d.content); } catch (e) { hufRejected = true; }
+            assert(hufRejected,
+                'seekable setDict(content-only) rejected on a Dictionary archive');
+        } finally {
+            sh.free();
         }
     }
 

--- a/wrappers/wasm/zxc_wasm.js
+++ b/wrappers/wasm/zxc_wasm.js
@@ -191,16 +191,11 @@ export default async function createZXC(moduleOverrides, factory) {
      */
     function _writeCompressOpts(level, checksum, seekable, dictPtr, dictSize, dictHufPtr) {
         const ptr = _malloc(COMPRESS_OPTS_SIZE);
-        // Zero-fill first
-        for (let i = 0; i < COMPRESS_OPTS_SIZE; i++) {
-            Module.HEAPU8[ptr + i] = 0;
-        }
-        // n_threads = 0 (offset 0)
-        Module.HEAP32[(ptr >> 2) + 0] = 0;
+        // Zero-fill covers n_threads (0), block_size (8, default),
+        // progress_cb (32) and user_data (36).
+        Module.HEAPU8.fill(0, ptr, ptr + COMPRESS_OPTS_SIZE);
         // level (offset 4)
         Module.HEAP32[(ptr >> 2) + 1] = level;
-        // block_size = 0 (default, offset 8)
-        Module.HEAPU32[(ptr >> 2) + 2] = 0;
         // checksum_enabled (offset 12)
         Module.HEAP32[(ptr >> 2) + 3] = checksum ? 1 : 0;
         // seekable (offset 16)
@@ -209,7 +204,6 @@ export default async function createZXC(moduleOverrides, factory) {
         Module.HEAPU32[(ptr >> 2) + 5] = dictPtr || 0;
         Module.HEAPU32[(ptr >> 2) + 6] = dictSize || 0;
         Module.HEAPU32[(ptr >> 2) + 7] = dictHufPtr || 0;
-        // progress_cb = NULL (offset 32), user_data = NULL (offset 36)
         return ptr;
     }
 
@@ -219,18 +213,14 @@ export default async function createZXC(moduleOverrides, factory) {
      */
     function _writeDecompressOpts(checksum, dictPtr, dictSize, dictHufPtr) {
         const ptr = _malloc(DECOMPRESS_OPTS_SIZE);
-        for (let i = 0; i < DECOMPRESS_OPTS_SIZE; i++) {
-            Module.HEAPU8[ptr + i] = 0;
-        }
-        // n_threads = 0 (offset 0)
-        Module.HEAP32[(ptr >> 2) + 0] = 0;
+        // Zero-fill covers n_threads (0), progress_cb (20) and user_data (24).
+        Module.HEAPU8.fill(0, ptr, ptr + DECOMPRESS_OPTS_SIZE);
         // checksum_enabled (offset 4)
         Module.HEAP32[(ptr >> 2) + 1] = checksum ? 1 : 0;
         // dict (offset 8), dict_size (offset 12), dict_huf (offset 16)
         Module.HEAPU32[(ptr >> 2) + 2] = dictPtr || 0;
         Module.HEAPU32[(ptr >> 2) + 3] = dictSize || 0;
         Module.HEAPU32[(ptr >> 2) + 4] = dictHufPtr || 0;
-        // progress_cb = NULL (offset 20), user_data = NULL (offset 24)
         return ptr;
     }
 
@@ -546,7 +536,9 @@ export default async function createZXC(moduleOverrides, factory) {
                 }
                 if (r === 0 && _readPos(inDescPtr) === srcLen) break;
             }
-            return _concatChunks(chunks, total);
+            // Single chunk is the common case (stageCap holds a full block):
+            // skip the concat copy.
+            return chunks.length === 1 ? chunks[0] : _concatChunks(chunks, total);
         }
 
         function drainEnd() {
@@ -565,7 +557,7 @@ export default async function createZXC(moduleOverrides, factory) {
                 }
                 if (r === 0) break;
             }
-            return _concatChunks(chunks, total);
+            return chunks.length === 1 ? chunks[0] : _concatChunks(chunks, total);
         }
 
         return {
@@ -648,7 +640,7 @@ export default async function createZXC(moduleOverrides, factory) {
                             exhausted = true;
                         }
                     }
-                    return _concatChunks(chunks, total);
+                    return chunks.length === 1 ? chunks[0] : _concatChunks(chunks, total);
                 } finally {
                     if (srcPtr) _free(srcPtr);
                 }

--- a/wrappers/wasm/zxc_wasm.js
+++ b/wrappers/wasm/zxc_wasm.js
@@ -35,7 +35,20 @@ export function detectZxc(buf) {
  * @returns {Promise<ZXC>} Resolved API object.
  */
 export default async function createZXC(moduleOverrides, factory) {
-    const ZXCModule = factory || (await import('./zxc.js')).default;
+    let ZXCModule = factory;
+    if (!ZXCModule) {
+        ZXCModule = (await import('./zxc.js')).default;
+        if (typeof ZXCModule !== 'function') {
+            try {
+                const { createRequire } = await import('node:module');
+                ZXCModule = createRequire(import.meta.url)('./zxc.js');
+            } catch (_) {
+                throw new Error(
+                    'ZXC: could not load ./zxc.js as a module factory; ' +
+                    'pass the Emscripten factory explicitly: createZXC({}, factory)');
+            }
+        }
+    }
     const Module = await ZXCModule(moduleOverrides || {});
 
     // --- Wrap C functions via cwrap ------------------------------------------
@@ -124,6 +137,14 @@ export default async function createZXC(moduleOverrides, factory) {
 
     const _malloc = Module._malloc;
     const _free   = Module._free;
+
+    const _getTempRet0 =
+        typeof Module.getTempRet0 === 'function' ? Module.getTempRet0 : null;
+    function _u64(low) {
+        const lo = low >>> 0;
+        const hi = _getTempRet0 ? (_getTempRet0() >>> 0) : 0;
+        return hi * 0x100000000 + lo;
+    }
 
     // --- Options struct layout -----------------------------------------------
     // zxc_compress_opts_t (WASM32 layout, all fields 4-byte aligned):
@@ -236,7 +257,7 @@ export default async function createZXC(moduleOverrides, factory) {
      *
      * @param {Uint8Array} data - Input data to compress.
      * @param {object} [opts] - Options.
-     * @param {number} [opts.level=3] - Compression level (1-6).
+     * @param {number} [opts.level=3] - Compression level (1-7).
      * @param {boolean} [opts.checksum=false] - Enable checksums.
      * @param {boolean} [opts.seekable=false] - Append seek table for random-access.
      * @param {Dictionary|Uint8Array} [opts.dict] - A {@link Dictionary}, or raw
@@ -303,7 +324,14 @@ export default async function createZXC(moduleOverrides, factory) {
         const srcPtr = _malloc(data.length);
         Module.HEAPU8.set(data, srcPtr);
 
-        const origSize = _get_decompressed_size(srcPtr, data.length);
+        const origSize = _u64(_get_decompressed_size(srcPtr, data.length));
+        if (origSize > 0x7FFFFFFF) {
+            // A wasm32 heap cannot address it; fail clearly instead of
+            // aborting inside malloc.
+            _free(srcPtr);
+            throw new Error(
+                `ZXC: decompressed size (${origSize} bytes) exceeds wasm32 addressable memory`);
+        }
         const dstPtr = _malloc(origSize || 1);
         const dictPtr = dict && dict.length > 0 ? _malloc(dict.length) : 0;
         if (dictPtr) Module.HEAPU8.set(dict, dictPtr);
@@ -343,10 +371,12 @@ export default async function createZXC(moduleOverrides, factory) {
      */
     function getDecompressedSize(data) {
         const ptr = _malloc(data.length);
-        Module.HEAPU8.set(data, ptr);
-        const size = _get_decompressed_size(ptr, data.length);
-        _free(ptr);
-        return size;
+        try {
+            Module.HEAPU8.set(data, ptr);
+            return _u64(_get_decompressed_size(ptr, data.length));
+        } finally {
+            _free(ptr);
+        }
     }
 
     /**
@@ -364,7 +394,7 @@ export default async function createZXC(moduleOverrides, factory) {
         const seekable = (opts && opts.seekable) || false;
 
         const optsPtr = _writeCompressOpts(level, checksum, seekable);
-        const cctx = _create_cctx(optsPtr);
+        let cctx = _create_cctx(optsPtr);
         _free(optsPtr);
 
         if (cctx === 0) throw new Error('ZXC: failed to create compression context');
@@ -391,9 +421,11 @@ export default async function createZXC(moduleOverrides, factory) {
                     _free(dstPtr);
                 }
             },
-            /** Free the context and release WASM memory. */
+            /** Free the context and release WASM memory. Idempotent. */
             free() {
+                if (!cctx) return;
                 _free_cctx(cctx);
+                cctx = 0;
             }
         };
     }
@@ -405,7 +437,7 @@ export default async function createZXC(moduleOverrides, factory) {
      * @returns {{ decompress: Function, free: Function }}
      */
     function createDecompressContext() {
-        const dctx = _create_dctx();
+        let dctx = _create_dctx();
         if (dctx === 0) throw new Error('ZXC: failed to create decompression context');
 
         return {
@@ -417,7 +449,12 @@ export default async function createZXC(moduleOverrides, factory) {
             decompress(data) {
                 const srcPtr = _malloc(data.length);
                 Module.HEAPU8.set(data, srcPtr);
-                const origSize = _get_decompressed_size(srcPtr, data.length);
+                const origSize = _u64(_get_decompressed_size(srcPtr, data.length));
+                if (origSize > 0x7FFFFFFF) {
+                    _free(srcPtr);
+                    throw new Error(
+                        `ZXC: decompressed size (${origSize} bytes) exceeds wasm32 addressable memory`);
+                }
                 const dstPtr = _malloc(origSize || 1);
                 try {
                     const result = _decompress_dctx(dctx, srcPtr, data.length, dstPtr, origSize, 0);
@@ -430,9 +467,11 @@ export default async function createZXC(moduleOverrides, factory) {
                     _free(dstPtr);
                 }
             },
-            /** Free the context and release WASM memory. */
+            /** Free the context and release WASM memory. Idempotent. */
             free() {
+                if (!dctx) return;
                 _free_dctx(dctx);
+                dctx = 0;
             }
         };
     }
@@ -478,7 +517,7 @@ export default async function createZXC(moduleOverrides, factory) {
         const checksum = (opts && opts.checksum) || false;
 
         const optsPtr = _writeCompressOpts(level, checksum, false);
-        const cs = _cstream_create(optsPtr);
+        let cs = _cstream_create(optsPtr);
         _free(optsPtr);
         if (cs === 0) throw new Error('ZXC: failed to create cstream');
 
@@ -545,12 +584,14 @@ export default async function createZXC(moduleOverrides, factory) {
             end() {
                 return drainEnd();
             },
-            /** Free the stream and its scratch buffers. */
+            /** Free the stream and its scratch buffers. Idempotent. */
             free() {
+                if (!cs) return;
                 _cstream_free(cs);
                 _free(inDescPtr);
                 _free(outDescPtr);
                 _free(stagePtr);
+                cs = 0;
             },
             inSize()  { return _cstream_in_size(cs); },
             outSize() { return _cstream_out_size(cs); }
@@ -566,7 +607,7 @@ export default async function createZXC(moduleOverrides, factory) {
     function createDStream(opts) {
         const checksum = (opts && opts.checksum) || false;
         const optsPtr  = _writeDecompressOpts(checksum);
-        const ds = _dstream_create(optsPtr);
+        let ds = _dstream_create(optsPtr);
         _free(optsPtr);
         if (ds === 0) throw new Error('ZXC: failed to create dstream');
 
@@ -614,11 +655,14 @@ export default async function createZXC(moduleOverrides, factory) {
             },
             /** True iff the file footer has been consumed and validated. */
             finished() { return _dstream_finished(ds) !== 0; },
+            /** Free the stream and its scratch buffers. Idempotent. */
             free() {
+                if (!ds) return;
                 _dstream_free(ds);
                 _free(inDescPtr);
                 _free(outDescPtr);
                 _free(stagePtr);
+                ds = 0;
             },
             inSize()  { return _dstream_in_size(ds); },
             outSize() { return _dstream_out_size(ds); }
@@ -657,7 +701,7 @@ export default async function createZXC(moduleOverrides, factory) {
         if (!srcPtr) throw new Error('ZXC: malloc failed for seekable buffer');
         Module.HEAPU8.set(data, srcPtr);
 
-        const handle = _seekable_open(srcPtr, srcLen);
+        let handle = _seekable_open(srcPtr, srcLen);
         if (handle === 0) {
             _free(srcPtr);
             throw new Error('ZXC: invalid seekable archive');
@@ -665,7 +709,7 @@ export default async function createZXC(moduleOverrides, factory) {
 
         return {
             numBlocks() { return _seekable_num_blocks(handle); },
-            decompressedSize() { return _seekable_decompressed_size(handle); },
+            decompressedSize() { return _u64(_seekable_decompressed_size(handle)); },
             blockCompressedSize(idx) {
                 if (idx < 0 || idx >= _seekable_num_blocks(handle)) return null;
                 return _seekable_block_comp_size(handle, idx);
@@ -677,26 +721,51 @@ export default async function createZXC(moduleOverrides, factory) {
             /**
              * Attach a pre-trained dictionary to this seekable handle.
              * Must be called before any decompressRange() call.
-             * @param {Uint8Array} dict - Dictionary content.
+             *
+             * When the archive was compressed with a shared literal Huffman
+             * table (or with a {@link Dictionary}), the same table must be
+             * supplied: the archive's dict_id binds the (content, table)
+             * pair, so content alone would be rejected with DICT_MISMATCH.
+             *
+             * @param {Dictionary|Uint8Array} dict - A {@link Dictionary}, or
+             *        raw dictionary content.
+             * @param {Uint8Array} [dictHuf] - Shared literal Huffman table
+             *        (128 bytes); redundant when `dict` is a {@link Dictionary}.
              */
-            setDict(dict) {
+            setDict(dict, dictHuf) {
+                if (dict instanceof Dictionary) {
+                    dictHuf = dict.huf;
+                    dict = dict.content;
+                }
                 if (!dict || dict.length === 0) {
                     throw new Error('ZXC: setDict requires a non-empty dictionary');
                 }
+                if (dictHuf && dictHuf.length !== ZXC_HUF_TABLE_SIZE) {
+                    throw new Error('ZXC: dictHuf must be exactly 128 bytes');
+                }
                 const dictPtr = _malloc(dict.length);
                 if (!dictPtr) throw new Error('ZXC: malloc failed for dictionary');
+                const hufPtr = dictHuf ? _malloc(ZXC_HUF_TABLE_SIZE) : 0;
                 try {
                     Module.HEAPU8.set(dict, dictPtr);
-                    const r = _seekable_set_dict(handle, dictPtr, dict.length);
+                    if (hufPtr) Module.HEAPU8.set(dictHuf, hufPtr);
+                    const r = _seekable_set_dict(handle, dictPtr, dict.length, hufPtr);
                     if (r < 0) {
                         throw new Error(`ZXC seekable set_dict error: ${_error_name(r)} (${r})`);
                     }
                 } finally {
                     _free(dictPtr);
+                    if (hufPtr) _free(hufPtr);
                 }
             },
             decompressRange(offset, length) {
                 if (length < 0) throw new Error('ZXC: length must be non-negative');
+                // The wasm shim carries the offset as a uint32 (no BigInt);
+                // values outside [0, 2^32-1] would silently wrap and return
+                // data from the wrong position.
+                if (!Number.isInteger(offset) || offset < 0 || offset > 0xFFFFFFFF) {
+                    throw new Error('ZXC: offset must be an integer in [0, 2^32-1]');
+                }
                 if (length === 0) return new Uint8Array(0);
                 const dstPtr = _malloc(length);
                 if (!dstPtr) throw new Error('ZXC: malloc failed for output buffer');
@@ -710,9 +779,12 @@ export default async function createZXC(moduleOverrides, factory) {
                     _free(dstPtr);
                 }
             },
+            /** Release the native handle and the WASM-side copy. Idempotent. */
             free() {
+                if (!handle) return;
                 _seekable_free(handle);
                 _free(srcPtr);
+                handle = 0;
             },
         };
     }
@@ -1126,6 +1198,11 @@ export default async function createZXC(moduleOverrides, factory) {
                     try { cs.free(); } catch (_) { /* idempotent */ }
                 }
             },
+            // Reader cancelled / writable aborted: flush() never runs, so the
+            // wasm stream context and staging buffers must be freed here.
+            cancel() {
+                try { cs.free(); } catch (_) { /* idempotent */ }
+            },
         });
     }
 
@@ -1168,6 +1245,11 @@ export default async function createZXC(moduleOverrides, factory) {
                 } finally {
                     try { ds.free(); } catch (_) { /* idempotent */ }
                 }
+            },
+            // Reader cancelled / writable aborted: flush() never runs, so the
+            // wasm stream context and staging buffers must be freed here.
+            cancel() {
+                try { ds.free(); } catch (_) { /* idempotent */ }
             },
         });
     }


### PR DESCRIPTION
Introduces a new `Level 7` (Ultra) compression preset, offering maximum density for the slowest compression, and updates all language wrappers to support it.

Enhances various aspects of the wrappers:
- **Go:** Improves dictionary handling with new error types and validation, refines option management in `Cctx` for consistent level/checksum application, fixes file handle duplication on Windows, adds plausibility checks for decompressed sizes, and enables zero-copy for dictionary training and seekable archive opening (Go 1.21+).
- **Node.js:** Refactors streaming APIs to use reusable staging buffers, improves error handling for `readAt` callbacks to prevent reentrant calls, and correctly slices output buffers to prevent exposing uninitialized memory. Updates the Emscripten build to use ES6 modules and correctly export 64-bit return values.
- **Python:** Ensures GIL safety for `Seekable` reader callbacks in multi-threaded contexts, correctly propagates callback exceptions, and enables zero-copy for `Seekable` archive opening by pinning input buffers. Adds validation for compression levels and `block_size` in streaming APIs.
- **Rust:** Expands `StreamCompressOptions` to allow `seekable` files, adds `compress_file_with_options` and `decompress_file_with_options` for more granular control, introduces new dictionary-related error types, and rejects dictionary options in push-streaming APIs.
- **WASM:** Enables ES6 module output for better browser integration, handles 64-bit return values, optimizes option struct writing, implements idempotent `free()` methods for contexts and streams, and adds specific validations for dictionary tables and `Seekable` offsets.

New dictionary error constants are introduced across all wrappers for more precise error reporting. Several internal memory management and allocation strategies are optimized for improved performance and reduced overhead.