### PR TITLE
feat: Caches dict Huffman tree upon attach

### DIFF
--- a/src/lib/zxc_common.c
+++ b/src/lib/zxc_common.c
@@ -403,7 +403,6 @@ void zxc_cctx_free(zxc_cctx_t* ctx) {
     ctx->opt_scratch_cap = 0;
     ctx->dict_buffer_cap = 0;
     ctx->dict_size = 0;
-    ctx->dict_huf_lengths = NULL;
     ctx->dict_huf_tree_ok = 0;
     ctx->lit_freq_acc = NULL;
 }
@@ -411,9 +410,10 @@ void zxc_cctx_free(zxc_cctx_t* ctx) {
 /**
  * @brief Attach the shared dictionary literal Huffman table to a context.
  *
- * Validates the 128-byte packed code-lengths header and stores the pointer
- * (caller-owned, must outlive the context); the tree is (re)built from these
- * lengths at decode/estimate time, not here. A NULL @p lengths is a no-op.
+ * Validates the 128-byte packed code-lengths header and builds the dictionary's
+ * PivCo tree, canonical codes and code lengths ONCE into the context
+ * (tree-at-attach); per-block encode/estimate/decode reuse them. @p lengths need
+ * only be valid during this call (the tree is a copy). A NULL @p lengths is a no-op.
  *
  * @param[in,out] ctx      Initialised context to attach the table to.
  * @param[in]     lengths  128-byte packed code lengths, or NULL for a no-op.
@@ -422,7 +422,6 @@ void zxc_cctx_free(zxc_cctx_t* ctx) {
  */
 int zxc_cctx_attach_dict_huf(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRICT lengths) {
     if (UNLIKELY(!ctx)) return ZXC_ERROR_NULL_INPUT;
-    ctx->dict_huf_lengths = lengths;
     ctx->dict_huf_tree_ok = 0;
     if (lengths == NULL) return ZXC_OK;
 
@@ -434,20 +433,13 @@ int zxc_cctx_attach_dict_huf(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRICT l
             break;
         }
     }
-    if (empty) {
-        ctx->dict_huf_lengths = NULL;
-        return ZXC_OK;
-    }
+    if (empty) return ZXC_OK; /* tree_ok stays 0: treated as "no shared table" */
 
     /* Tree-at-attach: unpack + build the PivCo tree and codes ONCE here; the
      * per-block encode/estimate/decode paths reuse them via the context. */
     const int rc = zxc_huf_dict_tree_build(lengths, &ctx->dict_huf_tree, ctx->dict_huf_codes,
                                            ctx->dict_huf_code_len);
-    if (UNLIKELY(rc != ZXC_OK)) {
-        ctx->dict_huf_lengths = NULL;
-        ctx->dict_huf_tree_ok = 0;
-        return rc;
-    }
+    if (UNLIKELY(rc != ZXC_OK)) return rc; /* tree_ok already 0 */
     ctx->dict_huf_tree_ok = 1;
     return ZXC_OK;
 }

--- a/src/lib/zxc_common.c
+++ b/src/lib/zxc_common.c
@@ -404,6 +404,7 @@ void zxc_cctx_free(zxc_cctx_t* ctx) {
     ctx->dict_buffer_cap = 0;
     ctx->dict_size = 0;
     ctx->dict_huf_lengths = NULL;
+    ctx->dict_huf_tree_ok = 0;
     ctx->lit_freq_acc = NULL;
 }
 
@@ -422,6 +423,7 @@ void zxc_cctx_free(zxc_cctx_t* ctx) {
 int zxc_cctx_attach_dict_huf(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRICT lengths) {
     if (UNLIKELY(!ctx)) return ZXC_ERROR_NULL_INPUT;
     ctx->dict_huf_lengths = lengths;
+    ctx->dict_huf_tree_ok = 0;
     if (lengths == NULL) return ZXC_OK;
 
     /* Empty (all-zero) table from a low-entropy corpus: treat it as "no shared table". */
@@ -437,10 +439,17 @@ int zxc_cctx_attach_dict_huf(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRICT l
         return ZXC_OK;
     }
 
-    uint8_t code_len[ZXC_HUF_NUM_SYMBOLS];
-    const int rc = zxc_huf_unpack_lengths(lengths, code_len);
-    if (UNLIKELY(rc != ZXC_OK)) ctx->dict_huf_lengths = NULL;
-    return rc;
+    /* Tree-at-attach: unpack + build the PivCo tree and codes ONCE here; the
+     * per-block encode/estimate/decode paths reuse them via the context. */
+    const int rc = zxc_huf_dict_tree_build(lengths, &ctx->dict_huf_tree, ctx->dict_huf_codes,
+                                           ctx->dict_huf_code_len);
+    if (UNLIKELY(rc != ZXC_OK)) {
+        ctx->dict_huf_lengths = NULL;
+        ctx->dict_huf_tree_ok = 0;
+        return rc;
+    }
+    ctx->dict_huf_tree_ok = 1;
+    return ZXC_OK;
 }
 
 /*

--- a/src/lib/zxc_common.c
+++ b/src/lib/zxc_common.c
@@ -103,6 +103,8 @@ typedef struct {
     size_t off_opt;
     /* both modes: [dict | data] concat scratch, present only when dict_size > 0. */
     size_t off_dict;
+    /* both modes: dict Huffman tree-at-attach state, present only when dict_size > 0. */
+    size_t off_dict_huf;
     /* Sub-buffer sizes (re-used by the partitioning step + zero-init). */
     size_t sz_hash_pos;
     size_t sz_hash_tags;
@@ -222,6 +224,8 @@ static zxc_cctx_layout_t compute_cctx_layout(const size_t chunk_size, const int 
                                      : (dict_size + chunk_size + ZXC_DECOMPRESS_TAIL_PAD);
         layout.off_dict = layout.total;
         layout.total += ZXC_ALIGN_CL(layout.sz_dict);
+        layout.off_dict_huf = layout.total;
+        layout.total += ZXC_ALIGN_CL(sizeof(zxc_dict_huf_state_t));
     }
     return layout;
 }
