### PR TITLE
 refactor: Drop the SIMD variants that duplicate the target baseline

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Clone LZbench
         run: |
           # git clone --depth 1 https://github.com/inikep/lzbench "${LZBENCH_DIR}"
-          git clone -b zxc-0.13.0 https://github.com/hellobertrand/lzbench "${LZBENCH_DIR}"
+          git clone -b zxc-0.13.2 https://github.com/hellobertrand/lzbench "${LZBENCH_DIR}"
 
       - name: Copy Lib ZXC
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,45 +170,40 @@ endmacro()
 
 set(ZXC_VARIANT_OBJECTS "")
 
-# --- 1. Default Variant (Scalar/Baseline) ---
-zxc_add_variant(_default "")
+# --- 1. Default Variant (target baseline) ---
+# Scalar everywhere except AArch64, where __ARM_NEON is always defined
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|arm64|ARM64" AND NOT MSVC)
+    zxc_add_variant(_default "-march=armv8-a+simd")
+else()
+    zxc_add_variant(_default "")
+endif()
 
 # --- 2. Architecture Specific Variants (skipped in no-intrinsics mode) ---
 if(ZXC_DISABLE_SIMD)
     message(STATUS "ZXC_DISABLE_SIMD: Skipping SIMD variants (no explicit AVX/NEON code paths).")
 else()
 if(CMAKE_SYSTEM_PROCESSOR MATCHES "amd64|x86_64|AMD64")
-    message(STATUS "Building x86_64 AVX2 and AVX512 variants...")
+    message(STATUS "Building x86_64 AVX2 and AVX512 variants (SSE2 tier = _default)...")
     if(MSVC)
-        # SSE2 for MSVC: SSE2 is the x86-64 baseline
-        zxc_add_variant(_sse2 "/D__SSE2__")
         # AVX2 for MSVC (Enables AVX2/BMI1/BMI2 sets)
         zxc_add_variant(_avx2 "/arch:AVX2;/D__BMI__;/D__BMI2__;/D__LZCNT__")
         # AVX512 for MSVC (VS2019 16.10+ supports /arch:AVX512)
         zxc_add_variant(_avx512 "/arch:AVX512;/D__BMI__;/D__BMI2__;/D__LZCNT__")
     else()
-        # SSE2 for GCC/Clang (x86-64 baseline)
-        zxc_add_variant(_sse2 "-msse2")
         # AVX2 for GCC/Clang
-        zxc_add_variant(_avx2 "-mavx2;-mfma;-mbmi;-mbmi2;-mlzcnt")
+        zxc_add_variant(_avx2 "-mavx2;-mbmi;-mbmi2;-mlzcnt")
         # AVX512 for GCC/Clang
         zxc_add_variant(_avx512
                         "-mavx512f;-mavx512bw;-mavx512vbmi;-mavx512vbmi2;-mbmi;-mbmi2;-mlzcnt")
     endif()
 
 elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|arm64|ARM64")
-    message(STATUS "Building AArch64 NEON variant...")
-    if(MSVC)
-        # MSVC for ARM64 implies NEON support by default.
-        zxc_add_variant(_neon "")
-    else()
-        # NEON is usually default on AArch64, but we add a specific variant for structure
-        zxc_add_variant(_neon "-march=armv8-a+simd")
-    endif()
+    # NEON tier = _default (mandatory on AArch64); nothing extra to compile.
+    message(STATUS "AArch64: NEON tier = _default variant.")
 
 elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "^arm")
     message(STATUS "Building ARM NEON variant...")
-    zxc_add_variant(_neon "-march=armv7-a;-mfpu=neon")
+    zxc_add_variant(_neon32 "-march=armv7-a;-mfpu=neon")
 endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,10 +170,20 @@ endmacro()
 
 set(ZXC_VARIANT_OBJECTS "")
 
+# Target family, resolved once: the _default baseline below and the per-ISA
+# variants further down encode one decision each and must not drift apart.
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "amd64|x86_64|AMD64")
+    set(ZXC_ARCH_X86_64 TRUE)
+elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|arm64|ARM64")
+    set(ZXC_ARCH_AARCH64 TRUE)
+elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "^arm")
+    set(ZXC_ARCH_ARM32 TRUE)
+endif()
+
 # --- 1. Default Variant (target baseline) ---
 # Scalar everywhere except AArch64, where __ARM_NEON is always defined
