### PR TITLE
refactor: Deduplicate the GLO/GHI decode loops

### DIFF
--- a/src/lib/zxc_decompress.c
+++ b/src/lib/zxc_decompress.c
@@ -426,6 +426,125 @@ static ZXC_NOINLINE void zxc_decode_copy_match_exact(uint8_t* d_ptr, const uint8
         d_ptr += ml;                                \
     } while (0)
 
+/**
+ * @brief Decodes one GLO sequence of a 4x batch: extracts ll/ml, applies the
+ *        varint extensions with their bounds checks, then emits via @p DECODE.
+ *
+ * Like @ref DECODE_SEQ_SAFE, references the call site's local names (e_ptr,
+ * e_end, l_ptr, l_end, d_ptr, d_end). @p RESERVE is the sum of the inline
+ * (pre-varint) literal lengths of the batch's remaining sequences, so one
+ * l_ptr bound covers the whole batch; @p N_REM counts the remaining
+ * sequences, reserving their worst-case inline output in the d_ptr bound
+ * (0 for the last sequence - the compiler folds the dead terms). @p ON_FAIL
+ * is `goto rollback_*` in the state-saving safe variants and
+ * `return ZXC_ERROR_OVERFLOW` otherwise.
+ *
+ */
+#define DECODE_GLO_SEQ(LL, ML, OFF, RESERVE, N_REM, DECODE, ON_FAIL)                   \
+    do {                                                                               \
+        uint64_t ll = (LL);                                                            \
+        uint64_t ml = (ML);                                                            \
+        if (UNLIKELY(ll == ZXC_TOKEN_LL_MASK)) {                                       \
+            ll += zxc_read_varint(&e_ptr, e_end);                                      \
+            const uint64_t reserve = (RESERVE);                                        \
+            if (UNLIKELY(ll + reserve > (size_t)(l_end - l_ptr) ||                     \
+                         ll + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))                 \
+                ON_FAIL;                                                               \
+        }                                                                              \
+        if (UNLIKELY(ml == ZXC_TOKEN_ML_MASK)) {                                       \
+            ml += zxc_read_varint(&e_ptr, e_end);                                      \
+            if (UNLIKELY(ll + ml + ZXC_LZ_MIN_MATCH_LEN +                              \
+                             (N_REM) * ZXC_GLO_MAX_INLINE_OUT_PER_SEQ + ZXC_PAD_SIZE > \
+                         (size_t)(d_end - d_ptr)))                                     \
+                ON_FAIL;                                                               \
+        }                                                                              \
+        ml += ZXC_LZ_MIN_MATCH_LEN;                                                    \
+        DECODE(ll, ml, OFF);                                                           \
+    } while (0)
+
+/**
+ * @brief One full GLO 4x batch: token word, four offsets (1- or 2-byte form),
+ *        four @ref DECODE_GLO_SEQ emissions, sequence-count update.
+ */
+#define DECODE_GLO_BATCH_4X(DECODE, ON_FAIL)                                                      \
+    do {                                                                                          \
+        uint32_t tokens = zxc_le32(t_ptr);                                                        \
+        t_ptr += sizeof(uint32_t);                                                                \
+        uint32_t off1 = ZXC_LZ_OFFSET_BIAS, off2 = ZXC_LZ_OFFSET_BIAS, off3 = ZXC_LZ_OFFSET_BIAS, \
+                 off4 = ZXC_LZ_OFFSET_BIAS;                                                       \
+        if (gh.enc_off == 1) {                                                                    \
+            uint32_t offsets = zxc_le32(o_ptr);                                                   \
+            o_ptr += sizeof(uint32_t);                                                            \
+            off1 += offsets & 0xFF;                                                               \
+            off2 += (offsets >> 8) & 0xFF;                                                        \
+            off3 += (offsets >> 16) & 0xFF;                                                       \
+            off4 += (offsets >> 24) & 0xFF;                                                       \
+        } else {                                                                                  \
+            uint64_t offsets = zxc_le64(o_ptr);                                                   \
+            o_ptr += sizeof(uint64_t);                                                            \
+            off1 += (uint32_t)(offsets & 0xFFFF);                                                 \
+            off2 += (uint32_t)((offsets >> 16) & 0xFFFF);                                         \
+            off3 += (uint32_t)((offsets >> 32) & 0xFFFF);                                         \
+            off4 += (uint32_t)((offsets >> 48) & 0xFFFF);                                         \
+        }                                                                                         \
+        DECODE_GLO_SEQ((tokens & 0x0F0) >> 4, (tokens & 0x00F), off1,                             \
+                       ((tokens >> 12) & 0xF) + ((tokens >> 20) & 0xF) + (tokens >> 28), 3U,      \
+                       DECODE, ON_FAIL);                                                          \
+        DECODE_GLO_SEQ((tokens & 0x0F000) >> 12, (tokens & 0x00F00) >> 8, off2,                   \
+                       ((tokens >> 20) & 0xF) + (tokens >> 28), 2U, DECODE, ON_FAIL);             \
+        DECODE_GLO_SEQ((tokens & 0x0F00000) >> 20, (tokens & 0x00F0000) >> 16, off3,              \
+                       (tokens >> 28), 1U, DECODE, ON_FAIL);                                      \
+        DECODE_GLO_SEQ((tokens >> 28), (tokens >> 24) & 0x0F, off4, 0, 0U, DECODE, ON_FAIL);      \
+        n_seq -= 4;                                                                               \
+    } while (0)
+
+/**
+ * @brief GHI twin of @ref DECODE_GLO_SEQ, decoding one sequence word @p S
+ *        (ll in the top byte, ml bits, 16-bit offset). References the call
+ *        site's extras_ptr/extras_end instead of e_ptr/e_end.
+ */
+#define DECODE_GHI_SEQ(S, RESERVE, N_REM, DECODE, ON_FAIL)                                   \
+    do {                                                                                     \
+        uint64_t ll = (S) >> 24;                                                             \
+        if (UNLIKELY(ll == ZXC_SEQ_LL_MASK)) {                                               \
+            ll += zxc_read_varint(&extras_ptr, extras_end);                                  \
+            const uint64_t reserve = (RESERVE);                                              \
+            if (UNLIKELY(ll + reserve > (size_t)(l_end - l_ptr) ||                           \
+                         ll + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))                       \
+                ON_FAIL;                                                                     \
+        }                                                                                    \
+        const uint32_t mb = ((S) >> 16) & 0xFF;                                              \
+        uint64_t ml = mb + ZXC_LZ_MIN_MATCH_LEN;                                             \
+        if (UNLIKELY(mb == ZXC_SEQ_ML_MASK)) {                                               \
+            ml += zxc_read_varint(&extras_ptr, extras_end);                                  \
+            if (UNLIKELY(ll + ml + (N_REM) * ZXC_GHI_MAX_INLINE_OUT_PER_SEQ + ZXC_PAD_SIZE > \
+                         (size_t)(d_end - d_ptr)))                                           \
+                ON_FAIL;                                                                     \
+        }                                                                                    \
+        const uint32_t off = ((S) & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;                            \
+        DECODE(ll, ml, off);                                                                 \
+    } while (0)
+
+/**
+ * @brief One full GHI 4x batch. @p PREFETCH is the literal-stream prefetch
+ *        statement of the post-threshold FAST loops ((void)0 elsewhere),
+ *        placed exactly where the hand-unrolled bodies had it.
+ */
+#define DECODE_GHI_BATCH_4X(DECODE, ON_FAIL, PREFETCH)                                 \
+    do {                                                                               \
+        uint32_t s1 = zxc_le32(seq_ptr);                                               \
+        uint32_t s2 = zxc_le32(seq_ptr + sizeof(uint32_t));                            \
+        uint32_t s3 = zxc_le32(seq_ptr + 2 * sizeof(uint32_t));                        \
+        uint32_t s4 = zxc_le32(seq_ptr + 3 * sizeof(uint32_t));                        \
+        seq_ptr += 4 * sizeof(uint32_t);                                               \
+        PREFETCH;                                                                      \
+        DECODE_GHI_SEQ(s1, (s2 >> 24) + (s3 >> 24) + (s4 >> 24), 3U, DECODE, ON_FAIL); \
+        DECODE_GHI_SEQ(s2, (s3 >> 24) + (s4 >> 24), 2U, DECODE, ON_FAIL);              \
+        DECODE_GHI_SEQ(s3, (s4 >> 24), 1U, DECODE, ON_FAIL);                           \
+        DECODE_GHI_SEQ(s4, 0, 0U, DECODE, ON_FAIL);                                    \
+        n_seq -= 4;                                                                    \
+    } while (0)
+
 /* The section decoders below are outlined COLD on purpose: they run once per
  * section (a call is noise), and keeping them out of the hot sequence-decode
  * loop protects its i-cache footprint - inlining them was measured at
@@ -704,8 +823,6 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(const zxc_cctx_t* RESTRIC
     // ll_max = 14, ml_max = 14 + 5 = 19, per-seq = 33, 4x = 132.
     // Add ZXC_PAD_SIZE (32) for the wild zxc_copy32 overshoot + 4 safety = 168.
     const uint8_t* const d_end_safe = d_end - (132 + ZXC_PAD_SIZE + 4);
-    const uint8_t* const d_end_safe_1x =
-        d_end - (ZXC_GLO_MAX_INLINE_OUT_PER_SEQ + ZXC_PAD_SIZE + 4);  // 69
 
     // Literal stream safe threshold for 4x-unrolled loops.
     // Without varint extension, max ll per sequence = ZXC_TOKEN_LL_MASK - 1 = 14.
@@ -744,103 +861,7 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(const zxc_cctx_t* RESTRIC
             uint8_t* const d_save = d_ptr;
             const uint8_t* const l_save = l_ptr;
             const size_t w_save = written;
-            uint32_t tokens = zxc_le32(t_ptr);
-            t_ptr += sizeof(uint32_t);
-
-            uint32_t off1 = ZXC_LZ_OFFSET_BIAS, off2 = ZXC_LZ_OFFSET_BIAS,
-                     off3 = ZXC_LZ_OFFSET_BIAS, off4 = ZXC_LZ_OFFSET_BIAS;
-            if (gh.enc_off == 1) {
-                uint32_t offsets = zxc_le32(o_ptr);
-                o_ptr += sizeof(uint32_t);
-                off1 += offsets & 0xFF;
-                off2 += (offsets >> 8) & 0xFF;
-                off3 += (offsets >> 16) & 0xFF;
-                off4 += (offsets >> 24) & 0xFF;
-            } else {
-                uint64_t offsets = zxc_le64(o_ptr);
-                o_ptr += sizeof(uint64_t);
-                off1 += (uint32_t)(offsets & 0xFFFF);
-                off2 += (uint32_t)((offsets >> 16) & 0xFFFF);
-                off3 += (uint32_t)((offsets >> 32) & 0xFFFF);
-                off4 += (uint32_t)((offsets >> 48) & 0xFFFF);
-            }
-
-            uint64_t ll1 = (tokens & 0x0F0) >> 4;
-            uint64_t ml1 = (tokens & 0x00F);
-            if (UNLIKELY(ll1 == ZXC_TOKEN_LL_MASK)) {
-                ll1 += zxc_read_varint(&e_ptr, e_end);
-                const uint64_t reserve =
-                    ((tokens >> 12) & 0xF) + ((tokens >> 20) & 0xF) + (tokens >> 28);
-                if (UNLIKELY(ll1 + reserve > (size_t)(l_end - l_ptr) ||
-                             ll1 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
-                    goto rollback_safe_4x;
-            }
-            if (UNLIKELY(ml1 == ZXC_TOKEN_ML_MASK)) {
-                ml1 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY(ll1 + ml1 + ZXC_LZ_MIN_MATCH_LEN +
-                                 3U * ZXC_GLO_MAX_INLINE_OUT_PER_SEQ + ZXC_PAD_SIZE >
-                             (size_t)(d_end - d_ptr)))
-                    goto rollback_safe_4x;
-            }
-            ml1 += ZXC_LZ_MIN_MATCH_LEN;
-            DECODE_SEQ_SAFE(ll1, ml1, off1);
-
-            uint64_t ll2 = (tokens & 0x0F000) >> 12;
-            uint64_t ml2 = (tokens & 0x00F00) >> 8;
-            if (UNLIKELY(ll2 == ZXC_TOKEN_LL_MASK)) {
-                ll2 += zxc_read_varint(&e_ptr, e_end);
-                const uint64_t reserve = ((tokens >> 20) & 0xF) + (tokens >> 28);
-                if (UNLIKELY(ll2 + reserve > (size_t)(l_end - l_ptr) ||
-                             ll2 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
-                    goto rollback_safe_4x;
-            }
-            if (UNLIKELY(ml2 == ZXC_TOKEN_ML_MASK)) {
-                ml2 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY(ll2 + ml2 + ZXC_LZ_MIN_MATCH_LEN +
-                                 2U * ZXC_GLO_MAX_INLINE_OUT_PER_SEQ + ZXC_PAD_SIZE >
-                             (size_t)(d_end - d_ptr)))
-                    goto rollback_safe_4x;
-            }
-            ml2 += ZXC_LZ_MIN_MATCH_LEN;
-            DECODE_SEQ_SAFE(ll2, ml2, off2);
-
-            uint64_t ll3 = (tokens & 0x0F00000) >> 20;
-            uint64_t ml3 = (tokens & 0x00F0000) >> 16;
-            if (UNLIKELY(ll3 == ZXC_TOKEN_LL_MASK)) {
-                ll3 += zxc_read_varint(&e_ptr, e_end);
-                const uint64_t reserve = (tokens >> 28);
-                if (UNLIKELY(ll3 + reserve > (size_t)(l_end - l_ptr) ||
-                             ll3 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
-                    goto rollback_safe_4x;
-            }
-            if (UNLIKELY(ml3 == ZXC_TOKEN_ML_MASK)) {
-                ml3 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY(ll3 + ml3 + ZXC_LZ_MIN_MATCH_LEN + ZXC_GLO_MAX_INLINE_OUT_PER_SEQ +
-                                 ZXC_PAD_SIZE >
-                             (size_t)(d_end - d_ptr)))
-                    goto rollback_safe_4x;
-            }
-            ml3 += ZXC_LZ_MIN_MATCH_LEN;
-            DECODE_SEQ_SAFE(ll3, ml3, off3);
-
-            uint64_t ll4 = (tokens >> 28);
-            uint64_t ml4 = (tokens >> 24) & 0x0F;
-            if (UNLIKELY(ll4 == ZXC_TOKEN_LL_MASK)) {
-                ll4 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY(ll4 > (size_t)(l_end - l_ptr) ||
-                             ll4 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
-                    goto rollback_safe_4x;
-            }
-            if (UNLIKELY(ml4 == ZXC_TOKEN_ML_MASK)) {
-                ml4 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY(ll4 + ml4 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE >
-                             (size_t)(d_end - d_ptr)))
-                    goto rollback_safe_4x;
-            }
-            ml4 += ZXC_LZ_MIN_MATCH_LEN;
-            DECODE_SEQ_SAFE(ll4, ml4, off4);
-
-            n_seq -= 4;
+            DECODE_GLO_BATCH_4X(DECODE_SEQ_SAFE, goto rollback_safe_4x);
             continue;
 
         rollback_safe_4x:
@@ -855,108 +876,7 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(const zxc_cctx_t* RESTRIC
     } else {
         while (n_seq >= 4 && d_ptr < d_end_safe && l_ptr < l_end_safe_4x &&
                written < bounds_threshold) {
-            uint32_t tokens = zxc_le32(t_ptr);
-            t_ptr += sizeof(uint32_t);
-
-            uint32_t off1 = ZXC_LZ_OFFSET_BIAS;
-            uint32_t off2 = ZXC_LZ_OFFSET_BIAS;
-            uint32_t off3 = ZXC_LZ_OFFSET_BIAS;
-            uint32_t off4 = ZXC_LZ_OFFSET_BIAS;
-
-            if (gh.enc_off == 1) {
-                // Read 4 x 1-byte offsets
-                uint32_t offsets = zxc_le32(o_ptr);
-                o_ptr += sizeof(uint32_t);
-                off1 += offsets & 0xFF;
-                off2 += (offsets >> 8) & 0xFF;
-                off3 += (offsets >> 16) & 0xFF;
-                off4 += (offsets >> 24) & 0xFF;
-            } else {
-                // Read 4 x 2-byte offsets
-                uint64_t offsets = zxc_le64(o_ptr);
-                o_ptr += sizeof(uint64_t);
-                off1 += (uint32_t)(offsets & 0xFFFF);
-                off2 += (uint32_t)((offsets >> 16) & 0xFFFF);
-                off3 += (uint32_t)((offsets >> 32) & 0xFFFF);
-                off4 += (uint32_t)((offsets >> 48) & 0xFFFF);
-            }
-
-            uint64_t ll1 = (tokens & 0x0F0) >> 4;
-            uint64_t ml1 = (tokens & 0x00F);
-            if (UNLIKELY(ll1 == ZXC_TOKEN_LL_MASK)) {
-                ll1 += zxc_read_varint(&e_ptr, e_end);
-                const uint64_t reserve =
-                    ((tokens >> 12) & 0xF) + ((tokens >> 20) & 0xF) + (tokens >> 28);
-                if (UNLIKELY(ll1 + reserve > (size_t)(l_end - l_ptr) ||
-                             ll1 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
-                    return ZXC_ERROR_OVERFLOW;
-            }
-            if (UNLIKELY(ml1 == ZXC_TOKEN_ML_MASK)) {
-                ml1 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY(ll1 + ml1 + ZXC_LZ_MIN_MATCH_LEN +
-                                 3U * ZXC_GLO_MAX_INLINE_OUT_PER_SEQ + ZXC_PAD_SIZE >
-                             (size_t)(d_end - d_ptr)))
-                    return ZXC_ERROR_OVERFLOW;
-            }
-            ml1 += ZXC_LZ_MIN_MATCH_LEN;
-            DECODE_SEQ_SAFE(ll1, ml1, off1);
-
-            uint64_t ll2 = (tokens & 0x0F000) >> 12;
-            uint64_t ml2 = (tokens & 0x00F00) >> 8;
-            if (UNLIKELY(ll2 == ZXC_TOKEN_LL_MASK)) {
-                ll2 += zxc_read_varint(&e_ptr, e_end);
-                const uint64_t reserve = ((tokens >> 20) & 0xF) + (tokens >> 28);
-                if (UNLIKELY(ll2 + reserve > (size_t)(l_end - l_ptr) ||
-                             ll2 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
-                    return ZXC_ERROR_OVERFLOW;
-            }
-            if (UNLIKELY(ml2 == ZXC_TOKEN_ML_MASK)) {
-                ml2 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY(ll2 + ml2 + ZXC_LZ_MIN_MATCH_LEN +
-                                 2U * ZXC_GLO_MAX_INLINE_OUT_PER_SEQ + ZXC_PAD_SIZE >
-                             (size_t)(d_end - d_ptr)))
-                    return ZXC_ERROR_OVERFLOW;
-            }
-            ml2 += ZXC_LZ_MIN_MATCH_LEN;
-            DECODE_SEQ_SAFE(ll2, ml2, off2);
-
-            uint64_t ll3 = (tokens & 0x0F00000) >> 20;
-            uint64_t ml3 = (tokens & 0x00F0000) >> 16;
-            if (UNLIKELY(ll3 == ZXC_TOKEN_LL_MASK)) {
-                ll3 += zxc_read_varint(&e_ptr, e_end);
-                const uint64_t reserve = (tokens >> 28);
-                if (UNLIKELY(ll3 + reserve > (size_t)(l_end - l_ptr) ||
-                             ll3 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
-                    return ZXC_ERROR_OVERFLOW;
-            }
-            if (UNLIKELY(ml3 == ZXC_TOKEN_ML_MASK)) {
-                ml3 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY(ll3 + ml3 + ZXC_LZ_MIN_MATCH_LEN + ZXC_GLO_MAX_INLINE_OUT_PER_SEQ +
-                                 ZXC_PAD_SIZE >
-                             (size_t)(d_end - d_ptr)))
-                    return ZXC_ERROR_OVERFLOW;
-            }
-            ml3 += ZXC_LZ_MIN_MATCH_LEN;
-            DECODE_SEQ_SAFE(ll3, ml3, off3);
-
-            uint64_t ll4 = (tokens >> 28);
-            uint64_t ml4 = (tokens >> 24) & 0x0F;
-            if (UNLIKELY(ll4 == ZXC_TOKEN_LL_MASK)) {
-                ll4 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY(ll4 > (size_t)(l_end - l_ptr) ||
-                             ll4 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
-                    return ZXC_ERROR_OVERFLOW;
-            }
-            if (UNLIKELY(ml4 == ZXC_TOKEN_ML_MASK)) {
-                ml4 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY(ll4 + ml4 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE >
-                             (size_t)(d_end - d_ptr)))
-                    return ZXC_ERROR_OVERFLOW;
-            }
-            ml4 += ZXC_LZ_MIN_MATCH_LEN;
-            DECODE_SEQ_SAFE(ll4, ml4, off4);
-
-            n_seq -= 4;
+            DECODE_GLO_BATCH_4X(DECODE_SEQ_SAFE, return ZXC_ERROR_OVERFLOW);
         }
     }
 
@@ -968,106 +888,7 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(const zxc_cctx_t* RESTRIC
             const uint8_t* const e_save = e_ptr;
             uint8_t* const d_save = d_ptr;
             const uint8_t* const l_save = l_ptr;
-            uint32_t tokens = zxc_le32(t_ptr);
-            t_ptr += sizeof(uint32_t);
-
-            uint32_t off1 = ZXC_LZ_OFFSET_BIAS;
-            uint32_t off2 = ZXC_LZ_OFFSET_BIAS;
-            uint32_t off3 = ZXC_LZ_OFFSET_BIAS;
-            uint32_t off4 = ZXC_LZ_OFFSET_BIAS;
-
-            if (gh.enc_off == 1) {
-                uint32_t offsets = zxc_le32(o_ptr);
-                o_ptr += sizeof(uint32_t);
-                off1 += offsets & 0xFF;
-                off2 += (offsets >> 8) & 0xFF;
-                off3 += (offsets >> 16) & 0xFF;
-                off4 += (offsets >> 24) & 0xFF;
-            } else {
-                uint64_t offsets = zxc_le64(o_ptr);
-                o_ptr += sizeof(uint64_t);
-                off1 += (uint32_t)(offsets & 0xFFFF);
-                off2 += (uint32_t)((offsets >> 16) & 0xFFFF);
-                off3 += (uint32_t)((offsets >> 32) & 0xFFFF);
-                off4 += (uint32_t)((offsets >> 48) & 0xFFFF);
-            }
-
-            uint64_t ll1 = (tokens & 0x0F0) >> 4;
-            uint64_t ml1 = (tokens & 0x00F);
-            if (UNLIKELY(ll1 == ZXC_TOKEN_LL_MASK)) {
-                ll1 += zxc_read_varint(&e_ptr, e_end);
-                const uint64_t reserve =
-                    ((tokens >> 12) & 0xF) + ((tokens >> 20) & 0xF) + (tokens >> 28);
-                if (UNLIKELY(ll1 + reserve > (size_t)(l_end - l_ptr) ||
-                             ll1 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
-                    goto rollback_fast_4x;
-            }
-            if (UNLIKELY(ml1 == ZXC_TOKEN_ML_MASK)) {
-                ml1 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY(ll1 + ml1 + ZXC_LZ_MIN_MATCH_LEN +
-                                 3U * ZXC_GLO_MAX_INLINE_OUT_PER_SEQ + ZXC_PAD_SIZE >
-                             (size_t)(d_end - d_ptr)))
-                    goto rollback_fast_4x;
-            }
-            ml1 += ZXC_LZ_MIN_MATCH_LEN;
-            DECODE_SEQ_FAST(ll1, ml1, off1);
-
-            uint64_t ll2 = (tokens & 0x0F000) >> 12;
-            uint64_t ml2 = (tokens & 0x00F00) >> 8;
-            if (UNLIKELY(ll2 == ZXC_TOKEN_LL_MASK)) {
-                ll2 += zxc_read_varint(&e_ptr, e_end);
-                const uint64_t reserve = ((tokens >> 20) & 0xF) + (tokens >> 28);
-                if (UNLIKELY(ll2 + reserve > (size_t)(l_end - l_ptr) ||
-                             ll2 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
-                    goto rollback_fast_4x;
-            }
-            if (UNLIKELY(ml2 == ZXC_TOKEN_ML_MASK)) {
-                ml2 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY(ll2 + ml2 + ZXC_LZ_MIN_MATCH_LEN +
-                                 2U * ZXC_GLO_MAX_INLINE_OUT_PER_SEQ + ZXC_PAD_SIZE >
-                             (size_t)(d_end - d_ptr)))
-                    goto rollback_fast_4x;
-            }
-            ml2 += ZXC_LZ_MIN_MATCH_LEN;
-            DECODE_SEQ_FAST(ll2, ml2, off2);
-
-            uint64_t ll3 = (tokens & 0x0F00000) >> 20;
-            uint64_t ml3 = (tokens & 0x00F0000) >> 16;
-            if (UNLIKELY(ll3 == ZXC_TOKEN_LL_MASK)) {
-                ll3 += zxc_read_varint(&e_ptr, e_end);
-                const uint64_t reserve = (tokens >> 28);
-                if (UNLIKELY(ll3 + reserve > (size_t)(l_end - l_ptr) ||
-                             ll3 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
-                    goto rollback_fast_4x;
-            }
-            if (UNLIKELY(ml3 == ZXC_TOKEN_ML_MASK)) {
-                ml3 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY(ll3 + ml3 + ZXC_LZ_MIN_MATCH_LEN + ZXC_GLO_MAX_INLINE_OUT_PER_SEQ +
-                                 ZXC_PAD_SIZE >
-                             (size_t)(d_end - d_ptr)))
-                    goto rollback_fast_4x;
-            }
-            ml3 += ZXC_LZ_MIN_MATCH_LEN;
-            DECODE_SEQ_FAST(ll3, ml3, off3);
-
-            uint64_t ll4 = (tokens >> 28);
-            uint64_t ml4 = (tokens >> 24) & 0x0F;
-            if (UNLIKELY(ll4 == ZXC_TOKEN_LL_MASK)) {
-                ll4 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY(ll4 > (size_t)(l_end - l_ptr) ||
-                             ll4 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
-                    goto rollback_fast_4x;
-            }
-            if (UNLIKELY(ml4 == ZXC_TOKEN_ML_MASK)) {
-                ml4 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY(ll4 + ml4 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE >
-                             (size_t)(d_end - d_ptr)))
-                    goto rollback_fast_4x;
-            }
-            ml4 += ZXC_LZ_MIN_MATCH_LEN;
-            DECODE_SEQ_FAST(ll4, ml4, off4);
-
-            n_seq -= 4;
+            DECODE_GLO_BATCH_4X(DECODE_SEQ_FAST, goto rollback_fast_4x);
             continue;
 
         rollback_fast_4x:
@@ -1080,107 +901,7 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(const zxc_cctx_t* RESTRIC
         }
     } else {
         while (n_seq >= 4 && d_ptr < d_end_safe && l_ptr < l_end_safe_4x) {
-            uint32_t tokens = zxc_le32(t_ptr);
-            t_ptr += sizeof(uint32_t);
-
-            uint32_t off1 = ZXC_LZ_OFFSET_BIAS;
-            uint32_t off2 = ZXC_LZ_OFFSET_BIAS;
-            uint32_t off3 = ZXC_LZ_OFFSET_BIAS;
-            uint32_t off4 = ZXC_LZ_OFFSET_BIAS;
-            if (gh.enc_off == 1) {
-                // Read 4 x 1-byte offsets
-                uint32_t offsets = zxc_le32(o_ptr);
-                o_ptr += sizeof(uint32_t);
-                off1 += offsets & 0xFF;
-                off2 += (offsets >> 8) & 0xFF;
-                off3 += (offsets >> 16) & 0xFF;
-                off4 += (offsets >> 24) & 0xFF;
-            } else {
-                // Read 4 x 2-byte offsets
-                uint64_t offsets = zxc_le64(o_ptr);
-                o_ptr += sizeof(uint64_t);
-                off1 += (uint32_t)(offsets & 0xFFFF);
-                off2 += (uint32_t)((offsets >> 16) & 0xFFFF);
-                off3 += (uint32_t)((offsets >> 32) & 0xFFFF);
-                off4 += (uint32_t)((offsets >> 48) & 0xFFFF);
-            }
-
-            uint64_t ll1 = (tokens & 0x0F0) >> 4;
-            uint64_t ml1 = (tokens & 0x00F);
-            if (UNLIKELY(ll1 == ZXC_TOKEN_LL_MASK)) {
-                ll1 += zxc_read_varint(&e_ptr, e_end);
-                const uint64_t reserve =
-                    ((tokens >> 12) & 0xF) + ((tokens >> 20) & 0xF) + (tokens >> 28);
-                if (UNLIKELY(ll1 + reserve > (size_t)(l_end - l_ptr) ||
-                             ll1 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
-                    return ZXC_ERROR_OVERFLOW;
-            }
-            if (UNLIKELY(ml1 == ZXC_TOKEN_ML_MASK)) {
-                ml1 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY(ll1 + ml1 + ZXC_LZ_MIN_MATCH_LEN +
-                                 3U * ZXC_GLO_MAX_INLINE_OUT_PER_SEQ + ZXC_PAD_SIZE >
-                             (size_t)(d_end - d_ptr)))
-                    return ZXC_ERROR_OVERFLOW;
-            }
-            ml1 += ZXC_LZ_MIN_MATCH_LEN;
-            DECODE_SEQ_FAST(ll1, ml1, off1);
-
-            uint64_t ll2 = (tokens & 0x0F000) >> 12;
-            uint64_t ml2 = (tokens & 0x00F00) >> 8;
-            if (UNLIKELY(ll2 == ZXC_TOKEN_LL_MASK)) {
-                ll2 += zxc_read_varint(&e_ptr, e_end);
-                const uint64_t reserve = ((tokens >> 20) & 0xF) + (tokens >> 28);
-                if (UNLIKELY(ll2 + reserve > (size_t)(l_end - l_ptr) ||
-                             ll2 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
-                    return ZXC_ERROR_OVERFLOW;
-            }
-            if (UNLIKELY(ml2 == ZXC_TOKEN_ML_MASK)) {
-                ml2 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY(ll2 + ml2 + ZXC_LZ_MIN_MATCH_LEN +
-                                 2U * ZXC_GLO_MAX_INLINE_OUT_PER_SEQ + ZXC_PAD_SIZE >
-                             (size_t)(d_end - d_ptr)))
-                    return ZXC_ERROR_OVERFLOW;
-            }
-            ml2 += ZXC_LZ_MIN_MATCH_LEN;
-            DECODE_SEQ_FAST(ll2, ml2, off2);
-
-            uint64_t ll3 = (tokens & 0x0F00000) >> 20;
-            uint64_t ml3 = (tokens & 0x00F0000) >> 16;
-            if (UNLIKELY(ll3 == ZXC_TOKEN_LL_MASK)) {
-                ll3 += zxc_read_varint(&e_ptr, e_end);
-                const uint64_t reserve = (tokens >> 28);
-                if (UNLIKELY(ll3 + reserve > (size_t)(l_end - l_ptr) ||
-                             ll3 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
-                    return ZXC_ERROR_OVERFLOW;
-            }
-            if (UNLIKELY(ml3 == ZXC_TOKEN_ML_MASK)) {
-                ml3 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY(ll3 + ml3 + ZXC_LZ_MIN_MATCH_LEN + ZXC_GLO_MAX_INLINE_OUT_PER_SEQ +
-                                 ZXC_PAD_SIZE >
-                             (size_t)(d_end - d_ptr)))
-                    return ZXC_ERROR_OVERFLOW;
-            }
-            ml3 += ZXC_LZ_MIN_MATCH_LEN;
-            DECODE_SEQ_FAST(ll3, ml3, off3);
-
-            uint64_t ll4 = (tokens >> 28);
-            uint64_t ml4 = (tokens >> 24) & 0x0F;
-            if (UNLIKELY(ll4 == ZXC_TOKEN_LL_MASK)) {
-                ll4 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY(ll4 > (size_t)(l_end - l_ptr) ||
-                             ll4 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
-                    return ZXC_ERROR_OVERFLOW;
-            }
-            if (UNLIKELY(ml4 == ZXC_TOKEN_ML_MASK)) {
-                ml4 += zxc_read_varint(&e_ptr, e_end);
-                if (UNLIKELY(ll4 + ml4 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE >
-                             (size_t)(d_end - d_ptr)))
-                    return ZXC_ERROR_OVERFLOW;
-            }
-            ml4 += ZXC_LZ_MIN_MATCH_LEN;
-            DECODE_SEQ_FAST(ll4, ml4, off4);
-
-            n_seq -= 4;
+            DECODE_GLO_BATCH_4X(DECODE_SEQ_FAST, return ZXC_ERROR_OVERFLOW);
         }
     }
 
@@ -1188,7 +909,7 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(const zxc_cctx_t* RESTRIC
     if (UNLIKELY(e_ptr > e_end)) return ZXC_ERROR_CORRUPT_DATA;
 
     // --- Remaining 1 sequence (Fast Path) ---
-    while (n_seq > 0 && d_ptr < d_end_safe_1x && l_ptr < l_end_safe_1x) {
+    while (n_seq > 0 && d_ptr < d_end_safe && l_ptr < l_end_safe_1x) {
         // Save pointers before reading (in case we need to fall back to Safe Path)
         const uint8_t* t_save = t_ptr;
         const uint8_t* o_save = o_ptr;
@@ -1385,87 +1106,7 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(const zxc_cctx_t* RESTRIC
             uint8_t* const d_save = d_ptr;
             const uint8_t* const l_save = l_ptr;
             const size_t w_save = written;
-            uint32_t s1 = zxc_le32(seq_ptr);
-            uint32_t s2 = zxc_le32(seq_ptr + sizeof(uint32_t));
-            uint32_t s3 = zxc_le32(seq_ptr + 2 * sizeof(uint32_t));
-            uint32_t s4 = zxc_le32(seq_ptr + 3 * sizeof(uint32_t));
-            seq_ptr += 4 * sizeof(uint32_t);
-
-            uint64_t ll1 = s1 >> 24;
-            if (UNLIKELY(ll1 == ZXC_SEQ_LL_MASK)) {
-                ll1 += zxc_read_varint(&extras_ptr, extras_end);
-                const uint64_t reserve = (s2 >> 24) + (s3 >> 24) + (s4 >> 24);
-                if (UNLIKELY(ll1 + reserve > (size_t)(l_end - l_ptr) ||
-                             ll1 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
-                    goto rollback_safe_4x;
-            }
-            uint32_t m1b = (s1 >> 16) & 0xFF;
-            uint64_t ml1 = m1b + ZXC_LZ_MIN_MATCH_LEN;
-            if (UNLIKELY(m1b == ZXC_SEQ_ML_MASK)) {
-                ml1 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY(ll1 + ml1 + 3U * ZXC_GHI_MAX_INLINE_OUT_PER_SEQ + ZXC_PAD_SIZE >
-                             (size_t)(d_end - d_ptr)))
-                    goto rollback_safe_4x;
-            }
-            uint32_t off1 = (s1 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
-            DECODE_SEQ_SAFE(ll1, ml1, off1);
-
-            uint64_t ll2 = s2 >> 24;
-            if (UNLIKELY(ll2 == ZXC_SEQ_LL_MASK)) {
-                ll2 += zxc_read_varint(&extras_ptr, extras_end);
-                const uint64_t reserve = (s3 >> 24) + (s4 >> 24);
-                if (UNLIKELY(ll2 + reserve > (size_t)(l_end - l_ptr) ||
-                             ll2 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
-                    goto rollback_safe_4x;
-            }
-            uint32_t m2b = (s2 >> 16) & 0xFF;
-            uint64_t ml2 = m2b + ZXC_LZ_MIN_MATCH_LEN;
-            if (UNLIKELY(m2b == ZXC_SEQ_ML_MASK)) {
-                ml2 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY(ll2 + ml2 + 2U * ZXC_GHI_MAX_INLINE_OUT_PER_SEQ + ZXC_PAD_SIZE >
-                             (size_t)(d_end - d_ptr)))
-                    goto rollback_safe_4x;
-            }
-            uint32_t off2 = (s2 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
-            DECODE_SEQ_SAFE(ll2, ml2, off2);
-
-            uint64_t ll3 = s3 >> 24;
-            if (UNLIKELY(ll3 == ZXC_SEQ_LL_MASK)) {
-                ll3 += zxc_read_varint(&extras_ptr, extras_end);
-                const uint64_t reserve = (s4 >> 24);
-                if (UNLIKELY(ll3 + reserve > (size_t)(l_end - l_ptr) ||
-                             ll3 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
-                    goto rollback_safe_4x;
-            }
-            uint32_t m3b = (s3 >> 16) & 0xFF;
-            uint64_t ml3 = m3b + ZXC_LZ_MIN_MATCH_LEN;
-            if (UNLIKELY(m3b == ZXC_SEQ_ML_MASK)) {
-                ml3 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY(ll3 + ml3 + ZXC_GHI_MAX_INLINE_OUT_PER_SEQ + ZXC_PAD_SIZE >
-                             (size_t)(d_end - d_ptr)))
-                    goto rollback_safe_4x;
-            }
-            uint32_t off3 = (s3 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
-            DECODE_SEQ_SAFE(ll3, ml3, off3);
-
-            uint64_t ll4 = s4 >> 24;
-            if (UNLIKELY(ll4 == ZXC_SEQ_LL_MASK)) {
-                ll4 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY(ll4 > (size_t)(l_end - l_ptr) ||
-                             ll4 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
-                    goto rollback_safe_4x;
-            }
-            uint32_t m4b = (s4 >> 16) & 0xFF;
-            uint64_t ml4 = m4b + ZXC_LZ_MIN_MATCH_LEN;
-            if (UNLIKELY(m4b == ZXC_SEQ_ML_MASK)) {
-                ml4 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY(ll4 + ml4 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
-                    goto rollback_safe_4x;
-            }
-            uint32_t off4 = (s4 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
-            DECODE_SEQ_SAFE(ll4, ml4, off4);
-
-            n_seq -= 4;
+            DECODE_GHI_BATCH_4X(DECODE_SEQ_SAFE, goto rollback_safe_4x, (void)0);
             continue;
 
         rollback_safe_4x:
@@ -1479,87 +1120,7 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(const zxc_cctx_t* RESTRIC
     } else {
         while (n_seq >= 4 && d_ptr < d_end_fast && l_ptr < l_end_safe_4x &&
                written < bounds_threshold) {
-            uint32_t s1 = zxc_le32(seq_ptr);
-            uint32_t s2 = zxc_le32(seq_ptr + sizeof(uint32_t));
-            uint32_t s3 = zxc_le32(seq_ptr + 2 * sizeof(uint32_t));
-            uint32_t s4 = zxc_le32(seq_ptr + 3 * sizeof(uint32_t));
-            seq_ptr += 4 * sizeof(uint32_t);
-
-            uint64_t ll1 = s1 >> 24;
-            if (UNLIKELY(ll1 == ZXC_SEQ_LL_MASK)) {
-                ll1 += zxc_read_varint(&extras_ptr, extras_end);
-                const uint64_t reserve = (s2 >> 24) + (s3 >> 24) + (s4 >> 24);
-                if (UNLIKELY(ll1 + reserve > (size_t)(l_end - l_ptr) ||
-                             ll1 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
-                    return ZXC_ERROR_OVERFLOW;
-            }
-            uint32_t m1b = (s1 >> 16) & 0xFF;
-            uint64_t ml1 = m1b + ZXC_LZ_MIN_MATCH_LEN;
-            if (UNLIKELY(m1b == ZXC_SEQ_ML_MASK)) {
-                ml1 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY(ll1 + ml1 + 3U * ZXC_GHI_MAX_INLINE_OUT_PER_SEQ + ZXC_PAD_SIZE >
-                             (size_t)(d_end - d_ptr)))
-                    return ZXC_ERROR_OVERFLOW;
-            }
-            uint32_t off1 = (s1 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
-            DECODE_SEQ_SAFE(ll1, ml1, off1);
-
-            uint64_t ll2 = s2 >> 24;
-            if (UNLIKELY(ll2 == ZXC_SEQ_LL_MASK)) {
-                ll2 += zxc_read_varint(&extras_ptr, extras_end);
-                const uint64_t reserve = (s3 >> 24) + (s4 >> 24);
-                if (UNLIKELY(ll2 + reserve > (size_t)(l_end - l_ptr) ||
-                             ll2 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
-                    return ZXC_ERROR_OVERFLOW;
-            }
-            uint32_t m2b = (s2 >> 16) & 0xFF;
-            uint64_t ml2 = m2b + ZXC_LZ_MIN_MATCH_LEN;
-            if (UNLIKELY(m2b == ZXC_SEQ_ML_MASK)) {
-                ml2 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY(ll2 + ml2 + 2U * ZXC_GHI_MAX_INLINE_OUT_PER_SEQ + ZXC_PAD_SIZE >
-                             (size_t)(d_end - d_ptr)))
-                    return ZXC_ERROR_OVERFLOW;
-            }
-            uint32_t off2 = (s2 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
-            DECODE_SEQ_SAFE(ll2, ml2, off2);
-
-            uint64_t ll3 = s3 >> 24;
-            if (UNLIKELY(ll3 == ZXC_SEQ_LL_MASK)) {
-                ll3 += zxc_read_varint(&extras_ptr, extras_end);
-                const uint64_t reserve = (s4 >> 24);
-                if (UNLIKELY(ll3 + reserve > (size_t)(l_end - l_ptr) ||
-                             ll3 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
-                    return ZXC_ERROR_OVERFLOW;
-            }
-            uint32_t m3b = (s3 >> 16) & 0xFF;
-            uint64_t ml3 = m3b + ZXC_LZ_MIN_MATCH_LEN;
-            if (UNLIKELY(m3b == ZXC_SEQ_ML_MASK)) {
-                ml3 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY(ll3 + ml3 + ZXC_GHI_MAX_INLINE_OUT_PER_SEQ + ZXC_PAD_SIZE >
-                             (size_t)(d_end - d_ptr)))
-                    return ZXC_ERROR_OVERFLOW;
-            }
-            uint32_t off3 = (s3 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
-            DECODE_SEQ_SAFE(ll3, ml3, off3);
-
-            uint64_t ll4 = s4 >> 24;
-            if (UNLIKELY(ll4 == ZXC_SEQ_LL_MASK)) {
-                ll4 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY(ll4 > (size_t)(l_end - l_ptr) ||
-                             ll4 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
-                    return ZXC_ERROR_OVERFLOW;
-            }
-            uint32_t m4b = (s4 >> 16) & 0xFF;
-            uint64_t ml4 = m4b + ZXC_LZ_MIN_MATCH_LEN;
-            if (UNLIKELY(m4b == ZXC_SEQ_ML_MASK)) {
-                ml4 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY(ll4 + ml4 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
-                    return ZXC_ERROR_OVERFLOW;
-            }
-            uint32_t off4 = (s4 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
-            DECODE_SEQ_SAFE(ll4, ml4, off4);
-
-            n_seq -= 4;
+            DECODE_GHI_BATCH_4X(DECODE_SEQ_SAFE, return ZXC_ERROR_OVERFLOW, (void)0);
         }
     }
 
@@ -1608,90 +1169,8 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(const zxc_cctx_t* RESTRIC
             const uint8_t* const e_save = extras_ptr;
             uint8_t* const d_save = d_ptr;
             const uint8_t* const l_save = l_ptr;
-            uint32_t s1 = zxc_le32(seq_ptr);
-            uint32_t s2 = zxc_le32(seq_ptr + sizeof(uint32_t));
-            uint32_t s3 = zxc_le32(seq_ptr + 2 * sizeof(uint32_t));
-            uint32_t s4 = zxc_le32(seq_ptr + 3 * sizeof(uint32_t));
-            seq_ptr += 4 * sizeof(uint32_t);
-
-            // Prefetch ahead in literal and extras streams to hide memory latency
-            ZXC_PREFETCH_READ(l_ptr + ZXC_CACHE_LINE_SIZE);
-
-            uint64_t ll1 = s1 >> 24;
-            if (UNLIKELY(ll1 == ZXC_SEQ_LL_MASK)) {
-                ll1 += zxc_read_varint(&extras_ptr, extras_end);
-                const uint64_t reserve = (s2 >> 24) + (s3 >> 24) + (s4 >> 24);
-                if (UNLIKELY(ll1 + reserve > (size_t)(l_end - l_ptr) ||
-                             ll1 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
-                    goto rollback_fast_4x;
-            }
-            uint32_t m1b = (s1 >> 16) & 0xFF;
-            uint64_t ml1 = m1b + ZXC_LZ_MIN_MATCH_LEN;
-            if (UNLIKELY(m1b == ZXC_SEQ_ML_MASK)) {
-                ml1 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY(ll1 + ml1 + 3U * ZXC_GHI_MAX_INLINE_OUT_PER_SEQ + ZXC_PAD_SIZE >
-                             (size_t)(d_end - d_ptr)))
-                    goto rollback_fast_4x;
-            }
-            uint32_t off1 = (s1 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
-            DECODE_SEQ_FAST(ll1, ml1, off1);
-
-            uint64_t ll2 = s2 >> 24;
-            if (UNLIKELY(ll2 == ZXC_SEQ_LL_MASK)) {
-                ll2 += zxc_read_varint(&extras_ptr, extras_end);
-                const uint64_t reserve = (s3 >> 24) + (s4 >> 24);
-                if (UNLIKELY(ll2 + reserve > (size_t)(l_end - l_ptr) ||
-                             ll2 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
-                    goto rollback_fast_4x;
-            }
-            uint32_t m2b = (s2 >> 16) & 0xFF;
-            uint64_t ml2 = m2b + ZXC_LZ_MIN_MATCH_LEN;
-            if (UNLIKELY(m2b == ZXC_SEQ_ML_MASK)) {
-                ml2 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY(ll2 + ml2 + 2U * ZXC_GHI_MAX_INLINE_OUT_PER_SEQ + ZXC_PAD_SIZE >
-                             (size_t)(d_end - d_ptr)))
-                    goto rollback_fast_4x;
-            }
-            uint32_t off2 = (s2 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
-            DECODE_SEQ_FAST(ll2, ml2, off2);
-
-            uint64_t ll3 = s3 >> 24;
-            if (UNLIKELY(ll3 == ZXC_SEQ_LL_MASK)) {
-                ll3 += zxc_read_varint(&extras_ptr, extras_end);
-                const uint64_t reserve = (s4 >> 24);
-                if (UNLIKELY(ll3 + reserve > (size_t)(l_end - l_ptr) ||
-                             ll3 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
-                    goto rollback_fast_4x;
-            }
-            uint32_t m3b = (s3 >> 16) & 0xFF;
-            uint64_t ml3 = m3b + ZXC_LZ_MIN_MATCH_LEN;
-            if (UNLIKELY(m3b == ZXC_SEQ_ML_MASK)) {
-                ml3 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY(ll3 + ml3 + ZXC_GHI_MAX_INLINE_OUT_PER_SEQ + ZXC_PAD_SIZE >
-                             (size_t)(d_end - d_ptr)))
-                    goto rollback_fast_4x;
-            }
-            uint32_t off3 = (s3 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
-            DECODE_SEQ_FAST(ll3, ml3, off3);
-
-            uint64_t ll4 = s4 >> 24;
-            if (UNLIKELY(ll4 == ZXC_SEQ_LL_MASK)) {
-                ll4 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY(ll4 > (size_t)(l_end - l_ptr) ||
-                             ll4 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
-                    goto rollback_fast_4x;
-            }
-            uint32_t m4b = (s4 >> 16) & 0xFF;
-            uint64_t ml4 = m4b + ZXC_LZ_MIN_MATCH_LEN;
-            if (UNLIKELY(m4b == ZXC_SEQ_ML_MASK)) {
-                ml4 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY(ll4 + ml4 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
-                    goto rollback_fast_4x;
-            }
-            uint32_t off4 = (s4 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
-            DECODE_SEQ_FAST(ll4, ml4, off4);
-
-            n_seq -= 4;
+            DECODE_GHI_BATCH_4X(DECODE_SEQ_FAST, goto rollback_fast_4x,
+                                ZXC_PREFETCH_READ(l_ptr + ZXC_CACHE_LINE_SIZE));
             continue;
 
         rollback_fast_4x:
@@ -1703,90 +1182,8 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(const zxc_cctx_t* RESTRIC
         }
     } else {
         while (n_seq >= 4 && d_ptr < d_end_fast && l_ptr < l_end_safe_4x) {
-            uint32_t s1 = zxc_le32(seq_ptr);
-            uint32_t s2 = zxc_le32(seq_ptr + sizeof(uint32_t));
-            uint32_t s3 = zxc_le32(seq_ptr + 2 * sizeof(uint32_t));
-            uint32_t s4 = zxc_le32(seq_ptr + 3 * sizeof(uint32_t));
-            seq_ptr += 4 * sizeof(uint32_t);
-
-            // Prefetch ahead in literal and extras streams to hide memory latency
-            ZXC_PREFETCH_READ(l_ptr + ZXC_CACHE_LINE_SIZE);
-
-            uint64_t ll1 = s1 >> 24;
-            if (UNLIKELY(ll1 == ZXC_SEQ_LL_MASK)) {
-                ll1 += zxc_read_varint(&extras_ptr, extras_end);
-                const uint64_t reserve = (s2 >> 24) + (s3 >> 24) + (s4 >> 24);
-                if (UNLIKELY(ll1 + reserve > (size_t)(l_end - l_ptr) ||
-                             ll1 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
-                    return ZXC_ERROR_OVERFLOW;
-            }
-            uint32_t m1b = (s1 >> 16) & 0xFF;
-            uint64_t ml1 = m1b + ZXC_LZ_MIN_MATCH_LEN;
-            if (UNLIKELY(m1b == ZXC_SEQ_ML_MASK)) {
-                ml1 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY(ll1 + ml1 + 3U * ZXC_GHI_MAX_INLINE_OUT_PER_SEQ + ZXC_PAD_SIZE >
-                             (size_t)(d_end - d_ptr)))
-                    return ZXC_ERROR_OVERFLOW;
-            }
-            uint32_t off1 = (s1 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
-            DECODE_SEQ_FAST(ll1, ml1, off1);
-
-            uint64_t ll2 = s2 >> 24;
-            if (UNLIKELY(ll2 == ZXC_SEQ_LL_MASK)) {
-                ll2 += zxc_read_varint(&extras_ptr, extras_end);
-                const uint64_t reserve = (s3 >> 24) + (s4 >> 24);
-                if (UNLIKELY(ll2 + reserve > (size_t)(l_end - l_ptr) ||
-                             ll2 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
-                    return ZXC_ERROR_OVERFLOW;
-            }
-            uint32_t m2b = (s2 >> 16) & 0xFF;
-            uint64_t ml2 = m2b + ZXC_LZ_MIN_MATCH_LEN;
-            if (UNLIKELY(m2b == ZXC_SEQ_ML_MASK)) {
-                ml2 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY(ll2 + ml2 + 2U * ZXC_GHI_MAX_INLINE_OUT_PER_SEQ + ZXC_PAD_SIZE >
-                             (size_t)(d_end - d_ptr)))
-                    return ZXC_ERROR_OVERFLOW;
-            }
-            uint32_t off2 = (s2 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
-            DECODE_SEQ_FAST(ll2, ml2, off2);
-
-            uint64_t ll3 = s3 >> 24;
-            if (UNLIKELY(ll3 == ZXC_SEQ_LL_MASK)) {
-                ll3 += zxc_read_varint(&extras_ptr, extras_end);
-                const uint64_t reserve = (s4 >> 24);
-                if (UNLIKELY(ll3 + reserve > (size_t)(l_end - l_ptr) ||
-                             ll3 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
-                    return ZXC_ERROR_OVERFLOW;
-            }
-            uint32_t m3b = (s3 >> 16) & 0xFF;
-            uint64_t ml3 = m3b + ZXC_LZ_MIN_MATCH_LEN;
-            if (UNLIKELY(m3b == ZXC_SEQ_ML_MASK)) {
-                ml3 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY(ll3 + ml3 + ZXC_GHI_MAX_INLINE_OUT_PER_SEQ + ZXC_PAD_SIZE >
-                             (size_t)(d_end - d_ptr)))
-                    return ZXC_ERROR_OVERFLOW;
-            }
-            uint32_t off3 = (s3 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
-            DECODE_SEQ_FAST(ll3, ml3, off3);
-
-            uint64_t ll4 = s4 >> 24;
-            if (UNLIKELY(ll4 == ZXC_SEQ_LL_MASK)) {
-                ll4 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY(ll4 > (size_t)(l_end - l_ptr) ||
-                             ll4 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
-                    return ZXC_ERROR_OVERFLOW;
-            }
-            uint32_t m4b = (s4 >> 16) & 0xFF;
-            uint64_t ml4 = m4b + ZXC_LZ_MIN_MATCH_LEN;
-            if (UNLIKELY(m4b == ZXC_SEQ_ML_MASK)) {
-                ml4 += zxc_read_varint(&extras_ptr, extras_end);
-                if (UNLIKELY(ll4 + ml4 + ZXC_PAD_SIZE > (size_t)(d_end - d_ptr)))
-                    return ZXC_ERROR_OVERFLOW;
-            }
-            uint32_t off4 = (s4 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
-            DECODE_SEQ_FAST(ll4, ml4, off4);
-
-            n_seq -= 4;
+            DECODE_GHI_BATCH_4X(DECODE_SEQ_FAST, return ZXC_ERROR_OVERFLOW,
+                                ZXC_PREFETCH_READ(l_ptr + ZXC_CACHE_LINE_SIZE));
         }
     }
 
@@ -2028,6 +1425,10 @@ static ZXC_NOINLINE int zxc_decode_block_ghi_safe(const zxc_cctx_t* RESTRICT ctx
     return zxc_decode_block_ghi_impl(ctx, src, src_size, dst, dst_capacity, 1, 0);
 }
 
+#undef DECODE_GHI_BATCH_4X
+#undef DECODE_GHI_SEQ
+#undef DECODE_GLO_BATCH_4X
+#undef DECODE_GLO_SEQ
 #undef DECODE_SEQ_FAST
 #undef DECODE_SEQ_SAFE
 

--- a/src/lib/zxc_decompress.c
+++ b/src/lib/zxc_decompress.c
@@ -1309,11 +1309,9 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(const zxc_cctx_t* RESTRIC
     // Copy remaining literals from source stream (literal exhaustion)
     if (UNLIKELY(l_ptr > l_end)) return ZXC_ERROR_CORRUPT_DATA;
     const size_t remaining_literals = (size_t)(l_end - l_ptr);
-    if (remaining_literals > 0) {
-        if (UNLIKELY(d_ptr + remaining_literals > d_end)) return ZXC_ERROR_OVERFLOW;
-        ZXC_MEMCPY(d_ptr, l_ptr, remaining_literals);
-        d_ptr += remaining_literals;
-    }
+    if (UNLIKELY(remaining_literals > (size_t)(d_end - d_ptr))) return ZXC_ERROR_OVERFLOW;
+    ZXC_MEMCPY(d_ptr, l_ptr, remaining_literals);
+    d_ptr += remaining_literals;
 
     return (int)(d_ptr - dst);
 }
@@ -1920,11 +1918,9 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(const zxc_cctx_t* RESTRIC
     // Copy remaining literals from source stream (literal exhaustion)
     if (UNLIKELY(l_ptr > l_end)) return ZXC_ERROR_CORRUPT_DATA;
     const size_t remaining_literals = (size_t)(l_end - l_ptr);
-    if (remaining_literals > 0) {
-        if (UNLIKELY(d_ptr + remaining_literals > d_end)) return ZXC_ERROR_OVERFLOW;
-        ZXC_MEMCPY(d_ptr, l_ptr, remaining_literals);
-        d_ptr += remaining_literals;
-    }
+    if (UNLIKELY(remaining_literals > (size_t)(d_end - d_ptr))) return ZXC_ERROR_OVERFLOW;
+    ZXC_MEMCPY(d_ptr, l_ptr, remaining_literals);
+    d_ptr += remaining_literals;
 
     return (int)(d_ptr - dst);
 }

--- a/src/lib/zxc_decompress.c
+++ b/src/lib/zxc_decompress.c
@@ -565,10 +565,11 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(const zxc_cctx_t* RESTRIC
     uint8_t* rle_buf = NULL;
 
     size_t lit_stream_size = (size_t)(desc[0].sizes & ZXC_SECTION_SIZE_MASK);
+    /* Decoded size of an encoded literal section (RAW ignores it). */
+    const size_t required_size = (size_t)(desc[0].sizes >> 32);
 
-    if (gh.enc_lit == ZXC_SECTION_ENCODING_HUFFMAN) {
-        /* Wire value 2: PivCo layout. */
-        const size_t required_size = (size_t)(desc[0].sizes >> 32);
+    if (gh.enc_lit == ZXC_SECTION_ENCODING_HUFFMAN ||
+        gh.enc_lit == ZXC_SECTION_ENCODING_HUFFMAN_DICT) {
         if (UNLIKELY(lit_stream_size > (size_t)(src + src_size - p_curr)))
             return ZXC_ERROR_CORRUPT_DATA;
         if (required_size == 0) {
@@ -577,31 +578,15 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(const zxc_cctx_t* RESTRIC
         } else {
             if (UNLIKELY(required_size > dst_capacity || required_size > SIZE_MAX - ZXC_PAD_SIZE))
                 return ZXC_ERROR_DST_TOO_SMALL;
-            const int rc = zxc_decode_lit_pivco(ctx, p_curr, lit_stream_size, required_size);
-            if (UNLIKELY(rc != ZXC_OK)) return rc;
-            l_ptr = ctx->lit_buffer;
-            l_end = ctx->lit_buffer + required_size;
-        }
-    } else if (gh.enc_lit == ZXC_SECTION_ENCODING_HUFFMAN_DICT) {
-        /* Shared dictionary table: no inline lengths header; the prebuilt
-         * decode table was attached to the context with the dictionary. */
-        const size_t required_size = (size_t)(desc[0].sizes >> 32);
-        if (UNLIKELY(lit_stream_size > (size_t)(src + src_size - p_curr)))
-            return ZXC_ERROR_CORRUPT_DATA;
-        if (required_size == 0) {
-            l_ptr = p_curr;
-            l_end = p_curr;
-        } else {
-            if (UNLIKELY(required_size > dst_capacity || required_size > SIZE_MAX - ZXC_PAD_SIZE))
-                return ZXC_ERROR_DST_TOO_SMALL;
-            const int rc = zxc_decode_lit_pivco_dict(ctx, p_curr, lit_stream_size, required_size);
+            const int rc =
+                (gh.enc_lit == ZXC_SECTION_ENCODING_HUFFMAN)
+                    ? zxc_decode_lit_pivco(ctx, p_curr, lit_stream_size, required_size)
+                    : zxc_decode_lit_pivco_dict(ctx, p_curr, lit_stream_size, required_size);
             if (UNLIKELY(rc != ZXC_OK)) return rc;
             l_ptr = ctx->lit_buffer;
             l_end = ctx->lit_buffer + required_size;
         }
     } else if (gh.enc_lit == ZXC_SECTION_ENCODING_RLE) {
-        const size_t required_size = (size_t)(desc[0].sizes >> 32);
-
         if (required_size > 0) {
             if (UNLIKELY(required_size > dst_capacity || required_size > SIZE_MAX - ZXC_PAD_SIZE))
                 return ZXC_ERROR_DST_TOO_SMALL;
@@ -719,6 +704,8 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(const zxc_cctx_t* RESTRIC
     // ll_max = 14, ml_max = 14 + 5 = 19, per-seq = 33, 4x = 132.
     // Add ZXC_PAD_SIZE (32) for the wild zxc_copy32 overshoot + 4 safety = 168.
     const uint8_t* const d_end_safe = d_end - (132 + ZXC_PAD_SIZE + 4);
+    const uint8_t* const d_end_safe_1x =
+        d_end - (ZXC_GLO_MAX_INLINE_OUT_PER_SEQ + ZXC_PAD_SIZE + 4);  // 69
 
     // Literal stream safe threshold for 4x-unrolled loops.
     // Without varint extension, max ll per sequence = ZXC_TOKEN_LL_MASK - 1 = 14.
@@ -1201,7 +1188,7 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(const zxc_cctx_t* RESTRIC
     if (UNLIKELY(e_ptr > e_end)) return ZXC_ERROR_CORRUPT_DATA;
 
     // --- Remaining 1 sequence (Fast Path) ---
-    while (n_seq > 0 && d_ptr < d_end_safe && l_ptr < l_end_safe_1x) {
+    while (n_seq > 0 && d_ptr < d_end_safe_1x && l_ptr < l_end_safe_1x) {
         // Save pointers before reading (in case we need to fall back to Safe Path)
         const uint8_t* t_save = t_ptr;
         const uint8_t* o_save = o_ptr;
@@ -1239,26 +1226,10 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(const zxc_cctx_t* RESTRIC
             break;
         }
 
-        {
-            const uint8_t* src_lit = l_ptr;
-            uint8_t* dst_lit = d_ptr;
-            zxc_copy32(dst_lit, src_lit);
-            if (UNLIKELY(ll > ZXC_PAD_SIZE)) {
-                dst_lit += ZXC_PAD_SIZE;
-                src_lit += ZXC_PAD_SIZE;
-                size_t rem = ll - ZXC_PAD_SIZE;
-                while (rem > ZXC_PAD_SIZE) {
-                    zxc_copy32(dst_lit, src_lit);
-                    dst_lit += ZXC_PAD_SIZE;
-                    src_lit += ZXC_PAD_SIZE;
-                    rem -= ZXC_PAD_SIZE;
-                }
-                zxc_copy32(dst_lit, src_lit);
-            }
-            l_ptr += ll;
-            d_ptr += ll;
-            written += ll;
-        }
+        zxc_decode_copy_literals(d_ptr, l_ptr, ll);
+        l_ptr += ll;
+        d_ptr += ll;
+        written += ll;
 
         {
             // Skip check if written >= bounds_threshold (256 for 8-bit, 65536 for 16-bit)
@@ -1852,26 +1823,10 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(const zxc_cctx_t* RESTRIC
         }
         uint32_t offset = (seq & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
 
-        {
-            const uint8_t* src_lit = l_ptr;
-            uint8_t* dst_lit = d_ptr;
-            zxc_copy32(dst_lit, src_lit);
-            if (UNLIKELY(ll > ZXC_PAD_SIZE)) {
-                dst_lit += ZXC_PAD_SIZE;
-                src_lit += ZXC_PAD_SIZE;
-                size_t rem = ll - ZXC_PAD_SIZE;
-                while (rem > ZXC_PAD_SIZE) {
-                    zxc_copy32(dst_lit, src_lit);
-                    dst_lit += ZXC_PAD_SIZE;
-                    src_lit += ZXC_PAD_SIZE;
-                    rem -= ZXC_PAD_SIZE;
-                }
-                zxc_copy32(dst_lit, src_lit);
-            }
-            l_ptr += ll;
-            d_ptr += ll;
-            written += ll;
-        }
+        zxc_decode_copy_literals(d_ptr, l_ptr, ll);
+        l_ptr += ll;
+        d_ptr += ll;
+        written += ll;
 
         {
             // Skip check if written >= bounds_threshold (256 for 8-bit, 65536 for 16-bit)
@@ -2080,10 +2035,11 @@ static ZXC_NOINLINE int zxc_decode_block_ghi_safe(const zxc_cctx_t* RESTRICT ctx
  * @brief Shared chunk-decode body: validates the block header, verifies the
  *        optional checksum, then dispatches on block type.
  *
- * @p has_dict is a compile-time constant: the no-dict instantiation folds the
- * GLO/GHI selection to the plain (inlinable) decoders, so
+ * @p has_dict and @p safe are compile-time constants: the no-dict instantiation
+ * folds the GLO/GHI selection to the plain (inlinable) decoders, so
  * @ref zxc_decompress_chunk_wrapper carries no dict code and matches the
- * dict-free build; the dict instantiation calls the NOINLINE @c _dict decoders.
+ * dict-free build; the dict and safe instantiations call the NOINLINE @c _dict
+ * / @c _safe decoders (the strict-tail safe path never carries a dict).
  *
  * @param[in,out] ctx       Decompression context.
  * @param[in]     src       Compressed block (header + payload + optional checksum).
@@ -2091,11 +2047,12 @@ static ZXC_NOINLINE int zxc_decode_block_ghi_safe(const zxc_cctx_t* RESTRICT ctx
  * @param[out]    dst       Destination buffer for the decoded block.
  * @param[in]     dst_cap   Capacity of @p dst in bytes.
  * @param[in]     has_dict  Compile-time flag: 1 = dictionary-aware decoders.
+ * @param[in]     safe      Compile-time flag: 1 = strict-tail safe decoders.
  * @return Bytes written on success, or a negative @ref zxc_error_t.
  */
 static ZXC_ALWAYS_INLINE int zxc_decompress_chunk_wrapper_body(
     const zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRICT src, const size_t src_sz,
-    uint8_t* RESTRICT dst, const size_t dst_cap, const int has_dict) {
+    uint8_t* RESTRICT dst, const size_t dst_cap, const int has_dict, const int safe) {
     if (UNLIKELY(src_sz < ZXC_BLOCK_HEADER_SIZE)) return ZXC_ERROR_SRC_TOO_SMALL;
 
     const uint8_t type = src[0];
@@ -2119,12 +2076,14 @@ static ZXC_ALWAYS_INLINE int zxc_decompress_chunk_wrapper_body(
 
     switch (type) {
         case ZXC_BLOCK_GLO:
-            decoded_sz = has_dict ? zxc_decode_block_glo_dict(ctx, data, comp_sz, dst, dst_cap)
-                                  : zxc_decode_block_glo(ctx, data, comp_sz, dst, dst_cap);
+            decoded_sz = safe       ? zxc_decode_block_glo_safe(ctx, data, comp_sz, dst, dst_cap)
+                         : has_dict ? zxc_decode_block_glo_dict(ctx, data, comp_sz, dst, dst_cap)
+                                    : zxc_decode_block_glo(ctx, data, comp_sz, dst, dst_cap);
             break;
         case ZXC_BLOCK_GHI:
-            decoded_sz = has_dict ? zxc_decode_block_ghi_dict(ctx, data, comp_sz, dst, dst_cap)
-                                  : zxc_decode_block_ghi(ctx, data, comp_sz, dst, dst_cap);
+            decoded_sz = safe       ? zxc_decode_block_ghi_safe(ctx, data, comp_sz, dst, dst_cap)
+                         : has_dict ? zxc_decode_block_ghi_dict(ctx, data, comp_sz, dst, dst_cap)
+                                    : zxc_decode_block_ghi(ctx, data, comp_sz, dst, dst_cap);
             break;
         case ZXC_BLOCK_RAW:
             // For RAW blocks, comp_sz == raw_sz (uncompressed data stored as-is)
@@ -2158,7 +2117,7 @@ static ZXC_ALWAYS_INLINE int zxc_decompress_chunk_wrapper_body(
 // cppcheck-suppress unusedFunction
 int zxc_decompress_chunk_wrapper(const zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRICT src,
                                  const size_t src_sz, uint8_t* RESTRICT dst, const size_t dst_cap) {
-    return zxc_decompress_chunk_wrapper_body(ctx, src, src_sz, dst, dst_cap, 0);
+    return zxc_decompress_chunk_wrapper_body(ctx, src, src_sz, dst, dst_cap, 0, 0);
 }
 
 /**
@@ -2179,16 +2138,16 @@ int zxc_decompress_chunk_wrapper(const zxc_cctx_t* RESTRICT ctx, const uint8_t* 
 int zxc_decompress_chunk_wrapper_dict(const zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRICT src,
                                       const size_t src_sz, uint8_t* RESTRICT dst,
                                       const size_t dst_cap) {
-    return zxc_decompress_chunk_wrapper_body(ctx, src, src_sz, dst, dst_cap, 1);
+    return zxc_decompress_chunk_wrapper_body(ctx, src, src_sz, dst, dst_cap, 1, 0);
 }
 
 /**
  * @brief Public strict-tail safe chunk decoder (dst_cap == exact decoded size).
  *
- * Validates the block header and optional checksum, then decodes via the
- * @c _safe decoders (no bounce buffer, no tail padding); RAW blocks are copied
- * directly. Dict inputs are not handled here (the caller routes them to the
- * bounce-capable path).
+ * Routes through @ref zxc_decompress_chunk_wrapper_body with @c safe=1, which
+ * calls the NOINLINE @c _safe decoders (no bounce buffer, no tail padding);
+ * RAW blocks are copied directly. Dict inputs are not handled here (the
+ * caller routes them to the bounce-capable path).
  *
  * @param[in,out] ctx     Decompression context.
  * @param[in]     src     Compressed block bytes.
@@ -2201,36 +2160,5 @@ int zxc_decompress_chunk_wrapper_dict(const zxc_cctx_t* RESTRICT ctx, const uint
 int zxc_decompress_chunk_wrapper_safe(const zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRICT src,
                                       const size_t src_sz, uint8_t* RESTRICT dst,
                                       const size_t dst_cap) {
-    if (UNLIKELY(src_sz < ZXC_BLOCK_HEADER_SIZE)) return ZXC_ERROR_SRC_TOO_SMALL;
-
-    const uint8_t type = src[0];
-    const uint32_t comp_sz = zxc_le32(src + 3);
-    const int has_crc = ctx->checksum_enabled;
-
-    const size_t expected_sz =
-        (size_t)ZXC_BLOCK_HEADER_SIZE + comp_sz + (has_crc ? ZXC_BLOCK_CHECKSUM_SIZE : 0);
-    if (UNLIKELY(src_sz < expected_sz)) return ZXC_ERROR_SRC_TOO_SMALL;
-
-    const uint8_t* data = src + ZXC_BLOCK_HEADER_SIZE;
-
-    if (has_crc) {
-        const uint32_t stored = zxc_le32(data + comp_sz);
-        const uint32_t calc = zxc_checksum(data, comp_sz, ZXC_CHECKSUM_RAPIDHASH);
-        if (UNLIKELY(stored != calc)) return ZXC_ERROR_BAD_CHECKSUM;
-    }
-
-    switch (type) {
-        case ZXC_BLOCK_GLO:
-            return zxc_decode_block_glo_safe(ctx, data, comp_sz, dst, dst_cap);
-        case ZXC_BLOCK_GHI:
-            return zxc_decode_block_ghi_safe(ctx, data, comp_sz, dst, dst_cap);
-        case ZXC_BLOCK_RAW:
-            if (UNLIKELY(comp_sz > dst_cap)) return ZXC_ERROR_DST_TOO_SMALL;
-            ZXC_MEMCPY(dst, data, comp_sz);
-            return (int)comp_sz;
-        case ZXC_BLOCK_EOF:
-            return ZXC_ERROR_CORRUPT_DATA;
-        default:
-            return ZXC_ERROR_BAD_BLOCK_TYPE;
-    }
+    return zxc_decompress_chunk_wrapper_body(ctx, src, src_sz, dst, dst_cap, 0, 1);
 }


### PR DESCRIPTION
Simplification pass on `zxc_decompress.c`, plus one small perf win.

- **Macro-fold the 4x-unrolled sequence bodies**: they are now generated by `DECODE_{GLO,GHI}_SEQ` / `DECODE_{GLO,GHI}_BATCH_4X`.
- **Cold-path cleanups**: trailing-literals tail folded (GLO+GHI), hand-inlined 1x literal copies replaced by `zxc_decode_copy_literals`, `chunk_wrapper_safe`folded into the shared wrapper body, twin HUFFMAN/HUFFMAN_DICT literal branches merged.