### PR TITLE
build: Fix MSVC /arch + /wd4244 flags (wrapdb CI warnings)

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -13,6 +13,14 @@ project('zxc', 'c',
 cc = meson.get_compiler('c')
 host_cpu = host_machine.cpu_family()
 
+msvc_syntax = cc.get_argument_syntax() == 'msvc'
+is_cl = cc.get_id() == 'msvc'
+
+# /wd4244: silence the block-bounded uint64->size_t narrowing that is lossless on
+# this codebase (only 32-bit MSVC targets warn; clean on GCC/Clang). Mirrors the
+# CMake build's per-target /wd4244.
+msvc_narrowing_args = msvc_syntax ? ['/wd4244'] : []
+
 # Keep in sync with ZXC_SOVERSION in CMakeLists.txt (bumps only on an ABI break).
 zxc_soversion = '4'
 
@@ -56,11 +64,20 @@ variant_sources = ['src/lib/zxc_compress.c',
 variant_sets = [['_default', []]]
 
 if host_cpu == 'x86_64'
-  variant_sets += [['_sse2',   ['-msse2']]]
-  variant_sets += [['_avx2',   ['-mavx2', '-mfma', '-mbmi', '-mbmi2', '-mlzcnt']]]
-  variant_sets += [['_avx512', ['-mavx512f', '-mavx512bw', '-mavx512vbmi', '-mavx512vbmi2', '-mbmi', '-mbmi2', '-mlzcnt']]]
+  if is_cl
+    # SSE2 is the x86-64 baseline; /arch:AVX2|AVX512 gate the wider paths. MSVC does
+    # not predefine __BMI__/__BMI2__/__LZCNT__ under /arch, so define them here.
+    variant_sets += [['_sse2',   ['/D__SSE2__']]]
+    variant_sets += [['_avx2',   ['/arch:AVX2', '/D__BMI__', '/D__BMI2__', '/D__LZCNT__']]]
+    variant_sets += [['_avx512', ['/arch:AVX512', '/D__BMI__', '/D__BMI2__', '/D__LZCNT__']]]
+  else
+    variant_sets += [['_sse2',   ['-msse2']]]
+    variant_sets += [['_avx2',   ['-mavx2', '-mfma', '-mbmi', '-mbmi2', '-mlzcnt']]]
+    variant_sets += [['_avx512', ['-mavx512f', '-mavx512bw', '-mavx512vbmi', '-mavx512vbmi2', '-mbmi', '-mbmi2', '-mlzcnt']]]
+  endif
 elif host_cpu == 'aarch64'
-  variant_sets += [['_neon', ['-march=armv8-a+simd']]]
+  # MSVC ARM64 implies NEON; passing -march=armv8-a+simd only warns D9002.
+  variant_sets += is_cl ? [['_neon', []]] : [['_neon', ['-march=armv8-a+simd']]]
 elif host_cpu == 'arm'
   variant_sets += [['_neon', ['-march=armv7-a', '-mfpu=neon']]]
 endif
@@ -71,7 +88,7 @@ foreach info : variant_sets
     obj = static_library(
       'zxc' + info[0] + '_' + src.underscorify(),
       src,
-      c_args : info[1] + ['-DZXC_FUNCTION_SUFFIX=' + info[0]] + lib_export_args,
+      c_args : info[1] + msvc_narrowing_args + ['-DZXC_FUNCTION_SUFFIX=' + info[0]] + lib_export_args,
       include_directories : libzxc_includes,
       pic : true,
     )
@@ -98,7 +115,7 @@ thread_dep = dependency('threads')
 libzxc = library('zxc',
   libzxc_sources,
   objects : variant_objects,
-  c_args : lib_export_args,
+  c_args : lib_export_args + msvc_narrowing_args,
   gnu_symbol_visibility : 'hidden',
   include_directories : libzxc_includes,
   dependencies : [thread_dep],
@@ -122,7 +139,7 @@ else
   libzxc_static = static_library('zxc_static',
     libzxc_sources,
     objects : variant_objects,
-    c_args : ['-DZXC_STATIC_DEFINE'],
+    c_args : ['-DZXC_STATIC_DEFINE'] + msvc_narrowing_args,
     include_directories : libzxc_includes,
     dependencies : [thread_dep],
     build_by_default : false,

--- a/src/lib/zxc_compress.c
+++ b/src/lib/zxc_compress.c
@@ -55,31 +55,6 @@ static ZXC_ALWAYS_INLINE uint32_t zxc_hash_func(const uint64_t val, const int us
     }
 }
 
-#if defined(ZXC_USE_AVX2)
-/**
- * @brief Reduces a 256-bit integer vector to a single scalar by finding the maximum unsigned 32-bit
- * integer element.
- *
- * This function performs a horizontal reduction across the 8 packed 32-bit unsigned integers
- * in the source vector to determine the maximum value.
- *
- * @param[in] v The 256-bit vector containing 8 unsigned 32-bit integers.
- * @return The maximum unsigned 32-bit integer found in the vector.
- */
-// codeql[cpp/unused-static-function] : Used conditionally when ZXC_USE_AVX2 is defined
-static ZXC_ALWAYS_INLINE uint32_t zxc_mm256_reduce_max_epu32(__m256i v) {
-    __m128i vlow = _mm256_castsi256_si128(v);        // Extract the lower 128 bits
-    __m128i vhigh = _mm256_extracti128_si256(v, 1);  // Extract the upper 128 bits
-    vlow = _mm_max_epu32(vlow, vhigh);               // Element-wise max of lower and upper halves
-    __m128i vshuf = _mm_shuffle_epi32(vlow, _MM_SHUFFLE(1, 0, 3, 2));  // Shuffle to swap pairs
-    vlow = _mm_max_epu32(vlow, vshuf);  // Max of original and swapped
-    vshuf =
-        _mm_shuffle_epi32(vlow, _MM_SHUFFLE(2, 3, 0, 1));  // Shuffle to bring remaining candidates
-    vlow = _mm_max_epu32(vlow, vshuf);                     // Final max comparison
-    return (uint32_t)_mm_cvtsi128_si32(vlow);              // Extract the scalar result
-}
-#endif
-
 #if defined(ZXC_USE_SSE2)
 /**
  * @brief SSE2 emulation of SSE4.1 @c _mm_blendv_epi8.

--- a/src/lib/zxc_pivco_tables.h
+++ b/src/lib/zxc_pivco_tables.h
@@ -34,7 +34,10 @@
 
 #include <stdint.h>
 
-#if defined(__GNUC__) || defined(__clang__)
+/* ELF/Mach-O visibility only: Windows PE/COFF targets (MinGW/MSYS2 GCC,
+ * clang-on-Windows) do not support it and warn -Wattributes, so gate on
+ * !_WIN32 exactly like ZXC_NO_EXPORT in zxc_export.h. */
+#if (defined(__GNUC__) || defined(__clang__)) && !defined(_WIN32)
 #define ZXC_HIDDEN __attribute__((visibility("hidden")))
 #else
 #define ZXC_HIDDEN


### PR DESCRIPTION
- meson.build: emit MSVC /arch:AVX2|AVX512 instead of GCC-style -m flags (cl rejects them with D9002), and add /wd4244 for the lossless block-bounded uint64->size_t narrowing on 32-bit MSVC. Mirrors CMake.
- zxc_pivco_tables.h: gate the ZXC_HIDDEN visibility attribute on !_WIN32 so MinGW/MSYS2 GCC stops warning -Wattributes (matches zxc_export.h).