-if(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|arm64|ARM64" AND NOT MSVC)
-    zxc_add_variant(_default "-march=armv8-a+simd")
+if(ZXC_ARCH_AARCH64 AND NOT MSVC)
+    zxc_add_variant(_default "-march=armv8-a")
 else()
     zxc_add_variant(_default "")
 endif()
@@ -182,7 +192,7 @@ endif()
 if(ZXC_DISABLE_SIMD)
     message(STATUS "ZXC_DISABLE_SIMD: Skipping SIMD variants (no explicit AVX/NEON code paths).")
 else()
-if(CMAKE_SYSTEM_PROCESSOR MATCHES "amd64|x86_64|AMD64")
+if(ZXC_ARCH_X86_64)
     message(STATUS "Building x86_64 AVX2 and AVX512 variants (SSE2 tier = _default)...")
     if(MSVC)
         # AVX2 for MSVC (Enables AVX2/BMI1/BMI2 sets)
@@ -197,12 +207,12 @@ if(CMAKE_SYSTEM_PROCESSOR MATCHES "amd64|x86_64|AMD64")
                         "-mavx512f;-mavx512bw;-mavx512vbmi;-mavx512vbmi2;-mbmi;-mbmi2;-mlzcnt")
     endif()
 
-elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|arm64|ARM64")
+elseif(ZXC_ARCH_AARCH64)
     # NEON tier = _default (mandatory on AArch64); nothing extra to compile.
     message(STATUS "AArch64: NEON tier = _default variant.")
 
-elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "^arm")
-    message(STATUS "Building ARM NEON variant...")
+elseif(ZXC_ARCH_ARM32)
+    message(STATUS "Building 32-bit ARM _neon32 variant...")
     zxc_add_variant(_neon32 "-march=armv7-a;-mfpu=neon")
 endif()
 endif()

--- a/meson.build
+++ b/meson.build
@@ -62,7 +62,7 @@ variant_sources = ['src/lib/zxc_compress.c',
                    'src/lib/zxc_huffman.c']
 
 # _default is scalar everywhere except AArch64, where __ARM_NEON is always defined
-default_args = (host_cpu == 'aarch64' and not is_cl) ? ['-march=armv8-a+simd'] : []
+default_args = (host_cpu == 'aarch64' and not msvc_syntax) ? ['-march=armv8-a'] : []
 variant_sets = [['_default', default_args]]
 
 if host_cpu == 'x86_64'

--- a/meson.build
+++ b/meson.build
@@ -61,25 +61,22 @@ variant_sources = ['src/lib/zxc_compress.c',
                    'src/lib/zxc_decompress.c',
                    'src/lib/zxc_huffman.c']
 
-variant_sets = [['_default', []]]
+# _default is scalar everywhere except AArch64, where __ARM_NEON is always defined
+default_args = (host_cpu == 'aarch64' and not is_cl) ? ['-march=armv8-a+simd'] : []
+variant_sets = [['_default', default_args]]
 
 if host_cpu == 'x86_64'
   if is_cl
-    # SSE2 is the x86-64 baseline; /arch:AVX2|AVX512 gate the wider paths. MSVC does
-    # not predefine __BMI__/__BMI2__/__LZCNT__ under /arch, so define them here.
-    variant_sets += [['_sse2',   ['/D__SSE2__']]]
+    # MSVC does not predefine __BMI__/__BMI2__/__LZCNT__ under /arch, define them here.
     variant_sets += [['_avx2',   ['/arch:AVX2', '/D__BMI__', '/D__BMI2__', '/D__LZCNT__']]]
     variant_sets += [['_avx512', ['/arch:AVX512', '/D__BMI__', '/D__BMI2__', '/D__LZCNT__']]]
   else
-    variant_sets += [['_sse2',   ['-msse2']]]
-    variant_sets += [['_avx2',   ['-mavx2', '-mfma', '-mbmi', '-mbmi2', '-mlzcnt']]]
+    variant_sets += [['_avx2',   ['-mavx2', '-mbmi', '-mbmi2', '-mlzcnt']]]
     variant_sets += [['_avx512', ['-mavx512f', '-mavx512bw', '-mavx512vbmi', '-mavx512vbmi2', '-mbmi', '-mbmi2', '-mlzcnt']]]
   endif
