### PR TITLE
fix: Improves robustness and refines memory management

### DIFF
--- a/README.md
+++ b/README.md
@@ -490,7 +490,7 @@ int64_t n = zxc_decompress_inplace(buf, need, archive_size, NULL);   // decode i
 // buf[0 .. n) now holds the decompressed data
 ```
 
-The required margin is one block plus the wild-copy tail (`block_size + ~2 KB`) — about **1 %** overhead on a large archive. An undersized buffer is rejected with `ZXC_ERROR_DST_TOO_SMALL`, never silent corruption. This is a library/API capability (like LZ4's and Zstd's in-place modes): it targets embedded/firmware integrators, not the file→file CLI, whose streaming decode is already memory-bounded.
+The required margin is one block plus the accumulated per-block framing overhead and the wild-copy tail (`block_size + nblocks x (8-12 B) + ~2 KB`) — about **1 %** overhead on a large archive; always size the buffer via `zxc_decompress_inplace_bound` rather than the formula. An undersized buffer is rejected with `ZXC_ERROR_DST_TOO_SMALL`, never silent corruption. This is a library/API capability (like LZ4's and Zstd's in-place modes): it targets embedded/firmware integrators, not the file→file CLI, whose streaming decode is already memory-bounded.
 
 ---
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -210,7 +210,10 @@ typedef enum {
     ZXC_ERROR_BAD_BLOCK_SIZE = -14, // invalid block size
     ZXC_ERROR_DICT_REQUIRED  = -15, // file requires a dictionary but none provided
     ZXC_ERROR_DICT_MISMATCH  = -16, // provided dictionary ID does not match header
-    ZXC_ERROR_DICT_TOO_LARGE = -17  // dictionary exceeds ZXC_DICT_SIZE_MAX
+    ZXC_ERROR_DICT_TOO_LARGE = -17, // dictionary exceeds ZXC_DICT_SIZE_MAX
+    ZXC_ERROR_BAD_LEVEL      = -18  // level unsupported by this context's workspace
+                                    // (static context dense-tier raise; out-of-range
+                                    // levels are otherwise silently clamped)
 } zxc_error_t;
 ```
 
