### PR TITLE
refactor: Compile ISA-independent dict tree setup once, not per-variant

### DIFF
--- a/src/lib/zxc_dispatch.c
+++ b/src/lib/zxc_dispatch.c
@@ -129,10 +129,6 @@ int zxc_huf_decode_section_dict_default(const uint8_t* RESTRICT payload, size_t 
                                         const zxc_pivco_tree_t* RESTRICT tree,
                                         const zxc_pivco_decode_aux_t* RESTRICT aux,
                                         uint8_t* RESTRICT scratch);
-int zxc_huf_dict_tree_build_default(const uint8_t* RESTRICT packed_lengths,
-                                    zxc_pivco_tree_t* RESTRICT tree, uint32_t* RESTRICT codes,
-                                    uint8_t* RESTRICT code_len,
-                                    zxc_pivco_decode_aux_t* RESTRICT aux);
 size_t zxc_huf_calc_size_dict_default(const uint32_t* RESTRICT freq,
                                       const uint8_t* RESTRICT code_len,
                                       const zxc_pivco_tree_t* RESTRICT tree);
@@ -597,12 +593,6 @@ int zxc_huf_decode_section_dict(const uint8_t* RESTRICT payload, const size_t pa
                                 const zxc_pivco_decode_aux_t* RESTRICT aux,
                                 uint8_t* RESTRICT scratch) {
     return zxc_huf_decode_section_dict_default(payload, payload_size, dst, n, tree, aux, scratch);
-}
-
-int zxc_huf_dict_tree_build(const uint8_t* RESTRICT packed_lengths, zxc_pivco_tree_t* RESTRICT tree,
-                            uint32_t* RESTRICT codes, uint8_t* RESTRICT code_len,
-                            zxc_pivco_decode_aux_t* RESTRICT aux) {
-    return zxc_huf_dict_tree_build_default(packed_lengths, tree, codes, code_len, aux);
 }
 
 size_t zxc_huf_calc_size_dict(const uint32_t* RESTRICT freq, const uint8_t* RESTRICT code_len,

--- a/src/lib/zxc_huffman.c
+++ b/src/lib/zxc_huffman.c
@@ -49,11 +49,24 @@
 #define zxc_huf_unpack_lengths ZXC_CAT(zxc_huf_unpack_lengths, ZXC_FUNCTION_SUFFIX)
 #define zxc_huf_calc_size ZXC_CAT(zxc_huf_calc_size, ZXC_FUNCTION_SUFFIX)
 #define zxc_huf_calc_size_dict ZXC_CAT(zxc_huf_calc_size_dict, ZXC_FUNCTION_SUFFIX)
-#define zxc_huf_dict_tree_build ZXC_CAT(zxc_huf_dict_tree_build, ZXC_FUNCTION_SUFFIX)
 #define zxc_huf_encode_section ZXC_CAT(zxc_huf_encode_section, ZXC_FUNCTION_SUFFIX)
 #define zxc_huf_encode_section_dict ZXC_CAT(zxc_huf_encode_section_dict, ZXC_FUNCTION_SUFFIX)
 #define zxc_huf_decode_section ZXC_CAT(zxc_huf_decode_section, ZXC_FUNCTION_SUFFIX)
 #define zxc_huf_decode_section_dict ZXC_CAT(zxc_huf_decode_section_dict, ZXC_FUNCTION_SUFFIX)
+#endif
+
+/* Mark the primary variant (only _default, or a no-suffix build) so ISA-
+ * independent cold code compiles once, not in every per-ISA copy. Keyed off the
+ * suffix value, so every build gets it with no extra flag. */
+#ifdef ZXC_FUNCTION_SUFFIX
+#define ZXC_PRIMARY__default 1
+#define ZXC_PRIMARY_CAT_(a, b) a##b
+#define ZXC_PRIMARY_CAT(a, b) ZXC_PRIMARY_CAT_(a, b)
+#if ZXC_PRIMARY_CAT(ZXC_PRIMARY_, ZXC_FUNCTION_SUFFIX)
+#define ZXC_VARIANT_PRIMARY 1
+#endif
+#else
+#define ZXC_VARIANT_PRIMARY 1
 #endif
 
 #include "../../include/zxc_error.h"
@@ -752,6 +765,9 @@ int zxc_huf_encode_section_dict(const uint8_t* RESTRICT literals, const size_t n
                                  0);
 }
 
+/* ISA-independent cold dict setup: emit once in the primary variant, not in
+ * every per-ISA copy (dead weight). zxc_pivco_tree_build stays per-variant. */
+#if defined(ZXC_VARIANT_PRIMARY)
 /**
  * @brief Precompute the topology-derived decoder tables for @p t.
  *
@@ -829,6 +845,7 @@ int zxc_huf_dict_tree_build(const uint8_t* RESTRICT packed_lengths, zxc_pivco_tr
     zxc_pivco_decode_aux_build(tree, aux);
     return ZXC_OK;
 }
+#endif /* ZXC_VARIANT_PRIMARY */
 
 /**
  * @brief Merge two adjacent child sequences under control bits.


### PR DESCRIPTION
zxc_huf_dict_tree_build is ISA-independent cold dict setup that the dispatcher always routes to the _default variant, yet they were compiled into every per-ISA copy of zxc_huffman.c. 
Gate them on a new ZXC_VARIANT_PRIMARY define, drop them from the suffix-macro block, and remove the now-redundant dispatch wrapper.