-elif host_cpu == 'aarch64'
-  # MSVC ARM64 implies NEON; passing -march=armv8-a+simd only warns D9002.
-  variant_sets += is_cl ? [['_neon', []]] : [['_neon', ['-march=armv8-a+simd']]]
 elif host_cpu == 'arm'
-  variant_sets += [['_neon', ['-march=armv7-a', '-mfpu=neon']]]
+  # _neon32: 32-bit ARM only (AArch64's NEON tier is _default).
+  variant_sets += [['_neon32', ['-march=armv7-a', '-mfpu=neon']]]
 endif
 
 variant_objects = []

--- a/src/lib/zxc_dispatch.c
+++ b/src/lib/zxc_dispatch.c
@@ -78,25 +78,16 @@ int zxc_decompress_chunk_wrapper_safe_avx2(const zxc_cctx_t* RESTRICT ctx,
 int zxc_decompress_chunk_wrapper_safe_avx512(const zxc_cctx_t* RESTRICT ctx,
                                              const uint8_t* RESTRICT src, const size_t src_sz,
                                              uint8_t* RESTRICT dst, const size_t dst_cap);
-int zxc_decompress_chunk_wrapper_sse2(const zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRICT src,
-                                      const size_t src_sz, uint8_t* RESTRICT dst,
-                                      const size_t dst_cap);
-int zxc_decompress_chunk_wrapper_dict_sse2(const zxc_cctx_t* RESTRICT ctx,
-                                           const uint8_t* RESTRICT src, const size_t src_sz,
-                                           uint8_t* RESTRICT dst, const size_t dst_cap);
-int zxc_decompress_chunk_wrapper_safe_sse2(const zxc_cctx_t* RESTRICT ctx,
-                                           const uint8_t* RESTRICT src, const size_t src_sz,
-                                           uint8_t* RESTRICT dst, const size_t dst_cap);
-#elif defined(__aarch64__) || defined(_M_ARM64) || defined(__arm__) || defined(_M_ARM)
-int zxc_decompress_chunk_wrapper_neon(const zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRICT src,
-                                      const size_t src_sz, uint8_t* RESTRICT dst,
-                                      const size_t dst_cap);
-int zxc_decompress_chunk_wrapper_dict_neon(const zxc_cctx_t* RESTRICT ctx,
-                                           const uint8_t* RESTRICT src, const size_t src_sz,
-                                           uint8_t* RESTRICT dst, const size_t dst_cap);
-int zxc_decompress_chunk_wrapper_safe_neon(const zxc_cctx_t* RESTRICT ctx,
-                                           const uint8_t* RESTRICT src, const size_t src_sz,
-                                           uint8_t* RESTRICT dst, const size_t dst_cap);
+#elif defined(__arm__) || defined(_M_ARM)
+int zxc_decompress_chunk_wrapper_neon32(const zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRICT src,
+                                        const size_t src_sz, uint8_t* RESTRICT dst,
+                                        const size_t dst_cap);
+int zxc_decompress_chunk_wrapper_dict_neon32(const zxc_cctx_t* RESTRICT ctx,
+                                             const uint8_t* RESTRICT src, const size_t src_sz,
+                                             uint8_t* RESTRICT dst, const size_t dst_cap);
+int zxc_decompress_chunk_wrapper_safe_neon32(const zxc_cctx_t* RESTRICT ctx,
+                                             const uint8_t* RESTRICT src, const size_t src_sz,
+                                             uint8_t* RESTRICT dst, const size_t dst_cap);
 #endif
 #endif
 
@@ -142,13 +133,10 @@ int zxc_compress_chunk_wrapper_avx2(zxc_cctx_t* RESTRICT ctx, const uint8_t* RES
 int zxc_compress_chunk_wrapper_avx512(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRICT src,
                                       const size_t src_sz, uint8_t* RESTRICT dst,
                                       const size_t dst_cap);
-int zxc_compress_chunk_wrapper_sse2(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRICT src,
-                                    const size_t src_sz, uint8_t* RESTRICT dst,
-                                    const size_t dst_cap);
-#elif defined(__aarch64__) || defined(_M_ARM64) || defined(__arm__) || defined(_M_ARM)
-int zxc_compress_chunk_wrapper_neon(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRICT src,
-                                    const size_t src_sz, uint8_t* RESTRICT dst,
-                                    const size_t dst_cap);
+#elif defined(__arm__) || defined(_M_ARM)
+int zxc_compress_chunk_wrapper_neon32(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRICT src,
+                                      const size_t src_sz, uint8_t* RESTRICT dst,
+                                      const size_t dst_cap);
 #endif
 
 /*
@@ -229,7 +217,7 @@ static zxc_cpu_feature_t zxc_detect_cpu_features(void) {
 #endif
 
 #elif defined(__aarch64__) || defined(_M_ARM64)
-    // ARM64 usually guarantees NEON
+    // Mandatory on AArch64, so _default is already the NEON tier: unused below.
     features = ZXC_CPU_NEON;
 
 #elif defined(__arm__) || defined(_M_ARM)
@@ -307,18 +295,15 @@ static int zxc_decompress_dispatch_init(const zxc_cctx_t* RESTRICT ctx, const ui
     } else if (cpu == ZXC_CPU_AVX2) {
         zxc_decompress_ptr_local = zxc_decompress_chunk_wrapper_avx2;
         zxc_decompress_dict_ptr_local = zxc_decompress_chunk_wrapper_dict_avx2;
-    } else if (cpu == ZXC_CPU_SSE2) {
-        zxc_decompress_ptr_local = zxc_decompress_chunk_wrapper_sse2;
-        zxc_decompress_dict_ptr_local = zxc_decompress_chunk_wrapper_dict_sse2;
     } else {
         zxc_decompress_ptr_local = zxc_decompress_chunk_wrapper_default;
         zxc_decompress_dict_ptr_local = zxc_decompress_chunk_wrapper_dict_default;
     }
-#elif defined(__aarch64__) || defined(_M_ARM64) || defined(__arm__) || defined(_M_ARM)
+#elif defined(__arm__) || defined(_M_ARM)
     // cppcheck-suppress knownConditionTrueFalse
     if (cpu == ZXC_CPU_NEON) {
-        zxc_decompress_ptr_local = zxc_decompress_chunk_wrapper_neon;
-        zxc_decompress_dict_ptr_local = zxc_decompress_chunk_wrapper_dict_neon;
+        zxc_decompress_ptr_local = zxc_decompress_chunk_wrapper_neon32;
+        zxc_decompress_dict_ptr_local = zxc_decompress_chunk_wrapper_dict_neon32;
     } else {
         zxc_decompress_ptr_local = zxc_decompress_chunk_wrapper_default;
         zxc_decompress_dict_ptr_local = zxc_decompress_chunk_wrapper_dict_default;
@@ -374,14 +359,12 @@ static int zxc_decompress_safe_dispatch_init(const zxc_cctx_t* RESTRICT ctx,
         zxc_decompress_safe_ptr_local = zxc_decompress_chunk_wrapper_safe_avx512;
     else if (cpu == ZXC_CPU_AVX2)
         zxc_decompress_safe_ptr_local = zxc_decompress_chunk_wrapper_safe_avx2;
-    else if (cpu == ZXC_CPU_SSE2)
-        zxc_decompress_safe_ptr_local = zxc_decompress_chunk_wrapper_safe_sse2;
     else
         zxc_decompress_safe_ptr_local = zxc_decompress_chunk_wrapper_safe_default;
-#elif defined(__aarch64__) || defined(_M_ARM64) || defined(__arm__) || defined(_M_ARM)
+#elif defined(__arm__) || defined(_M_ARM)
     // cppcheck-suppress knownConditionTrueFalse
     if (cpu == ZXC_CPU_NEON)
-        zxc_decompress_safe_ptr_local = zxc_decompress_chunk_wrapper_safe_neon;
+        zxc_decompress_safe_ptr_local = zxc_decompress_chunk_wrapper_safe_neon32;
     else
         zxc_decompress_safe_ptr_local = zxc_decompress_chunk_wrapper_safe_default;
 #else
@@ -430,14 +413,12 @@ static int zxc_compress_dispatch_init(zxc_cctx_t* RESTRICT ctx, const uint8_t* R
         zxc_compress_ptr_local = zxc_compress_chunk_wrapper_avx512;
     else if (cpu == ZXC_CPU_AVX2)
         zxc_compress_ptr_local = zxc_compress_chunk_wrapper_avx2;
-    else if (cpu == ZXC_CPU_SSE2)
-        zxc_compress_ptr_local = zxc_compress_chunk_wrapper_sse2;
     else
         zxc_compress_ptr_local = zxc_compress_chunk_wrapper_default;
-#elif defined(__aarch64__) || defined(_M_ARM64) || defined(__arm__) || defined(_M_ARM)
+#elif defined(__arm__) || defined(_M_ARM)
     // cppcheck-suppress knownConditionTrueFalse
     if (cpu == ZXC_CPU_NEON)
-        zxc_compress_ptr_local = zxc_compress_chunk_wrapper_neon;
+        zxc_compress_ptr_local = zxc_compress_chunk_wrapper_neon32;
     else
         zxc_compress_ptr_local = zxc_compress_chunk_wrapper_default;
 #else

--- a/src/lib/zxc_dispatch.c
+++ b/src/lib/zxc_dispatch.c
@@ -150,11 +150,11 @@ int zxc_compress_chunk_wrapper_neon32(zxc_cctx_t* RESTRICT ctx, const uint8_t* R
  * @brief Detected CPU SIMD capability level.
  */
 typedef enum {
-    ZXC_CPU_GENERIC = 0, /**< @brief Scalar-only fallback.   */
-    ZXC_CPU_AVX2 = 1,    /**< @brief x86-64 AVX2 available.  */
+    ZXC_CPU_GENERIC = 0, /**< @brief Scalar-only fallback. */
+    ZXC_CPU_AVX2 = 1,    /**< @brief x86-64 AVX2 available. */
     ZXC_CPU_AVX512 = 2,  /**< @brief x86-64 AVX-512F+BW available. */
-    ZXC_CPU_NEON = 3,    /**< @brief ARM NEON available.      */
-    ZXC_CPU_SSE2 = 4     /**< @brief x86 SSE2 available (no AVX2); x86-64 baseline. */
+    ZXC_CPU_NEON = 3,    /**< @brief ARM NEON available. */
+    ZXC_CPU_SSE2 = 4     /**< @brief x86 SSE2 available (x86-64 baseline) */
 } zxc_cpu_feature_t;
 
 /**
@@ -300,7 +300,6 @@ static int zxc_decompress_dispatch_init(const zxc_cctx_t* RESTRICT ctx, const ui
         zxc_decompress_dict_ptr_local = zxc_decompress_chunk_wrapper_dict_default;
     }
 #elif defined(__arm__) || defined(_M_ARM)
-    // cppcheck-suppress knownConditionTrueFalse
     if (cpu == ZXC_CPU_NEON) {
         zxc_decompress_ptr_local = zxc_decompress_chunk_wrapper_neon32;
         zxc_decompress_dict_ptr_local = zxc_decompress_chunk_wrapper_dict_neon32;
@@ -362,7 +361,6 @@ static int zxc_decompress_safe_dispatch_init(const zxc_cctx_t* RESTRICT ctx,
     else
         zxc_decompress_safe_ptr_local = zxc_decompress_chunk_wrapper_safe_default;
 #elif defined(__arm__) || defined(_M_ARM)
-    // cppcheck-suppress knownConditionTrueFalse
     if (cpu == ZXC_CPU_NEON)
         zxc_decompress_safe_ptr_local = zxc_decompress_chunk_wrapper_safe_neon32;
     else
@@ -416,7 +414,6 @@ static int zxc_compress_dispatch_init(zxc_cctx_t* RESTRICT ctx, const uint8_t* R
     else
         zxc_compress_ptr_local = zxc_compress_chunk_wrapper_default;
 #elif defined(__arm__) || defined(_M_ARM)
-    // cppcheck-suppress knownConditionTrueFalse
     if (cpu == ZXC_CPU_NEON)
         zxc_compress_ptr_local = zxc_compress_chunk_wrapper_neon32;
     else

--- a/wrappers/rust/zxc-sys/build.rs
+++ b/wrappers/rust/zxc-sys/build.rs
@@ -10,9 +10,12 @@
 //! This script compiles the ZXC C library with Function Multi-Versioning (FMV)
 //! to support runtime CPU feature detection and optimized code paths.
 //!
-//! On ARM64: Compiles `_default` only (NEON is the AArch64 baseline, so
-//!            `_default` already is the NEON build)
-//! On x86_64: Compiles `_default` (the SSE2 baseline), `_avx2` and `_avx512`
+//! On x86_64: `_default` (the SSE2 baseline), `_avx2` and `_avx512`
+//! On ARM64:  `_default` only - NEON is the AArch64 baseline, so `_default`
+//!            already is the NEON build
+//! On ARM32:  `_default`, plus `_neon32` on hard-float Linux/Android (NEON is
+//!            optional there and probed at run time via HWCAP)
+//! Elsewhere (i686, RISC-V, POWER, s390x, ...): `_default` only
 
 use std::env;
 use std::fs;
@@ -187,10 +190,19 @@ fn main() {
     );
 
     let target = env::var("TARGET").unwrap_or_default();
+    let is_msvc = target.contains("msvc");
     let is_arm64 = target.contains("aarch64") || target.contains("arm64");
-    let is_x86_64 = target.contains("x86_64") || target.contains("i686");
+    let is_x86_64 = target.contains("x86_64");
+    let is_x86_32 = target.contains("i686") || target.contains("i586");
     let is_arm32 = !is_arm64 && (target.starts_with("arm") || target.starts_with("thumb"));
-    let arm32_has_neon = is_arm32 && target.ends_with("hf");
+    let arm32_has_neon = is_arm32
+        && target.ends_with("hf")
+        && (target.contains("linux") || target.contains("android"));
+    let arm64_baseline: &[&str] = if is_arm64 && !is_msvc {
+        &["-march=armv8-a"]
+    } else {
+        &[]
+    };
 
     // =========================================================================
     // Core library files (common to all architectures)
@@ -215,8 +227,13 @@ fn main() {
     // Function Multi-Versioning: Compile variants with different suffixes
     // =========================================================================
 
-    if is_x86_64 {
+    // SSE2 is already the x86-64 baseline (no-op there) but not the i686 one,
+    // where the core does need it raised.
+    if is_x86_64 || is_x86_32 {
         core_build.flag_if_supported("-msse2");
+    }
+    for flag in arm64_baseline {
+        core_build.flag_if_supported(flag);
     }
     if is_arm32 && !arm32_has_neon {
         core_build.define("ZXC_ONLY_DEFAULT", None);
@@ -225,19 +242,13 @@ fn main() {
     core_build.compile("zxc_core");
 
     // --- Default variant (baseline, always compiled) ---
-    let default_flags: &[&str] = if is_arm64 && !target.contains("msvc") {
-        &["-march=armv8-a+simd"]
-    } else {
-        &[]
-    };
-    compile_variant(&include_dir, &src_lib, "_default", default_flags);
+    compile_variant(&include_dir, &src_lib, "_default", arm64_baseline);
 
     // --- Architecture-specific variants ---
     // The per-variant flags mirror zxc_add_variant() in CMakeLists.txt;
     // keep both in sync. MSVC ignores GCC-style -m flags silently, so it
     // needs its own /arch spellings plus the __BMI*__/__LZCNT__ macros the
     // sources test (cl.exe never defines them itself).
-    let is_msvc = target.contains("msvc");
     if arm32_has_neon {
         compile_variant(
             &include_dir,

--- a/wrappers/rust/zxc-sys/build.rs
+++ b/wrappers/rust/zxc-sys/build.rs
@@ -10,8 +10,9 @@
 //! This script compiles the ZXC C library with Function Multi-Versioning (FMV)
 //! to support runtime CPU feature detection and optimized code paths.
 //!
-//! On ARM64: Compiles `_default` and `_neon` variants
-//! On x86_64: Compiles `_default`, `_sse2`, `_avx2`, and `_avx512` variants
+//! On ARM64: Compiles `_default` only (NEON is the AArch64 baseline, so
+//!            `_default` already is the NEON build)
+//! On x86_64: Compiles `_default` (the SSE2 baseline), `_avx2` and `_avx512`
 
 use std::env;
 use std::fs;
@@ -188,6 +189,8 @@ fn main() {
     let target = env::var("TARGET").unwrap_or_default();
     let is_arm64 = target.contains("aarch64") || target.contains("arm64");
     let is_x86_64 = target.contains("x86_64") || target.contains("i686");
+    let is_arm32 = !is_arm64 && (target.starts_with("arm") || target.starts_with("thumb"));
+    let arm32_has_neon = is_arm32 && target.ends_with("hf");
 
     // =========================================================================
     // Core library files (common to all architectures)
@@ -212,18 +215,22 @@ fn main() {
     // Function Multi-Versioning: Compile variants with different suffixes
     // =========================================================================
 
-    // Add architecture-specific flags to core build BEFORE compiling
-    if is_arm64 {
-        core_build.flag_if_supported("-march=armv8-a+crc");
-    } else if is_x86_64 {
+    if is_x86_64 {
         core_build.flag_if_supported("-msse2");
-        core_build.flag_if_supported("-mpclmul");
+    }
+    if is_arm32 && !arm32_has_neon {
+        core_build.define("ZXC_ONLY_DEFAULT", None);
     }
 
     core_build.compile("zxc_core");
 
     // --- Default variant (baseline, always compiled) ---
-    compile_variant(&include_dir, &src_lib, "_default", &[]);
+    let default_flags: &[&str] = if is_arm64 && !target.contains("msvc") {
+        &["-march=armv8-a+simd"]
+    } else {
+        &[]
+    };
+    compile_variant(&include_dir, &src_lib, "_default", default_flags);
 
     // --- Architecture-specific variants ---
     // The per-variant flags mirror zxc_add_variant() in CMakeLists.txt;
@@ -231,10 +238,14 @@ fn main() {
     // needs its own /arch spellings plus the __BMI*__/__LZCNT__ macros the
     // sources test (cl.exe never defines them itself).
     let is_msvc = target.contains("msvc");
-    if is_arm64 {
-        compile_variant(&include_dir, &src_lib, "_neon", &["-march=armv8-a+simd"]);
+    if arm32_has_neon {
+        compile_variant(
+            &include_dir,
+            &src_lib,
+            "_neon32",
+            &["-march=armv7-a", "-mfpu=neon"],
+        );
     } else if is_x86_64 && is_msvc {
-        compile_variant(&include_dir, &src_lib, "_sse2", &["/D__SSE2__"]);
         compile_variant(
             &include_dir,
             &src_lib,
@@ -248,14 +259,11 @@ fn main() {
             &["/arch:AVX512", "/D__BMI__", "/D__BMI2__", "/D__LZCNT__"],
         );
     } else if is_x86_64 {
-        // SSE2 variant: the x86-64 baseline (also covers any i686 built with
-        // SSE2).
-        compile_variant(&include_dir, &src_lib, "_sse2", &["-msse2"]);
         compile_variant(
             &include_dir,
             &src_lib,
             "_avx2",
-            &["-mavx2", "-mfma", "-mbmi", "-mbmi2", "-mlzcnt"],
+            &["-mavx2", "-mbmi", "-mbmi2", "-mlzcnt"],
         );
         compile_variant(
             &include_dir,


### PR DESCRIPTION
SSE2 is the x86_64 baseline and NEON the arm64 one, so _default already was those tiers: the dedicated _sse2 / _neon variants were byte-identical copies we compiled and shipped for nothing. Route their tier to _default instead.
32-bit ARM keeps its variant, renamed _neon32: NEON is optional there and picked at run time, so _default really is the scalar fallback.

 On arm64, _default takes over the `-march=armv8-a+simd` that _neon carried, so the shipped baseline stays ARMv8.0 rather than whatever the build host offers.

Also drop flags that emit nothing (`-mfma`; `+crc` and `-mpclmul` in the Rust build), and fix the Rust wrapper's long-standing link failure on 32-bit ARM, which never built the NEON tier the dispatcher asks for.