@@ -956,6 +959,10 @@ typedef struct {
 
 The library reads `[src+pos .. src+size)` and writes `[dst+pos .. dst+size)`,
 advancing `pos` by what it consumed/produced.  Buffers are caller-owned.
+The whole `[dst+pos .. dst+size)` window is writable scratch: with enough
+remaining capacity the decoder decodes blocks straight into it with
+speculative (wild-copy) stores, so bytes beyond the final `pos` are
+unspecified — never keep live data inside the declared capacity.
 
 ### Compression
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -384,8 +384,12 @@ ZXC_EXPORT size_t zxc_decompress_inplace_bound(
 ```
 
 Reads `src`'s header and footer (no decoding) and returns the single-buffer
-size `zxc_decompress_inplace` needs: `decompressed_size` plus a one-block +
-wild-copy safety margin (`block_size + ZXC_DECOMPRESS_TAIL_PAD`).
+size `zxc_decompress_inplace` needs: `decompressed_size` plus the safety
+margin `block_size + nblocks x (block header + per-block checksum, if any) +
+file footer + ZXC_DECOMPRESS_TAIL_PAD` — one block, the accumulated per-block
+framing overhead (incompressible blocks make the compressed stream run that
+much longer than the output), the footer, and the wild-copy tail. Always size
+the buffer with this function rather than re-deriving the formula.
 
 **Returns**: required buffer size, or `0` if `src` is not a valid archive.
 

--- a/docs/FORMAT.md
+++ b/docs/FORMAT.md
@@ -234,12 +234,13 @@ lengths alone, the set of *flat roots*: an internal node is a flat root iff
 1. it is not itself inside another flat subtree (BFS order resolves this:
    parents are classified first), and
 2. every leaf below it sits at the same relative depth `D`, and
-3. `D == 2`, `D == 4`, or `D >= 7`.
+3. `D >= 2`.
 
 (Completeness of the trie makes condition 2 imply a perfect binary subtree of
-`2^D` leaves. The depth set {2, 4, ≥7} is a fixed format rule: those are the
-shapes where direct code unpacking beats the level-merge cascade in the
-reference decoder.)
+`2^D` leaves. Every maximal complete subtree of depth `D >= 2` is a flat
+root — a fixed format rule. The reference decoder unpacks the packed codes
+directly, with SIMD kernels for `D` in 2..6 and a scalar table lookup for
+`D >= 7`, instead of running the level-merge cascade.)
 
 Every internal node that is neither a flat root nor a descendant of one is a
 **bitmap node**: its run holds one branch bit per symbol routed through it,

--- a/docs/WHITEPAPER.md
+++ b/docs/WHITEPAPER.md
@@ -73,7 +73,7 @@ replaces the layout with **Pivoted Coding Huffman** (level-ordered Huffman):
     AVX-512-VBMI2, a 2-instruction merge). No gather instructions, no
     per-symbol dependency chain; throughput scales with SIMD width.
 *   **Flat-subtree fast path (format rule)**: perfect subtrees whose leaves
-    all sit at relative depth `D ∈ {2, 4, ≥ 7}` skip the per-level bitmaps and
+    all sit at the same relative depth `D ≥ 2` skip the per-level bitmaps and
     store packed `D`-bit residual codes instead (FORMAT.md § 5.2.1). Dense
     tree regions — the common case for 8-bit-capped level-6 tables — then
     decode by direct table unpacking instead of `D` merge rounds.
@@ -954,7 +954,7 @@ Benchmarks were conducted using lzbench 2.2.1 (from @inikep), compiled with GCC 
 
 For integrators that hold the whole archive in RAM — firmware unpackers, game asset loaders, FOTA payloads — ZXC decompresses **inside a single buffer**, removing the second (output) allocation entirely. The compressed archive is placed **flush-right** in a buffer of size `zxc_decompress_inplace_bound(...)`, and `zxc_decompress_inplace()` decodes left-to-right into the same memory.
 
-The safety argument is exact. Decompression consumes `c` compressed bytes and produces `d ≥ c` decompressed bytes (a ZXC block never expands — it falls back to a RAW block otherwise), so the gap between the flush-right read cursor and the left-to-right write cursor shrinks *monotonically* and reaches its minimum only at the very end. Per block, safety requires `output_through_k + wild_copy_pad ≤ compressed_start_of_block_k`, which holds for every block once the buffer carries a margin of one block plus the decoder's wild-copy tail (`block_size + ZXC_DECOMPRESS_TAIL_PAD`). The bound is derived from the archive header (block size) and footer (decompressed size) without decoding; an undersized buffer is rejected (`ZXC_ERROR_DST_TOO_SMALL`), never allowed to corrupt.
+The safety argument is exact. Decompression consumes `c` compressed bytes and produces `d ≥ c` decompressed bytes per block payload (a ZXC block never expands — it falls back to a RAW block otherwise), but each block also carries its framing (header + optional checksum), so on incompressible input the compressed stream runs `nblocks × framing` bytes longer than the output. Per block, safety requires `output_through_k + wild_copy_pad ≤ compressed_start_of_block_k`, which holds for every block once the buffer carries a margin of one block plus the accumulated per-block framing plus the decoder's wild-copy tail (`block_size + nblocks × (header + optional checksum) + footer + ZXC_DECOMPRESS_TAIL_PAD`). The bound is derived from the archive header (block size) and footer (decompressed size) without decoding; an undersized buffer is rejected (`ZXC_ERROR_DST_TOO_SMALL`), never allowed to corrupt.
 
 Peak decode memory therefore drops from *compressed + decompressed* to *decompressed + ~1 %*. This mirrors the in-place decode modes of LZ4 (`LZ4_DECOMPRESS_INPLACE_MARGIN`) and Zstd (decompression margin) — a library capability for embedded integration, orthogonal to the streaming CLI, whose block-at-a-time decode is already memory-bounded. Dictionary archives are supported (they resolve through the context's own bounce buffer, which does not alias the in-place buffer).
 

--- a/include/zxc_buffer.h
+++ b/include/zxc_buffer.h
@@ -131,7 +131,9 @@ ZXC_EXPORT uint64_t zxc_compress_bound(const size_t input_size);
  * @note @p src and @p dst must not overlap (same contract as memcpy).
  *
  * @return The number of bytes written to dst (>0 on success),
- *         or a negative zxc_error_t code (e.g., ZXC_ERROR_DST_TOO_SMALL) on failure.
+ *         or a negative zxc_error_t code (e.g., ZXC_ERROR_DST_TOO_SMALL,
+ *         or ZXC_ERROR_BAD_LEVEL for a level above @ref ZXC_LEVEL_ULTRA)
+ *         on failure.
  */
 ZXC_EXPORT int64_t zxc_compress(const void* src, const size_t src_size, void* dst,
                                 const size_t dst_capacity, const zxc_compress_opts_t* opts);
@@ -204,11 +206,17 @@ ZXC_EXPORT int64_t zxc_decompress_inplace(void* buffer, const size_t buffer_capa
  * This function reads the file footer to extract the original uncompressed size
  * without performing any decompression. Useful for allocating output buffers.
  *
+ * The footer is untrusted input: the value is checked for plausibility against
+ * the archive size (each block costs at least a block header and decodes to at
+ * most one block), so a forged footer claiming an absurd size returns 0 rather
+ * than driving an oversized allocation.
+ *
  * @param[in] src       Pointer to the compressed data buffer.
  * @param[in] src_size  Size of the compressed data in bytes.
  *
- * @return The original uncompressed size in bytes, or 0 if the buffer is invalid
- *         or too small to contain a valid ZXC archive.
+ * @return The original uncompressed size in bytes, or 0 if the buffer is invalid,
+ *         too small to contain a valid ZXC archive, or carries an implausible
+ *         footer value.
  */
 ZXC_EXPORT uint64_t zxc_get_decompressed_size(const void* src, const size_t src_size);
 
@@ -327,7 +335,10 @@ ZXC_EXPORT uint64_t zxc_decompress_block_bound(const size_t uncompressed_size);
  * @return Compressed block size in bytes (> 0) on success,
  *         or a negative @ref zxc_error_t code on failure.
  *         Returns @ref ZXC_ERROR_BAD_BLOCK_SIZE if
- *         @p src_size > @ref ZXC_BLOCK_SIZE_MAX.
+ *         @p src_size > @ref ZXC_BLOCK_SIZE_MAX, and
+ *         @ref ZXC_ERROR_BAD_LEVEL for a level above @ref ZXC_LEVEL_ULTRA
+ *         (or, on a static context, a level raise the workspace cannot
+ *         accommodate).
  */
 ZXC_EXPORT int64_t zxc_compress_block(zxc_cctx* cctx, const void* src, size_t src_size, void* dst,
                                       size_t dst_capacity, const zxc_compress_opts_t* opts);
@@ -458,7 +469,9 @@ ZXC_EXPORT uint64_t zxc_estimate_cctx_size(size_t src_size, int level);
  * The returned context must be freed with zxc_free_cctx().
  *
  * @param[in] opts  Compression options for eager init, or NULL for lazy init.
- * @return Pointer to the new context, or @c NULL on allocation failure.
+ * @return Pointer to the new context, or @c NULL on allocation failure or
+ *         invalid options (block size not a power of two in range, or level
+ *         above @ref ZXC_LEVEL_ULTRA).
  */
 ZXC_EXPORT zxc_cctx* zxc_create_cctx(const zxc_compress_opts_t* opts);
 
@@ -476,7 +489,11 @@ ZXC_EXPORT void zxc_free_cctx(zxc_cctx* cctx);
  *
  * Identical to zxc_compress() but reuses the internal buffers from @p cctx,
  * avoiding per-call malloc/free overhead.  The context automatically
- * re-initializes when block_size or level changes between calls.
+ * re-initializes when block_size changes between calls, or when a level
+ * raise into @ref ZXC_LEVEL_DENSITY requires the optimal-parser scratch
+ * that lower-level inits do not allocate.  On a static (caller-workspace)
+ * context such a raise is rejected with @ref ZXC_ERROR_BAD_LEVEL instead,
+ * since the workspace cannot grow.
  *
  * Options are **sticky**: settings passed via @p opts are remembered and
  * reused on subsequent calls where @p opts is NULL.  The initial sticky
@@ -610,7 +627,10 @@ ZXC_EXPORT size_t zxc_static_cctx_workspace_size(const size_t block_size, const 
  * pass options requesting a different @c block_size return
  * @ref ZXC_ERROR_BAD_BLOCK_SIZE without re-initialising.  A different
  * @c level / @c checksum_enabled is honoured per-call without
- * re-partitioning.
+ * re-partitioning, except a raise into @ref ZXC_LEVEL_DENSITY on a
+ * workspace carved below it: that would require the optimal-parser
+ * scratch the workspace does not carry, so the call returns
+ * @ref ZXC_ERROR_BAD_LEVEL.
  *
  * @param[in,out] workspace       Caller-allocated buffer, cache-line aligned.
  * @param[in]     workspace_size  Capacity of @p workspace in bytes.

--- a/include/zxc_buffer.h
+++ b/include/zxc_buffer.h
@@ -129,11 +129,11 @@ ZXC_EXPORT uint64_t zxc_compress_bound(const size_t input_size);
  *                         (this call is single-threaded and blocking).
  *
  * @note @p src and @p dst must not overlap (same contract as memcpy).
+ * @note Levels above @ref ZXC_LEVEL_ULTRA are silently clamped to
+ *       @ref ZXC_LEVEL_ULTRA; levels <= 0 select @ref ZXC_LEVEL_DEFAULT.
  *
  * @return The number of bytes written to dst (>0 on success),
- *         or a negative zxc_error_t code (e.g., ZXC_ERROR_DST_TOO_SMALL,
- *         or ZXC_ERROR_BAD_LEVEL for a level above @ref ZXC_LEVEL_ULTRA)
- *         on failure.
+ *         or a negative zxc_error_t code (e.g., ZXC_ERROR_DST_TOO_SMALL) on failure.
  */
 ZXC_EXPORT int64_t zxc_compress(const void* src, const size_t src_size, void* dst,
                                 const size_t dst_capacity, const zxc_compress_opts_t* opts);
@@ -336,9 +336,9 @@ ZXC_EXPORT uint64_t zxc_decompress_block_bound(const size_t uncompressed_size);
  *         or a negative @ref zxc_error_t code on failure.
  *         Returns @ref ZXC_ERROR_BAD_BLOCK_SIZE if
  *         @p src_size > @ref ZXC_BLOCK_SIZE_MAX, and
- *         @ref ZXC_ERROR_BAD_LEVEL for a level above @ref ZXC_LEVEL_ULTRA
- *         (or, on a static context, a level raise the workspace cannot
- *         accommodate).
+ *         @ref ZXC_ERROR_BAD_LEVEL on a static context for a level raise
+ *         the workspace cannot accommodate (levels above
+ *         @ref ZXC_LEVEL_ULTRA are otherwise silently clamped).
  */
 ZXC_EXPORT int64_t zxc_compress_block(zxc_cctx* cctx, const void* src, size_t src_size, void* dst,
                                       size_t dst_capacity, const zxc_compress_opts_t* opts);
@@ -468,10 +468,12 @@ ZXC_EXPORT uint64_t zxc_estimate_cctx_size(size_t src_size, int level);
  *
  * The returned context must be freed with zxc_free_cctx().
  *
+ * Levels above @ref ZXC_LEVEL_ULTRA are silently clamped to
+ * @ref ZXC_LEVEL_ULTRA.
+ *
  * @param[in] opts  Compression options for eager init, or NULL for lazy init.
- * @return Pointer to the new context, or @c NULL on allocation failure or
- *         invalid options (block size not a power of two in range, or level
- *         above @ref ZXC_LEVEL_ULTRA).
+ * @return Pointer to the new context, or @c NULL on allocation failure or an
+ *         invalid block size (not a power of two in range).
  */
 ZXC_EXPORT zxc_cctx* zxc_create_cctx(const zxc_compress_opts_t* opts);
 
@@ -497,7 +499,8 @@ ZXC_EXPORT void zxc_free_cctx(zxc_cctx* cctx);
  *
  * Options are **sticky**: settings passed via @p opts are remembered and
  * reused on subsequent calls where @p opts is NULL.  The initial sticky
- * values come from the @p opts passed to zxc_create_cctx().
+ * values come from the @p opts passed to zxc_create_cctx().  Levels above
+ * @ref ZXC_LEVEL_ULTRA are silently clamped.
  *
  * @param[in,out] cctx         Reusable compression context.
  * @param[in]     src          Source data.

--- a/include/zxc_error.h
+++ b/include/zxc_error.h
@@ -71,6 +71,10 @@ typedef enum {
     ZXC_ERROR_DICT_MISMATCH = -16,  /**< Provided dictionary ID does not match the file header. */
     ZXC_ERROR_DICT_TOO_LARGE = -17, /**< Dictionary exceeds maximum allowed size. */
 
+    /* Parameter errors */
+    ZXC_ERROR_BAD_LEVEL = -18, /**< Compression level out of range, or not supported
+                                    by this context's workspace. */
+
 } zxc_error_t;
 
 /**

--- a/include/zxc_error.h
+++ b/include/zxc_error.h
@@ -72,8 +72,7 @@ typedef enum {
     ZXC_ERROR_DICT_TOO_LARGE = -17, /**< Dictionary exceeds maximum allowed size. */
 
     /* Parameter errors */
-    ZXC_ERROR_BAD_LEVEL = -18, /**< Compression level out of range, or not supported
-                                    by this context's workspace. */
+    ZXC_ERROR_BAD_LEVEL = -18, /**< Compression level not supported by this context's workspace. */
 
 } zxc_error_t;
 

--- a/include/zxc_pstream.h
+++ b/include/zxc_pstream.h
@@ -98,6 +98,12 @@ typedef struct {
  * @c dst.  The library writes starting at @c dst+pos and advances @c pos by
  * the number of bytes produced.  The caller drains @c [dst, dst+pos) and
  * resets @c pos to 0 between rounds (or grows @c size).
+ *
+ * The ENTIRE region @c [dst+pos, dst+size) must be treated as writable
+ * scratch: when the remaining capacity is large enough, the decoder writes
+ * blocks directly into it using speculative (wild-copy) stores, so bytes
+ * beyond the final @c pos are unspecified after a call.  Do not keep live
+ * data inside the declared capacity.
  */
 typedef struct {
     void* dst;   /**< Caller-owned output region. */
@@ -119,13 +125,16 @@ typedef struct zxc_dstream_s zxc_dstream;
  * All settings from @p opts are copied into the context.  After this call,
  * the @p opts struct may be freed or reused.
  *
- * Only @c level, @c block_size, and @c checksum_enabled are honoured.
- * @c n_threads is ignored (this API is single-threaded; use
- * @ref zxc_stream_compress for the multi-threaded @c FILE* pipeline).
+ * Only @c level, @c block_size, and @c checksum_enabled are honoured
+ * (levels above @ref ZXC_LEVEL_ULTRA are clamped).  @c n_threads is ignored
+ * (this API is single-threaded; use @ref zxc_stream_compress for the
+ * multi-threaded @c FILE* pipeline).  Dictionary options are rejected: the
+ * push-stream format carries no dict_id, so passing @c dict / @c dict_size /
+ * @c dict_huf makes creation fail rather than silently dropping them.
  *
  * If @p opts is not @c NULL, the honoured fields must contain valid values.
- * Invalid option values (for example an unsupported @c block_size) cause
- * stream creation to fail.
+ * Invalid option values (for example an unsupported @c block_size or a
+ * dictionary) cause stream creation to fail.
  *
  * @param[in] opts  Compression options, or @c NULL for all defaults.
  * @return Allocated context to be released with @ref zxc_cstream_free,
@@ -228,11 +237,14 @@ ZXC_EXPORT size_t zxc_cstream_out_size(const zxc_cstream* cs);
  *
  * All settings from @p opts are copied into the context.  Only
  * @c checksum_enabled is honoured (controls whether per-block and global
- * checksums are verified when present).
+ * checksums are verified when present).  Dictionary options are rejected
+ * (the push-stream format carries no dict_id): passing @c dict /
+ * @c dict_size / @c dict_huf makes creation fail rather than silently
+ * ignoring them.
  *
  * @param[in] opts  Decompression options, or @c NULL for defaults.
  * @return Allocated context to be released with @ref zxc_dstream_free,
- *         or @c NULL on allocation failure.
+ *         or @c NULL on allocation failure or dictionary options in @p opts.
  */
 ZXC_EXPORT zxc_dstream* zxc_dstream_create(const zxc_decompress_opts_t* opts);
 

--- a/src/lib/zxc_common.c
+++ b/src/lib/zxc_common.c
@@ -138,15 +138,35 @@ typedef struct {
  *                        the [dict | data] concat buffer.
  * @return Fully populated layout; @c .total is the required workspace size.
  */
+/**
+ * @brief Worst-case sequence count for one block. Shared by the compressor's
+ *        buffer sizing and the decoder's token scratch: the decode side must
+ *        accept exactly what the compress side can emit, so both derive from
+ *        this single expression.
+ */
+static ZXC_ALWAYS_INLINE size_t zxc_cctx_max_seq(const size_t chunk_size) {
+    return chunk_size / ZXC_LZ_MIN_MATCH_LEN + 16;
+}
+
+/**
+ * @brief Decode-side entropy scratch sizes for one block: token scratch
+ *        (worst-case sequence count + wild-read pad) and PivCo ping-pong
+ *        scratch. Single definition shared by the layout (full provisioning:
+ *        static workspaces) and the lazy heap allocator
+ *        (@ref zxc_cctx_alloc_entropy_scratch), so the two can never drift.
+ */
+static void zxc_dctx_entropy_sizes(const size_t chunk_size, size_t* RESTRICT sz_tok,
+                                   size_t* RESTRICT sz_pivco) {
+    *sz_tok = zxc_cctx_max_seq(chunk_size) + ZXC_PAD_SIZE;
+    *sz_pivco = chunk_size + ZXC_PIVCO_SCRATCH_PAD;
+}
+
 static zxc_cctx_layout_t compute_cctx_layout(const size_t chunk_size, const int mode,
-                                             const int level, const size_t dict_size) {
+                                             const int level, const size_t dict_size,
+                                             const int defer_entropy_scratch) {
     zxc_cctx_layout_t layout = {0};
 
-    /* Worst-case sequence count for one block. Shared by the compressor's
-     * buffer sizing and the decoder's token scratch: the decode side must
-     * accept exactly what the compress side can emit, so both derive from
-     * this single expression. */
-    const size_t max_seq = chunk_size / ZXC_LZ_MIN_MATCH_LEN + 16;
+    const size_t max_seq = zxc_cctx_max_seq(chunk_size);
 
     if (mode == 0) {
         /* Decompress: work_buf + lit_buffer, both padded for wild-copy
@@ -160,19 +180,22 @@ static zxc_cctx_layout_t compute_cctx_layout(const size_t chunk_size, const int 
         layout.total += ZXC_ALIGN_CL(sz_work);
         layout.off_lit_dctx = layout.total;
         layout.total += ZXC_ALIGN_CL(sz_lit);
-        /* Token-section decode scratch (level-7 GLO blocks Huffman-code the token
-         * stream). Sized to the worst-case sequence count + wild-read pad, matching
-         * the compressor's max_seq bound. Provisioned regardless of level since the
-         * decoder cannot predict per-block enc_litlen. */
-        layout.sz_tok_dctx = max_seq + ZXC_PAD_SIZE;
-        layout.off_tok_dctx = layout.total;
-        layout.total += ZXC_ALIGN_CL(layout.sz_tok_dctx);
-        /* PivCo (enc 2/3) decode scratch: odd tree levels ping-pong through this
-         * buffer while even levels use the destination. Sized for the largest
-         * section a block can carry (chunk_size literals). */
-        layout.sz_pivco_dctx = chunk_size + ZXC_PIVCO_SCRATCH_PAD;
-        layout.off_pivco_dctx = layout.total;
-        layout.total += ZXC_ALIGN_CL(layout.sz_pivco_dctx);
+        /* Token-section decode scratch (level-7 GLO blocks Huffman-code the
+         * token stream) + PivCo ping-pong scratch. The decoder cannot predict
+         * per-block enc_lit/enc_litlen, so static workspaces provision both
+         * up front (no-alloc contract); heap contexts defer them to the first
+         * entropy section instead (~1.2 x chunk_size that L1-5 archives never
+         * pay), see zxc_cctx_alloc_entropy_scratch. */
+        if (!defer_entropy_scratch) {
+            size_t sz_tok = 0, sz_pivco = 0;
+            zxc_dctx_entropy_sizes(chunk_size, &sz_tok, &sz_pivco);
+            layout.sz_tok_dctx = sz_tok;
+            layout.off_tok_dctx = layout.total;
+            layout.total += ZXC_ALIGN_CL(layout.sz_tok_dctx);
+            layout.sz_pivco_dctx = sz_pivco;
+            layout.off_pivco_dctx = layout.total;
+            layout.total += ZXC_ALIGN_CL(layout.sz_pivco_dctx);
+        }
     } else {
         /* Compress: 6 partitions + optional opt_scratch at level >= ZXC_LEVEL_DENSITY. */
         const uint32_t offset_bits = zxc_log2_u32((uint32_t)chunk_size);
@@ -252,7 +275,7 @@ static zxc_cctx_layout_t compute_cctx_layout(const size_t chunk_size, const int 
 size_t zxc_cctx_compute_workspace_size(const size_t chunk_size, const int mode, const int level,
                                        const size_t dict_size) {
     if (UNLIKELY(chunk_size == 0)) return 0;
-    return compute_cctx_layout(chunk_size, mode, level, dict_size).total;
+    return compute_cctx_layout(chunk_size, mode, level, dict_size, 0).total;
 }
 
 /**
@@ -276,11 +299,12 @@ size_t zxc_cctx_compute_workspace_size(const size_t chunk_size, const int mode, 
  */
 int zxc_cctx_init_in_workspace(zxc_cctx_t* RESTRICT ctx, void* RESTRICT workspace,
                                const size_t workspace_size, const size_t chunk_size, const int mode,
-                               const int level, const int checksum_enabled,
-                               const size_t dict_size) {
+                               const int level, const int checksum_enabled, const size_t dict_size,
+                               const int defer_entropy_scratch) {
     if (UNLIKELY(!ctx || !workspace || chunk_size == 0)) return ZXC_ERROR_NULL_INPUT;
 
-    const zxc_cctx_layout_t layout = compute_cctx_layout(chunk_size, mode, level, dict_size);
+    const zxc_cctx_layout_t layout =
+        compute_cctx_layout(chunk_size, mode, level, dict_size, defer_entropy_scratch);
     if (UNLIKELY(workspace_size < layout.total)) return ZXC_ERROR_DST_TOO_SMALL;
 
     ZXC_MEMSET(ctx, 0, sizeof(zxc_cctx_t));
@@ -310,10 +334,12 @@ int zxc_cctx_init_in_workspace(zxc_cctx_t* RESTRICT ctx, void* RESTRICT workspac
         ctx->work_buf_cap = chunk_size + ZXC_DECOMPRESS_TAIL_PAD;
         ctx->lit_buffer = mem + layout.off_lit_dctx;
         ctx->lit_buffer_cap = chunk_size + ZXC_PAD_SIZE;
-        ctx->tok_buffer = mem + layout.off_tok_dctx;
-        ctx->tok_buffer_cap = layout.sz_tok_dctx;
-        ctx->pivco_scratch = mem + layout.off_pivco_dctx;
-        ctx->pivco_scratch_cap = layout.sz_pivco_dctx;
+        if (layout.sz_pivco_dctx) {
+            ctx->tok_buffer = mem + layout.off_tok_dctx;
+            ctx->tok_buffer_cap = layout.sz_tok_dctx;
+            ctx->pivco_scratch = mem + layout.off_pivco_dctx;
+            ctx->pivco_scratch_cap = layout.sz_pivco_dctx;
+        }
         return ZXC_OK;
     }
 
@@ -358,14 +384,21 @@ int zxc_cctx_init_in_workspace(zxc_cctx_t* RESTRICT ctx, void* RESTRICT workspac
  */
 int zxc_cctx_init(zxc_cctx_t* RESTRICT ctx, const size_t chunk_size, const int mode,
                   const int level, const int checksum_enabled, const size_t dict_size) {
-    const size_t total = zxc_cctx_compute_workspace_size(chunk_size, mode, level, dict_size);
+    if (UNLIKELY(chunk_size == 0)) return ZXC_ERROR_NULL_INPUT;
+    /* Defer the decode-side entropy scratch allocation to the first entropy
+     * section (zxc_cctx_alloc_entropy_scratch) when the caller is a heap context.
+     * Static workspaces must provision it up front (no allocation is ever allowed
+     * later). */
+    const int defer_entropy = (mode == 0);
+    const size_t total =
+        compute_cctx_layout(chunk_size, mode, level, dict_size, defer_entropy).total;
     if (UNLIKELY(total == 0)) return ZXC_ERROR_NULL_INPUT;
 
     uint8_t* const mem = (uint8_t*)ZXC_ALIGNED_MALLOC(total, ZXC_CACHE_LINE_SIZE);
     if (UNLIKELY(!mem)) return ZXC_ERROR_MEMORY;
 
     const int rc = zxc_cctx_init_in_workspace(ctx, mem, total, chunk_size, mode, level,
-                                              checksum_enabled, dict_size);
+                                              checksum_enabled, dict_size, defer_entropy);
     if (UNLIKELY(rc != ZXC_OK)) {
         // LCOV_EXCL_START
         ZXC_ALIGNED_FREE(mem);
@@ -374,6 +407,32 @@ int zxc_cctx_init(zxc_cctx_t* RESTRICT ctx, const size_t chunk_size, const int m
     }
     /* Library-owned buffer: record the allocation so zxc_cctx_free frees it. */
     ctx->memory_block = mem;
+    return ZXC_OK;
+}
+
+/**
+ * @brief Lazily allocates the deferred decode-side entropy scratch.
+ *
+ * Public contract at the declaration in @c zxc_internal.h. One aligned block
+ * carries [tok_buffer | pivco_scratch], sized by @ref zxc_dctx_entropy_sizes
+ * (the same source the full-provision layout uses), owned by the context and
+ * released by @ref zxc_cctx_free.
+ */
+int zxc_cctx_alloc_entropy_scratch(zxc_cctx_t* ctx) {
+    if (LIKELY(ctx->pivco_scratch != NULL)) return ZXC_OK;
+
+    size_t sz_tok = 0, sz_pivco = 0;
+    zxc_dctx_entropy_sizes(ctx->chunk_size, &sz_tok, &sz_pivco);
+    const size_t total = ZXC_ALIGN_CL(sz_tok) + ZXC_ALIGN_CL(sz_pivco);
+
+    uint8_t* const mem = (uint8_t*)ZXC_ALIGNED_MALLOC(total, ZXC_CACHE_LINE_SIZE);
+    if (UNLIKELY(!mem)) return ZXC_ERROR_MEMORY;  // LCOV_EXCL_LINE
+
+    ctx->entropy_block = mem;
+    ctx->tok_buffer = mem;
+    ctx->tok_buffer_cap = sz_tok;
+    ctx->pivco_scratch = mem + ZXC_ALIGN_CL(sz_tok);
+    ctx->pivco_scratch_cap = sz_pivco;
     return ZXC_OK;
 }
 
@@ -389,6 +448,10 @@ void zxc_cctx_free(zxc_cctx_t* ctx) {
     if (ctx->memory_block) {
         ZXC_ALIGNED_FREE(ctx->memory_block);
         ctx->memory_block = NULL;
+    }
+    if (ctx->entropy_block) {
+        ZXC_ALIGNED_FREE(ctx->entropy_block);
+        ctx->entropy_block = NULL;
     }
 
     ctx->lit_buffer = NULL;

--- a/src/lib/zxc_common.c
+++ b/src/lib/zxc_common.c
@@ -187,7 +187,8 @@ static zxc_cctx_layout_t compute_cctx_layout(const size_t chunk_size, const int 
          * entropy section instead (~1.2 x chunk_size that L1-5 archives never
          * pay), see zxc_cctx_alloc_entropy_scratch. */
         if (!defer_entropy_scratch) {
-            size_t sz_tok = 0, sz_pivco = 0;
+            size_t sz_tok = 0;
+            size_t sz_pivco = 0;
             zxc_dctx_entropy_sizes(chunk_size, &sz_tok, &sz_pivco);
             layout.sz_tok_dctx = sz_tok;
             layout.off_tok_dctx = layout.total;
@@ -421,7 +422,8 @@ int zxc_cctx_init(zxc_cctx_t* RESTRICT ctx, const size_t chunk_size, const int m
 int zxc_cctx_alloc_entropy_scratch(zxc_cctx_t* ctx) {
     if (LIKELY(ctx->pivco_scratch != NULL)) return ZXC_OK;
 
-    size_t sz_tok = 0, sz_pivco = 0;
+    size_t sz_tok = 0;
+    size_t sz_pivco = 0;
     zxc_dctx_entropy_sizes(ctx->chunk_size, &sz_tok, &sz_pivco);
     const size_t total = ZXC_ALIGN_CL(sz_tok) + ZXC_ALIGN_CL(sz_pivco);
 

--- a/src/lib/zxc_common.c
+++ b/src/lib/zxc_common.c
@@ -142,6 +142,12 @@ static zxc_cctx_layout_t compute_cctx_layout(const size_t chunk_size, const int 
                                              const int level, const size_t dict_size) {
     zxc_cctx_layout_t layout = {0};
 
+    /* Worst-case sequence count for one block. Shared by the compressor's
+     * buffer sizing and the decoder's token scratch: the decode side must
+     * accept exactly what the compress side can emit, so both derive from
+     * this single expression. */
+    const size_t max_seq = chunk_size / ZXC_LZ_MIN_MATCH_LEN + 16;
+
     if (mode == 0) {
         /* Decompress: work_buf + lit_buffer, both padded for wild-copy
          * overshoot and sized worst-case (chunk_size + ZXC_DECOMPRESS_TAIL_PAD).
@@ -158,7 +164,7 @@ static zxc_cctx_layout_t compute_cctx_layout(const size_t chunk_size, const int 
          * stream). Sized to the worst-case sequence count + wild-read pad, matching
          * the compressor's max_seq bound. Provisioned regardless of level since the
          * decoder cannot predict per-block enc_litlen. */
-        layout.sz_tok_dctx = (chunk_size / ZXC_LZ_MIN_MATCH_LEN + 16) + ZXC_PAD_SIZE;
+        layout.sz_tok_dctx = max_seq + ZXC_PAD_SIZE;
         layout.off_tok_dctx = layout.total;
         layout.total += ZXC_ALIGN_CL(layout.sz_tok_dctx);
         /* PivCo (enc 2/3) decode scratch: odd tree levels ping-pong through this
@@ -170,7 +176,7 @@ static zxc_cctx_layout_t compute_cctx_layout(const size_t chunk_size, const int 
     } else {
         /* Compress: 6 partitions + optional opt_scratch at level >= ZXC_LEVEL_DENSITY. */
         const uint32_t offset_bits = zxc_log2_u32((uint32_t)chunk_size);
-        layout.max_seq = chunk_size / ZXC_LZ_MIN_MATCH_LEN + 16;
+        layout.max_seq = max_seq;
         layout.sz_hash_pos = ZXC_LZ_HASH_SIZE * sizeof(uint32_t);
         layout.sz_hash_tags = ZXC_LZ_HASH_SIZE * sizeof(uint8_t);
         const size_t sz_chain = ZXC_LZ_WINDOW_SIZE * sizeof(uint16_t);
@@ -441,10 +447,11 @@ int zxc_cctx_attach_dict_huf(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRICT l
     }
     if (UNLIKELY(empty || ctx->dict_huf == NULL)) return ZXC_OK;
 
-    /* Tree-at-attach: unpack + build the PivCo tree and codes once here; the
-     * per-block encode/estimate/decode paths reuse them via the context. */
+    /* Tree-at-attach: unpack + build the PivCo tree, codes and decoder tables
+     * once here; the per-block encode/estimate/decode paths reuse them via
+     * the context. */
     const int rc = zxc_huf_dict_tree_build(lengths, &ctx->dict_huf->tree, ctx->dict_huf->codes,
-                                           ctx->dict_huf->code_len);
+                                           ctx->dict_huf->code_len, &ctx->dict_huf->dec);
     if (UNLIKELY(rc != ZXC_OK)) return rc;
     ctx->dict_huf_tree_ok = 1;
     return ZXC_OK;
@@ -908,6 +915,8 @@ const char* zxc_error_name(const int code) {
             return "ZXC_ERROR_DICT_MISMATCH";
         case ZXC_ERROR_DICT_TOO_LARGE:
             return "ZXC_ERROR_DICT_TOO_LARGE";
+        case ZXC_ERROR_BAD_LEVEL:
+            return "ZXC_ERROR_BAD_LEVEL";
         default:
             return "ZXC_UNKNOWN_ERROR";
     }

--- a/src/lib/zxc_decompress.c
+++ b/src/lib/zxc_decompress.c
@@ -426,15 +426,35 @@ static ZXC_NOINLINE void zxc_decode_copy_match_exact(uint8_t* d_ptr, const uint8
         d_ptr += ml;                                \
     } while (0)
 
-/* PivCo section decodes are outlined COLD: they run once per SECTION (a call
- * is noise there), and keeping their bodies out of the sequence-decode
- * monolith preserves its i-cache footprint for levels 1-5, whose blocks never
- * take these branches (the inline branches grew the primary GLO wrapper by
- * ~520 B at the token-entropy commit and cost ~3-5% at levels 3-5). */
+/* The section decoders below are outlined COLD on purpose: they run once per
+ * section (a call is noise), and keeping them out of the hot sequence-decode
+ * loop protects its i-cache footprint - inlining them was measured at
+ * ~3-5% slower on levels 3-5, which never take these branches. */
+/**
+ * @brief Ensures the entropy decode scratch (tok_buffer + pivco_scratch) is
+ *        available before decoding an entropy section.
+ *
+ * Heap contexts defer this scratch to the first entropy section
+ * (@ref zxc_cctx_alloc_entropy_scratch allocates it once); static workspaces
+ * pre-carve it, making this a no-op. The const cast is sound: every context
+ * lives in writable memory (heap allocation or caller workspace) - the
+ * decode chain is const only because steady-state decoding never mutates
+ * the context.
+ *
+ * @param[in] ctx  Decompression context (mutated on the first entropy block).
+ * @return @ref ZXC_OK, or @ref ZXC_ERROR_MEMORY on allocation failure.
+ */
+static ZXC_NOINLINE ZXC_COLD int zxc_ensure_entropy_scratch(const zxc_cctx_t* RESTRICT ctx) {
+    if (LIKELY(ctx->pivco_scratch != NULL)) return ZXC_OK;
+    return zxc_cctx_alloc_entropy_scratch((zxc_cctx_t*)(uintptr_t)ctx);
+}
+
 static ZXC_NOINLINE ZXC_COLD int zxc_decode_lit_pivco(const zxc_cctx_t* RESTRICT ctx,
                                                       const uint8_t* RESTRICT payload,
                                                       const size_t psize,
                                                       const size_t required_size) {
+    const int arc = zxc_ensure_entropy_scratch(ctx);
+    if (UNLIKELY(arc != ZXC_OK)) return arc;
     if (UNLIKELY(ctx->lit_buffer_cap < required_size + ZXC_PAD_SIZE ||
                  ctx->pivco_scratch_cap < required_size + ZXC_PIVCO_SCRATCH_PAD))
         return ZXC_ERROR_CORRUPT_DATA;
@@ -447,6 +467,8 @@ static ZXC_NOINLINE ZXC_COLD int zxc_decode_lit_pivco_dict(const zxc_cctx_t* RES
                                                            const size_t psize,
                                                            const size_t required_size) {
     if (UNLIKELY(!ctx->dict_huf_tree_ok)) return ZXC_ERROR_DICT_REQUIRED;
+    const int arc = zxc_ensure_entropy_scratch(ctx);
+    if (UNLIKELY(arc != ZXC_OK)) return arc;
     if (UNLIKELY(ctx->lit_buffer_cap < required_size + ZXC_PAD_SIZE ||
                  ctx->pivco_scratch_cap < required_size + ZXC_PIVCO_SCRATCH_PAD))
         return ZXC_ERROR_CORRUPT_DATA;
@@ -458,6 +480,8 @@ static ZXC_NOINLINE ZXC_COLD int zxc_decode_lit_pivco_dict(const zxc_cctx_t* RES
 static ZXC_NOINLINE ZXC_COLD int zxc_decode_tok_pivco(const zxc_cctx_t* RESTRICT ctx,
                                                       const uint8_t* RESTRICT payload,
                                                       const size_t psize, const size_t n_tok) {
+    const int arc = zxc_ensure_entropy_scratch(ctx);
+    if (UNLIKELY(arc != ZXC_OK)) return arc;
     if (UNLIKELY(n_tok + ZXC_PAD_SIZE > ctx->tok_buffer_cap ||
                  n_tok + ZXC_PIVCO_SCRATCH_PAD > ctx->pivco_scratch_cap))
         return ZXC_ERROR_CORRUPT_DATA;

--- a/src/lib/zxc_decompress.c
+++ b/src/lib/zxc_decompress.c
@@ -451,7 +451,8 @@ static ZXC_NOINLINE ZXC_COLD int zxc_decode_lit_pivco_dict(const zxc_cctx_t* RES
                  ctx->pivco_scratch_cap < required_size + ZXC_PIVCO_SCRATCH_PAD))
         return ZXC_ERROR_CORRUPT_DATA;
     return zxc_huf_decode_section_dict(payload, psize, ctx->lit_buffer, required_size,
-                                       &ctx->dict_huf->tree, ctx->pivco_scratch);
+                                       &ctx->dict_huf->tree, &ctx->dict_huf->dec,
+                                       ctx->pivco_scratch);
 }
 
 static ZXC_NOINLINE ZXC_COLD int zxc_decode_tok_pivco(const zxc_cctx_t* RESTRICT ctx,

--- a/src/lib/zxc_dispatch.c
+++ b/src/lib/zxc_dispatch.c
@@ -666,7 +666,7 @@ int64_t zxc_compress(const void* RESTRICT src, const size_t src_size, void* REST
 
     const int checksum_enabled = opts ? opts->checksum_enabled : 0;
     const int seekable = opts ? opts->seekable : 0;
-    const int level = (opts && opts->level > 0) ? opts->level : ZXC_LEVEL_DEFAULT;
+    const int level = zxc_level_clamp((opts && opts->level > 0) ? opts->level : ZXC_LEVEL_DEFAULT);
     const size_t block_size =
         (opts && opts->block_size > 0) ? opts->block_size : ZXC_BLOCK_SIZE_DEFAULT;
     const uint8_t* dict = opts ? (const uint8_t*)opts->dict : NULL;
@@ -675,7 +675,6 @@ int64_t zxc_compress(const void* RESTRICT src, const size_t src_size, void* REST
 
     if (UNLIKELY(dict_size > ZXC_DICT_SIZE_MAX)) return ZXC_ERROR_DICT_TOO_LARGE;
     if (UNLIKELY(!zxc_validate_block_size(block_size))) return ZXC_ERROR_BAD_BLOCK_SIZE;
-    if (UNLIKELY(level > ZXC_LEVEL_ULTRA)) return ZXC_ERROR_BAD_LEVEL;
 
     const uint32_t did = (dict && dict_size > 0) ? zxc_dict_id(dict, dict_size, dict_huf) : 0;
 
@@ -1226,15 +1225,11 @@ zxc_cctx* zxc_create_cctx(const zxc_compress_opts_t* opts) {
     if (UNLIKELY(!cctx)) return NULL;  // LCOV_EXCL_LINE
 
     /* Resolve and store sticky defaults. */
-    cctx->stored_level = (opts && opts->level > 0) ? opts->level : ZXC_LEVEL_DEFAULT;
+    cctx->stored_level =
+        zxc_level_clamp((opts && opts->level > 0) ? opts->level : ZXC_LEVEL_DEFAULT);
     cctx->stored_block_size =
         (opts && opts->block_size > 0) ? opts->block_size : ZXC_BLOCK_SIZE_DEFAULT;
     cctx->stored_checksum = opts ? opts->checksum_enabled : 0;
-
-    if (UNLIKELY(cctx->stored_level > ZXC_LEVEL_ULTRA)) {
-        ZXC_FREE(cctx);
-        return NULL;
-    }
 
     if (opts) {
         // LCOV_EXCL_START
@@ -1294,12 +1289,11 @@ int64_t zxc_compress_cctx(zxc_cctx* cctx, const void* RESTRICT src, const size_t
     if (UNLIKELY(!src || !dst || src_size == 0 || dst_capacity == 0)) return ZXC_ERROR_NULL_INPUT;
 
     const int checksum_enabled = opts ? opts->checksum_enabled : cctx->stored_checksum;
-    const int level = (opts && opts->level > 0) ? opts->level : cctx->stored_level;
+    const int level = zxc_level_clamp((opts && opts->level > 0) ? opts->level : cctx->stored_level);
     const size_t block_size =
         (opts && opts->block_size > 0) ? opts->block_size : cctx->stored_block_size;
 
     if (UNLIKELY(!zxc_validate_block_size(block_size))) return ZXC_ERROR_BAD_BLOCK_SIZE;
-    if (UNLIKELY(level > ZXC_LEVEL_ULTRA)) return ZXC_ERROR_BAD_LEVEL;
 
     /* Static cctx: block_size is locked at workspace init.  Reject any opts
      * that would force a re-partition, since the workspace cannot grow.
@@ -1601,7 +1595,7 @@ int64_t zxc_compress_block(zxc_cctx* cctx, const void* RESTRICT src, const size_
     if (UNLIKELY(src_size > ZXC_BLOCK_SIZE_MAX)) return ZXC_ERROR_BAD_BLOCK_SIZE;
 
     const int checksum_enabled = opts ? opts->checksum_enabled : cctx->stored_checksum;
-    const int level = (opts && opts->level > 0) ? opts->level : cctx->stored_level;
+    const int level = zxc_level_clamp((opts && opts->level > 0) ? opts->level : cctx->stored_level);
     /* For block API, block_size == src_size (the caller compresses one block at a time). */
     const size_t block_size =
         (opts && opts->block_size > 0) ? opts->block_size : cctx->stored_block_size;
@@ -1614,8 +1608,6 @@ int64_t zxc_compress_block(zxc_cctx* cctx, const void* RESTRICT src, const size_
     const size_t base_block_size = (block_size > min_bs) ? block_size : min_bs;
     const size_t effective_block_size =
         b_dict_size > 0 ? zxc_block_size_ceil(b_dict_size + base_block_size) : base_block_size;
-
-    if (UNLIKELY(level > ZXC_LEVEL_ULTRA)) return ZXC_ERROR_BAD_LEVEL;
 
     /* Static cctx: the workspace cannot grow, so reject any request that
      * would force a re-partition - a different effective block size, or a
@@ -1896,7 +1888,7 @@ zxc_cctx* zxc_init_static_cctx(void* RESTRICT workspace, const size_t workspace_
 
     uint8_t* const inner_ws = (uint8_t*)workspace + ZXC_STATIC_CCTX_HDR_SIZE;
     if (UNLIKELY(zxc_cctx_init_in_workspace(&cctx->inner, inner_ws, inner_sz, block_size, 1, level,
-                                            checksum_enabled, 0) != ZXC_OK))
+                                            checksum_enabled, 0, 0) != ZXC_OK))
         return NULL;
 
     cctx->owns_workspace = 1;
@@ -1955,7 +1947,7 @@ zxc_dctx* zxc_init_static_dctx(void* RESTRICT workspace, const size_t workspace_
     /* mode == 0 init: checksum_enabled is updated per-call from the file
      * header flags, so it does not need to be locked at workspace init. */
     if (UNLIKELY(zxc_cctx_init_in_workspace(&dctx->inner, inner_ws, inner_sz, block_size, 0, 0, 0,
-                                            0) != ZXC_OK))
+                                            0, 0) != ZXC_OK))
         return NULL;
 
     dctx->owns_workspace = 1;

--- a/src/lib/zxc_dispatch.c
+++ b/src/lib/zxc_dispatch.c
@@ -127,10 +127,12 @@ int zxc_huf_encode_section_dict_default(const uint8_t* RESTRICT literals, size_t
 int zxc_huf_decode_section_dict_default(const uint8_t* RESTRICT payload, size_t payload_size,
                                         uint8_t* RESTRICT dst, size_t n,
                                         const zxc_pivco_tree_t* RESTRICT tree,
+                                        const zxc_pivco_decode_aux_t* RESTRICT aux,
                                         uint8_t* RESTRICT scratch);
 int zxc_huf_dict_tree_build_default(const uint8_t* RESTRICT packed_lengths,
                                     zxc_pivco_tree_t* RESTRICT tree, uint32_t* RESTRICT codes,
-                                    uint8_t* RESTRICT code_len);
+                                    uint8_t* RESTRICT code_len,
+                                    zxc_pivco_decode_aux_t* RESTRICT aux);
 size_t zxc_huf_calc_size_dict_default(const uint32_t* RESTRICT freq,
                                       const uint8_t* RESTRICT code_len,
                                       const zxc_pivco_tree_t* RESTRICT tree);
@@ -591,13 +593,16 @@ int zxc_huf_encode_section_dict(const uint8_t* RESTRICT literals, const size_t n
 
 int zxc_huf_decode_section_dict(const uint8_t* RESTRICT payload, const size_t payload_size,
                                 uint8_t* RESTRICT dst, const size_t n,
-                                const zxc_pivco_tree_t* RESTRICT tree, uint8_t* RESTRICT scratch) {
-    return zxc_huf_decode_section_dict_default(payload, payload_size, dst, n, tree, scratch);
+                                const zxc_pivco_tree_t* RESTRICT tree,
+                                const zxc_pivco_decode_aux_t* RESTRICT aux,
+                                uint8_t* RESTRICT scratch) {
+    return zxc_huf_decode_section_dict_default(payload, payload_size, dst, n, tree, aux, scratch);
 }
 
 int zxc_huf_dict_tree_build(const uint8_t* RESTRICT packed_lengths, zxc_pivco_tree_t* RESTRICT tree,
-                            uint32_t* RESTRICT codes, uint8_t* RESTRICT code_len) {
-    return zxc_huf_dict_tree_build_default(packed_lengths, tree, codes, code_len);
+                            uint32_t* RESTRICT codes, uint8_t* RESTRICT code_len,
+                            zxc_pivco_decode_aux_t* RESTRICT aux) {
+    return zxc_huf_dict_tree_build_default(packed_lengths, tree, codes, code_len, aux);
 }
 
 size_t zxc_huf_calc_size_dict(const uint32_t* RESTRICT freq, const uint8_t* RESTRICT code_len,
@@ -670,6 +675,7 @@ int64_t zxc_compress(const void* RESTRICT src, const size_t src_size, void* REST
 
     if (UNLIKELY(dict_size > ZXC_DICT_SIZE_MAX)) return ZXC_ERROR_DICT_TOO_LARGE;
     if (UNLIKELY(!zxc_validate_block_size(block_size))) return ZXC_ERROR_BAD_BLOCK_SIZE;
+    if (UNLIKELY(level > ZXC_LEVEL_ULTRA)) return ZXC_ERROR_BAD_LEVEL;
 
     const uint32_t did = (dict && dict_size > 0) ? zxc_dict_id(dict, dict_size, dict_huf) : 0;
 
@@ -1027,6 +1033,30 @@ static uint64_t zxc_inplace_margin(const uint64_t d, const size_t chunk_size, co
 }
 
 /**
+ * @brief Shared archive probe for the in-place entry points: validates the
+ *        magic + file header, then reads the footer's decompressed size and
+ *        derives the in-place margin.
+ *
+ * Keeping this parse in one place guarantees @ref zxc_decompress_inplace_bound
+ * and @ref zxc_decompress_inplace always agree on what a buffer of at least
+ * the bound must satisfy.
+ *
+ * @return ZXC_OK, or a negative @ref zxc_error_t on an invalid archive.
+ */
+static int zxc_inplace_probe(const uint8_t* comp, const size_t comp_size, uint64_t* d,
+                             uint64_t* margin) {
+    if (UNLIKELY(zxc_le32(comp) != ZXC_MAGIC_WORD)) return ZXC_ERROR_BAD_MAGIC;
+    size_t chunk_size = 0;
+    int has_cs = 0;
+    uint32_t did = 0;
+    if (UNLIKELY(zxc_read_file_header(comp, comp_size, &chunk_size, &has_cs, &did) != ZXC_OK))
+        return ZXC_ERROR_BAD_HEADER;
+    *d = zxc_le64(comp + comp_size - ZXC_FILE_FOOTER_SIZE);
+    *margin = zxc_inplace_margin(*d, chunk_size, has_cs);
+    return ZXC_OK;
+}
+
+/**
  * @brief Minimum single-buffer size for a safe in-place decode of @p src.
  *
  * Reads the archive header (block size) and footer (decompressed size) without
@@ -1043,15 +1073,8 @@ static uint64_t zxc_inplace_margin(const uint64_t d, const size_t chunk_size, co
 // cppcheck-suppress unusedFunction
 size_t zxc_decompress_inplace_bound(const void* src, const size_t src_size) {
     if (UNLIKELY(!src || src_size < ZXC_FILE_HEADER_SIZE + ZXC_FILE_FOOTER_SIZE)) return 0;
-    if (UNLIKELY(zxc_le32(src) != ZXC_MAGIC_WORD)) return 0;
-    size_t chunk_size = 0;
-    int has_cs = 0;
-    uint32_t did = 0;
-    if (UNLIKELY(zxc_read_file_header((const uint8_t*)src, src_size, &chunk_size, &has_cs, &did) !=
-                 ZXC_OK))
-        return 0;
-    const uint64_t d = zxc_le64((const uint8_t*)src + src_size - ZXC_FILE_FOOTER_SIZE);
-    const uint64_t margin = zxc_inplace_margin(d, chunk_size, has_cs);
+    uint64_t d = 0, margin = 0;
+    if (UNLIKELY(zxc_inplace_probe((const uint8_t*)src, src_size, &d, &margin) != ZXC_OK)) return 0;
     if (UNLIKELY(margin > (uint64_t)SIZE_MAX || d > (uint64_t)SIZE_MAX - margin)) return 0;
     return (size_t)(d + margin);
 }
@@ -1084,14 +1107,9 @@ int64_t zxc_decompress_inplace(void* buffer, const size_t buffer_capacity, const
         return ZXC_ERROR_NULL_INPUT;
     uint8_t* const buf = (uint8_t*)buffer;
     const uint8_t* const comp = buf + (buffer_capacity - comp_size); /* flush-right */
-    if (UNLIKELY(zxc_le32(comp) != ZXC_MAGIC_WORD)) return ZXC_ERROR_BAD_HEADER;
-    size_t chunk_size = 0;
-    int has_cs = 0;
-    uint32_t did = 0;
-    if (UNLIKELY(zxc_read_file_header(comp, comp_size, &chunk_size, &has_cs, &did) != ZXC_OK))
+    uint64_t d = 0, margin = 0;
+    if (UNLIKELY(zxc_inplace_probe(comp, comp_size, &d, &margin) != ZXC_OK))
         return ZXC_ERROR_BAD_HEADER;
-    const uint64_t d = zxc_le64(comp + comp_size - ZXC_FILE_FOOTER_SIZE);
-    const uint64_t margin = zxc_inplace_margin(d, chunk_size, has_cs);
     if (UNLIKELY(d > (uint64_t)buffer_capacity || (uint64_t)buffer_capacity - d < margin))
         return ZXC_ERROR_DST_TOO_SMALL;
     return zxc_decompress_frame(comp, comp_size, buf, buffer_capacity, opts);
@@ -1101,10 +1119,16 @@ int64_t zxc_decompress_inplace(void* buffer, const size_t buffer_capacity, const
  * @brief Reads the decompressed size from a ZXC-compressed buffer.
  *
  * The size is stored in the file footer (last @ref ZXC_FILE_FOOTER_SIZE bytes).
+ * The footer is untrusted input, so the value is checked for plausibility
+ * against the archive itself: every decoded block costs at least
+ * @ref ZXC_BLOCK_HEADER_SIZE compressed bytes and expands to at most one
+ * block size, which bounds the ratio an authentic archive can reach. A size
+ * beyond that bound (a forged footer) returns 0, so callers sizing an output
+ * allocation from this value inherit the check.
  *
  * @param[in] src      Compressed data.
  * @param[in] src_size Size of @p src in bytes.
- * @return Original uncompressed size, or 0 on error.
+ * @return Original uncompressed size, or 0 on error or an implausible footer.
  */
 uint64_t zxc_get_decompressed_size(const void* src, const size_t src_size) {
     if (UNLIKELY(src_size < ZXC_FILE_HEADER_SIZE + ZXC_FILE_FOOTER_SIZE)) return 0;
@@ -1112,8 +1136,24 @@ uint64_t zxc_get_decompressed_size(const void* src, const size_t src_size) {
     const uint8_t* const p = (const uint8_t*)src;
     if (UNLIKELY(zxc_le32(p) != ZXC_MAGIC_WORD)) return 0;
 
+    size_t chunk_size = 0;
+    int has_cs = 0;
+    uint32_t did = 0;
+    if (UNLIKELY(zxc_read_file_header(p, src_size, &chunk_size, &has_cs, &did) != ZXC_OK)) return 0;
+
     const uint8_t* const footer = p + src_size - ZXC_FILE_FOOTER_SIZE;
-    return zxc_le64(footer);
+    const uint64_t d = zxc_le64(footer);
+
+    /* Plausibility: an archive of src_size bytes cannot carry more blocks
+     * than src_size / ZXC_BLOCK_HEADER_SIZE, and each block decodes to at
+     * most chunk_size bytes. Division form keeps the compare overflow-free
+     * (the usual `(d + chunk - 1) / chunk` ceil would wrap for a forged d
+     * near UINT64_MAX). */
+    const uint64_t blocks_needed =
+        chunk_size ? d / (uint64_t)chunk_size + (d % (uint64_t)chunk_size != 0) : 0;
+    if (UNLIKELY(blocks_needed > (uint64_t)(src_size / ZXC_BLOCK_HEADER_SIZE))) return 0;
+
+    return d;
 }
 
 /**
@@ -1191,6 +1231,11 @@ zxc_cctx* zxc_create_cctx(const zxc_compress_opts_t* opts) {
         (opts && opts->block_size > 0) ? opts->block_size : ZXC_BLOCK_SIZE_DEFAULT;
     cctx->stored_checksum = opts ? opts->checksum_enabled : 0;
 
+    if (UNLIKELY(cctx->stored_level > ZXC_LEVEL_ULTRA)) {
+        ZXC_FREE(cctx);
+        return NULL;
+    }
+
     if (opts) {
         // LCOV_EXCL_START
         if (UNLIKELY(!zxc_validate_block_size(cctx->stored_block_size) ||
@@ -1254,19 +1299,28 @@ int64_t zxc_compress_cctx(zxc_cctx* cctx, const void* RESTRICT src, const size_t
         (opts && opts->block_size > 0) ? opts->block_size : cctx->stored_block_size;
 
     if (UNLIKELY(!zxc_validate_block_size(block_size))) return ZXC_ERROR_BAD_BLOCK_SIZE;
+    if (UNLIKELY(level > ZXC_LEVEL_ULTRA)) return ZXC_ERROR_BAD_LEVEL;
 
     /* Static cctx: block_size is locked at workspace init.  Reject any opts
      * that would force a re-partition, since the workspace cannot grow.
-     * level / checksum_enabled may still vary per call. */
+     * level / checksum_enabled may still vary per call - except a raise into
+     * the optimal-parser tier, whose opt_scratch region a workspace carved at
+     * level < ZXC_LEVEL_DENSITY does not carry. */
     if (UNLIKELY(cctx->owns_workspace && block_size != cctx->last_block_size))
         return ZXC_ERROR_BAD_BLOCK_SIZE;
+    if (UNLIKELY(cctx->owns_workspace && level >= ZXC_LEVEL_DENSITY && !cctx->inner.opt_scratch))
+        return ZXC_ERROR_BAD_LEVEL;
 
     cctx->stored_level = level;
     cctx->stored_block_size = block_size;
     cctx->stored_checksum = checksum_enabled;
 
-    /* Re-init only when block_size changed (it drives buffer sizes). */
-    if (UNLIKELY(!cctx->initialized || cctx->last_block_size != block_size)) {
+    /* Re-init when block_size changed (it drives buffer sizes), or when a
+     * per-call level raise into the optimal-parser tier requires the
+     * opt_scratch region that inits at level < ZXC_LEVEL_DENSITY do not
+     * allocate (using it NULL would crash). */
+    if (UNLIKELY(!cctx->initialized || cctx->last_block_size != block_size ||
+                 (level >= ZXC_LEVEL_DENSITY && !cctx->inner.opt_scratch))) {
         if (cctx->initialized) {
             // LCOV_EXCL_START
             zxc_cctx_free(&cctx->inner);
@@ -1522,8 +1576,10 @@ int64_t zxc_decompress_dctx(zxc_dctx* dctx, const void* RESTRICT src, const size
  * block with no header / EOF / footer, so @p src_size must not exceed
  * @c ZXC_BLOCK_SIZE_MAX (use the frame or streaming APIs for larger inputs).
  * With a dictionary in @p opts, [dict | block] is assembled in the cctx-owned
- * bounce buffer before encoding. Inner buffers are re-initialised only when the
- * effective block size changes.
+ * bounce buffer before encoding. Inner buffers are re-initialised when the
+ * effective block size changes, or when a per-call level raise into the
+ * optimal-parser tier requires the opt_scratch region; static contexts
+ * reject both cases instead (the workspace cannot grow).
  *
  * @param[in,out] cctx          Reusable compression context.
  * @param[in]     src           Source block bytes.
@@ -1558,6 +1614,19 @@ int64_t zxc_compress_block(zxc_cctx* cctx, const void* RESTRICT src, const size_
     const size_t base_block_size = (block_size > min_bs) ? block_size : min_bs;
     const size_t effective_block_size =
         b_dict_size > 0 ? zxc_block_size_ceil(b_dict_size + base_block_size) : base_block_size;
+
+    if (UNLIKELY(level > ZXC_LEVEL_ULTRA)) return ZXC_ERROR_BAD_LEVEL;
+
+    /* Static cctx: the workspace cannot grow, so reject any request that
+     * would force a re-partition - a different effective block size, or a
+     * per-call level raise into the optimal-parser tier whose opt_scratch
+     * region the workspace does not carry. A heap re-init here would violate
+     * the static API's no-allocation contract, and the replacement workspace
+     * could never be freed (zxc_free_cctx is a no-op for static contexts). */
+    if (UNLIKELY(cctx->owns_workspace && effective_block_size != cctx->last_block_size))
+        return ZXC_ERROR_BAD_BLOCK_SIZE;
+    if (UNLIKELY(cctx->owns_workspace && level >= ZXC_LEVEL_DENSITY && !cctx->inner.opt_scratch))
+        return ZXC_ERROR_BAD_LEVEL;
 
     cctx->stored_level = level;
     cctx->stored_block_size = effective_block_size;

--- a/src/lib/zxc_dispatch.c
+++ b/src/lib/zxc_dispatch.c
@@ -1072,7 +1072,8 @@ static int zxc_inplace_probe(const uint8_t* comp, const size_t comp_size, uint64
 // cppcheck-suppress unusedFunction
 size_t zxc_decompress_inplace_bound(const void* src, const size_t src_size) {
     if (UNLIKELY(!src || src_size < ZXC_FILE_HEADER_SIZE + ZXC_FILE_FOOTER_SIZE)) return 0;
-    uint64_t d = 0, margin = 0;
+    uint64_t d = 0;
+    uint64_t margin = 0;
     if (UNLIKELY(zxc_inplace_probe((const uint8_t*)src, src_size, &d, &margin) != ZXC_OK)) return 0;
     if (UNLIKELY(margin > (uint64_t)SIZE_MAX || d > (uint64_t)SIZE_MAX - margin)) return 0;
     return (size_t)(d + margin);
@@ -1106,7 +1107,8 @@ int64_t zxc_decompress_inplace(void* buffer, const size_t buffer_capacity, const
         return ZXC_ERROR_NULL_INPUT;
     uint8_t* const buf = (uint8_t*)buffer;
     const uint8_t* const comp = buf + (buffer_capacity - comp_size); /* flush-right */
-    uint64_t d = 0, margin = 0;
+    uint64_t d = 0;
+    uint64_t margin = 0;
     if (UNLIKELY(zxc_inplace_probe(comp, comp_size, &d, &margin) != ZXC_OK))
         return ZXC_ERROR_BAD_HEADER;
     if (UNLIKELY(d > (uint64_t)buffer_capacity || (uint64_t)buffer_capacity - d < margin))

--- a/src/lib/zxc_huffman.c
+++ b/src/lib/zxc_huffman.c
@@ -672,7 +672,10 @@ static int zxc_pivco_encode_core(const uint8_t* RESTRICT literals, const size_t 
 
     /* Per-node bit cursors; emit MSB-first code bits while descending. At a
      * flat root, emit the symbol's packed D-bit residual (bit j = branch at
-     * subtree level j) in one shot and stop descending. */
+     * subtree level j) in one shot and stop descending.
+     * Batching the per-bit RMW (read-modify-write) brings nothing:
+     * per-node accumulators would still touch memory once per bit, and flat
+     * roots already absorb the dense levels in one shot. */
     uint32_t wpos[ZXC_PIVCO_MAX_NODES];
     ZXC_MEMSET(wpos, 0, (size_t)t->n_nodes * sizeof(uint32_t));
     for (size_t i = 0; i < n_literals; i++) {

--- a/src/lib/zxc_huffman.c
+++ b/src/lib/zxc_huffman.c
@@ -435,6 +435,12 @@ static int zxc_pivco_tree_build(const uint8_t* RESTRICT code_len, zxc_pivco_tree
         for (int l = 1; l <= ZXC_HUF_MAX_CODE_LEN_ULTRA; l++)
             kraft += bl_count[l] << (ZXC_HUF_MAX_CODE_LEN_ULTRA - l);
         if (UNLIKELY(kraft != (1U << ZXC_HUF_MAX_CODE_LEN_ULTRA))) return -1;
+    } else {
+        /* Degenerate single-symbol table: the format requires the lone symbol
+         * to have code length exactly 1 (FORMAT.md, decoder validation
+         * requirements); the encoder never emits anything else. Reject longer
+         * unary chains. */
+        if (UNLIKELY(bl_count[1] != 1)) return -1;
     }
 
     uint32_t next_code[ZXC_HUF_MAX_CODE_LEN_ULTRA + 2] = {0};
@@ -592,32 +598,24 @@ static ZXC_ALWAYS_INLINE size_t zxc_pivco_run_bytes(const uint32_t count, const 
 
 size_t zxc_huf_calc_size(const uint32_t* RESTRICT freq, const uint8_t* RESTRICT code_len,
                          const int with_header) {
+    zxc_pivco_tree_t t;
+    if (UNLIKELY(zxc_pivco_tree_build(code_len, &t, NULL) != 0)) return SIZE_MAX;
+    const size_t body = zxc_huf_calc_size_dict(freq, code_len, &t);
+    if (UNLIKELY(body == SIZE_MAX)) return SIZE_MAX;
+    return body + (with_header ? (size_t)ZXC_HUF_TABLE_SIZE : 0);
+}
+
+/**
+ * @brief Sizing core shared with zxc_huf_calc_size: exact payload size of one
+ *        PivCo section for a prebuilt tree (tree-at-attach dict sections call
+ *        it directly; they carry no inline lengths header).
+ */
+size_t zxc_huf_calc_size_dict(const uint32_t* RESTRICT freq, const uint8_t* RESTRICT code_len,
+                              const zxc_pivco_tree_t* RESTRICT tree) {
     /* Encodability is part of the estimate: a histogram symbol without a
      * code (dict table not covering this block) has no leaf, so the counts
      * below would silently ignore it and undercount. Such a candidate cannot
      * be emitted -- report it as unencodable instead. */
-    for (int k = 0; k < ZXC_HUF_NUM_SYMBOLS; k++)
-        if (UNLIKELY(freq[k] != 0 && code_len[k] == 0)) return SIZE_MAX;
-    zxc_pivco_tree_t t;
-    if (UNLIKELY(zxc_pivco_tree_build(code_len, &t, NULL) != 0)) return SIZE_MAX;
-    uint32_t count[ZXC_PIVCO_MAX_NODES];
-    zxc_pivco_counts(&t, freq, count);
-    size_t total = with_header ? (size_t)ZXC_HUF_TABLE_SIZE : 0;
-    for (int i = 0; i < t.n_nodes; i++) {
-        const int nid = t.bfs[i];
-        if (t.covered[nid] || t.nd[nid].sym >= 0) continue;
-        total += zxc_pivco_run_bytes(count[nid], t.flat_d[nid]);
-    }
-    return total;
-}
-
-/**
- * @brief zxc_huf_calc_size for a dict section: same exact-size rule, but the
- *        tree comes prebuilt from the context (tree-at-attach) and the section
- *        has no inline lengths header.
- */
-size_t zxc_huf_calc_size_dict(const uint32_t* RESTRICT freq, const uint8_t* RESTRICT code_len,
-                              const zxc_pivco_tree_t* RESTRICT tree) {
     for (int k = 0; k < ZXC_HUF_NUM_SYMBOLS; k++)
         if (UNLIKELY(freq[k] != 0 && code_len[k] == 0)) return SIZE_MAX;
     uint32_t count[ZXC_PIVCO_MAX_NODES];
@@ -752,18 +750,80 @@ int zxc_huf_encode_section_dict(const uint8_t* RESTRICT literals, const size_t n
 }
 
 /**
+ * @brief Precompute the topology-derived decoder tables for @p t.
+ *
+ * Mirrors exactly what zxc_pivco_decode_core builds inline for per-section
+ * trees: the leaf-pair skip flags, and each flat root's packed-code -> symbol
+ * table (bit j of the code = branch taken at subtree level j). Both depend
+ * only on the tree, so a frame-constant (dictionary) tree computes them once
+ * here instead of once per decoded section.
+ */
+static void zxc_pivco_decode_aux_build(const zxc_pivco_tree_t* RESTRICT t,
+                                       zxc_pivco_decode_aux_t* RESTRICT aux) {
+    ZXC_MEMSET(aux->skip, 0, sizeof(aux->skip));
+    for (int i = 0; i < t->n_nodes; i++) {
+        const zxc_pivco_node_t* nd = &t->nd[t->bfs[i]];
+        if (nd->sym >= 0) continue;
+        const int ch0 = nd->child[0];
+        const int ch1 = nd->child[1];
+        if (ch0 >= 0 && ch1 >= 0 && t->nd[ch0].sym >= 0 && t->nd[ch1].sym >= 0) {
+            aux->skip[ch0] = 1;
+            aux->skip[ch1] = 1;
+        }
+    }
+
+    /* Flat subtrees have disjoint leaves, so the concatenated tables fit in
+     * ZXC_HUF_NUM_SYMBOLS pool entries (see zxc_pivco_decode_aux_t). */
+    uint32_t pool_off = 0;
+    for (int i = 0; i < t->n_nodes; i++) {
+        const int nid = t->bfs[i];
+        if (t->covered[nid] || !t->flat_d[nid]) continue;
+        aux->c2s_off[nid] = (uint16_t)pool_off;
+        uint8_t* const c2s = aux->c2s_pool + pool_off;
+        pool_off += 1U << t->flat_d[nid];
+        int16_t stk_n[ZXC_HUF_MAX_CODE_LEN_ULTRA + 1];
+        uint16_t stk_p[ZXC_HUF_MAX_CODE_LEN_ULTRA + 1];
+        uint8_t stk_l[ZXC_HUF_MAX_CODE_LEN_ULTRA + 1];
+        int sp = 0;
+        stk_n[0] = (int16_t)nid;
+        stk_p[0] = 0;
+        stk_l[0] = 0;
+        while (sp >= 0) {
+            const int cn = stk_n[sp];
+            const uint32_t cp = stk_p[sp];
+            const int cl = stk_l[sp];
+            sp--;
+            if (t->nd[cn].sym >= 0) {
+                c2s[cp] = (uint8_t)t->nd[cn].sym;
+                continue;
+            }
+            sp++;
+            stk_n[sp] = t->nd[cn].child[0];
+            stk_p[sp] = (uint16_t)cp;
+            stk_l[sp] = (uint8_t)(cl + 1);
+            sp++;
+            stk_n[sp] = t->nd[cn].child[1];
+            stk_p[sp] = (uint16_t)(cp | (1U << cl));
+            stk_l[sp] = (uint8_t)(cl + 1);
+        }
+    }
+}
+
+/**
  * @brief Prebuild a dict table's decode/encode state (tree-at-attach).
  *
- * Unpacks the 128-byte packed lengths and builds the PivCo tree and canonical
- * codes once; the outputs are frame-constant, so per-block encode, estimate and
- * decode reuse them instead of rebuilding (the pre-v7 cached-decode-table form,
- * restored for the PivCo layout).
+ * Unpacks the 128-byte packed lengths and builds the PivCo tree, canonical
+ * codes and decoder tables once; the outputs are frame-constant, so per-block
+ * encode, estimate and decode reuse them instead of rebuilding (the pre-v7
+ * cached-decode-table form, restored for the PivCo layout).
  */
 int zxc_huf_dict_tree_build(const uint8_t* RESTRICT packed_lengths, zxc_pivco_tree_t* RESTRICT tree,
-                            uint32_t* RESTRICT codes, uint8_t* RESTRICT code_len) {
+                            uint32_t* RESTRICT codes, uint8_t* RESTRICT code_len,
+                            zxc_pivco_decode_aux_t* RESTRICT aux) {
     const int rc = zxc_huf_unpack_lengths(packed_lengths, code_len);
     if (UNLIKELY(rc != ZXC_OK)) return rc;
     if (UNLIKELY(zxc_pivco_tree_build(code_len, tree, codes) != 0)) return ZXC_ERROR_CORRUPT_DATA;
+    zxc_pivco_decode_aux_build(tree, aux);
     return ZXC_OK;
 }
 
@@ -1390,10 +1450,16 @@ static ZXC_ALWAYS_INLINE void zxc_pivco_emit_leaf_pair(uint8_t* RESTRICT out, co
  * symbol counts. Pass 2 rebuilds sequences bottom-up, one level at a time,
  * ping-ponging between dst (even depths, depth 0 = final output) and scratch
  * (odd depths); a level's writes never alias its reads.
+ *
+ * @p aux carries the topology-derived tables (leaf-pair skip flags, flat-root
+ * c2s) precomputed at attach for a frame-constant dictionary tree; NULL for
+ * per-section trees, which rebuild them inline below.
  */
 static int zxc_pivco_decode_core(const uint8_t* RESTRICT payload, const size_t payload_size,
                                  uint8_t* RESTRICT dst, const size_t n,
-                                 const zxc_pivco_tree_t* RESTRICT t, uint8_t* RESTRICT scratch) {
+                                 const zxc_pivco_tree_t* RESTRICT t,
+                                 const zxc_pivco_decode_aux_t* RESTRICT aux,
+                                 uint8_t* RESTRICT scratch) {
     if (UNLIKELY(n == 0)) return ZXC_ERROR_CORRUPT_DATA;
 
     /* Pass 1: node counts + bit-run pointers, straight from the wire order. */
@@ -1463,18 +1529,25 @@ static int zxc_pivco_decode_core(const uint8_t* RESTRICT payload, const size_t p
     }
 
     /* Leaf-pair parents emit both runs directly from their bits (XOR-blend),
-     * so their children never need materialising: flag them for skipping. */
-    uint8_t skip[ZXC_PIVCO_MAX_NODES];
-    ZXC_MEMSET(skip, 0, sizeof(skip));
-    for (int i = 0; i < t->n_nodes; i++) {
-        const zxc_pivco_node_t* nd = &t->nd[t->bfs[i]];
-        if (nd->sym >= 0) continue;
-        const int ch0 = nd->child[0];
-        const int ch1 = nd->child[1];
-        if (ch0 >= 0 && ch1 >= 0 && t->nd[ch0].sym >= 0 && t->nd[ch1].sym >= 0) {
-            skip[ch0] = 1;
-            skip[ch1] = 1;
+     * so their children never need materialising: flag them for skipping.
+     * A dictionary tree carries these flags precomputed in aux. */
+    uint8_t skip_local[ZXC_PIVCO_MAX_NODES];
+    const uint8_t* skip;
+    if (aux) {
+        skip = aux->skip;
+    } else {
+        ZXC_MEMSET(skip_local, 0, sizeof(skip_local));
+        for (int i = 0; i < t->n_nodes; i++) {
+            const zxc_pivco_node_t* nd = &t->nd[t->bfs[i]];
+            if (nd->sym >= 0) continue;
+            const int ch0 = nd->child[0];
+            const int ch1 = nd->child[1];
+            if (ch0 >= 0 && ch1 >= 0 && t->nd[ch0].sym >= 0 && t->nd[ch1].sym >= 0) {
+                skip_local[ch0] = 1;
+                skip_local[ch1] = 1;
+            }
         }
+        skip = skip_local;
     }
 
     /* Pass 2: bottom-up level reconstruction. */
@@ -1490,34 +1563,41 @@ static int zxc_pivco_decode_core(const uint8_t* RESTRICT payload, const size_t p
             if (nd->sym >= 0) {
                 ZXC_MEMSET(buf_d + seq_off[nid], (uint8_t)nd->sym, c);
             } else if (t->flat_d[nid]) {
-                /* Build the packed-path -> symbol table (complete subtree of
-                 * depth D: 2^D leaves), then unpack the code run directly. */
+                /* Packed-path -> symbol table (complete subtree of depth D:
+                 * 2^D leaves): precomputed at attach for a dictionary tree,
+                 * else built here, then unpack the code run directly. */
                 const int D = t->flat_d[nid];
-                uint8_t c2s[1U << ZXC_HUF_MAX_CODE_LEN_ULTRA];
-                int16_t stk_n[ZXC_HUF_MAX_CODE_LEN_ULTRA + 1];
-                uint16_t stk_p[ZXC_HUF_MAX_CODE_LEN_ULTRA + 1];
-                uint8_t stk_l[ZXC_HUF_MAX_CODE_LEN_ULTRA + 1];
-                int sp = 0;
-                stk_n[0] = (int16_t)nid;
-                stk_p[0] = 0;
-                stk_l[0] = 0;
-                while (sp >= 0) {
-                    const int cn = stk_n[sp];
-                    const uint32_t cp = stk_p[sp];
-                    const int cl = stk_l[sp];
-                    sp--;
-                    if (t->nd[cn].sym >= 0) {
-                        c2s[cp] = (uint8_t)t->nd[cn].sym;
-                        continue;
+                uint8_t c2s_local[1U << ZXC_HUF_MAX_CODE_LEN_ULTRA];
+                const uint8_t* c2s;
+                if (aux) {
+                    c2s = aux->c2s_pool + aux->c2s_off[nid];
+                } else {
+                    int16_t stk_n[ZXC_HUF_MAX_CODE_LEN_ULTRA + 1];
+                    uint16_t stk_p[ZXC_HUF_MAX_CODE_LEN_ULTRA + 1];
+                    uint8_t stk_l[ZXC_HUF_MAX_CODE_LEN_ULTRA + 1];
+                    int sp = 0;
+                    stk_n[0] = (int16_t)nid;
+                    stk_p[0] = 0;
+                    stk_l[0] = 0;
+                    while (sp >= 0) {
+                        const int cn = stk_n[sp];
+                        const uint32_t cp = stk_p[sp];
+                        const int cl = stk_l[sp];
+                        sp--;
+                        if (t->nd[cn].sym >= 0) {
+                            c2s_local[cp] = (uint8_t)t->nd[cn].sym;
+                            continue;
+                        }
+                        sp++;
+                        stk_n[sp] = t->nd[cn].child[0];
+                        stk_p[sp] = (uint16_t)cp;
+                        stk_l[sp] = (uint8_t)(cl + 1);
+                        sp++;
+                        stk_n[sp] = t->nd[cn].child[1];
+                        stk_p[sp] = (uint16_t)(cp | (1U << cl));
+                        stk_l[sp] = (uint8_t)(cl + 1);
                     }
-                    sp++;
-                    stk_n[sp] = t->nd[cn].child[0];
-                    stk_p[sp] = (uint16_t)cp;
-                    stk_l[sp] = (uint8_t)(cl + 1);
-                    sp++;
-                    stk_n[sp] = t->nd[cn].child[1];
-                    stk_p[sp] = (uint16_t)(cp | (1U << cl));
-                    stk_l[sp] = (uint8_t)(cl + 1);
+                    c2s = c2s_local;
                 }
                 zxc_pivco_unpack_flat(buf_d + seq_off[nid], c, D, bit_ptr[nid], c2s);
             } else {
@@ -1561,18 +1641,21 @@ int zxc_huf_decode_section(const uint8_t* RESTRICT payload, const size_t payload
     zxc_pivco_tree_t t;
     if (UNLIKELY(zxc_pivco_tree_build(code_len, &t, NULL) != 0)) return ZXC_ERROR_CORRUPT_DATA;
     return zxc_pivco_decode_core(payload + ZXC_HUF_TABLE_SIZE, payload_size - ZXC_HUF_TABLE_SIZE,
-                                 dst, n, &t, scratch);
+                                 dst, n, &t, NULL, scratch);
 }
 
 /**
  * @brief Decode a shared-dictionary literal section (no inline header).
  *
  * Same as @ref zxc_huf_decode_section, but against the dictionary's PivCo
- * @p tree, prebuilt ONCE at attach time by @ref zxc_huf_dict_tree_build
- * (wire value enc_lit = 3) -- no per-block unpack or tree rebuild.
+ * @p tree and decoder tables @p aux, prebuilt ONCE at attach time by
+ * @ref zxc_huf_dict_tree_build (wire value enc_lit = 3) -- no per-block
+ * unpack, tree rebuild, or c2s/skip rebuild.
  */
 int zxc_huf_decode_section_dict(const uint8_t* RESTRICT payload, const size_t payload_size,
                                 uint8_t* RESTRICT dst, const size_t n,
-                                const zxc_pivco_tree_t* RESTRICT tree, uint8_t* RESTRICT scratch) {
-    return zxc_pivco_decode_core(payload, payload_size, dst, n, tree, scratch);
+                                const zxc_pivco_tree_t* RESTRICT tree,
+                                const zxc_pivco_decode_aux_t* RESTRICT aux,
+                                uint8_t* RESTRICT scratch) {
+    return zxc_pivco_decode_core(payload, payload_size, dst, n, tree, aux, scratch);
 }

--- a/src/lib/zxc_internal.h
+++ b/src/lib/zxc_internal.h
@@ -735,6 +735,17 @@ static inline int zxc_ss_prem_huf_q8(const int level) {
 #define ZXC_HUF_MIN_LITERALS 139
 /** @} */
 
+/** @brief Clamps a resolved compression level to the supported ceiling.
+ *
+ *         Out-of-range levels above ::ZXC_LEVEL_ULTRA are silently clamped
+ *         (never rejected) at every compress entry point, so `level = 99`
+ *         behaves as ULTRA across the buffer, context, block and stream APIs
+ *         and every language binding inherits the same policy. Levels <= 0
+ *         select the caller's default before this is applied. */
+static inline int zxc_level_clamp(const int level) {
+    return (level > ZXC_LEVEL_ULTRA) ? ZXC_LEVEL_ULTRA : level;
+}
+
 /** @brief Encoder Huffman code-length cap for a compression @p level: levels below
  *         ::ZXC_LEVEL_ULTRA use ::ZXC_HUF_MAX_CODE_LEN_DENSITY, ::ZXC_LEVEL_ULTRA uses
  *         the full ::ZXC_HUF_MAX_CODE_LEN_ULTRA ceiling (denser codes, slower decode).
@@ -1578,10 +1589,16 @@ typedef struct {
     uint8_t* work_buf;              /**< Padded scratch buffer for buffer-API decompression. */
     size_t work_buf_cap;            /**< Capacity of the work buffer. */
     uint8_t* tok_buffer;            /**< Decode scratch for a Huffman-coded GLO token
-                                         section (enc_litlen == HUFFMAN); NULL on compress. */
+                                         section (enc_litlen == HUFFMAN); NULL on compress.
+                                         Heap decode contexts defer it (with pivco_scratch)
+                                         to the first entropy section, see entropy_block. */
     size_t tok_buffer_cap;          /**< Capacity of tok_buffer in bytes. */
     uint8_t* pivco_scratch;         /**< Level ping-pong scratch for PivCo decode. */
     size_t pivco_scratch_cap;       /**< Capacity of pivco_scratch in bytes. */
+    void* entropy_block;            /**< Lazy allocation backing tok_buffer + pivco_scratch
+                                         (heap decode contexts, first entropy block only).
+                                         NULL on compress contexts and static workspaces.
+                                         Freed by zxc_cctx_free. */
     uint8_t* opt_scratch;           /**< Optimal-parser DP scratch (level >= 6 only,
                                          lazy-allocated, packs dp/parent_len/parent_off/actions).
                                          Also reused as transient scratch for the
@@ -1685,12 +1702,31 @@ size_t zxc_cctx_compute_workspace_size(const size_t chunk_size, const int mode, 
  * @param[in]  dict_size         Dictionary prefill size; when > 0 the workspace
  *                               must include the [dict | data] concat buffer and
  *                               @c ctx->dict_buffer is set into it.
+ * @param[in]  defer_entropy_scratch  Non-zero (heap decode contexts only) to
+ *                               leave the tok/PivCo decode scratch out of the
+ *                               partition; it is then lazily allocated by
+ *                               @ref zxc_cctx_alloc_entropy_scratch on the
+ *                               first entropy section. Static workspaces must
+ *                               pass 0 (no-allocation contract).
  * @return @c ZXC_OK on success, @c ZXC_ERROR_DST_TOO_SMALL if the workspace
  *         is too small, or another negative @ref zxc_error_t.
  */
 int zxc_cctx_init_in_workspace(zxc_cctx_t* RESTRICT ctx, void* RESTRICT workspace,
                                const size_t workspace_size, const size_t chunk_size, const int mode,
-                               const int level, const int checksum_enabled, const size_t dict_size);
+                               const int level, const int checksum_enabled, const size_t dict_size,
+                               const int defer_entropy_scratch);
+
+/**
+ * @brief Lazily allocates the decode-side entropy scratch (tok_buffer +
+ *        pivco_scratch) for a heap context initialised with deferral.
+ *
+ * No-op when the scratch is already present (static workspaces pre-carve it;
+ * subsequent entropy blocks reuse the first allocation). The block is owned
+ * by the context (@c entropy_block) and released by @ref zxc_cctx_free.
+ *
+ * @return @ref ZXC_OK, or @ref ZXC_ERROR_MEMORY on allocation failure.
+ */
+int zxc_cctx_alloc_entropy_scratch(zxc_cctx_t* ctx);
 
 /**
  * @brief Releases the internal buffers owned by a context.

--- a/src/lib/zxc_internal.h
+++ b/src/lib/zxc_internal.h
@@ -622,25 +622,46 @@ typedef struct {
 } zxc_pivco_tree_t;
 
 /**
+ * @brief Precomputed decode-side tables derived from a ::zxc_pivco_tree_t.
+ *
+ * Pure functions of the tree topology (no dependence on section data):
+ * @c skip flags the children of leaf-pair parents (emitted directly by the
+ * parent's XOR-blend, never materialised), and @c c2s_pool holds each flat
+ * root's packed-code -> symbol table at @c c2s_off[nid]. Flat subtrees have
+ * disjoint leaves, so the pool never exceeds ZXC_HUF_NUM_SYMBOLS entries; the
+ * +16 slack covers zxc_pivco_unpack_flat's SIMD table loads, which round a
+ * table up to 16 entries. Per-section trees rebuild these inline in
+ * zxc_pivco_decode_core; dictionary trees build them ONCE at attach so the
+ * small-block dict decode path stops repaying the DFS + fills per block.
+ */
+typedef struct {
+    uint8_t skip[ZXC_PIVCO_MAX_NODES];          /**< 1 = child of a leaf-pair parent. */
+    uint16_t c2s_off[ZXC_PIVCO_MAX_NODES];      /**< Flat roots: offset into c2s_pool. */
+    uint8_t c2s_pool[ZXC_HUF_NUM_SYMBOLS + 16]; /**< Concatenated c2s tables. */
+} zxc_pivco_decode_aux_t;
+
+/**
  * @brief Frame-constant dictionary Huffman state, prebuilt once at attach.
  *
  * Bundles everything the per-block dict paths reuse: the PivCo @c tree (decoder
- * + estimator), and the canonical @c codes / @c code_len (encoder). Carved from
- * the context workspace only when @c dict_size > 0, so no-dict contexts pay
- * nothing for it. Built by @ref zxc_huf_dict_tree_build via
- * @c zxc_cctx_attach_dict_huf.
+ * + estimator), the canonical @c codes / @c code_len (encoder), and the
+ * decode-side @c dec tables. Carved from the context workspace only when
+ * @c dict_size > 0, so no-dict contexts pay nothing for it. Built by
+ * @ref zxc_huf_dict_tree_build via @c zxc_cctx_attach_dict_huf.
  */
 typedef struct {
     zxc_pivco_tree_t tree;                 /**< PivCo tree from the shared literal table. */
     uint32_t codes[ZXC_HUF_NUM_SYMBOLS];   /**< Canonical codes (encoder side). */
     uint8_t code_len[ZXC_HUF_NUM_SYMBOLS]; /**< Unpacked code lengths. */
+    zxc_pivco_decode_aux_t dec;            /**< Precomputed decoder tables. */
 } zxc_dict_huf_state_t;
 /** @brief RLE margin shift: source of the legacy below-ULTRA premium used by
  *         ::zxc_ss_prem_rle_q8 (256 >> shift reproduces the historical
  *         RLE-vs-RAW margin exactly). */
 #define ZXC_RLE_MARGIN_SHIFT 5
 /** @brief Huffman margin shift: source of the legacy below-ULTRA premium used
- *         by ::zxc_ss_prem_huf_q8, and of the ::ZXC_HUF_MIN_LITERALS floor. */
+ *         by ::zxc_ss_prem_huf_q8 (the frozen ::ZXC_HUF_MIN_LITERALS floor was
+ *         also historically derived from it). */
 #define ZXC_HUF_MARGIN_SHIFT 5
 
 /** @name Space-speed section selection
@@ -700,15 +721,18 @@ static inline int zxc_ss_prem_huf_q8(const int level) {
     return (level >= ZXC_LEVEL_DENSITY) ? 4 : (256 >> ZXC_HUF_MARGIN_SHIFT);
 }
 /** @} */
-/** @brief Absolute floor below which Huffman cannot beat RAW even with
- *         zero-entropy literals after the @ref ZXC_HUF_MARGIN_SHIFT margin.
+/** @brief Absolute floor (in literals) below which a Huffman candidate is
+ *         never evaluated.
  *
- *         Derivation: the call site requires `huf_total < baseline * (M-1)/M`
- *         with `M = 1 << ZXC_HUF_MARGIN_SHIFT`. */
-#define ZXC_HUF_MIN_LITERALS                                                                 \
-    (((ZXC_HUF_TABLE_SIZE + 6) /* historical margin floor */ * (1 << ZXC_HUF_MARGIN_SHIFT) + \
-      ((1 << ZXC_HUF_MARGIN_SHIFT) - 2)) /                                                   \
-     ((1 << ZXC_HUF_MARGIN_SHIFT) - 1))
+ *         Frozen byte-stability threshold. The value was originally derived
+ *         from v6 wire geometry (128-byte lengths table + 6-byte sub-stream
+ *         sizes) under the pre-Lagrangian `huf_total < baseline * (M-1)/M`
+ *         call-site rule; neither input exists in v7 (sub-stream sizes are
+ *         derived, selection uses J = size + lambda * tax), but raising or
+ *         lowering the floor changes which blocks pick Huffman and therefore
+ *         the emitted archive bytes, so it stays frozen at the historical
+ *         value rather than being re-derived. */
+#define ZXC_HUF_MIN_LITERALS 139
 /** @} */
 
 /** @brief Encoder Huffman code-length cap for a compression @p level: levels below
@@ -1473,10 +1497,12 @@ int zxc_huf_encode_section(const uint8_t* RESTRICT literals, size_t n_literals,
                            uint8_t* RESTRICT dst, size_t dst_cap);
 
 /** @brief Unpack a dict table's 128-byte packed lengths and prebuild its PivCo
- *  tree, canonical codes and code lengths (tree-at-attach). All three outputs
- *  are frame-constant; per-block encode/estimate/decode then skip the rebuild. */
+ *  tree, canonical codes, code lengths and decoder tables (tree-at-attach).
+ *  All outputs are frame-constant; per-block encode/estimate/decode then skip
+ *  the rebuild. */
 int zxc_huf_dict_tree_build(const uint8_t* RESTRICT packed_lengths, zxc_pivco_tree_t* RESTRICT tree,
-                            uint32_t* RESTRICT codes, uint8_t* RESTRICT code_len);
+                            uint32_t* RESTRICT codes, uint8_t* RESTRICT code_len,
+                            zxc_pivco_decode_aux_t* RESTRICT aux);
 
 /** @brief zxc_huf_calc_size for a dict section: prebuilt @p tree, no header. */
 size_t zxc_huf_calc_size_dict(const uint32_t* RESTRICT freq, const uint8_t* RESTRICT code_len,
@@ -1494,10 +1520,13 @@ int zxc_huf_encode_section_dict(const uint8_t* RESTRICT literals, size_t n_liter
 int zxc_huf_decode_section(const uint8_t* RESTRICT payload, size_t payload_size,
                            uint8_t* RESTRICT dst, size_t n, uint8_t* RESTRICT scratch);
 
-/** @brief Decode a PivCo dict section against a prebuilt dict @p tree. */
+/** @brief Decode a PivCo dict section against a prebuilt dict @p tree and its
+ *  attach-time decoder tables @p aux. */
 int zxc_huf_decode_section_dict(const uint8_t* RESTRICT payload, size_t payload_size,
                                 uint8_t* RESTRICT dst, size_t n,
-                                const zxc_pivco_tree_t* RESTRICT tree, uint8_t* RESTRICT scratch);
+                                const zxc_pivco_tree_t* RESTRICT tree,
+                                const zxc_pivco_decode_aux_t* RESTRICT aux,
+                                uint8_t* RESTRICT scratch);
 
 /* ---------------------------------------------------------------------------
  * Compression / decompression context.
@@ -1604,9 +1633,11 @@ int zxc_cctx_init(zxc_cctx_t* ctx, const size_t chunk_size, const int mode, cons
 /**
  * @brief Attach the shared dictionary literal table to an initialised context.
  *
- * Validates the 128-byte packed code-lengths header and stores the pointer
- * (caller-owned, must outlive the context's use); the tree is (re)built from
- * these lengths at decode/estimate time, not here. A NULL @p lengths is a no-op.
+ * Validates the 128-byte packed code-lengths header and builds the PivCo tree,
+ * canonical codes and decoder tables ONCE into the context (tree-at-attach);
+ * per-block encode/estimate/decode reuse them. @p lengths need only be valid
+ * during this call (everything is copied into the context workspace). A NULL
+ * @p lengths is a no-op.
  *
  * @return @ref ZXC_OK on success, @ref ZXC_ERROR_CORRUPT_DATA if the lengths
  *         header is structurally invalid (bad nibble, Kraft inequality).

--- a/src/lib/zxc_pstream.c
+++ b/src/lib/zxc_pstream.c
@@ -252,32 +252,41 @@ static int cs_drain_pending(zxc_cstream* cs, zxc_outbuf_t* out) {
  *
  * Copies @p opts into the new context, applying defaults for any zero-valued
  * field (@c level -> @ref ZXC_LEVEL_DEFAULT, @c block_size ->
- * @ref ZXC_BLOCK_SIZE_DEFAULT).  Forces single-threaded operation
- * (@c n_threads = 0), disables progress callbacks, seekable framing and
- * dictionary options (those modes belong to the @c FILE*-based pipeline;
- * the push-stream format carries no dict_id).  Pre-sizes the
+ * @ref ZXC_BLOCK_SIZE_DEFAULT; levels above @ref ZXC_LEVEL_ULTRA are
+ * clamped).  Forces single-threaded operation (@c n_threads = 0) and
+ * disables progress callbacks and seekable framing (those modes belong to
+ * the @c FILE*-based pipeline).  Dictionary options are REJECTED (the
+ * push-stream format carries no dict_id, so a dictionary would produce
+ * undecodable archives): passing any of @c dict / @c dict_size / @c dict_huf
+ * returns @c NULL rather than silently dropping them.  Pre-sizes the
  * @c pending buffer so that the file header / footer paths never need a
  * realloc.
  *
  * @param[in] opts Compression options, or @c NULL for full defaults.
  * @return New stream owned by the caller, or @c NULL on allocation
- *         failure / invalid option values.
+ *         failure / invalid option values (including dictionary options).
  */
 zxc_cstream* zxc_cstream_create(const zxc_compress_opts_t* opts) {
     zxc_cstream* cs = (zxc_cstream*)ZXC_CALLOC(1, sizeof(*cs));
     if (UNLIKELY(!cs)) return NULL;  // LCOV_EXCL_LINE
 
     if (opts) cs->opts = *opts;
+
+    /* The push-stream format carries no dict_id, so a dictionary here would
+     * produce archives that decode wrong (or not at all) elsewhere. */
+    if (UNLIKELY(cs->opts.dict || cs->opts.dict_size || cs->opts.dict_huf)) {
+        ZXC_FREE(cs);
+        return NULL;
+    }
+
     if (cs->opts.level == 0) cs->opts.level = ZXC_LEVEL_DEFAULT;
+    cs->opts.level = zxc_level_clamp(cs->opts.level);
     if (cs->opts.block_size == 0) cs->opts.block_size = ZXC_BLOCK_SIZE_DEFAULT;
     /* n_threads is ignored on this single-threaded path. */
     cs->opts.n_threads = 0;
     cs->opts.progress_cb = NULL;
     cs->opts.user_data = NULL;
     cs->opts.seekable = 0;
-    cs->opts.dict = NULL;
-    cs->opts.dict_size = 0;
-    cs->opts.dict_huf = NULL;
     cs->block_size = cs->opts.block_size;
 
     cs->cctx = zxc_create_cctx(&cs->opts);
@@ -824,6 +833,10 @@ zxc_dstream* zxc_dstream_create(const zxc_decompress_opts_t* opts) {
     zxc_dstream* ds = (zxc_dstream*)ZXC_CALLOC(1, sizeof(*ds));
     if (UNLIKELY(!ds)) return NULL;  // LCOV_EXCL_LINE
     if (opts) ds->opts = *opts;
+    if (UNLIKELY(ds->opts.dict || ds->opts.dict_size || ds->opts.dict_huf)) {
+        ZXC_FREE(ds);
+        return NULL;
+    }
     ds->opts.n_threads = 0;
     ds->opts.progress_cb = NULL;
     ds->opts.user_data = NULL;

--- a/tests/test_buffer_api.c
+++ b/tests/test_buffer_api.c
@@ -153,6 +153,23 @@ int test_get_decompressed_size() {
     }
     printf("  [PASS] Invalid magic word\n");
 
+    // 4. Forged footer: an implausible size (far beyond what the archive's
+    //    block count could decode to) must return 0, not drive a huge
+    //    allocation in callers that size buffers from this value.
+    uint8_t* forged = malloc((size_t)comp_size);
+    memcpy(forged, compressed, (size_t)comp_size);
+    uint8_t* footer_size = forged + comp_size - ZXC_FILE_FOOTER_SIZE;
+    for (int i = 0; i < 8; i++) footer_size[i] = 0xFF; // size = 2^64 - 1
+    if (zxc_get_decompressed_size(forged, (size_t)comp_size) != 0) {
+        printf("Failed: Should return 0 for a forged (implausible) footer size\n");
+        free(forged);
+        free(src);
+        free(compressed);
+        return 0;
+    }
+    free(forged);
+    printf("  [PASS] Forged footer size rejected\n");
+
     printf("PASS\n\n");
     free(src);
     free(compressed);

--- a/tests/test_common.h
+++ b/tests/test_common.h
@@ -80,6 +80,7 @@ int test_decompress_block_bound(void);
 
 /* Context API */
 int test_opaque_context_api(void);
+int test_cctx_level_raise_reinit(void);
 int test_estimate_cctx_size(void);
 
 /* Static Context API */
@@ -87,6 +88,7 @@ int test_static_ctx_roundtrip_all_levels(void);
 int test_static_ctx_size_query(void);
 int test_static_ctx_workspace_too_small(void);
 int test_static_ctx_block_size_locked(void);
+int test_static_ctx_level_raise_rejected(void);
 int test_static_ctx_null_inputs(void);
 
 /* Stream API */
@@ -179,6 +181,7 @@ int test_seekable_mt_full_file(void);
 /* Format (on-disk) */
 int test_huffman_codec(void);
 int test_huffman_codec_dict(void);
+int test_huffman_single_symbol_validation(void);
 int test_eof_block_structure(void);
 int test_header_checksum(void);
 int test_global_checksum_order(void);

--- a/tests/test_context_api.c
+++ b/tests/test_context_api.c
@@ -139,25 +139,36 @@ int test_cctx_level_raise_reinit() {
     }
     printf("  [PASS] level 3 -> 6 raise through the block API\n");
 
-    /* 3. Out-of-range levels are rejected, not silently clamped to ULTRA. */
-    zxc_compress_opts_t bad = {.level = 99, .checksum_enabled = 0};
-    if (zxc_compress(src, src_sz, comp, comp_cap, &bad) != ZXC_ERROR_BAD_LEVEL) {
-        printf("  [FAIL] zxc_compress(level=99) must return ZXC_ERROR_BAD_LEVEL\n");
+    /* 3. Out-of-range levels are silently clamped to ULTRA: level 99 must
+     * produce the exact archive level 7 produces, on every entry point. */
+    zxc_compress_opts_t lvl7 = {.level = ZXC_LEVEL_ULTRA, .checksum_enabled = 0};
+    zxc_compress_opts_t lvl99 = {.level = 99, .checksum_enabled = 0};
+    uint8_t* comp7 = malloc(comp_cap);
+    if (!comp7) goto fail;
+    const int64_t c7 = zxc_compress(src, src_sz, comp7, comp_cap, &lvl7);
+    const int64_t c99 = zxc_compress(src, src_sz, comp, comp_cap, &lvl99);
+    if (c7 <= 0 || c99 != c7 || memcmp(comp, comp7, (size_t)c7) != 0) {
+        printf("  [FAIL] zxc_compress(level=99) must clamp to ULTRA (c7=%lld c99=%lld)\n",
+               (long long)c7, (long long)c99);
+        free(comp7);
         goto fail;
     }
-    if (zxc_compress_cctx(cctx, src, src_sz, comp, comp_cap, &bad) != ZXC_ERROR_BAD_LEVEL) {
-        printf("  [FAIL] zxc_compress_cctx(level=99) must return ZXC_ERROR_BAD_LEVEL\n");
+    free(comp7);
+    if (zxc_compress_cctx(cctx, src, src_sz, comp, comp_cap, &lvl99) != c7) {
+        printf("  [FAIL] zxc_compress_cctx(level=99) must clamp to ULTRA\n");
         goto fail;
     }
-    if (zxc_compress_block(cctx, src, src_sz, comp, comp_cap, &bad) != ZXC_ERROR_BAD_LEVEL) {
-        printf("  [FAIL] zxc_compress_block(level=99) must return ZXC_ERROR_BAD_LEVEL\n");
+    if (zxc_compress_block(cctx, src, src_sz, comp, comp_cap, &lvl99) <= 0) {
+        printf("  [FAIL] zxc_compress_block(level=99) must clamp to ULTRA\n");
         goto fail;
     }
-    if (zxc_create_cctx(&bad) != NULL) {
-        printf("  [FAIL] zxc_create_cctx(level=99) must return NULL\n");
+    zxc_cctx* cctx99 = zxc_create_cctx(&lvl99);
+    if (!cctx99) {
+        printf("  [FAIL] zxc_create_cctx(level=99) must clamp, not fail\n");
         goto fail;
     }
-    printf("  [PASS] level 99 rejected across entry points\n");
+    zxc_free_cctx(cctx99);
+    printf("  [PASS] level 99 silently clamped to ULTRA across entry points\n");
 
     zxc_free_cctx(cctx);
     zxc_free_dctx(dctx);

--- a/tests/test_context_api.c
+++ b/tests/test_context_api.c
@@ -86,6 +86,96 @@ fail:
     return 0;
 }
 
+/* Regression: a cctx created below ZXC_LEVEL_DENSITY has no opt_scratch; a
+ * per-call level raise into the optimal-parser tier must re-init the inner
+ * buffers instead of dereferencing the NULL scratch (crash before the fix).
+ * Also covers the new out-of-range level validation (ZXC_ERROR_BAD_LEVEL). */
+int test_cctx_level_raise_reinit() {
+    printf("=== TEST: Opaque Context API - level raise re-init + level validation ===\n");
+
+    const size_t src_sz = 8192;
+    uint8_t* src = malloc(src_sz);
+    const size_t comp_cap = (size_t)zxc_compress_bound(src_sz);
+    uint8_t* comp = malloc(comp_cap);
+    uint8_t* dec = malloc(src_sz);
+    zxc_cctx* cctx = NULL;
+    zxc_dctx* dctx = NULL;
+    if (!src || !comp || !dec) goto fail;
+    gen_lz_data(src, src_sz);
+
+    /* 1. Eager init at level 3 (no opt_scratch), then raise to 7 in place. */
+    zxc_compress_opts_t create_opts = {.level = 3, .checksum_enabled = 0};
+    cctx = zxc_create_cctx(&create_opts);
+    dctx = zxc_create_dctx();
+    if (!cctx || !dctx) {
+        printf("  [FAIL] create returned NULL\n");
+        goto fail;
+    }
+    zxc_compress_opts_t raise = {.level = ZXC_LEVEL_ULTRA, .checksum_enabled = 0};
+    const int64_t csz = zxc_compress_cctx(cctx, src, src_sz, comp, comp_cap, &raise);
+    if (csz <= 0) {
+        printf("  [FAIL] level-7 raise on level-3 cctx returned %lld\n", (long long)csz);
+        goto fail;
+    }
+    const int64_t dsz = zxc_decompress_dctx(dctx, comp, (size_t)csz, dec, src_sz, NULL);
+    if (dsz != (int64_t)src_sz || memcmp(src, dec, src_sz) != 0) {
+        printf("  [FAIL] roundtrip after level raise (dsz=%lld)\n", (long long)dsz);
+        goto fail;
+    }
+    printf("  [PASS] level 3 -> 7 raise re-inits and roundtrips\n");
+
+    /* 2. Same raise through the block API on a fresh low-level cctx. */
+    zxc_free_cctx(cctx);
+    cctx = zxc_create_cctx(&create_opts);
+    if (!cctx) {
+        printf("  [FAIL] re-create returned NULL\n");
+        goto fail;
+    }
+    zxc_compress_opts_t raise6 = {.level = ZXC_LEVEL_DENSITY, .checksum_enabled = 0};
+    const int64_t bsz = zxc_compress_block(cctx, src, src_sz, comp, comp_cap, &raise6);
+    if (bsz <= 0) {
+        printf("  [FAIL] level-6 block raise returned %lld\n", (long long)bsz);
+        goto fail;
+    }
+    printf("  [PASS] level 3 -> 6 raise through the block API\n");
+
+    /* 3. Out-of-range levels are rejected, not silently clamped to ULTRA. */
+    zxc_compress_opts_t bad = {.level = 99, .checksum_enabled = 0};
+    if (zxc_compress(src, src_sz, comp, comp_cap, &bad) != ZXC_ERROR_BAD_LEVEL) {
+        printf("  [FAIL] zxc_compress(level=99) must return ZXC_ERROR_BAD_LEVEL\n");
+        goto fail;
+    }
+    if (zxc_compress_cctx(cctx, src, src_sz, comp, comp_cap, &bad) != ZXC_ERROR_BAD_LEVEL) {
+        printf("  [FAIL] zxc_compress_cctx(level=99) must return ZXC_ERROR_BAD_LEVEL\n");
+        goto fail;
+    }
+    if (zxc_compress_block(cctx, src, src_sz, comp, comp_cap, &bad) != ZXC_ERROR_BAD_LEVEL) {
+        printf("  [FAIL] zxc_compress_block(level=99) must return ZXC_ERROR_BAD_LEVEL\n");
+        goto fail;
+    }
+    if (zxc_create_cctx(&bad) != NULL) {
+        printf("  [FAIL] zxc_create_cctx(level=99) must return NULL\n");
+        goto fail;
+    }
+    printf("  [PASS] level 99 rejected across entry points\n");
+
+    zxc_free_cctx(cctx);
+    zxc_free_dctx(dctx);
+    free(src);
+    free(comp);
+    free(dec);
+    printf("PASS\n\n");
+    return 1;
+
+fail:
+    zxc_free_cctx(cctx);
+    zxc_free_dctx(dctx);
+    free(src);
+    free(comp);
+    free(dec);
+    return 0;
+}
+
 int test_estimate_cctx_size() {
     printf("=== TEST: Unit - zxc_estimate_cctx_size ===\n");
 

--- a/tests/test_format.c
+++ b/tests/test_format.c
@@ -145,12 +145,14 @@ static int huf_dict_roundtrip_case(const char* label, const uint8_t* literals, s
         return 0;
     }
 
-    /* Tree-at-attach: prebuild the shared table's tree/codes once, as
-     * zxc_cctx_attach_dict_huf does; the dict codec entry points take it. */
+    /* Tree-at-attach: prebuild the shared table's tree/codes/decoder tables
+     * once, as zxc_cctx_attach_dict_huf does; the dict codec entry points
+     * take them. */
     zxc_pivco_tree_t tree;
+    zxc_pivco_decode_aux_t aux;
     uint32_t codes[ZXC_HUF_NUM_SYMBOLS];
     uint8_t tree_len[ZXC_HUF_NUM_SYMBOLS];
-    if (zxc_huf_dict_tree_build(packed, &tree, codes, tree_len) != ZXC_OK ||
+    if (zxc_huf_dict_tree_build(packed, &tree, codes, tree_len, &aux) != ZXC_OK ||
         memcmp(tree_len, code_len, sizeof(tree_len)) != 0) {
         printf("Failed [%s]: dict_tree_build\n", label);
         return 0;
@@ -188,14 +190,14 @@ static int huf_dict_roundtrip_case(const char* label, const uint8_t* literals, s
         goto fail;
     }
 
-    if (zxc_huf_decode_section_dict(enc, (size_t)written, dec, n, &tree, scr) != ZXC_OK ||
+    if (zxc_huf_decode_section_dict(enc, (size_t)written, dec, n, &tree, &aux, scr) != ZXC_OK ||
         memcmp(literals, dec, n) != 0) {
         printf("Failed [%s]: decode_section_dict roundtrip mismatch\n", label);
         goto fail;
     }
 
     /* Error paths: truncated payload, undersized dst_cap. */
-    if (zxc_huf_decode_section_dict(enc, 0, dec, n, &tree, scr) == ZXC_OK) {
+    if (zxc_huf_decode_section_dict(enc, 0, dec, n, &tree, &aux, scr) == ZXC_OK) {
         printf("Failed [%s]: truncated payload accepted\n", label);
         goto fail;
     }
@@ -265,11 +267,12 @@ int test_huffman_codec_dict() {
         freq['!']++;    /* keep the histogram in sync with the mutated buffer */
         uint8_t enc[1024];
         zxc_pivco_tree_t tree;
+        zxc_pivco_decode_aux_t aux;
         uint32_t codes[ZXC_HUF_NUM_SYMBOLS];
         uint8_t packed[ZXC_HUF_TABLE_SIZE];
         uint8_t tree_len[ZXC_HUF_NUM_SYMBOLS];
         zxc_huf_pack_lengths(code_len, packed);
-        if (zxc_huf_dict_tree_build(packed, &tree, codes, tree_len) != ZXC_OK) {
+        if (zxc_huf_dict_tree_build(packed, &tree, codes, tree_len, &aux) != ZXC_OK) {
             printf("Failed: dict_tree_build (code-less literal case)\n");
             free(buf);
             return 0;
@@ -284,6 +287,46 @@ int test_huffman_codec_dict() {
     }
 
     free(buf);
+    printf("PASS\n\n");
+    return 1;
+}
+
+/* Regression: a degenerate single-symbol table must carry code_len == 1
+ * (FORMAT.md, decoder validation requirements). The v6 decoder rejected a
+ * lone symbol with a longer length; the v7 rewrite briefly accepted it. */
+int test_huffman_single_symbol_validation() {
+    printf("=== TEST: Unit - Huffman single-symbol table validation ===\n");
+
+    zxc_pivco_tree_t tree;
+    zxc_pivco_decode_aux_t aux;
+    uint32_t codes[ZXC_HUF_NUM_SYMBOLS];
+    uint8_t tree_len[ZXC_HUF_NUM_SYMBOLS];
+    uint8_t code_len[ZXC_HUF_NUM_SYMBOLS];
+    uint8_t packed[ZXC_HUF_TABLE_SIZE];
+
+    /* Lone symbol with code length 1: the only legal degenerate form. */
+    memset(code_len, 0, sizeof(code_len));
+    code_len['A'] = 1;
+    zxc_huf_pack_lengths(code_len, packed);
+    if (zxc_huf_dict_tree_build(packed, &tree, codes, tree_len, &aux) != ZXC_OK) {
+        printf("Failed: single symbol with code_len=1 must be accepted\n");
+        return 0;
+    }
+    printf("  [PASS] single symbol, code_len=1 accepted\n");
+
+    /* Lone symbol with any longer length is declared corrupt by the format. */
+    for (int len = 2; len <= ZXC_HUF_MAX_CODE_LEN_ULTRA; len++) {
+        memset(code_len, 0, sizeof(code_len));
+        code_len['A'] = (uint8_t)len;
+        zxc_huf_pack_lengths(code_len, packed);
+        if (zxc_huf_dict_tree_build(packed, &tree, codes, tree_len, &aux) !=
+            ZXC_ERROR_CORRUPT_DATA) {
+            printf("Failed: single symbol with code_len=%d must be rejected\n", len);
+            return 0;
+        }
+    }
+    printf("  [PASS] single symbol, code_len 2..%d rejected\n", ZXC_HUF_MAX_CODE_LEN_ULTRA);
+
     printf("PASS\n\n");
     return 1;
 }

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -65,12 +65,14 @@ static const test_entry_t g_tests[] = {
 
     /* --- Context API --- */
     TEST_CASE(test_opaque_context_api),
+    TEST_CASE(test_cctx_level_raise_reinit),
     TEST_CASE(test_estimate_cctx_size),
 
     /* --- Static Context API --- */
     TEST_CASE(test_static_ctx_size_query),
     TEST_CASE(test_static_ctx_workspace_too_small),
     TEST_CASE(test_static_ctx_block_size_locked),
+    TEST_CASE(test_static_ctx_level_raise_rejected),
     TEST_CASE(test_static_ctx_null_inputs),
     TEST_CASE(test_static_ctx_roundtrip_all_levels),
 
@@ -104,6 +106,7 @@ static const test_entry_t g_tests[] = {
     /* --- Format (on-disk) --- */
     TEST_CASE(test_huffman_codec),
     TEST_CASE(test_huffman_codec_dict),
+    TEST_CASE(test_huffman_single_symbol_validation),
     TEST_CASE(test_eof_block_structure),
     TEST_CASE(test_header_checksum),
     TEST_CASE(test_global_checksum_order),

--- a/tests/test_pstream_api.c
+++ b/tests/test_pstream_api.c
@@ -395,6 +395,22 @@ int test_pstream_invalid_args(void) {
     if (zxc_dstream_in_size(NULL) != 0) return 0;
     if (zxc_dstream_out_size(NULL) != 0) return 0;
 
+    /* Dictionary options are rejected at create time (the push-stream format
+     * carries no dict_id): a dictionary must never be silently dropped. */
+    {
+        static const uint8_t d[4] = {1, 2, 3, 4};
+        zxc_compress_opts_t copts = {.level = 3, .dict = d, .dict_size = sizeof(d)};
+        if (zxc_cstream_create(&copts) != NULL) {
+            printf("  [FAIL] cstream_create must reject dict opts\n");
+            return 0;
+        }
+        zxc_decompress_opts_t dopts_dict = {.dict = d, .dict_size = sizeof(d)};
+        if (zxc_dstream_create(&dopts_dict) != NULL) {
+            printf("  [FAIL] dstream_create must reject dict opts\n");
+            return 0;
+        }
+    }
+
     /* Malformed descriptors must be rejected before any helper does an
      * unchecked memcpy() that could underflow size_t arithmetic or
      * dereference NULL. */

--- a/tests/test_static_ctx.c
+++ b/tests/test_static_ctx.c
@@ -255,6 +255,86 @@ int test_static_ctx_block_size_locked(void) {
     return 1;
 }
 
+/* Regression: a static cctx carved below ZXC_LEVEL_DENSITY has no opt_scratch
+ * and its workspace cannot grow. A per-call raise into the optimal-parser tier
+ * must be rejected with ZXC_ERROR_BAD_LEVEL - before the fix it silently
+ * heap-allocated a replacement workspace (violating the no-allocation
+ * contract) and leaked it, or crashed on the NULL scratch via the frame API. */
+int test_static_ctx_level_raise_rejected(void) {
+    printf("=== TEST: Static Context API - level raise rejected ===\n");
+
+    const size_t pinned_bs = 64 * 1024;
+    const size_t ws_sz = zxc_static_cctx_workspace_size(pinned_bs, ZXC_LEVEL_DEFAULT);
+    void* const ws = test_aligned_alloc(64, ws_sz);
+    if (!ws) {
+        printf("  [FAIL] aligned_alloc\n");
+        return 0;
+    }
+
+    zxc_compress_opts_t opts = {.level = ZXC_LEVEL_DEFAULT, .block_size = pinned_bs};
+    zxc_cctx* const cctx = zxc_init_static_cctx(ws, ws_sz, &opts);
+    if (!cctx) {
+        printf("  [FAIL] init_static_cctx\n");
+        test_aligned_free(ws);
+        return 0;
+    }
+
+    uint8_t src[256] = {0};
+    uint8_t dst[1024];
+
+    /* Frame API: raise to 7 must fail cleanly. */
+    zxc_compress_opts_t raise = {.level = ZXC_LEVEL_ULTRA, .block_size = pinned_bs};
+    const int64_t rc = zxc_compress_cctx(cctx, src, sizeof(src), dst, sizeof(dst), &raise);
+    if (rc != ZXC_ERROR_BAD_LEVEL) {
+        printf("  [FAIL] frame raise: expected ZXC_ERROR_BAD_LEVEL, got %lld\n", (long long)rc);
+        goto fail;
+    }
+
+    /* Block API: raise to 6 must fail cleanly too. */
+    zxc_compress_opts_t raise6 = {.level = ZXC_LEVEL_DENSITY, .block_size = pinned_bs};
+    const int64_t rc2 = zxc_compress_block(cctx, src, sizeof(src), dst, sizeof(dst), &raise6);
+    if (rc2 != ZXC_ERROR_BAD_LEVEL) {
+        printf("  [FAIL] block raise: expected ZXC_ERROR_BAD_LEVEL, got %lld\n", (long long)rc2);
+        goto fail;
+    }
+
+    /* The context is still usable at its pinned level afterwards. */
+    const int64_t rc3 = zxc_compress_cctx(cctx, src, sizeof(src), dst, sizeof(dst), NULL);
+    if (rc3 <= 0) {
+        printf("  [FAIL] pinned-level compress after rejection returned %lld\n", (long long)rc3);
+        goto fail;
+    }
+
+    /* A static workspace carved AT the dense tier accepts its own level. */
+    {
+        const size_t ws7_sz = zxc_static_cctx_workspace_size(pinned_bs, ZXC_LEVEL_ULTRA);
+        void* const ws7 = test_aligned_alloc(64, ws7_sz);
+        if (!ws7) {
+            printf("  [FAIL] aligned_alloc (level 7 ws)\n");
+            goto fail;
+        }
+        zxc_compress_opts_t opts7 = {.level = ZXC_LEVEL_ULTRA, .block_size = pinned_bs};
+        zxc_cctx* const cctx7 = zxc_init_static_cctx(ws7, ws7_sz, &opts7);
+        if (!cctx7 ||
+            zxc_compress_cctx(cctx7, src, sizeof(src), dst, sizeof(dst), &opts7) <= 0) {
+            printf("  [FAIL] level-7 static cctx should compress at level 7\n");
+            test_aligned_free(ws7);
+            goto fail;
+        }
+        test_aligned_free(ws7);
+    }
+
+    zxc_free_cctx(cctx);
+    test_aligned_free(ws);
+    printf("  [PASS] dense-tier raise rejected, pinned level still works\n");
+    return 1;
+
+fail:
+    zxc_free_cctx(cctx);
+    test_aligned_free(ws);
+    return 0;
+}
+
 /* Verify NULL inputs are gracefully rejected. */
 int test_static_ctx_null_inputs(void) {
     printf("=== TEST: Static Context API - NULL inputs ===\n");

--- a/wrappers/go/zxc.go
+++ b/wrappers/go/zxc.go
@@ -165,6 +165,7 @@ var (
 	ErrDictRequired = &Error{Code: int(C.ZXC_ERROR_DICT_REQUIRED), Name: "archive requires a dictionary"}
 	ErrDictMismatch = &Error{Code: int(C.ZXC_ERROR_DICT_MISMATCH), Name: "dictionary ID mismatch"}
 	ErrDictTooLarge = &Error{Code: int(C.ZXC_ERROR_DICT_TOO_LARGE), Name: "dictionary exceeds maximum size"}
+	ErrBadLevel     = &Error{Code: int(C.ZXC_ERROR_BAD_LEVEL), Name: "compression level out of range"}
 	ErrInvalidData  = errors.New("zxc: invalid compressed data")
 
 	// ErrBadHufTable is returned when a shared literal Huffman table does not
@@ -214,6 +215,8 @@ func errorFromCode(code C.int64_t) error {
 		return ErrDictMismatch
 	case int(C.ZXC_ERROR_DICT_TOO_LARGE):
 		return ErrDictTooLarge
+	case int(C.ZXC_ERROR_BAD_LEVEL):
+		return ErrBadLevel
 	default:
 		return fmt.Errorf("zxc: unknown error (code %d)", int(code))
 	}

--- a/wrappers/go/zxc_buffer.go
+++ b/wrappers/go/zxc_buffer.go
@@ -161,19 +161,19 @@ func Decompress(data []byte, opts ...Option) ([]byte, error) {
 		C.size_t(len(data)),
 	))
 
-	// The size comes from the (untrusted) footer with no plausibility check in
-	// C. Reject values that cannot be allocated or that exceed the format's
-	// maximum expansion (a block header is 8 bytes and decodes to at most
-	// ZXC_BLOCK_SIZE_MAX bytes) instead of panicking in make().
-	const maxRatio = uint64(C.ZXC_BLOCK_SIZE_MAX) / 8
-	if size > math.MaxInt || size/maxRatio > uint64(len(data)) {
+	// The footer value is plausibility-checked in C (a forged size returns 0);
+	// only guard what Go's make() cannot represent.
+	if size > math.MaxInt {
 		return nil, ErrInvalidData
 	}
 
 	if size == 0 {
-		// Either a valid empty-payload archive or invalid input. Let the C
-		// decoder decide: it returns 0 for a valid empty archive, or a negative
-		// error code for invalid input. Decode into a zero-length buffer.
+		// Either a valid empty-payload archive, or invalid input (bad header,
+		// or a footer whose size failed the C-side plausibility check). Let
+		// the C decoder decide: it returns 0 for a valid empty archive, or a
+		// negative error code otherwise. Decode into a zero-length buffer;
+		// DST_TOO_SMALL here can only mean the footer contradicts the payload
+		// (the caller supplied no buffer), so report it as invalid data.
 		var dummy [1]byte
 		written := C.zxc_decompress(
 			unsafe.Pointer(&data[0]),
@@ -183,6 +183,9 @@ func Decompress(data []byte, opts ...Option) ([]byte, error) {
 			&dopts,
 		)
 		if written < 0 {
+			if int(written) == int(C.ZXC_ERROR_DST_TOO_SMALL) {
+				return nil, ErrInvalidData
+			}
 			return nil, errorFromCode(written)
 		}
 		if written != 0 {

--- a/wrappers/nodejs/lib/index.d.ts
+++ b/wrappers/nodejs/lib/index.d.ts
@@ -54,6 +54,7 @@ export const ERROR_DICT_REQUIRED: number;
 export const ERROR_DICT_MISMATCH: number;
 /** Dictionary exceeds maximum allowed size. */
 export const ERROR_DICT_TOO_LARGE: number;
+export const ERROR_BAD_LEVEL: number;
 
 export interface CompressOptions {
     /** Compression level (1-7). Defaults to LEVEL_DEFAULT. */

--- a/wrappers/nodejs/lib/index.js
+++ b/wrappers/nodejs/lib/index.js
@@ -37,6 +37,7 @@ const ERROR_BAD_BLOCK_SIZE = native.ERROR_BAD_BLOCK_SIZE;
 const ERROR_DICT_REQUIRED  = native.ERROR_DICT_REQUIRED;
 const ERROR_DICT_MISMATCH  = native.ERROR_DICT_MISMATCH;
 const ERROR_DICT_TOO_LARGE = native.ERROR_DICT_TOO_LARGE;
+const ERROR_BAD_LEVEL      = native.ERROR_BAD_LEVEL;
 
 /**
  * Returns the minimum supported compression level (currently 1).
@@ -665,4 +666,5 @@ module.exports = {
     ERROR_DICT_REQUIRED,
     ERROR_DICT_MISMATCH,
     ERROR_DICT_TOO_LARGE,
+    ERROR_BAD_LEVEL,
 };

--- a/wrappers/nodejs/src/zxc_addon.cc
+++ b/wrappers/nodejs/src/zxc_addon.cc
@@ -1134,6 +1134,7 @@ static Napi::Object Init(Napi::Env env, Napi::Object exports) {
     exports.Set("ERROR_DICT_REQUIRED", Napi::Number::New(env, ZXC_ERROR_DICT_REQUIRED));
     exports.Set("ERROR_DICT_MISMATCH", Napi::Number::New(env, ZXC_ERROR_DICT_MISMATCH));
     exports.Set("ERROR_DICT_TOO_LARGE", Napi::Number::New(env, ZXC_ERROR_DICT_TOO_LARGE));
+    exports.Set("ERROR_BAD_LEVEL", Napi::Number::New(env, ZXC_ERROR_BAD_LEVEL));
 
     return exports;
 }

--- a/wrappers/python/src/zxc/__init__.py
+++ b/wrappers/python/src/zxc/__init__.py
@@ -75,6 +75,7 @@ from ._zxc import (
     ERROR_DICT_REQUIRED,
     ERROR_DICT_MISMATCH,
     ERROR_DICT_TOO_LARGE,
+    ERROR_BAD_LEVEL,
 )
 
 try:
@@ -148,6 +149,7 @@ __all__ = [
     "ERROR_DICT_REQUIRED",
     "ERROR_DICT_MISMATCH",
     "ERROR_DICT_TOO_LARGE",
+    "ERROR_BAD_LEVEL",
 ]
 
 def min_level() -> int:

--- a/wrappers/python/src/zxc/__init__.py
+++ b/wrappers/python/src/zxc/__init__.py
@@ -300,6 +300,7 @@ def compress(data, level = LEVEL_DEFAULT, checksum = False, dict = None, dict_hu
     Args:
         data: Bytes-like object to compress.
         level: Compression level. Use constants like LEVEL_FASTEST, LEVEL_DEFAULT, etc.
+            Values above LEVEL_ULTRA are silently clamped; values <= 0 select the default.
         checksum: If True, append a checksum for integrity verification.
         dict: Optional pre-trained dictionary content (bytes) to prime the
             compressor. Must be passed (matching by ID) to `decompress`.

--- a/wrappers/python/src/zxc/__init__.pyi
+++ b/wrappers/python/src/zxc/__init__.pyi
@@ -34,6 +34,7 @@ ERROR_BAD_BLOCK_SIZE: int
 ERROR_DICT_REQUIRED: int
 ERROR_DICT_MISMATCH: int
 ERROR_DICT_TOO_LARGE: int
+ERROR_BAD_LEVEL: int
 
 # ---------- types ----------
 class FileLike(Protocol):

--- a/wrappers/python/src/zxc/_zxc.c
+++ b/wrappers/python/src/zxc/_zxc.c
@@ -66,6 +66,17 @@ static int grow_output(uint8_t** buf, size_t* cap, size_t out_len, size_t want) 
     return 0;
 }
 
+// Validates a compression level, raising ValueError when out of range.
+// Returns 0 on success, -1 with the exception set otherwise.
+static int validate_level(const int level) {
+    if (level < zxc_min_level() || level > zxc_max_level()) {
+        PyErr_Format(PyExc_ValueError, "level must be in [%d, %d], got %d", zxc_min_level(),
+                     zxc_max_level(), level);
+        return -1;
+    }
+    return 0;
+}
+
 // =============================================================================
 // Wrapper functions
 // =============================================================================
@@ -235,6 +246,7 @@ PyMODINIT_FUNC PyInit__zxc(void) {
     PyModule_AddIntConstant(m, "ERROR_DICT_REQUIRED", ZXC_ERROR_DICT_REQUIRED);
     PyModule_AddIntConstant(m, "ERROR_DICT_MISMATCH", ZXC_ERROR_DICT_MISMATCH);
     PyModule_AddIntConstant(m, "ERROR_DICT_TOO_LARGE", ZXC_ERROR_DICT_TOO_LARGE);
+    PyModule_AddIntConstant(m, "ERROR_BAD_LEVEL", ZXC_ERROR_BAD_LEVEL);
 
     return m;
 }
@@ -268,10 +280,8 @@ static PyObject* pyzxc_compress(PyObject* self, PyObject* args, PyObject* kwargs
         return NULL;
     }
 
-    if (level < zxc_min_level() || level > zxc_max_level()) {
+    if (validate_level(level) < 0) {
         PyBuffer_Release(&view);
-        PyErr_Format(PyExc_ValueError, "level must be in [%d, %d], got %d", zxc_min_level(),
-                     zxc_max_level(), level);
         return NULL;
     }
 
@@ -486,11 +496,7 @@ static PyObject* pyzxc_stream_compress(PyObject* self, PyObject* args, PyObject*
         return NULL;
     }
 
-    if (level < zxc_min_level() || level > zxc_max_level()) {
-        PyErr_Format(PyExc_ValueError, "level must be in [%d, %d], got %d", zxc_min_level(),
-                     zxc_max_level(), level);
-        return NULL;
-    }
+    if (validate_level(level) < 0) return NULL;
 
     if (dict_obj && dict_obj != Py_None) {
         if (PyObject_GetBuffer(dict_obj, &dict_view, PyBUF_SIMPLE) < 0) return NULL;
@@ -1080,11 +1086,7 @@ static PyObject* pyzxc_cstream_create(PyObject* self, PyObject* args, PyObject* 
                      ZXC_BLOCK_SIZE_MIN, ZXC_BLOCK_SIZE_MAX, block_size);
         return NULL;
     }
-    if (level < zxc_min_level() || level > zxc_max_level()) {
-        PyErr_Format(PyExc_ValueError, "level must be in [%d, %d], got %d", zxc_min_level(),
-                     zxc_max_level(), level);
-        return NULL;
-    }
+    if (validate_level(level) < 0) return NULL;
 
     zxc_compress_opts_t copts = {0};
     copts.level = level;

--- a/wrappers/python/src/zxc/_zxc.c
+++ b/wrappers/python/src/zxc/_zxc.c
@@ -66,16 +66,6 @@ static int grow_output(uint8_t** buf, size_t* cap, size_t out_len, size_t want) 
     return 0;
 }
 
-// Validates a compression level, raising ValueError when out of range.
-// Returns 0 on success, -1 with the exception set otherwise.
-static int validate_level(const int level) {
-    if (level < zxc_min_level() || level > zxc_max_level()) {
-        PyErr_Format(PyExc_ValueError, "level must be in [%d, %d], got %d", zxc_min_level(),
-                     zxc_max_level(), level);
-        return -1;
-    }
-    return 0;
-}
 
 // =============================================================================
 // Wrapper functions
@@ -280,10 +270,6 @@ static PyObject* pyzxc_compress(PyObject* self, PyObject* args, PyObject* kwargs
         return NULL;
     }
 
-    if (validate_level(level) < 0) {
-        PyBuffer_Release(&view);
-        return NULL;
-    }
 
     if (dict_obj && dict_obj != Py_None) {
         if (PyObject_GetBuffer(dict_obj, &dict_view, PyBUF_SIMPLE) < 0) {
@@ -495,8 +481,6 @@ static PyObject* pyzxc_stream_compress(PyObject* self, PyObject* args, PyObject*
                                      &level, &checksum, &seekable, &dict_obj, &dict_huf_obj)) {
         return NULL;
     }
-
-    if (validate_level(level) < 0) return NULL;
 
     if (dict_obj && dict_obj != Py_None) {
         if (PyObject_GetBuffer(dict_obj, &dict_view, PyBUF_SIMPLE) < 0) return NULL;
@@ -1086,8 +1070,6 @@ static PyObject* pyzxc_cstream_create(PyObject* self, PyObject* args, PyObject* 
                      ZXC_BLOCK_SIZE_MIN, ZXC_BLOCK_SIZE_MAX, block_size);
         return NULL;
     }
-    if (validate_level(level) < 0) return NULL;
-
     zxc_compress_opts_t copts = {0};
     copts.level = level;
     copts.checksum_enabled = checksum;

--- a/wrappers/rust/zxc-sys/src/lib.rs
+++ b/wrappers/rust/zxc-sys/src/lib.rs
@@ -158,6 +158,9 @@ pub const ZXC_ERROR_DICT_MISMATCH: i32 = -16;
 /// Dictionary exceeds maximum allowed size
 pub const ZXC_ERROR_DICT_TOO_LARGE: i32 = -17;
 
+/// Compression level out of range, or not supported by this context's workspace
+pub const ZXC_ERROR_BAD_LEVEL: i32 = -18;
+
 // =============================================================================
 // Dictionary Constants
 // =============================================================================

--- a/wrappers/rust/zxc/src/error.rs
+++ b/wrappers/rust/zxc/src/error.rs
@@ -9,10 +9,10 @@
 
 use zxc_sys::{
     ZXC_ERROR_BAD_BLOCK_SIZE, ZXC_ERROR_BAD_BLOCK_TYPE, ZXC_ERROR_BAD_CHECKSUM,
-    ZXC_ERROR_BAD_HEADER, ZXC_ERROR_BAD_MAGIC, ZXC_ERROR_BAD_OFFSET, ZXC_ERROR_BAD_VERSION,
-    ZXC_ERROR_CORRUPT_DATA, ZXC_ERROR_DICT_MISMATCH, ZXC_ERROR_DICT_REQUIRED,
-    ZXC_ERROR_DICT_TOO_LARGE, ZXC_ERROR_DST_TOO_SMALL, ZXC_ERROR_IO, ZXC_ERROR_MEMORY,
-    ZXC_ERROR_NULL_INPUT, ZXC_ERROR_OVERFLOW, ZXC_ERROR_SRC_TOO_SMALL,
+    ZXC_ERROR_BAD_HEADER, ZXC_ERROR_BAD_LEVEL, ZXC_ERROR_BAD_MAGIC, ZXC_ERROR_BAD_OFFSET,
+    ZXC_ERROR_BAD_VERSION, ZXC_ERROR_CORRUPT_DATA, ZXC_ERROR_DICT_MISMATCH,
+    ZXC_ERROR_DICT_REQUIRED, ZXC_ERROR_DICT_TOO_LARGE, ZXC_ERROR_DST_TOO_SMALL, ZXC_ERROR_IO,
+    ZXC_ERROR_MEMORY, ZXC_ERROR_NULL_INPUT, ZXC_ERROR_OVERFLOW, ZXC_ERROR_SRC_TOO_SMALL,
 };
 
 /// Errors that can occur during ZXC operations.
@@ -86,6 +86,10 @@ pub enum Error {
     #[error("dictionary exceeds maximum allowed size")]
     DictTooLarge,
 
+    /// The compression level is out of range or unsupported by this context
+    #[error("compression level out of range")]
+    BadLevel,
+
     /// The requested options are not supported by this API
     #[error("unsupported option: {0}")]
     Unsupported(&'static str),
@@ -119,6 +123,7 @@ pub(crate) fn error_from_code(code: i64) -> Error {
         ZXC_ERROR_DICT_REQUIRED => Error::DictRequired,
         ZXC_ERROR_DICT_MISMATCH => Error::DictMismatch,
         ZXC_ERROR_DICT_TOO_LARGE => Error::DictTooLarge,
+        ZXC_ERROR_BAD_LEVEL => Error::BadLevel,
         _ => Error::Unknown(code as i32),
     }
 }

--- a/wrappers/wasm/zxc_wasm.js
+++ b/wrappers/wasm/zxc_wasm.js
@@ -484,8 +484,12 @@ export default async function createZXC(moduleOverrides, factory) {
         return Module.HEAPU32[(bufPtr >> 2) + 2];
     }
 
-    /* Concatenate JS-side slices into a single Uint8Array. */
+    /* Concatenate JS-side slices into a single Uint8Array. A single chunk is
+     * the common case (the staging buffer holds a full block): return it
+     * as-is and skip the concat copy (chunks are already heap-independent
+     * .slice() copies). */
     function _concatChunks(chunks, totalLen) {
+        if (chunks.length === 1) return chunks[0];
         const out = new Uint8Array(totalLen);
         let off = 0;
         for (const c of chunks) {
@@ -536,9 +540,7 @@ export default async function createZXC(moduleOverrides, factory) {
                 }
                 if (r === 0 && _readPos(inDescPtr) === srcLen) break;
             }
-            // Single chunk is the common case (stageCap holds a full block):
-            // skip the concat copy.
-            return chunks.length === 1 ? chunks[0] : _concatChunks(chunks, total);
+            return _concatChunks(chunks, total);
         }
 
         function drainEnd() {
@@ -557,7 +559,7 @@ export default async function createZXC(moduleOverrides, factory) {
                 }
                 if (r === 0) break;
             }
-            return chunks.length === 1 ? chunks[0] : _concatChunks(chunks, total);
+            return _concatChunks(chunks, total);
         }
 
         return {
@@ -640,7 +642,7 @@ export default async function createZXC(moduleOverrides, factory) {
                             exhausted = true;
                         }
                     }
-                    return chunks.length === 1 ? chunks[0] : _concatChunks(chunks, total);
+                    return _concatChunks(chunks, total);
                 } finally {
                     if (srcPtr) _free(srcPtr);
                 }


### PR DESCRIPTION
This PR enhances the robustness of decompression, particularly for in-place and dictionary-based operations, and optimizes memory usage by deferring certain allocations. It also refines error handling for compression levels and clarifies various aspects of the API and format documentation.

### Key Changes

#### Robustness & Error Handling

*   Introduces `ZXC_ERROR_BAD_LEVEL` to cleanly reject compression level raises that exceed a static context's pre-allocated workspace capacity.
*   Adds a plausibility check for decompressed sizes reported in archive footers within `zxc_get_decompressed_size` and in-place decompression functions, preventing oversized allocations from potentially forged values.
*   Enforces format rules for degenerate Huffman single-symbol tables, rejecting invalid code lengths greater than one.
*   Clamps out-of-range compression levels (e.g., `level=99`) to `ZXC_LEVEL_ULTRA` across all compression entry points, ensuring consistent behavior without unexpected failures.
*   Refines error propagation in the Go wrapper for `ZXC_ERROR_DST_TOO_SMALL` and leverages the C-side footer plausibility check for decompressed size retrieval.

#### Memory Management

*   Defers the allocation of decode-side entropy scratch buffers (`tok_buffer`, `pivco_scratch`) for heap-allocated decompression contexts, reducing the upfront memory footprint for common decompression scenarios. Static contexts continue to provision this memory eagerly.
*   Precomputes Huffman decoder tables (skip flags and flat-root code-to-symbol tables) at dictionary attach time (`zxc_cctx_attach_dict_huf`), avoiding redundant per-block recomputation during dictionary-based decompression.

#### API & Documentation Clarity

*   Explicitly rejects dictionary options when creating push-stream contexts (`zxc_cstream_create`, `zxc_dstream_create`), as the push-stream format does not support dictionary IDs, preventing the creation of undecodable archives.
*   Updates `README.md` and `docs/API.md` to provide a more precise formula for calculating the `zxc_decompress_inplace_bound` and clarify that destination buffers for in-place and push-stream modes are treated as writable scratch beyond the final output `pos`.
*   Refines the description of Huffman format rules for flat-subtree fast paths in `docs/FORMAT.md` and `docs/WHITEPAPER.md`.
*   Adds `ZXC_ERROR_BAD_LEVEL` to the public API and all language bindings (Go, Node.js, Python, Rust).

#### Test Coverage

*   Adds new unit tests for `zxc_cctx_level_raise_reinit` to verify dynamic workspace re-initialization on level changes.
*   Introduces `test_static_ctx_level_raise_rejected` to confirm that static contexts correctly reject level raises beyond their allocated capacity.
*   Enhances `test_get_decompressed_size` with a forged footer scenario to ensure robust handling of malicious input.
*   Adds `test_huffman_single_symbol_validation` to cover the new Huffman table validation.