@@ -292,6 +296,7 @@ int zxc_cctx_init_in_workspace(zxc_cctx_t* RESTRICT ctx, void* RESTRICT workspac
     if (dict_size > 0) {
         ctx->dict_buffer = mem + layout.off_dict;
         ctx->dict_buffer_cap = layout.sz_dict;
+        ctx->dict_huf = (zxc_dict_huf_state_t*)(void*)(mem + layout.off_dict_huf);
     }
 
     if (mode == 0) {
@@ -394,6 +399,7 @@ void zxc_cctx_free(zxc_cctx_t* ctx) {
     ctx->pivco_scratch = NULL;
     ctx->opt_scratch = NULL;
     ctx->dict_buffer = NULL;
+    ctx->dict_huf = NULL;
 
     ctx->epoch = 0;
     ctx->lit_buffer_cap = 0;
@@ -433,13 +439,13 @@ int zxc_cctx_attach_dict_huf(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRICT l
             break;
         }
     }
-    if (empty) return ZXC_OK; /* tree_ok stays 0: treated as "no shared table" */
+    if (UNLIKELY(empty || ctx->dict_huf == NULL)) return ZXC_OK;
 
-    /* Tree-at-attach: unpack + build the PivCo tree and codes ONCE here; the
+    /* Tree-at-attach: unpack + build the PivCo tree and codes once here; the
      * per-block encode/estimate/decode paths reuse them via the context. */
-    const int rc = zxc_huf_dict_tree_build(lengths, &ctx->dict_huf_tree, ctx->dict_huf_codes,
-                                           ctx->dict_huf_code_len);
-    if (UNLIKELY(rc != ZXC_OK)) return rc; /* tree_ok already 0 */
+    const int rc = zxc_huf_dict_tree_build(lengths, &ctx->dict_huf->tree, ctx->dict_huf->codes,
+                                           ctx->dict_huf->code_len);
+    if (UNLIKELY(rc != ZXC_OK)) return rc;
     ctx->dict_huf_tree_ok = 1;
     return ZXC_OK;
 }

--- a/src/lib/zxc_compress.c
+++ b/src/lib/zxc_compress.c
@@ -1669,7 +1669,7 @@ parse_done:;
         /* zxc_huf_calc_size returns SIZE_MAX for unencodable candidates
          * (a literal byte without a code in the shared table). */
         huf_dict_total_size =
-            zxc_huf_calc_size_dict(lit_freq, ctx->dict_huf_code_len, &ctx->dict_huf_tree);
+            zxc_huf_calc_size_dict(lit_freq, ctx->dict_huf->code_len, &ctx->dict_huf->tree);
         if (huf_dict_total_size != SIZE_MAX) {
             /* Same J rule against the running winner: vs the per-block Huffman
              * candidate the equal entropy taxes cancel (pure size comparison),
@@ -1754,8 +1754,8 @@ parse_done:;
         p_curr += written;
     } else if (enc_lit == ZXC_SECTION_ENCODING_HUFFMAN_DICT) {
         const int written =
-            zxc_huf_encode_section_dict(literals, lit_c, lit_freq, ctx->dict_huf_code_len,
-                                        &ctx->dict_huf_tree, ctx->dict_huf_codes, p_curr, rem);
+            zxc_huf_encode_section_dict(literals, lit_c, lit_freq, ctx->dict_huf->code_len,
+                                        &ctx->dict_huf->tree, ctx->dict_huf->codes, p_curr, rem);
         if (UNLIKELY(written < 0)) return written;
         if (UNLIKELY((size_t)written != huf_dict_total_size)) return ZXC_ERROR_DST_TOO_SMALL;
         p_curr += written;

--- a/src/lib/zxc_compress.c
+++ b/src/lib/zxc_compress.c
@@ -29,6 +29,7 @@
 #define zxc_huf_build_code_lengths ZXC_CAT(zxc_huf_build_code_lengths, ZXC_FUNCTION_SUFFIX)
 #define zxc_huf_unpack_lengths ZXC_CAT(zxc_huf_unpack_lengths, ZXC_FUNCTION_SUFFIX)
 #define zxc_huf_calc_size ZXC_CAT(zxc_huf_calc_size, ZXC_FUNCTION_SUFFIX)
+#define zxc_huf_calc_size_dict ZXC_CAT(zxc_huf_calc_size_dict, ZXC_FUNCTION_SUFFIX)
 #define zxc_huf_encode_section ZXC_CAT(zxc_huf_encode_section, ZXC_FUNCTION_SUFFIX)
 #define zxc_huf_encode_section_dict ZXC_CAT(zxc_huf_encode_section_dict, ZXC_FUNCTION_SUFFIX)
 #endif

--- a/src/lib/zxc_compress.c
+++ b/src/lib/zxc_compress.c
@@ -1658,9 +1658,7 @@ parse_done:;
      * viable on literal sections far below ZXC_HUF_MIN_LITERALS. Exact size
      * accounting; invalid (a literal byte without a code) drops the candidate. */
     size_t huf_dict_total_size = SIZE_MAX;
-    uint8_t dict_code_len[ZXC_HUF_NUM_SYMBOLS];
-    if (level >= ZXC_LEVEL_DENSITY && ctx->dict_huf_lengths != NULL && lit_c > 0 &&
-        zxc_huf_unpack_lengths(ctx->dict_huf_lengths, dict_code_len) == ZXC_OK) {
+    if (level >= ZXC_LEVEL_DENSITY && ctx->dict_huf_tree_ok && lit_c > 0) {
         /* The dict candidate runs on sections too small for the per-block
          * table, so the histogram may not have been built above. */
         if (huf_total_size == SIZE_MAX) {
@@ -1669,7 +1667,8 @@ parse_done:;
         }
         /* zxc_huf_calc_size returns SIZE_MAX for unencodable candidates
          * (a literal byte without a code in the shared table). */
-        huf_dict_total_size = zxc_huf_calc_size(lit_freq, dict_code_len, 0);
+        huf_dict_total_size =
+            zxc_huf_calc_size_dict(lit_freq, ctx->dict_huf_code_len, &ctx->dict_huf_tree);
         if (huf_dict_total_size != SIZE_MAX) {
             /* Same J rule against the running winner: vs the per-block Huffman
              * candidate the equal entropy taxes cancel (pure size comparison),
@@ -1754,7 +1753,8 @@ parse_done:;
         p_curr += written;
     } else if (enc_lit == ZXC_SECTION_ENCODING_HUFFMAN_DICT) {
         const int written =
-            zxc_huf_encode_section_dict(literals, lit_c, lit_freq, dict_code_len, p_curr, rem);
+            zxc_huf_encode_section_dict(literals, lit_c, lit_freq, ctx->dict_huf_code_len,
+                                        &ctx->dict_huf_tree, ctx->dict_huf_codes, p_curr, rem);
         if (UNLIKELY(written < 0)) return written;
         if (UNLIKELY((size_t)written != huf_dict_total_size)) return ZXC_ERROR_DST_TOO_SMALL;
         p_curr += written;

--- a/src/lib/zxc_decompress.c
+++ b/src/lib/zxc_decompress.c
@@ -446,12 +446,12 @@ static ZXC_NOINLINE ZXC_COLD int zxc_decode_lit_pivco_dict(const zxc_cctx_t* RES
                                                            const uint8_t* RESTRICT payload,
                                                            const size_t psize,
                                                            const size_t required_size) {
-    if (UNLIKELY(ctx->dict_huf_lengths == NULL)) return ZXC_ERROR_DICT_REQUIRED;
+    if (UNLIKELY(!ctx->dict_huf_tree_ok)) return ZXC_ERROR_DICT_REQUIRED;
     if (UNLIKELY(ctx->lit_buffer_cap < required_size + ZXC_PAD_SIZE ||
                  ctx->pivco_scratch_cap < required_size + ZXC_PIVCO_SCRATCH_PAD))
         return ZXC_ERROR_CORRUPT_DATA;
     return zxc_huf_decode_section_dict(payload, psize, ctx->lit_buffer, required_size,
-                                       ctx->dict_huf_lengths, ctx->pivco_scratch);
+                                       &ctx->dict_huf_tree, ctx->pivco_scratch);
 }
 
 static ZXC_NOINLINE ZXC_COLD int zxc_decode_tok_pivco(const zxc_cctx_t* RESTRICT ctx,

--- a/src/lib/zxc_decompress.c
+++ b/src/lib/zxc_decompress.c
@@ -451,7 +451,7 @@ static ZXC_NOINLINE ZXC_COLD int zxc_decode_lit_pivco_dict(const zxc_cctx_t* RES
                  ctx->pivco_scratch_cap < required_size + ZXC_PIVCO_SCRATCH_PAD))
         return ZXC_ERROR_CORRUPT_DATA;
     return zxc_huf_decode_section_dict(payload, psize, ctx->lit_buffer, required_size,
-                                       &ctx->dict_huf_tree, ctx->pivco_scratch);
+                                       &ctx->dict_huf->tree, ctx->pivco_scratch);
 }
 
 static ZXC_NOINLINE ZXC_COLD int zxc_decode_tok_pivco(const zxc_cctx_t* RESTRICT ctx,

--- a/src/lib/zxc_dispatch.c
+++ b/src/lib/zxc_dispatch.c
@@ -120,12 +120,20 @@ int zxc_huf_decode_section_default(const uint8_t* RESTRICT payload, size_t paylo
                                    uint8_t* RESTRICT dst, size_t n, uint8_t* RESTRICT scratch);
 int zxc_huf_encode_section_dict_default(const uint8_t* RESTRICT literals, size_t n_literals,
                                         const uint32_t* RESTRICT freq,
-                                        const uint8_t* RESTRICT code_len, uint8_t* RESTRICT dst,
+                                        const uint8_t* RESTRICT code_len,
+                                        const zxc_pivco_tree_t* RESTRICT tree,
+                                        const uint32_t* RESTRICT codes, uint8_t* RESTRICT dst,
                                         size_t dst_cap);
 int zxc_huf_decode_section_dict_default(const uint8_t* RESTRICT payload, size_t payload_size,
                                         uint8_t* RESTRICT dst, size_t n,
-                                        const uint8_t* RESTRICT packed_lengths,
+                                        const zxc_pivco_tree_t* RESTRICT tree,
                                         uint8_t* RESTRICT scratch);
+int zxc_huf_dict_tree_build_default(const uint8_t* RESTRICT packed_lengths,
+                                    zxc_pivco_tree_t* RESTRICT tree, uint32_t* RESTRICT codes,
+                                    uint8_t* RESTRICT code_len);
+size_t zxc_huf_calc_size_dict_default(const uint32_t* RESTRICT freq,
+                                      const uint8_t* RESTRICT code_len,
+                                      const zxc_pivco_tree_t* RESTRICT tree);
 void zxc_huf_pack_lengths_default(const uint8_t* RESTRICT code_len, uint8_t* RESTRICT out);
 int zxc_huf_unpack_lengths_default(const uint8_t* RESTRICT in, uint8_t* RESTRICT code_len);
 
@@ -574,15 +582,27 @@ int zxc_huf_decode_section(const uint8_t* RESTRICT payload, const size_t payload
 
 int zxc_huf_encode_section_dict(const uint8_t* RESTRICT literals, const size_t n_literals,
                                 const uint32_t* RESTRICT freq, const uint8_t* RESTRICT code_len,
-                                uint8_t* RESTRICT dst, const size_t dst_cap) {
-    return zxc_huf_encode_section_dict_default(literals, n_literals, freq, code_len, dst, dst_cap);
+                                const zxc_pivco_tree_t* RESTRICT tree,
+                                const uint32_t* RESTRICT codes, uint8_t* RESTRICT dst,
+                                const size_t dst_cap) {
+    return zxc_huf_encode_section_dict_default(literals, n_literals, freq, code_len, tree, codes,
+                                               dst, dst_cap);
 }
 
 int zxc_huf_decode_section_dict(const uint8_t* RESTRICT payload, const size_t payload_size,
                                 uint8_t* RESTRICT dst, const size_t n,
-                                const uint8_t* RESTRICT packed_lengths, uint8_t* RESTRICT scratch) {
-    return zxc_huf_decode_section_dict_default(payload, payload_size, dst, n, packed_lengths,
-                                               scratch);
+                                const zxc_pivco_tree_t* RESTRICT tree, uint8_t* RESTRICT scratch) {
+    return zxc_huf_decode_section_dict_default(payload, payload_size, dst, n, tree, scratch);
+}
+
+int zxc_huf_dict_tree_build(const uint8_t* RESTRICT packed_lengths, zxc_pivco_tree_t* RESTRICT tree,
+                            uint32_t* RESTRICT codes, uint8_t* RESTRICT code_len) {
+    return zxc_huf_dict_tree_build_default(packed_lengths, tree, codes, code_len);
+}
+
+size_t zxc_huf_calc_size_dict(const uint32_t* RESTRICT freq, const uint8_t* RESTRICT code_len,
+                              const zxc_pivco_tree_t* RESTRICT tree) {
+    return zxc_huf_calc_size_dict_default(freq, code_len, tree);
 }
 
 /**

--- a/src/lib/zxc_huffman.c
+++ b/src/lib/zxc_huffman.c
@@ -48,6 +48,8 @@
 #define zxc_huf_pack_lengths ZXC_CAT(zxc_huf_pack_lengths, ZXC_FUNCTION_SUFFIX)
 #define zxc_huf_unpack_lengths ZXC_CAT(zxc_huf_unpack_lengths, ZXC_FUNCTION_SUFFIX)
 #define zxc_huf_calc_size ZXC_CAT(zxc_huf_calc_size, ZXC_FUNCTION_SUFFIX)
+#define zxc_huf_calc_size_dict ZXC_CAT(zxc_huf_calc_size_dict, ZXC_FUNCTION_SUFFIX)
+#define zxc_huf_dict_tree_build ZXC_CAT(zxc_huf_dict_tree_build, ZXC_FUNCTION_SUFFIX)
 #define zxc_huf_encode_section ZXC_CAT(zxc_huf_encode_section, ZXC_FUNCTION_SUFFIX)
 #define zxc_huf_encode_section_dict ZXC_CAT(zxc_huf_encode_section_dict, ZXC_FUNCTION_SUFFIX)
 #define zxc_huf_decode_section ZXC_CAT(zxc_huf_decode_section, ZXC_FUNCTION_SUFFIX)
@@ -383,30 +385,6 @@ int zxc_huf_unpack_lengths(const uint8_t* RESTRICT in, uint8_t* RESTRICT code_le
  * ZXC_PIVCO_SCRATCH_PAD on scratch.
  */
 
-#define ZXC_PIVCO_MAX_NODES (2 * ZXC_HUF_NUM_SYMBOLS - 1)
-
-typedef struct {
-    int16_t child[2]; /* node index, -1 = absent */
-    int16_t sym;      /* >= 0: leaf symbol; -1: internal */
-} zxc_pivco_node_t;
-
-typedef struct {
-    zxc_pivco_node_t nd[ZXC_PIVCO_MAX_NODES];
-    int16_t bfs[ZXC_PIVCO_MAX_NODES]; /* node ids in BFS (== wire) order */
-    int16_t lvl_start[ZXC_HUF_MAX_CODE_LEN_ULTRA + 2];
-    int n_nodes;
-    int max_depth;
-    /* Flat-subtree fast path: flat_d[nid] = D (>= 2) when nid roots a MAXIMAL
-     * complete subtree whose leaves all sit exactly D levels below it; such a
-     * node's wire run is its symbols' packed D-bit residual codes instead of
-     * D levels of partition bitmaps (same bit count, decode = unpack+lookup).
-     * covered[nid] = 1 for every strict descendant of a flat root: those nodes
-     * do not exist on the wire nor in the level buffers. Both sides derive
-     * this from the code lengths alone, so nothing is signalled. */
-    uint8_t flat_d[ZXC_PIVCO_MAX_NODES];
-    uint8_t covered[ZXC_PIVCO_MAX_NODES];
-} zxc_pivco_tree_t;
-
 static ZXC_ALWAYS_INLINE int zxc_pivco_popcnt32(const uint32_t v) {
 #if defined(__GNUC__) || defined(__clang__)
     return __builtin_popcount(v);
@@ -634,6 +612,26 @@ size_t zxc_huf_calc_size(const uint32_t* RESTRICT freq, const uint8_t* RESTRICT 
 }
 
 /**
+ * @brief zxc_huf_calc_size for a dict section: same exact-size rule, but the
+ *        tree comes prebuilt from the context (tree-at-attach) and the section
+ *        has no inline lengths header.
+ */
+size_t zxc_huf_calc_size_dict(const uint32_t* RESTRICT freq, const uint8_t* RESTRICT code_len,
+                              const zxc_pivco_tree_t* RESTRICT tree) {
+    for (int k = 0; k < ZXC_HUF_NUM_SYMBOLS; k++)
+        if (UNLIKELY(freq[k] != 0 && code_len[k] == 0)) return SIZE_MAX;
+    uint32_t count[ZXC_PIVCO_MAX_NODES];
+    zxc_pivco_counts(tree, freq, count);
+    size_t total = 0;
+    for (int i = 0; i < tree->n_nodes; i++) {
+        const int nid = tree->bfs[i];
+        if (tree->covered[nid] || tree->nd[nid].sym >= 0) continue;
+        total += zxc_pivco_run_bytes(count[nid], tree->flat_d[nid]);
+    }
+    return total;
+}
+
+/**
  * @brief Shared PivCo section encoder body.
  *
  * Walks each input symbol root-to-leaf once, appending its branch bit to the
@@ -641,6 +639,7 @@ size_t zxc_huf_calc_size(const uint32_t* RESTRICT freq, const uint8_t* RESTRICT 
  */
 static int zxc_pivco_encode_core(const uint8_t* RESTRICT literals, const size_t n_literals,
                                  const uint32_t* RESTRICT freq, const uint8_t* RESTRICT code_len,
+                                 const zxc_pivco_tree_t* RESTRICT t, const uint32_t* RESTRICT codes,
                                  uint8_t* RESTRICT dst, const size_t dst_cap,
                                  const int with_header) {
     if (UNLIKELY(n_literals == 0)) return ZXC_ERROR_CORRUPT_DATA;
@@ -649,23 +648,20 @@ static int zxc_pivco_encode_core(const uint8_t* RESTRICT literals, const size_t 
      * back to a per-block table, but a direct call must fail loudly). */
     for (int k = 0; k < ZXC_HUF_NUM_SYMBOLS; k++)
         if (UNLIKELY(freq[k] != 0 && code_len[k] == 0)) return ZXC_ERROR_CORRUPT_DATA;
-    zxc_pivco_tree_t t;
-    uint32_t codes[ZXC_HUF_NUM_SYMBOLS];
-    if (UNLIKELY(zxc_pivco_tree_build(code_len, &t, codes) != 0)) return ZXC_ERROR_CORRUPT_DATA;
 
     uint32_t count[ZXC_PIVCO_MAX_NODES];
-    zxc_pivco_counts(&t, freq, count);
+    zxc_pivco_counts(t, freq, count);
 
     /* Byte offsets of every wire-visible internal node's run, in BFS order:
      * bitmap runs (1 bit/symbol) or, for flat roots, packed code runs
      * (flat_d bits/symbol). Covered nodes have no run. */
     uint32_t bit_off[ZXC_PIVCO_MAX_NODES];
     size_t payload = 0;
-    for (int i = 0; i < t.n_nodes; i++) {
-        const int nid = t.bfs[i];
-        if (t.covered[nid] || t.nd[nid].sym >= 0) continue;
+    for (int i = 0; i < t->n_nodes; i++) {
+        const int nid = t->bfs[i];
+        if (t->covered[nid] || t->nd[nid].sym >= 0) continue;
         bit_off[nid] = (uint32_t)payload;
-        payload += zxc_pivco_run_bytes(count[nid], t.flat_d[nid]);
+        payload += zxc_pivco_run_bytes(count[nid], t->flat_d[nid]);
     }
     const size_t hdr = with_header ? (size_t)ZXC_HUF_TABLE_SIZE : 0;
     /* +2: the packed-code emitter uses a 3-byte read-modify-write that may
@@ -680,13 +676,13 @@ static int zxc_pivco_encode_core(const uint8_t* RESTRICT literals, const size_t 
      * flat root, emit the symbol's packed D-bit residual (bit j = branch at
      * subtree level j) in one shot and stop descending. */
     uint32_t wpos[ZXC_PIVCO_MAX_NODES];
-    ZXC_MEMSET(wpos, 0, (size_t)t.n_nodes * sizeof(uint32_t));
+    ZXC_MEMSET(wpos, 0, (size_t)t->n_nodes * sizeof(uint32_t));
     for (size_t i = 0; i < n_literals; i++) {
         const uint8_t s = literals[i];
         const uint32_t c = codes[s];
         int cur = 0;
         for (int d = code_len[s] - 1; d >= 0; d--) {
-            const int fd = t.flat_d[cur];
+            const int fd = t->flat_d[cur];
             if (fd) {
                 /* residual = low fd bits of the canonical code, bit-reversed
                  * so that packed bit j is the branch taken at level j. */
@@ -706,7 +702,7 @@ static int zxc_pivco_encode_core(const uint8_t* RESTRICT literals, const size_t 
             const uint32_t bit = (c >> d) & 1U;
             const uint32_t p = wpos[cur]++;
             out[bit_off[cur] + (p >> 3)] |= (uint8_t)(bit << (p & 7));
-            cur = t.nd[cur].child[bit];
+            cur = t->nd[cur].child[bit];
         }
     }
     return (int)(hdr + payload);
@@ -732,20 +728,43 @@ static int zxc_pivco_encode_core(const uint8_t* RESTRICT literals, const size_t 
 int zxc_huf_encode_section(const uint8_t* RESTRICT literals, const size_t n_literals,
                            const uint32_t* RESTRICT freq, const uint8_t* RESTRICT code_len,
                            uint8_t* RESTRICT dst, const size_t dst_cap) {
-    return zxc_pivco_encode_core(literals, n_literals, freq, code_len, dst, dst_cap, 1);
+    zxc_pivco_tree_t t;
+    uint32_t codes[ZXC_HUF_NUM_SYMBOLS];
+    if (UNLIKELY(zxc_pivco_tree_build(code_len, &t, codes) != 0)) return ZXC_ERROR_CORRUPT_DATA;
+    return zxc_pivco_encode_core(literals, n_literals, freq, code_len, &t, codes, dst, dst_cap, 1);
 }
 
 /**
  * @brief Encode a literal section against a shared dictionary table.
  *
  * Same payload as @ref zxc_huf_encode_section with the 128-byte lengths
- * header omitted: @p code_len comes from the dictionary's shared literal
- * table (wire value enc_lit = 3).
+ * header omitted: @p code_len / @p tree / @p codes come from the dictionary's
+ * shared literal table, prebuilt ONCE at attach by @ref zxc_huf_dict_tree_build
+ * (wire value enc_lit = 3).
  */
 int zxc_huf_encode_section_dict(const uint8_t* RESTRICT literals, const size_t n_literals,
                                 const uint32_t* RESTRICT freq, const uint8_t* RESTRICT code_len,
-                                uint8_t* RESTRICT dst, const size_t dst_cap) {
-    return zxc_pivco_encode_core(literals, n_literals, freq, code_len, dst, dst_cap, 0);
+                                const zxc_pivco_tree_t* RESTRICT tree,
+                                const uint32_t* RESTRICT codes, uint8_t* RESTRICT dst,
+                                const size_t dst_cap) {
+    return zxc_pivco_encode_core(literals, n_literals, freq, code_len, tree, codes, dst, dst_cap,
+                                 0);
+}
+
+/**
+ * @brief Prebuild a dict table's decode/encode state (tree-at-attach).
+ *
+ * Unpacks the 128-byte packed lengths and builds the PivCo tree and canonical
+ * codes once; the outputs are frame-constant, so per-block encode, estimate and
+ * decode reuse them instead of rebuilding (the pre-v7 cached-decode-table form,
+ * restored for the PivCo layout).
+ */
+int zxc_huf_dict_tree_build(const uint8_t* RESTRICT packed_lengths, zxc_pivco_tree_t* RESTRICT tree,
+                            uint32_t* RESTRICT codes, uint8_t* RESTRICT code_len) {
+    const int rc = zxc_huf_unpack_lengths(packed_lengths, code_len);
+    if (UNLIKELY(rc != ZXC_OK)) return rc;
+    if (UNLIKELY(zxc_pivco_tree_build(code_len, tree, codes) != 0)) return ZXC_ERROR_CORRUPT_DATA;
+    return ZXC_OK;
 }
 
 /**
@@ -1374,11 +1393,8 @@ static ZXC_ALWAYS_INLINE void zxc_pivco_emit_leaf_pair(uint8_t* RESTRICT out, co
  */
 static int zxc_pivco_decode_core(const uint8_t* RESTRICT payload, const size_t payload_size,
                                  uint8_t* RESTRICT dst, const size_t n,
-                                 const uint8_t* RESTRICT code_len, uint8_t* RESTRICT scratch) {
-    zxc_pivco_tree_t t;
-
-    if (UNLIKELY(n == 0 || zxc_pivco_tree_build(code_len, &t, NULL) != 0))
-        return ZXC_ERROR_CORRUPT_DATA;
+                                 const zxc_pivco_tree_t* RESTRICT t, uint8_t* RESTRICT scratch) {
+    if (UNLIKELY(n == 0)) return ZXC_ERROR_CORRUPT_DATA;
 
     /* Pass 1: node counts + bit-run pointers, straight from the wire order. */
     uint32_t count[ZXC_PIVCO_MAX_NODES];
@@ -1386,14 +1402,14 @@ static int zxc_pivco_decode_core(const uint8_t* RESTRICT payload, const size_t p
     count[0] = (uint32_t)n;
     const uint8_t* p = payload;
     const uint8_t* const pend = payload + payload_size;
-    for (int i = 0; i < t.n_nodes; i++) {
-        const int nid = t.bfs[i];
-        const zxc_pivco_node_t* nd = &t.nd[nid];
-        if (t.covered[nid] || nd->sym >= 0) continue;
+    for (int i = 0; i < t->n_nodes; i++) {
+        const int nid = t->bfs[i];
+        const zxc_pivco_node_t* nd = &t->nd[nid];
+        if (t->covered[nid] || nd->sym >= 0) continue;
         const uint32_t c = count[nid];
-        if (t.flat_d[nid]) {
+        if (t->flat_d[nid]) {
             /* Packed-code run: no partition below, nothing to popcount. */
-            const size_t fbytes = zxc_pivco_run_bytes(c, t.flat_d[nid]);
+            const size_t fbytes = zxc_pivco_run_bytes(c, t->flat_d[nid]);
             if (UNLIKELY((size_t)(pend - p) < fbytes)) return ZXC_ERROR_CORRUPT_DATA;
             bit_ptr[nid] = p;
             p += fbytes;
@@ -1436,11 +1452,11 @@ static int zxc_pivco_decode_core(const uint8_t* RESTRICT payload, const size_t p
 
     /* Per-level sequence offsets (BFS order => children contiguous). */
     uint32_t seq_off[ZXC_PIVCO_MAX_NODES];
-    for (int d = 0; d <= t.max_depth; d++) {
+    for (int d = 0; d <= t->max_depth; d++) {
         uint32_t off = 0;
-        for (int i = t.lvl_start[d]; i < t.lvl_start[d + 1]; i++) {
-            const int nid = t.bfs[i];
-            if (t.covered[nid]) continue; /* not materialised anywhere */
+        for (int i = t->lvl_start[d]; i < t->lvl_start[d + 1]; i++) {
+            const int nid = t->bfs[i];
+            if (t->covered[nid]) continue; /* not materialised anywhere */
             seq_off[nid] = off;
             off += count[nid];
         }
@@ -1450,33 +1466,33 @@ static int zxc_pivco_decode_core(const uint8_t* RESTRICT payload, const size_t p
      * so their children never need materialising: flag them for skipping. */
     uint8_t skip[ZXC_PIVCO_MAX_NODES];
     ZXC_MEMSET(skip, 0, sizeof(skip));
-    for (int i = 0; i < t.n_nodes; i++) {
-        const zxc_pivco_node_t* nd = &t.nd[t.bfs[i]];
+    for (int i = 0; i < t->n_nodes; i++) {
+        const zxc_pivco_node_t* nd = &t->nd[t->bfs[i]];
         if (nd->sym >= 0) continue;
         const int ch0 = nd->child[0];
         const int ch1 = nd->child[1];
-        if (ch0 >= 0 && ch1 >= 0 && t.nd[ch0].sym >= 0 && t.nd[ch1].sym >= 0) {
+        if (ch0 >= 0 && ch1 >= 0 && t->nd[ch0].sym >= 0 && t->nd[ch1].sym >= 0) {
             skip[ch0] = 1;
             skip[ch1] = 1;
         }
     }
 
     /* Pass 2: bottom-up level reconstruction. */
-    for (int d = t.max_depth; d >= 0; d--) {
+    for (int d = t->max_depth; d >= 0; d--) {
         uint8_t* const buf_d = (d & 1) ? scratch : dst;
         const uint8_t* const buf_c = (d & 1) ? dst : scratch; /* children at d+1 (read-only) */
-        for (int i = t.lvl_start[d]; i < t.lvl_start[d + 1]; i++) {
-            const int nid = t.bfs[i];
-            if (t.covered[nid]) continue; /* lives inside a flat root's run */
-            const zxc_pivco_node_t* nd = &t.nd[nid];
+        for (int i = t->lvl_start[d]; i < t->lvl_start[d + 1]; i++) {
+            const int nid = t->bfs[i];
+            if (t->covered[nid]) continue; /* lives inside a flat root's run */
+            const zxc_pivco_node_t* nd = &t->nd[nid];
             const uint32_t c = count[nid];
             if (c == 0 || skip[nid]) continue;
             if (nd->sym >= 0) {
                 ZXC_MEMSET(buf_d + seq_off[nid], (uint8_t)nd->sym, c);
-            } else if (t.flat_d[nid]) {
+            } else if (t->flat_d[nid]) {
                 /* Build the packed-path -> symbol table (complete subtree of
                  * depth D: 2^D leaves), then unpack the code run directly. */
-                const int D = t.flat_d[nid];
+                const int D = t->flat_d[nid];
                 uint8_t c2s[1U << ZXC_HUF_MAX_CODE_LEN_ULTRA];
                 int16_t stk_n[ZXC_HUF_MAX_CODE_LEN_ULTRA + 1];
                 uint16_t stk_p[ZXC_HUF_MAX_CODE_LEN_ULTRA + 1];
@@ -1490,16 +1506,16 @@ static int zxc_pivco_decode_core(const uint8_t* RESTRICT payload, const size_t p
                     const uint32_t cp = stk_p[sp];
                     const int cl = stk_l[sp];
                     sp--;
-                    if (t.nd[cn].sym >= 0) {
-                        c2s[cp] = (uint8_t)t.nd[cn].sym;
+                    if (t->nd[cn].sym >= 0) {
+                        c2s[cp] = (uint8_t)t->nd[cn].sym;
                         continue;
                     }
                     sp++;
-                    stk_n[sp] = t.nd[cn].child[0];
+                    stk_n[sp] = t->nd[cn].child[0];
                     stk_p[sp] = (uint16_t)cp;
                     stk_l[sp] = (uint8_t)(cl + 1);
                     sp++;
-                    stk_n[sp] = t.nd[cn].child[1];
+                    stk_n[sp] = t->nd[cn].child[1];
                     stk_p[sp] = (uint16_t)(cp | (1U << cl));
                     stk_l[sp] = (uint8_t)(cl + 1);
                 }
@@ -1507,9 +1523,9 @@ static int zxc_pivco_decode_core(const uint8_t* RESTRICT payload, const size_t p
             } else {
                 const int ch0 = nd->child[0];
                 const int ch1 = nd->child[1];
-                if (ch0 >= 0 && ch1 >= 0 && t.nd[ch0].sym >= 0 && t.nd[ch1].sym >= 0) {
-                    zxc_pivco_emit_leaf_pair(buf_d + seq_off[nid], c, (uint8_t)t.nd[ch0].sym,
-                                             (uint8_t)t.nd[ch1].sym, bit_ptr[nid]);
+                if (ch0 >= 0 && ch1 >= 0 && t->nd[ch0].sym >= 0 && t->nd[ch1].sym >= 0) {
+                    zxc_pivco_emit_leaf_pair(buf_d + seq_off[nid], c, (uint8_t)t->nd[ch0].sym,
+                                             (uint8_t)t->nd[ch1].sym, bit_ptr[nid]);
                     continue;
                 }
                 const uint32_t nl = ch0 >= 0 ? count[ch0] : 0;
@@ -1542,22 +1558,21 @@ int zxc_huf_decode_section(const uint8_t* RESTRICT payload, const size_t payload
     uint8_t code_len[ZXC_HUF_NUM_SYMBOLS];
     const int rc = zxc_huf_unpack_lengths(payload, code_len);
     if (UNLIKELY(rc != ZXC_OK)) return rc;
+    zxc_pivco_tree_t t;
+    if (UNLIKELY(zxc_pivco_tree_build(code_len, &t, NULL) != 0)) return ZXC_ERROR_CORRUPT_DATA;
     return zxc_pivco_decode_core(payload + ZXC_HUF_TABLE_SIZE, payload_size - ZXC_HUF_TABLE_SIZE,
-                                 dst, n, code_len, scratch);
+                                 dst, n, &t, scratch);
 }
 
 /**
  * @brief Decode a shared-dictionary literal section (no inline header).
  *
- * Same as @ref zxc_huf_decode_section, but the code lengths come from
- * @p packed_lengths (the dictionary's 128-byte shared literal table,
- * validated once at attach time; wire value enc_lit = 3).
+ * Same as @ref zxc_huf_decode_section, but against the dictionary's PivCo
+ * @p tree, prebuilt ONCE at attach time by @ref zxc_huf_dict_tree_build
+ * (wire value enc_lit = 3) -- no per-block unpack or tree rebuild.
  */
 int zxc_huf_decode_section_dict(const uint8_t* RESTRICT payload, const size_t payload_size,
                                 uint8_t* RESTRICT dst, const size_t n,
-                                const uint8_t* RESTRICT packed_lengths, uint8_t* RESTRICT scratch) {
-    uint8_t code_len[ZXC_HUF_NUM_SYMBOLS];
-    const int rc = zxc_huf_unpack_lengths(packed_lengths, code_len);
-    if (UNLIKELY(rc != ZXC_OK)) return rc;
-    return zxc_pivco_decode_core(payload, payload_size, dst, n, code_len, scratch);
+                                const zxc_pivco_tree_t* RESTRICT tree, uint8_t* RESTRICT scratch) {
+    return zxc_pivco_decode_core(payload, payload_size, dst, n, tree, scratch);
 }

--- a/src/lib/zxc_internal.h
+++ b/src/lib/zxc_internal.h
@@ -1529,32 +1529,30 @@ typedef struct {
     uint8_t* literals;       /**< Buffer for literal bytes. */
 
     /* Cold zone: configuration / scratch / resizeable. */
-    uint8_t* lit_buffer;             /**< Scratch buffer for literals (RLE / Huffman). */
-    size_t lit_buffer_cap;           /**< Current capacity of the scratch buffer. */
-    uint8_t* work_buf;               /**< Padded scratch buffer for buffer-API decompression. */
-    size_t work_buf_cap;             /**< Capacity of the work buffer. */
-    uint8_t* tok_buffer;             /**< Decode scratch for a Huffman-coded GLO token
-                                          section (enc_litlen == HUFFMAN); NULL on compress. */
-    size_t tok_buffer_cap;           /**< Capacity of tok_buffer in bytes. */
-    uint8_t* pivco_scratch;          /**< Level ping-pong scratch for PivCo decode. */
-    size_t pivco_scratch_cap;        /**< Capacity of pivco_scratch in bytes. */
-    uint8_t* opt_scratch;            /**< Optimal-parser DP scratch (level >= 6 only,
-                                          lazy-allocated, packs dp/parent_len/parent_off/actions).
-                                          Also reused as transient scratch for the
-                                          length-limited Huffman code-length builder. */
-    size_t opt_scratch_cap;          /**< Current capacity of opt_scratch in bytes. */
-    int checksum_enabled;            /**< 1 if checksum calculation/verification is enabled. */
-    int compression_level;           /**< Compression level. */
-    size_t dict_size;                /**< Dictionary prefill size (0 = no dictionary). */
-    uint8_t* dict_buffer;            /**< [dict | data] concat scratch carved from memory_block
-                                          when dict_size > 0 (NULL otherwise). */
-    size_t dict_buffer_cap;          /**< Capacity of dict_buffer in bytes (0 = none). */
-    const uint8_t* dict_huf_lengths; /**< Shared dictionary literal table: 128-byte
-                                          packed code-lengths header (NULL = none). Set via
-                                          zxc_cctx_attach_dict_huf; caller-owned memory. */
-    zxc_pivco_tree_t dict_huf_tree;  /**< Tree-at-attach: PivCo tree prebuilt from
-                                          dict_huf_lengths (valid iff dict_huf_tree_ok),
-                                          so per-block decode/estimate skip the rebuild. */
+    uint8_t* lit_buffer;            /**< Scratch buffer for literals (RLE / Huffman). */
+    size_t lit_buffer_cap;          /**< Current capacity of the scratch buffer. */
+    uint8_t* work_buf;              /**< Padded scratch buffer for buffer-API decompression. */
+    size_t work_buf_cap;            /**< Capacity of the work buffer. */
+    uint8_t* tok_buffer;            /**< Decode scratch for a Huffman-coded GLO token
+                                         section (enc_litlen == HUFFMAN); NULL on compress. */
+    size_t tok_buffer_cap;          /**< Capacity of tok_buffer in bytes. */
+    uint8_t* pivco_scratch;         /**< Level ping-pong scratch for PivCo decode. */
+    size_t pivco_scratch_cap;       /**< Capacity of pivco_scratch in bytes. */
+    uint8_t* opt_scratch;           /**< Optimal-parser DP scratch (level >= 6 only,
+                                         lazy-allocated, packs dp/parent_len/parent_off/actions).
+                                         Also reused as transient scratch for the
+                                         length-limited Huffman code-length builder. */
+    size_t opt_scratch_cap;         /**< Current capacity of opt_scratch in bytes. */
+    int checksum_enabled;           /**< 1 if checksum calculation/verification is enabled. */
+    int compression_level;          /**< Compression level. */
+    size_t dict_size;               /**< Dictionary prefill size (0 = no dictionary). */
+    uint8_t* dict_buffer;           /**< [dict | data] concat scratch carved from memory_block
+                                         when dict_size > 0 (NULL otherwise). */
+    size_t dict_buffer_cap;         /**< Capacity of dict_buffer in bytes (0 = none). */
+    zxc_pivco_tree_t dict_huf_tree; /**< Tree-at-attach: PivCo tree prebuilt from the
+                                         dictionary's 128-byte shared literal table by
+                                         zxc_cctx_attach_dict_huf (valid iff dict_huf_tree_ok),
+                                         so per-block decode/estimate skip the rebuild. */
     uint32_t dict_huf_codes[ZXC_HUF_NUM_SYMBOLS];   /**< Canonical codes of the dict table
                                           (encoder side), built with the tree at attach. */
     uint8_t dict_huf_code_len[ZXC_HUF_NUM_SYMBOLS]; /**< Unpacked dict code lengths (attach). */

--- a/src/lib/zxc_internal.h
+++ b/src/lib/zxc_internal.h
@@ -586,6 +586,40 @@ extern "C" {
 #define ZXC_HUF_MAX_CODE_LEN_DENSITY 8
 /** @brief Alphabet size: one entry per possible byte value. */
 #define ZXC_HUF_NUM_SYMBOLS 256
+
+/** @brief Upper bound on PivCo tree nodes (full binary tree over the alphabet). */
+#define ZXC_PIVCO_MAX_NODES (2 * ZXC_HUF_NUM_SYMBOLS - 1)
+
+/** @brief One PivCo Huffman tree node. */
+typedef struct {
+    int16_t child[2]; /* node index, -1 = absent */
+    int16_t sym;      /* >= 0: leaf symbol; -1: internal */
+} zxc_pivco_node_t;
+
+/**
+ * @brief Canonical Huffman tree in PivCo (level-ordered) form.
+ *
+ * Derived deterministically from the 128-byte packed code lengths by
+ * zxc_huf_dict_tree_build / the section decoders; pure value type (index-based,
+ * no internal pointers), safe to copy or embed. Embedded in ::zxc_cctx_t so a
+ * dictionary's shared table is built ONCE at attach instead of per block.
+ */
+typedef struct {
+    zxc_pivco_node_t nd[ZXC_PIVCO_MAX_NODES];
+    int16_t bfs[ZXC_PIVCO_MAX_NODES]; /* node ids in BFS (== wire) order */
+    int16_t lvl_start[ZXC_HUF_MAX_CODE_LEN_ULTRA + 2];
+    int n_nodes;
+    int max_depth;
+    /* Flat-subtree fast path: flat_d[nid] = D (>= 2) when nid roots a MAXIMAL
+     * complete subtree whose leaves all sit exactly D levels below it; such a
+     * node's wire run is its symbols' packed D-bit residual codes instead of
+     * D levels of partition bitmaps (same bit count, decode = unpack+lookup).
+     * covered[nid] = 1 for every strict descendant of a flat root: those nodes
+     * do not exist on the wire nor in the level buffers. Both sides derive
+     * this from the code lengths alone, so nothing is signalled. */
+    uint8_t flat_d[ZXC_PIVCO_MAX_NODES];
+    uint8_t covered[ZXC_PIVCO_MAX_NODES];
+} zxc_pivco_tree_t;
 /** @brief RLE margin shift: source of the legacy below-ULTRA premium used by
  *         ::zxc_ss_prem_rle_q8 (256 >> shift reproduces the historical
  *         RLE-vs-RAW margin exactly). */
@@ -1423,20 +1457,32 @@ int zxc_huf_encode_section(const uint8_t* RESTRICT literals, size_t n_literals,
                            const uint32_t* RESTRICT freq, const uint8_t* RESTRICT code_len,
                            uint8_t* RESTRICT dst, size_t dst_cap);
 
-/** @brief Encode a PivCo section against shared-dictionary code lengths (no header). */
+/** @brief Unpack a dict table's 128-byte packed lengths and prebuild its PivCo
+ *  tree, canonical codes and code lengths (tree-at-attach). All three outputs
+ *  are frame-constant; per-block encode/estimate/decode then skip the rebuild. */
+int zxc_huf_dict_tree_build(const uint8_t* RESTRICT packed_lengths, zxc_pivco_tree_t* RESTRICT tree,
+                            uint32_t* RESTRICT codes, uint8_t* RESTRICT code_len);
+
+/** @brief zxc_huf_calc_size for a dict section: prebuilt @p tree, no header. */
+size_t zxc_huf_calc_size_dict(const uint32_t* RESTRICT freq, const uint8_t* RESTRICT code_len,
+                              const zxc_pivco_tree_t* RESTRICT tree);
+
+/** @brief Encode a PivCo section against a prebuilt dict tree/codes (no header). */
 int zxc_huf_encode_section_dict(const uint8_t* RESTRICT literals, size_t n_literals,
                                 const uint32_t* RESTRICT freq, const uint8_t* RESTRICT code_len,
-                                uint8_t* RESTRICT dst, size_t dst_cap);
+                                const zxc_pivco_tree_t* RESTRICT tree,
+                                const uint32_t* RESTRICT codes, uint8_t* RESTRICT dst,
+                                size_t dst_cap);
 
 /** @brief Decode a PivCo literal section into @p dst (exactly @p n bytes).
  *  @p dst needs ZXC_PAD_SIZE slack, @p scratch at least n + ZXC_PIVCO_SCRATCH_PAD. */
 int zxc_huf_decode_section(const uint8_t* RESTRICT payload, size_t payload_size,
                            uint8_t* RESTRICT dst, size_t n, uint8_t* RESTRICT scratch);
 
-/** @brief Decode a PivCo dict section (code lengths from @p packed_lengths). */
+/** @brief Decode a PivCo dict section against a prebuilt dict @p tree. */
 int zxc_huf_decode_section_dict(const uint8_t* RESTRICT payload, size_t payload_size,
                                 uint8_t* RESTRICT dst, size_t n,
-                                const uint8_t* RESTRICT packed_lengths, uint8_t* RESTRICT scratch);
+                                const zxc_pivco_tree_t* RESTRICT tree, uint8_t* RESTRICT scratch);
 
 /* ---------------------------------------------------------------------------
  * Compression / decompression context.
@@ -1506,9 +1552,16 @@ typedef struct {
     const uint8_t* dict_huf_lengths; /**< Shared dictionary literal table: 128-byte
                                           packed code-lengths header (NULL = none). Set via
                                           zxc_cctx_attach_dict_huf; caller-owned memory. */
-    uint32_t* lit_freq_acc;          /**< Trainer hook: when non-NULL, the GLO encoder
-                                          accumulates post-LZ literal byte frequencies here
-                                          (256 entries). NULL outside dictionary training. */
+    zxc_pivco_tree_t dict_huf_tree;  /**< Tree-at-attach: PivCo tree prebuilt from
+                                          dict_huf_lengths (valid iff dict_huf_tree_ok),
+                                          so per-block decode/estimate skip the rebuild. */
+    uint32_t dict_huf_codes[ZXC_HUF_NUM_SYMBOLS];   /**< Canonical codes of the dict table
+                                          (encoder side), built with the tree at attach. */
+    uint8_t dict_huf_code_len[ZXC_HUF_NUM_SYMBOLS]; /**< Unpacked dict code lengths (attach). */
+    int dict_huf_tree_ok;                           /**< 1 when the three fields above are valid. */
+    uint32_t* lit_freq_acc; /**< Trainer hook: when non-NULL, the GLO encoder
+                                 accumulates post-LZ literal byte frequencies here
+                                 (256 entries). NULL outside dictionary training. */
 
     /* Block-size derived parameters (computed once at init). */
     size_t chunk_size;    /**< Effective block size in bytes. */

--- a/src/lib/zxc_internal.h
+++ b/src/lib/zxc_internal.h
@@ -620,6 +620,21 @@ typedef struct {
     uint8_t flat_d[ZXC_PIVCO_MAX_NODES];
     uint8_t covered[ZXC_PIVCO_MAX_NODES];
 } zxc_pivco_tree_t;
+
+/**
+ * @brief Frame-constant dictionary Huffman state, prebuilt once at attach.
+ *
+ * Bundles everything the per-block dict paths reuse: the PivCo @c tree (decoder
+ * + estimator), and the canonical @c codes / @c code_len (encoder). Carved from
+ * the context workspace only when @c dict_size > 0, so no-dict contexts pay
+ * nothing for it. Built by @ref zxc_huf_dict_tree_build via
+ * @c zxc_cctx_attach_dict_huf.
+ */
+typedef struct {
+    zxc_pivco_tree_t tree;                 /**< PivCo tree from the shared literal table. */
+    uint32_t codes[ZXC_HUF_NUM_SYMBOLS];   /**< Canonical codes (encoder side). */
+    uint8_t code_len[ZXC_HUF_NUM_SYMBOLS]; /**< Unpacked code lengths. */
+} zxc_dict_huf_state_t;
 /** @brief RLE margin shift: source of the legacy below-ULTRA premium used by
  *         ::zxc_ss_prem_rle_q8 (256 >> shift reproduces the historical
  *         RLE-vs-RAW margin exactly). */
@@ -1549,17 +1564,14 @@ typedef struct {
     uint8_t* dict_buffer;           /**< [dict | data] concat scratch carved from memory_block
                                          when dict_size > 0 (NULL otherwise). */
     size_t dict_buffer_cap;         /**< Capacity of dict_buffer in bytes (0 = none). */
-    zxc_pivco_tree_t dict_huf_tree; /**< Tree-at-attach: PivCo tree prebuilt from the
-                                         dictionary's 128-byte shared literal table by
-                                         zxc_cctx_attach_dict_huf (valid iff dict_huf_tree_ok),
-                                         so per-block decode/estimate skip the rebuild. */
-    uint32_t dict_huf_codes[ZXC_HUF_NUM_SYMBOLS];   /**< Canonical codes of the dict table
-                                          (encoder side), built with the tree at attach. */
-    uint8_t dict_huf_code_len[ZXC_HUF_NUM_SYMBOLS]; /**< Unpacked dict code lengths (attach). */
-    int dict_huf_tree_ok;                           /**< 1 when the three fields above are valid. */
-    uint32_t* lit_freq_acc; /**< Trainer hook: when non-NULL, the GLO encoder
-                                 accumulates post-LZ literal byte frequencies here
-                                 (256 entries). NULL outside dictionary training. */
+    zxc_dict_huf_state_t* dict_huf; /**< Tree-at-attach state (PivCo tree + codes + code
+                                         lengths), carved from the workspace only when
+                                         dict_size > 0 (NULL otherwise); built once by
+                                         zxc_cctx_attach_dict_huf. Valid iff dict_huf_tree_ok. */
+    int dict_huf_tree_ok;           /**< 1 when *dict_huf is built and valid. */
+    uint32_t* lit_freq_acc;         /**< Trainer hook: when non-NULL, the GLO encoder
+                                         accumulates post-LZ literal byte frequencies here
+                                         (256 entries). NULL outside dictionary training. */
 
     /* Block-size derived parameters (computed once at init). */
     size_t chunk_size;    /**< Effective block size in bytes. */

--- a/tests/test_format.c
+++ b/tests/test_format.c
@@ -147,7 +147,7 @@ static int huf_dict_roundtrip_case(const char* label, const uint8_t* literals, s
 
     /* Tree-at-attach: prebuild the shared table's tree/codes once, as
      * zxc_cctx_attach_dict_huf does; the dict codec entry points take it. */
-    static zxc_pivco_tree_t tree;
+    zxc_pivco_tree_t tree;
     uint32_t codes[ZXC_HUF_NUM_SYMBOLS];
     uint8_t tree_len[ZXC_HUF_NUM_SYMBOLS];
     if (zxc_huf_dict_tree_build(packed, &tree, codes, tree_len) != ZXC_OK ||
@@ -264,7 +264,7 @@ int test_huffman_codec_dict() {
         buf[100] = '!'; /* unseen in training: no code assigned */
         freq['!']++;    /* keep the histogram in sync with the mutated buffer */
         uint8_t enc[1024];
-        static zxc_pivco_tree_t tree;
+        zxc_pivco_tree_t tree;
         uint32_t codes[ZXC_HUF_NUM_SYMBOLS];
         uint8_t packed[ZXC_HUF_TABLE_SIZE];
         uint8_t tree_len[ZXC_HUF_NUM_SYMBOLS];

--- a/tests/test_format.c
+++ b/tests/test_format.c
@@ -145,6 +145,17 @@ static int huf_dict_roundtrip_case(const char* label, const uint8_t* literals, s
         return 0;
     }
 
+    /* Tree-at-attach: prebuild the shared table's tree/codes once, as
+     * zxc_cctx_attach_dict_huf does; the dict codec entry points take it. */
+    static zxc_pivco_tree_t tree;
+    uint32_t codes[ZXC_HUF_NUM_SYMBOLS];
+    uint8_t tree_len[ZXC_HUF_NUM_SYMBOLS];
+    if (zxc_huf_dict_tree_build(packed, &tree, codes, tree_len) != ZXC_OK ||
+        memcmp(tree_len, code_len, sizeof(tree_len)) != 0) {
+        printf("Failed [%s]: dict_tree_build\n", label);
+        return 0;
+    }
+
     const size_t cap = ZXC_HUF_TABLE_SIZE + 2 * n + 4096;
     uint8_t* enc = (uint8_t*)malloc(cap);
     uint8_t* enc_blk = (uint8_t*)malloc(cap);
@@ -155,7 +166,8 @@ static int huf_dict_roundtrip_case(const char* label, const uint8_t* literals, s
         goto fail;
     }
 
-    const int written = zxc_huf_encode_section_dict(literals, n, freq, code_len, enc, cap);
+    const int written =
+        zxc_huf_encode_section_dict(literals, n, freq, code_len, &tree, codes, enc, cap);
     if (written < 0) {
         printf("Failed [%s]: encode_section_dict -> %d\n", label, written);
         goto fail;
@@ -176,18 +188,18 @@ static int huf_dict_roundtrip_case(const char* label, const uint8_t* literals, s
         goto fail;
     }
 
-    if (zxc_huf_decode_section_dict(enc, (size_t)written, dec, n, packed, scr) != ZXC_OK ||
+    if (zxc_huf_decode_section_dict(enc, (size_t)written, dec, n, &tree, scr) != ZXC_OK ||
         memcmp(literals, dec, n) != 0) {
         printf("Failed [%s]: decode_section_dict roundtrip mismatch\n", label);
         goto fail;
     }
 
     /* Error paths: truncated payload, undersized dst_cap. */
-    if (zxc_huf_decode_section_dict(enc, 0, dec, n, packed, scr) == ZXC_OK) {
+    if (zxc_huf_decode_section_dict(enc, 0, dec, n, &tree, scr) == ZXC_OK) {
         printf("Failed [%s]: truncated payload accepted\n", label);
         goto fail;
     }
-    if (zxc_huf_encode_section_dict(literals, n, freq, code_len, enc, 4) !=
+    if (zxc_huf_encode_section_dict(literals, n, freq, code_len, &tree, codes, enc, 4) !=
         ZXC_ERROR_DST_TOO_SMALL) {
         printf("Failed [%s]: undersized dst_cap not rejected\n", label);
         goto fail;
@@ -252,8 +264,18 @@ int test_huffman_codec_dict() {
         buf[100] = '!'; /* unseen in training: no code assigned */
         freq['!']++;    /* keep the histogram in sync with the mutated buffer */
         uint8_t enc[1024];
-        if (zxc_huf_encode_section_dict(buf, 256, freq, code_len, enc, sizeof(enc)) !=
-            ZXC_ERROR_CORRUPT_DATA) {
+        static zxc_pivco_tree_t tree;
+        uint32_t codes[ZXC_HUF_NUM_SYMBOLS];
+        uint8_t packed[ZXC_HUF_TABLE_SIZE];
+        uint8_t tree_len[ZXC_HUF_NUM_SYMBOLS];
+        zxc_huf_pack_lengths(code_len, packed);
+        if (zxc_huf_dict_tree_build(packed, &tree, codes, tree_len) != ZXC_OK) {
+            printf("Failed: dict_tree_build (code-less literal case)\n");
+            free(buf);
+            return 0;
+        }
+        if (zxc_huf_encode_section_dict(buf, 256, freq, code_len, &tree, codes, enc,
+                                        sizeof(enc)) != ZXC_ERROR_CORRUPT_DATA) {
             printf("Failed: code-less literal not rejected by encode_section_dict\n");
             free(buf);
             return 0;


### PR DESCRIPTION
Optimizes dictionary literal Huffman processing by moving the tree and code generation out of the per-block hot path.

This change significantly improves performance by:
*   Introducing a `zxc_dict_huf_state_t` structure within the compression context (`zxc_cctx_t`) to store the dictionary's PivCo Huffman tree, canonical codes, and unpacked code lengths.
*   Allocating memory for this state directly within the context's workspace when a dictionary is active.
*   Modifying `zxc_cctx_attach_dict_huf` to build this dictionary Huffman state *once* during context attachment, rather than rebuilding it for every block.
*   Updating all dictionary-aware Huffman encoding, decoding, and size calculation functions to directly utilize this prebuilt and cached state from the context.

This reduces redundant computation, lowering CPU overhead during compression and decompression of dictionary-referenced literal sections.