### PR TITLE
style: Format wrapper sources and guard it in CI

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -41,6 +41,8 @@ Executes fuzz testing using ClusterFuzzLite with multiple sanitizers (address, u
 
 Performs static analysis using Cppcheck and Clang Static Analyzer. Runs memory leak detection with Valgrind to ensure code quality and identify potential bugs.
 
+Also enforces formatting, one job per language, each running that ecosystem's canonical tool: `c-format` (clang-format, via `make format-check`), `rust-format` (`cargo fmt`), `go-format` (`gofmt`), `python-format` (`black`) and `nodejs-format` (`prettier`, covering both the Node.js and WASM wrappers). Formatter versions are pinned so a new release of one cannot turn CI red on a commit that touched nothing.
+
 ### security.yml - Code Security
 **Triggers:** Push to main, pull requests
 
@@ -73,27 +75,27 @@ Regenerates [`CHANGELOG.md`](../../CHANGELOG.md) with [`git-cliff`](https://git-
 
 ## Language Bindings
 
-### wrapper-rust-publish.yml - Publish Rust Crates
+### wrapper-rust.yml - Wrapper Rust
 **Triggers:** Release published, manual dispatch
 
 Tests and publishes Rust crates to crates.io. Verifies the version matches the release tag, runs tests across platforms, and publishes `zxc-compress-sys` (FFI bindings) followed by `zxc-compress` (safe wrapper).
 
-### wrapper-python-publish.yml - Publish Python Package
+### wrapper-python.yml - Wrapper Python
 **Triggers:** Release published, manual dispatch
 
 Builds platform-specific wheels using `cibuildwheel` for Linux (x86_64, ARM64), macOS (ARM64, Intel), and Windows (AMD64, ARM64). Tests wheels against Python 3.12-3.13, then publishes to PyPI via trusted publishing.
 
-### wrapper-wasm.yml - WASM Build & Test
+### wrapper-wasm.yml - Wrapper WASM
 **Triggers:** Release published, publish on main, manual dispatch
 
 Builds the WebAssembly target using Emscripten SDK. Compiles the library with SIMD disabled (scalar codepath) and no threading, then runs a Node.js roundtrip test suite covering all compression levels, reusable contexts, and error handling. Uploads `zxc.js` + `zxc.wasm` as build artifacts.
 
-### wrapper-nodejs-publish.yml - Publish Node.js Package
+### wrapper-nodejs.yml - Wrapper Node.js
 **Triggers:** Release published, manual dispatch
 
 Builds and publishes the Node.js package to npm. Handles the compilation of native bindings and ensures the package is correctly versioned and distributed.
 
-### wrapper-go-test.yml - Test Go Package
+### wrapper-go.yml - Wrapper Go
 **Triggers:** Release published, manual dispatch
 
 Runs comprehensive tests for the Go bindings across various platforms and architectures to ensure the Go package is stable and functional.

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -15,7 +15,7 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
 
 jobs:
-  format:
+  c-format:
     name: Code Quality - Clang-Format
     runs-on: ubuntu-latest
 
@@ -34,6 +34,76 @@ jobs:
         run: make format-check
         env:
           CLANG_FORMAT: clang-format-22
+
+  rust-format:
+    name: Code Quality - Rustfmt
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install rustfmt
+        run: rustup component add rustfmt
+
+      - name: Check Formatting
+        working-directory: wrappers/rust
+        run: cargo fmt --all --check
+
+  go-format:
+    name: Code Quality - Gofmt
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version: stable
+
+      # gofmt -l lists offending files but still exits 0, so fail on any output.
+      - name: Check Formatting
+        run: |
+          unformatted=$(gofmt -l wrappers/go)
+          if [ -n "$unformatted" ]; then
+            echo "::error::gofmt would reformat:"; echo "$unformatted"
+            exit 1
+          fi
+
+  python-format:
+    name: Code Quality - Black
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      # Pinned: an unpinned formatter turns CI red on the day it changes style.
+      - name: Install Black
+        run: pipx install black==26.5.1
+
+      - name: Check Formatting
+        run: black --check wrappers/python/src wrappers/python/tests
+
+  js-format:
+    name: Code Quality - Prettier
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      # Hand-written JS only: build-wasm/zxc.js is emscripten output, and the
+      # nodejs/wasm build/ and node_modules/ trees are not ours to format.
+      - name: Check Formatting
+        run: |
+          npx --yes prettier@3.9.5 --check \
+            "wrappers/nodejs/lib/*.js" \
+            "wrappers/nodejs/test/*.js" \
+            "wrappers/wasm/*.mjs" \
+            "wrappers/wasm/zxc_wasm.js"
 
   cppcheck:
     name: Code Quality - Cppcheck

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -63,7 +63,6 @@ jobs:
         with:
           go-version: stable
 
-      # gofmt -l lists offending files but still exits 0, so fail on any output.
       - name: Check Formatting
         run: |
           unformatted=$(gofmt -l wrappers/go)
@@ -80,7 +79,6 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      # Pinned: an unpinned formatter turns CI red on the day it changes style.
       - name: Install Black
         run: pipx install black==26.5.1
 
@@ -95,8 +93,6 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      # Hand-written JS only: build-wasm/zxc.js is emscripten output, and the
-      # nodejs/wasm build/ and node_modules/ trees are not ours to format.
       - name: Check Formatting
         run: |
           npx --yes prettier@3.9.5 --check \

--- a/.github/workflows/wrapper-go.yml
+++ b/.github/workflows/wrapper-go.yml
@@ -1,4 +1,4 @@
-name: Test Go Package
+name: Wrapper Go
 
 on:
   workflow_dispatch:

--- a/.github/workflows/wrapper-nodejs.yml
+++ b/.github/workflows/wrapper-nodejs.yml
@@ -1,4 +1,4 @@
-name: Publish Node.js Package
+name: Wrapper Node.js
 
 on:
   workflow_dispatch:

--- a/.github/workflows/wrapper-python.yml
+++ b/.github/workflows/wrapper-python.yml
@@ -1,4 +1,4 @@
-name: Publish Python Package
+name: Wrapper Python
 
 on:
   workflow_dispatch:

--- a/.github/workflows/wrapper-rust.yml
+++ b/.github/workflows/wrapper-rust.yml
@@ -1,4 +1,4 @@
-name: Publish Rust Crates
+name: Wrapper Rust
 
 on:
   workflow_dispatch:

--- a/.github/workflows/wrapper-wasm.yml
+++ b/.github/workflows/wrapper-wasm.yml
@@ -3,7 +3,7 @@
 # Copyright (c) 2025-2026 Bertrand Lebonnois and contributors.
 # SPDX-License-Identifier: BSD-3-Clause
 
-name: WASM Build
+name: Wrapper WASM
 
 on:
   workflow_dispatch:

--- a/wrappers/nodejs/lib/index.js
+++ b/wrappers/nodejs/lib/index.js
@@ -5,46 +5,46 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-'use strict';
+"use strict";
 
-const { Transform } = require('node:stream');
-const native = require('../build/Release/zxc_nodejs.node');
+const { Transform } = require("node:stream");
+const native = require("../build/Release/zxc_nodejs.node");
 
 // Re-export compression level constants
-const LEVEL_FASTEST  = native.LEVEL_FASTEST;
-const LEVEL_FAST     = native.LEVEL_FAST;
-const LEVEL_DEFAULT  = native.LEVEL_DEFAULT;
+const LEVEL_FASTEST = native.LEVEL_FASTEST;
+const LEVEL_FAST = native.LEVEL_FAST;
+const LEVEL_DEFAULT = native.LEVEL_DEFAULT;
 const LEVEL_BALANCED = native.LEVEL_BALANCED;
-const LEVEL_COMPACT  = native.LEVEL_COMPACT;
-const LEVEL_DENSITY  = native.LEVEL_DENSITY;
-const LEVEL_ULTRA    = native.LEVEL_ULTRA;
+const LEVEL_COMPACT = native.LEVEL_COMPACT;
+const LEVEL_DENSITY = native.LEVEL_DENSITY;
+const LEVEL_ULTRA = native.LEVEL_ULTRA;
 
 // Re-export error constants
-const ERROR_MEMORY         = native.ERROR_MEMORY;
-const ERROR_DST_TOO_SMALL  = native.ERROR_DST_TOO_SMALL;
-const ERROR_SRC_TOO_SMALL  = native.ERROR_SRC_TOO_SMALL;
-const ERROR_BAD_MAGIC      = native.ERROR_BAD_MAGIC;
-const ERROR_BAD_VERSION    = native.ERROR_BAD_VERSION;
-const ERROR_BAD_HEADER     = native.ERROR_BAD_HEADER;
-const ERROR_BAD_CHECKSUM   = native.ERROR_BAD_CHECKSUM;
-const ERROR_CORRUPT_DATA   = native.ERROR_CORRUPT_DATA;
-const ERROR_BAD_OFFSET     = native.ERROR_BAD_OFFSET;
-const ERROR_OVERFLOW       = native.ERROR_OVERFLOW;
-const ERROR_IO             = native.ERROR_IO;
-const ERROR_NULL_INPUT     = native.ERROR_NULL_INPUT;
+const ERROR_MEMORY = native.ERROR_MEMORY;
+const ERROR_DST_TOO_SMALL = native.ERROR_DST_TOO_SMALL;
+const ERROR_SRC_TOO_SMALL = native.ERROR_SRC_TOO_SMALL;
+const ERROR_BAD_MAGIC = native.ERROR_BAD_MAGIC;
+const ERROR_BAD_VERSION = native.ERROR_BAD_VERSION;
+const ERROR_BAD_HEADER = native.ERROR_BAD_HEADER;
+const ERROR_BAD_CHECKSUM = native.ERROR_BAD_CHECKSUM;
+const ERROR_CORRUPT_DATA = native.ERROR_CORRUPT_DATA;
+const ERROR_BAD_OFFSET = native.ERROR_BAD_OFFSET;
+const ERROR_OVERFLOW = native.ERROR_OVERFLOW;
+const ERROR_IO = native.ERROR_IO;
+const ERROR_NULL_INPUT = native.ERROR_NULL_INPUT;
 const ERROR_BAD_BLOCK_TYPE = native.ERROR_BAD_BLOCK_TYPE;
 const ERROR_BAD_BLOCK_SIZE = native.ERROR_BAD_BLOCK_SIZE;
-const ERROR_DICT_REQUIRED  = native.ERROR_DICT_REQUIRED;
-const ERROR_DICT_MISMATCH  = native.ERROR_DICT_MISMATCH;
+const ERROR_DICT_REQUIRED = native.ERROR_DICT_REQUIRED;
+const ERROR_DICT_MISMATCH = native.ERROR_DICT_MISMATCH;
 const ERROR_DICT_TOO_LARGE = native.ERROR_DICT_TOO_LARGE;
-const ERROR_BAD_LEVEL      = native.ERROR_BAD_LEVEL;
+const ERROR_BAD_LEVEL = native.ERROR_BAD_LEVEL;
 
 /**
  * Returns the minimum supported compression level (currently 1).
  * @returns {number}
  */
 function minLevel() {
-    return native.minLevel();
+  return native.minLevel();
 }
 
 /**
@@ -52,7 +52,7 @@ function minLevel() {
  * @returns {number}
  */
 function maxLevel() {
-    return native.maxLevel();
+  return native.maxLevel();
 }
 
 /**
@@ -60,7 +60,7 @@ function maxLevel() {
  * @returns {number}
  */
 function defaultLevel() {
-    return native.defaultLevel();
+  return native.defaultLevel();
 }
 
 /**
@@ -69,7 +69,7 @@ function defaultLevel() {
  * @returns {string}
  */
 function libraryVersion() {
-    return native.libraryVersion();
+  return native.libraryVersion();
 }
 
 /**
@@ -79,10 +79,10 @@ function libraryVersion() {
  * @returns {string} Error name (e.g., "ZXC_ERROR_DST_TOO_SMALL").
  */
 function errorName(code) {
-    if (typeof code !== 'number') {
-        throw new TypeError('code must be a number');
-    }
-    return native.errorName(code);
+  if (typeof code !== "number") {
+    throw new TypeError("code must be a number");
+  }
+  return native.errorName(code);
 }
 
 /**
@@ -93,10 +93,10 @@ function errorName(code) {
  * @returns {number} Maximum required buffer size in bytes.
  */
 function compressBound(inputSize) {
-    if (typeof inputSize !== 'number' || inputSize < 0) {
-        throw new TypeError('inputSize must be a non-negative number');
-    }
-    return native.compressBound(inputSize);
+  if (typeof inputSize !== "number" || inputSize < 0) {
+    throw new TypeError("inputSize must be a non-negative number");
+  }
+  return native.compressBound(inputSize);
 }
 
 /**
@@ -106,10 +106,11 @@ function compressBound(inputSize) {
  * @returns {Buffer|undefined}
  */
 function toDictBuffer(dict) {
-    if (dict === undefined || dict === null) return undefined;
-    if (Buffer.isBuffer(dict)) return dict;
-    if (dict instanceof Uint8Array) return Buffer.from(dict.buffer, dict.byteOffset, dict.byteLength);
-    throw new TypeError('dict must be a Buffer or Uint8Array');
+  if (dict === undefined || dict === null) return undefined;
+  if (Buffer.isBuffer(dict)) return dict;
+  if (dict instanceof Uint8Array)
+    return Buffer.from(dict.buffer, dict.byteOffset, dict.byteLength);
+  throw new TypeError("dict must be a Buffer or Uint8Array");
 }
 
 /**
@@ -120,15 +121,16 @@ function toDictBuffer(dict) {
  * @returns {Buffer} Raw dictionary content suitable for `options.dict`.
  */
 function trainDict(samples, maxSize = native.DICT_SIZE_MAX) {
-    if (!Array.isArray(samples) || samples.length === 0) {
-        throw new TypeError('samples must be a non-empty array of Buffers');
-    }
-    const bufs = samples.map((s) => {
-        if (Buffer.isBuffer(s)) return s;
-        if (s instanceof Uint8Array) return Buffer.from(s.buffer, s.byteOffset, s.byteLength);
-        throw new TypeError('samples entries must be Buffers or Uint8Arrays');
-    });
-    return native.trainDict(bufs, maxSize);
+  if (!Array.isArray(samples) || samples.length === 0) {
+    throw new TypeError("samples must be a non-empty array of Buffers");
+  }
+  const bufs = samples.map((s) => {
+    if (Buffer.isBuffer(s)) return s;
+    if (s instanceof Uint8Array)
+      return Buffer.from(s.buffer, s.byteOffset, s.byteLength);
+    throw new TypeError("samples entries must be Buffers or Uint8Arrays");
+  });
+  return native.trainDict(bufs, maxSize);
 }
 
 /**
@@ -137,10 +139,10 @@ function trainDict(samples, maxSize = native.DICT_SIZE_MAX) {
  * @returns {number}
  */
 function dictId(content) {
-    if (!Buffer.isBuffer(content)) {
-        throw new TypeError('content must be a Buffer');
-    }
-    return native.dictId(content);
+  if (!Buffer.isBuffer(content)) {
+    throw new TypeError("content must be a Buffer");
+  }
+  return native.dictId(content);
 }
 
 /**
@@ -149,10 +151,10 @@ function dictId(content) {
  * @returns {number}
  */
 function getDictId(archive) {
-    if (!Buffer.isBuffer(archive)) {
-        throw new TypeError('archive must be a Buffer');
-    }
-    return native.getDictId(archive);
+  if (!Buffer.isBuffer(archive)) {
+    throw new TypeError("archive must be a Buffer");
+  }
+  return native.getDictId(archive);
 }
 
 /**
@@ -161,10 +163,10 @@ function getDictId(archive) {
  * @returns {number}
  */
 function dictGetId(zxd) {
-    if (!Buffer.isBuffer(zxd)) {
-        throw new TypeError('zxd must be a Buffer');
-    }
-    return native.dictGetId(zxd);
+  if (!Buffer.isBuffer(zxd)) {
+    throw new TypeError("zxd must be a Buffer");
+  }
+  return native.dictGetId(zxd);
 }
 
 /**
@@ -176,10 +178,10 @@ function dictGetId(zxd) {
  * @returns {Buffer} The encoded `.zxd` file.
  */
 function dictSave(content, hufLengths) {
-    if (!Buffer.isBuffer(content) || !Buffer.isBuffer(hufLengths)) {
-        throw new TypeError('content and hufLengths must be Buffers');
-    }
-    return native.dictSave(content, hufLengths);
+  if (!Buffer.isBuffer(content) || !Buffer.isBuffer(hufLengths)) {
+    throw new TypeError("content and hufLengths must be Buffers");
+  }
+  return native.dictSave(content, hufLengths);
 }
 
 /**
@@ -191,18 +193,19 @@ function dictSave(content, hufLengths) {
  * @returns {Buffer} 128-byte packed table for {@link dictSave} / `options.dictHuf`.
  */
 function trainDictHuf(samples, dict) {
-    if (!Array.isArray(samples)) {
-        throw new TypeError('samples must be an array of Buffers');
-    }
-    if (!Buffer.isBuffer(dict)) {
-        throw new TypeError('dict must be a Buffer');
-    }
-    const bufs = samples.map((s, i) => {
-        if (Buffer.isBuffer(s)) return s;
-        if (s instanceof Uint8Array) return Buffer.from(s.buffer, s.byteOffset, s.byteLength);
-        throw new TypeError(`samples[${i}] must be a Buffer or Uint8Array`);
-    });
-    return native.trainDictHuf(bufs, dict);
+  if (!Array.isArray(samples)) {
+    throw new TypeError("samples must be an array of Buffers");
+  }
+  if (!Buffer.isBuffer(dict)) {
+    throw new TypeError("dict must be a Buffer");
+  }
+  const bufs = samples.map((s, i) => {
+    if (Buffer.isBuffer(s)) return s;
+    if (s instanceof Uint8Array)
+      return Buffer.from(s.buffer, s.byteOffset, s.byteLength);
+    throw new TypeError(`samples[${i}] must be a Buffer or Uint8Array`);
+  });
+  return native.trainDictHuf(bufs, dict);
 }
 
 /**
@@ -212,10 +215,10 @@ function trainDictHuf(samples, dict) {
  * @returns {Buffer | null}
  */
 function dictHuf(zxd) {
-    if (!Buffer.isBuffer(zxd)) {
-        throw new TypeError('zxd must be a Buffer');
-    }
-    return native.dictHuf(zxd);
+  if (!Buffer.isBuffer(zxd)) {
+    throw new TypeError("zxd must be a Buffer");
+  }
+  return native.dictHuf(zxd);
 }
 
 /**
@@ -228,57 +231,64 @@ function dictHuf(zxd) {
  * `Seekable#setDict`.
  */
 class Dictionary {
-    /**
-     * @param {Buffer} content - Raw LZ-window content bytes.
-     * @param {Buffer} huf - 128-byte shared literal Huffman table.
-     * @param {number} id - Dictionary ID binding the (content, table) pair.
-     */
-    constructor(content, huf, id) {
-        if (!Buffer.isBuffer(content) || !Buffer.isBuffer(huf) || huf.length !== 128) {
-            throw new TypeError('Dictionary requires (content: Buffer, huf: 128-byte Buffer)');
-        }
-        this.content = content;
-        this.huf = huf;
-        this.id = id >>> 0;
+  /**
+   * @param {Buffer} content - Raw LZ-window content bytes.
+   * @param {Buffer} huf - 128-byte shared literal Huffman table.
+   * @param {number} id - Dictionary ID binding the (content, table) pair.
+   */
+  constructor(content, huf, id) {
+    if (
+      !Buffer.isBuffer(content) ||
+      !Buffer.isBuffer(huf) ||
+      huf.length !== 128
+    ) {
+      throw new TypeError(
+        "Dictionary requires (content: Buffer, huf: 128-byte Buffer)",
+      );
     }
+    this.content = content;
+    this.huf = huf;
+    this.id = id >>> 0;
+  }
 
-    /**
-     * Train a complete dictionary (content + shared table) from samples.
-     * @param {Array<Buffer|Uint8Array>} samples
-     * @returns {Dictionary}
-     */
-    static train(samples) {
-        if (!Array.isArray(samples)) {
-            throw new TypeError('samples must be an array of Buffers');
-        }
-        const bufs = samples.map((s, i) => {
-            if (Buffer.isBuffer(s)) return s;
-            if (s instanceof Uint8Array) return Buffer.from(s.buffer, s.byteOffset, s.byteLength);
-            throw new TypeError(`samples[${i}] must be a Buffer or Uint8Array`);
-        });
-        return Dictionary.load(native.dictTrain(bufs));
+  /**
+   * Train a complete dictionary (content + shared table) from samples.
+   * @param {Array<Buffer|Uint8Array>} samples
+   * @returns {Dictionary}
+   */
+  static train(samples) {
+    if (!Array.isArray(samples)) {
+      throw new TypeError("samples must be an array of Buffers");
     }
+    const bufs = samples.map((s, i) => {
+      if (Buffer.isBuffer(s)) return s;
+      if (s instanceof Uint8Array)
+        return Buffer.from(s.buffer, s.byteOffset, s.byteLength);
+      throw new TypeError(`samples[${i}] must be a Buffer or Uint8Array`);
+    });
+    return Dictionary.load(native.dictTrain(bufs));
+  }
 
-    /**
-     * Parse `.zxd` bytes into a Dictionary (owned copies).
-     * @param {Buffer} zxd
-     * @returns {Dictionary}
-     */
-    static load(zxd) {
-        if (!Buffer.isBuffer(zxd)) {
-            throw new TypeError('zxd must be a Buffer');
-        }
-        const { content, huf, id } = native.dictLoad(zxd);
-        return new Dictionary(content, huf, id);
+  /**
+   * Parse `.zxd` bytes into a Dictionary (owned copies).
+   * @param {Buffer} zxd
+   * @returns {Dictionary}
+   */
+  static load(zxd) {
+    if (!Buffer.isBuffer(zxd)) {
+      throw new TypeError("zxd must be a Buffer");
     }
+    const { content, huf, id } = native.dictLoad(zxd);
+    return new Dictionary(content, huf, id);
+  }
 
-    /**
-     * Serialize back to `.zxd` file bytes.
-     * @returns {Buffer}
-     */
-    save() {
-        return native.dictSave(this.content, this.huf);
-    }
+  /**
+   * Serialize back to `.zxd` file bytes.
+   * @returns {Buffer}
+   */
+  save() {
+    return native.dictSave(this.content, this.huf);
+  }
 }
 
 /**
@@ -286,10 +296,13 @@ class Dictionary {
  * @returns {{dict: Buffer|undefined, dictHuf: Buffer|undefined}}
  */
 function _splitDictOption(options) {
-    if (options.dict instanceof Dictionary) {
-        return { dict: options.dict.content, dictHuf: options.dict.huf };
-    }
-    return { dict: toDictBuffer(options.dict), dictHuf: toDictBuffer(options.dictHuf) };
+  if (options.dict instanceof Dictionary) {
+    return { dict: options.dict.content, dictHuf: options.dict.huf };
+  }
+  return {
+    dict: toDictBuffer(options.dict),
+    dictHuf: toDictBuffer(options.dictHuf),
+  };
 }
 
 /**
@@ -298,10 +311,10 @@ function _splitDictOption(options) {
  * @returns {{ content: Buffer, huf: Buffer, id: number }}
  */
 function dictLoad(zxd) {
-    if (!Buffer.isBuffer(zxd)) {
-        throw new TypeError('zxd must be a Buffer');
-    }
-    return native.dictLoad(zxd);
+  if (!Buffer.isBuffer(zxd)) {
+    throw new TypeError("zxd must be a Buffer");
+  }
+  return native.dictLoad(zxd);
 }
 
 /**
@@ -316,16 +329,16 @@ function dictLoad(zxd) {
  * @returns {Buffer} Compressed data.
  */
 function compress(data, options = {}) {
-    if (!Buffer.isBuffer(data)) {
-        throw new TypeError('data must be a Buffer');
-    }
+  if (!Buffer.isBuffer(data)) {
+    throw new TypeError("data must be a Buffer");
+  }
 
-    const level = options.level ?? LEVEL_DEFAULT;
-    const checksum = options.checksum ?? false;
-    const seekable = options.seekable ?? false;
-    const { dict, dictHuf } = _splitDictOption(options);
+  const level = options.level ?? LEVEL_DEFAULT;
+  const checksum = options.checksum ?? false;
+  const seekable = options.seekable ?? false;
+  const { dict, dictHuf } = _splitDictOption(options);
 
-    return native.compress(data, level, checksum, seekable, dict, dictHuf);
+  return native.compress(data, level, checksum, seekable, dict, dictHuf);
 }
 
 /**
@@ -336,10 +349,10 @@ function compress(data, options = {}) {
  * @returns {number} Original uncompressed size in bytes, or 0 if invalid.
  */
 function getDecompressedSize(data) {
-    if (!Buffer.isBuffer(data)) {
-        throw new TypeError('data must be a Buffer');
-    }
-    return native.getDecompressedSize(data);
+  if (!Buffer.isBuffer(data)) {
+    throw new TypeError("data must be a Buffer");
+  }
+  return native.getDecompressedSize(data);
 }
 
 /**
@@ -353,19 +366,19 @@ function getDecompressedSize(data) {
  * @returns {Buffer} Decompressed data.
  */
 function decompress(data, options = {}) {
-    if (!Buffer.isBuffer(data)) {
-        throw new TypeError('data must be a Buffer');
-    }
+  if (!Buffer.isBuffer(data)) {
+    throw new TypeError("data must be a Buffer");
+  }
 
-    const checksum = options.checksum ?? false;
-    const { dict, dictHuf } = _splitDictOption(options);
+  const checksum = options.checksum ?? false;
+  const { dict, dictHuf } = _splitDictOption(options);
 
-    let size = options.size;
-    if (size === undefined) {
-        size = getDecompressedSize(data);
-    }
+  let size = options.size;
+  if (size === undefined) {
+    size = getDecompressedSize(data);
+  }
 
-    return native.decompress(data, size, checksum, dict, dictHuf);
+  return native.decompress(data, size, checksum, dict, dictHuf);
 }
 
 /**
@@ -423,10 +436,10 @@ const Seekable = native.Seekable;
  * @returns {number}
  */
 function seekTableSize(numBlocks) {
-    if (typeof numBlocks !== 'number' || numBlocks < 0) {
-        throw new TypeError('numBlocks must be a non-negative number');
-    }
-    return native.seekTableSize(numBlocks);
+  if (typeof numBlocks !== "number" || numBlocks < 0) {
+    throw new TypeError("numBlocks must be a non-negative number");
+  }
+  return native.seekTableSize(numBlocks);
 }
 
 /**
@@ -440,16 +453,15 @@ function seekTableSize(numBlocks) {
  * @returns {Buffer} The encoded seek table.
  */
 function writeSeekTable(compSizes) {
-    if (!Array.isArray(compSizes) || compSizes.length === 0) {
-        throw new TypeError('compSizes must be a non-empty array of numbers');
-    }
-    return native.writeSeekTable(compSizes);
+  if (!Array.isArray(compSizes) || compSizes.length === 0) {
+    throw new TypeError("compSizes must be a non-empty array of numbers");
+  }
+  return native.writeSeekTable(compSizes);
 }
 
 // =============================================================================
 // stream.Transform adapters over the push streaming API
 // =============================================================================
-
 
 /**
  * Returns true if `buf` starts with the ZXC file magic word.
@@ -459,13 +471,15 @@ function writeSeekTable(compSizes) {
  * not validate the rest of the header or the footer.
  *
  * Magic word identifying a ZXC file frame: little-endian 0x9CB02EF5.
- * 
+ *
  * @param {Buffer|Uint8Array} buf
  * @returns {boolean}
  */
 function detectZxc(buf) {
-    if (!buf || buf.length < 4) return false;
-    return buf[0] === 0xF5 && buf[1] === 0x2E && buf[2] === 0xB0 && buf[3] === 0x9C;
+  if (!buf || buf.length < 4) return false;
+  return (
+    buf[0] === 0xf5 && buf[1] === 0x2e && buf[2] === 0xb0 && buf[3] === 0x9c
+  );
 }
 
 /**
@@ -481,44 +495,43 @@ function detectZxc(buf) {
  *   );
  */
 class CompressStream extends Transform {
-    constructor(options = {}) {
-        const { level, checksum, blockSize, ...transformOpts } = options;
-        super(transformOpts);
-        this._cs = new CStream({
-            ...(level === undefined ? {} : { level }),
-            ...(checksum === undefined ? {} : { checksum }),
-            ...(blockSize === undefined ? {} : { blockSize }),
-        });
-    }
+  constructor(options = {}) {
+    const { level, checksum, blockSize, ...transformOpts } = options;
+    super(transformOpts);
+    this._cs = new CStream({
+      ...(level === undefined ? {} : { level }),
+      ...(checksum === undefined ? {} : { checksum }),
+      ...(blockSize === undefined ? {} : { blockSize }),
+    });
+  }
 
-    _transform(chunk, encoding, callback) {
-        try {
-            const buf = Buffer.isBuffer(chunk)
-                ? chunk
-                : Buffer.from(chunk, typeof encoding === 'string' ? encoding : 'utf8');
-            const out = this._cs.compress(buf);
-            if (out.length > 0) this.push(out);
-            callback();
-        } catch (err) {
-            callback(err);
-        }
+  _transform(chunk, encoding, callback) {
+    try {
+      const enc = typeof encoding === "string" ? encoding : "utf8";
+      const buf = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk, enc);
+      const out = this._cs.compress(buf);
+      if (out.length > 0) this.push(out);
+      callback();
+    } catch (err) {
+      callback(err);
     }
+  }
 
-    _flush(callback) {
-        try {
-            const tail = this._cs.end();
-            if (tail.length > 0) this.push(tail);
-            this._cs.close();
-            callback();
-        } catch (err) {
-            callback(err);
-        }
+  _flush(callback) {
+    try {
+      const tail = this._cs.end();
+      if (tail.length > 0) this.push(tail);
+      this._cs.close();
+      callback();
+    } catch (err) {
+      callback(err);
     }
+  }
 
-    _destroy(err, callback) {
-        this._cs.close();
-        callback(err);
-    }
+  _destroy(err, callback) {
+    this._cs.close();
+    callback(err);
+  }
 }
 
 /**
@@ -537,47 +550,48 @@ class CompressStream extends Transform {
  *   );
  */
 class DecompressStream extends Transform {
-    constructor(options = {}) {
-        const { checksum, ...transformOpts } = options;
-        super(transformOpts);
-        this._ds = new DStream({
-            ...(checksum === undefined ? {} : { checksum }),
-        });
-    }
+  constructor(options = {}) {
+    const { checksum, ...transformOpts } = options;
+    super(transformOpts);
+    this._ds = new DStream({
+      ...(checksum === undefined ? {} : { checksum }),
+    });
+  }
 
-    _transform(chunk, encoding, callback) {
-        try {
-            const buf = Buffer.isBuffer(chunk)
-                ? chunk
-                : Buffer.from(chunk, typeof encoding === 'string' ? encoding : 'utf8');
-            const out = this._ds.decompress(buf);
-            if (out.length > 0) this.push(out);
-            callback();
-        } catch (err) {
-            callback(err);
-        }
+  _transform(chunk, encoding, callback) {
+    try {
+      const enc = typeof encoding === "string" ? encoding : "utf8";
+      const buf = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk, enc);
+      const out = this._ds.decompress(buf);
+      if (out.length > 0) this.push(out);
+      callback();
+    } catch (err) {
+      callback(err);
     }
+  }
 
-    _flush(callback) {
-        try {
-            if (!this._ds.finished()) {
-                const err = new Error('zxc: input drained before footer (truncated frame)');
-                err.code = 'ZXC_TRUNCATED';
-                this._ds.close();
-                callback(err);
-                return;
-            }
-            this._ds.close();
-            callback();
-        } catch (err) {
-            callback(err);
-        }
-    }
-
-    _destroy(err, callback) {
+  _flush(callback) {
+    try {
+      if (!this._ds.finished()) {
+        const err = new Error(
+          "zxc: input drained before footer (truncated frame)",
+        );
+        err.code = "ZXC_TRUNCATED";
         this._ds.close();
         callback(err);
+        return;
+      }
+      this._ds.close();
+      callback();
+    } catch (err) {
+      callback(err);
     }
+  }
+
+  _destroy(err, callback) {
+    this._ds.close();
+    callback(err);
+  }
 }
 
 /**
@@ -586,7 +600,7 @@ class DecompressStream extends Transform {
  * @returns {CompressStream}
  */
 function createCompressStream(options) {
-    return new CompressStream(options);
+  return new CompressStream(options);
 }
 
 /**
@@ -595,76 +609,76 @@ function createCompressStream(options) {
  * @returns {DecompressStream}
  */
 function createDecompressStream(options) {
-    return new DecompressStream(options);
+  return new DecompressStream(options);
 }
 
 module.exports = {
-    // Functions
-    compress,
-    decompress,
-    compressBound,
-    getDecompressedSize,
+  // Functions
+  compress,
+  decompress,
+  compressBound,
+  getDecompressedSize,
 
-    // Dictionary API
-    trainDict,
-    dictId,
-    getDictId,
-    dictGetId,
-    dictSave,
-    dictLoad,
-    trainDictHuf,
-    dictHuf,
-    Dictionary,
+  // Dictionary API
+  trainDict,
+  dictId,
+  getDictId,
+  dictGetId,
+  dictSave,
+  dictLoad,
+  trainDictHuf,
+  dictHuf,
+  Dictionary,
 
-    // Push streaming classes
-    CStream,
-    DStream,
+  // Push streaming classes
+  CStream,
+  DStream,
 
-    // Seekable random-access decompression
-    Seekable,
-    seekTableSize,
-    writeSeekTable,
+  // Seekable random-access decompression
+  Seekable,
+  seekTableSize,
+  writeSeekTable,
 
-    // stream.Transform adapters
-    CompressStream,
-    DecompressStream,
-    createCompressStream,
-    createDecompressStream,
-    detectZxc,
+  // stream.Transform adapters
+  CompressStream,
+  DecompressStream,
+  createCompressStream,
+  createDecompressStream,
+  detectZxc,
 
-    // Library info helpers
-    minLevel,
-    maxLevel,
-    defaultLevel,
-    libraryVersion,
+  // Library info helpers
+  minLevel,
+  maxLevel,
+  defaultLevel,
+  libraryVersion,
 
-    // Constants
-    LEVEL_FASTEST,
-    LEVEL_FAST,
-    LEVEL_DEFAULT,
-    LEVEL_BALANCED,
-    LEVEL_COMPACT,
-    LEVEL_DENSITY,
-    LEVEL_ULTRA,
+  // Constants
+  LEVEL_FASTEST,
+  LEVEL_FAST,
+  LEVEL_DEFAULT,
+  LEVEL_BALANCED,
+  LEVEL_COMPACT,
+  LEVEL_DENSITY,
+  LEVEL_ULTRA,
 
-    // Error handling
-    errorName,
-    ERROR_MEMORY,
-    ERROR_DST_TOO_SMALL,
-    ERROR_SRC_TOO_SMALL,
-    ERROR_BAD_MAGIC,
-    ERROR_BAD_VERSION,
-    ERROR_BAD_HEADER,
-    ERROR_BAD_CHECKSUM,
-    ERROR_CORRUPT_DATA,
-    ERROR_BAD_OFFSET,
-    ERROR_OVERFLOW,
-    ERROR_IO,
-    ERROR_NULL_INPUT,
-    ERROR_BAD_BLOCK_TYPE,
-    ERROR_BAD_BLOCK_SIZE,
-    ERROR_DICT_REQUIRED,
-    ERROR_DICT_MISMATCH,
-    ERROR_DICT_TOO_LARGE,
-    ERROR_BAD_LEVEL,
+  // Error handling
+  errorName,
+  ERROR_MEMORY,
+  ERROR_DST_TOO_SMALL,
+  ERROR_SRC_TOO_SMALL,
+  ERROR_BAD_MAGIC,
+  ERROR_BAD_VERSION,
+  ERROR_BAD_HEADER,
+  ERROR_BAD_CHECKSUM,
+  ERROR_CORRUPT_DATA,
+  ERROR_BAD_OFFSET,
+  ERROR_OVERFLOW,
+  ERROR_IO,
+  ERROR_NULL_INPUT,
+  ERROR_BAD_BLOCK_TYPE,
+  ERROR_BAD_BLOCK_SIZE,
+  ERROR_DICT_REQUIRED,
+  ERROR_DICT_MISMATCH,
+  ERROR_DICT_TOO_LARGE,
+  ERROR_BAD_LEVEL,
 };

--- a/wrappers/nodejs/test/zxc.dict.test.js
+++ b/wrappers/nodejs/test/zxc.dict.test.js
@@ -5,9 +5,9 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-'use strict';
+"use strict";
 
-const zxc = require('../lib/index');
+const zxc = require("../lib/index");
 
 // =============================================================================
 // Pre-trained dictionary support
@@ -16,182 +16,186 @@ const zxc = require('../lib/index');
 // Build a set of similar samples that share a lot of structure, so a trained
 // dictionary has something to capture.
 function buildSamples(count = 8) {
-    const samples = [];
-    for (let i = 0; i < count; i++) {
-        const obj = {
-            id: 1000 + i,
-            type: 'user-record',
-            createdAt: '2026-06-05T00:00:00Z',
-            status: 'active',
-            roles: ['reader', 'writer', 'admin'],
-            payload: `the quick brown fox jumps over the lazy dog #${i}`,
-        };
-        samples.push(Buffer.from(JSON.stringify(obj)));
-    }
-    return samples;
+  const samples = [];
+  for (let i = 0; i < count; i++) {
+    const obj = {
+      id: 1000 + i,
+      type: "user-record",
+      createdAt: "2026-06-05T00:00:00Z",
+      status: "active",
+      roles: ["reader", "writer", "admin"],
+      payload: `the quick brown fox jumps over the lazy dog #${i}`,
+    };
+    samples.push(Buffer.from(JSON.stringify(obj)));
+  }
+  return samples;
 }
 
-describe('trainDict', () => {
-    test('produces non-empty dictionary content from similar samples', () => {
-        const dict = zxc.trainDict(buildSamples(8));
-        expect(Buffer.isBuffer(dict)).toBe(true);
-        expect(dict.length).toBeGreaterThan(0);
-        expect(dict.length).toBeLessThanOrEqual(65535);
-    });
+describe("trainDict", () => {
+  test("produces non-empty dictionary content from similar samples", () => {
+    const dict = zxc.trainDict(buildSamples(8));
+    expect(Buffer.isBuffer(dict)).toBe(true);
+    expect(dict.length).toBeGreaterThan(0);
+    expect(dict.length).toBeLessThanOrEqual(65535);
+  });
 
-    test('honors a smaller maxSize cap', () => {
-        const dict = zxc.trainDict(buildSamples(8), 1024);
-        expect(dict.length).toBeLessThanOrEqual(1024);
-    });
+  test("honors a smaller maxSize cap", () => {
+    const dict = zxc.trainDict(buildSamples(8), 1024);
+    expect(dict.length).toBeLessThanOrEqual(1024);
+  });
 
-    test('rejects non-array / empty input', () => {
-        expect(() => zxc.trainDict('nope')).toThrow(TypeError);
-        expect(() => zxc.trainDict([])).toThrow(TypeError);
-    });
+  test("rejects non-array / empty input", () => {
+    expect(() => zxc.trainDict("nope")).toThrow(TypeError);
+    expect(() => zxc.trainDict([])).toThrow(TypeError);
+  });
 });
 
-describe('dictionary compress/decompress roundtrip', () => {
-    const dict = zxc.trainDict(buildSamples(8));
+describe("dictionary compress/decompress roundtrip", () => {
+  const dict = zxc.trainDict(buildSamples(8));
+  const original = Buffer.from(
+    JSON.stringify({
+      id: 2000,
+      type: "user-record",
+      createdAt: "2026-06-05T00:00:00Z",
+      status: "active",
+      roles: ["reader", "writer", "admin"],
+      payload: "the quick brown fox jumps over the lazy dog #new",
+    }),
+  );
+
+  test("compress with {dict} then decompress with {dict} equals original", () => {
+    const compressed = zxc.compress(original, { dict });
+    const restored = zxc.decompress(compressed, { dict });
+    expect(restored).toEqual(original);
+  });
+
+  test("archive references the dictionary id", () => {
+    const compressed = zxc.compress(original, { dict });
+    expect(zxc.getDictId(compressed)).toBe(zxc.dictId(dict));
+    expect(zxc.getDictId(compressed)).not.toBe(0);
+  });
+
+  test("decompressing a dict archive without the dictionary throws", () => {
+    const compressed = zxc.compress(original, { dict });
+    expect(() => zxc.decompress(compressed)).toThrow();
+  });
+
+  test("a non-dictionary archive reports dict id 0", () => {
+    const compressed = zxc.compress(original);
+    expect(zxc.getDictId(compressed)).toBe(0);
+  });
+});
+
+describe("dictionary id consistency", () => {
+  const dict = zxc.trainDict(buildSamples(8));
+  const huf = zxc.trainDictHuf(buildSamples(8), dict);
+
+  test("dictId(content) === getDictId(archive); .zxd id binds the table", () => {
     const original = Buffer.from(
-        JSON.stringify({
-            id: 2000,
-            type: 'user-record',
-            createdAt: '2026-06-05T00:00:00Z',
-            status: 'active',
-            roles: ['reader', 'writer', 'admin'],
-            payload: 'the quick brown fox jumps over the lazy dog #new',
-        }),
+      "the quick brown fox jumps over the lazy dog".repeat(4),
     );
+    const compressed = zxc.compress(original, { dict });
+    const zxd = zxc.dictSave(dict, huf);
 
-    test('compress with {dict} then decompress with {dict} equals original', () => {
-        const compressed = zxc.compress(original, { dict });
-        const restored = zxc.decompress(compressed, { dict });
-        expect(restored).toEqual(original);
-    });
+    const idContent = zxc.dictId(dict);
+    const idArchive = zxc.getDictId(compressed);
+    const idZxd = zxc.dictGetId(zxd);
 
-    test('archive references the dictionary id', () => {
-        const compressed = zxc.compress(original, { dict });
-        expect(zxc.getDictId(compressed)).toBe(zxc.dictId(dict));
-        expect(zxc.getDictId(compressed)).not.toBe(0);
-    });
-
-    test('decompressing a dict archive without the dictionary throws', () => {
-        const compressed = zxc.compress(original, { dict });
-        expect(() => zxc.decompress(compressed)).toThrow();
-    });
-
-    test('a non-dictionary archive reports dict id 0', () => {
-        const compressed = zxc.compress(original);
-        expect(zxc.getDictId(compressed)).toBe(0);
-    });
+    expect(idContent).toBe(idArchive);
+    // The .zxd id covers (content, table): non-zero, distinct from the
+    // content-only id.
+    expect(idZxd).not.toBe(0);
+    expect(idZxd).not.toBe(idContent);
+    expect(zxc.dictHuf(zxd)).toEqual(huf);
+  });
 });
 
-describe('dictionary id consistency', () => {
-    const dict = zxc.trainDict(buildSamples(8));
-    const huf = zxc.trainDictHuf(buildSamples(8), dict);
+describe("dictSave / dictLoad", () => {
+  const dict = zxc.trainDict(buildSamples(8));
+  const huf = zxc.trainDictHuf(buildSamples(8), dict);
 
-    test('dictId(content) === getDictId(archive); .zxd id binds the table', () => {
-        const original = Buffer.from('the quick brown fox jumps over the lazy dog'.repeat(4));
-        const compressed = zxc.compress(original, { dict });
-        const zxd = zxc.dictSave(dict, huf);
+  test("roundtrips content and id", () => {
+    const zxd = zxc.dictSave(dict, huf);
+    expect(Buffer.isBuffer(zxd)).toBe(true);
+    expect(zxd.length).toBeGreaterThan(dict.length);
 
-        const idContent = zxc.dictId(dict);
-        const idArchive = zxc.getDictId(compressed);
-        const idZxd = zxc.dictGetId(zxd);
+    const loaded = zxc.dictLoad(zxd);
+    expect(loaded.content).toEqual(dict);
+    expect(loaded.id).toBe(zxc.dictGetId(zxd));
+  });
 
-        expect(idContent).toBe(idArchive);
-        // The .zxd id covers (content, table): non-zero, distinct from the
-        // content-only id.
-        expect(idZxd).not.toBe(0);
-        expect(idZxd).not.toBe(idContent);
-        expect(zxc.dictHuf(zxd)).toEqual(huf);
-    });
+  test("dictLoad rejects garbage", () => {
+    expect(() => zxc.dictLoad(Buffer.from("not a zxd file at all"))).toThrow();
+  });
 });
 
-describe('dictSave / dictLoad', () => {
-    const dict = zxc.trainDict(buildSamples(8));
-    const huf = zxc.trainDictHuf(buildSamples(8), dict);
+describe("Dictionary object", () => {
+  test("train / save / load roundtrip and compress with {dict: Dictionary}", () => {
+    const d = zxc.Dictionary.train(buildSamples(8));
+    expect(Buffer.isBuffer(d.content)).toBe(true);
+    expect(d.content.length).toBeGreaterThan(0);
+    expect(d.huf.length).toBe(128);
+    expect(d.id).not.toBe(0);
 
-    test('roundtrips content and id', () => {
-        const zxd = zxc.dictSave(dict, huf);
-        expect(Buffer.isBuffer(zxd)).toBe(true);
-        expect(zxd.length).toBeGreaterThan(dict.length);
+    // save() -> load() preserves the (content, table, id) triple.
+    const reloaded = zxc.Dictionary.load(d.save());
+    expect(reloaded.content).toEqual(d.content);
+    expect(reloaded.huf).toEqual(d.huf);
+    expect(reloaded.id).toBe(d.id);
 
-        const loaded = zxc.dictLoad(zxd);
-        expect(loaded.content).toEqual(dict);
-        expect(loaded.id).toBe(zxc.dictGetId(zxd));
-    });
+    // One-call train matches the primitive 2-step training.
+    expect(d.content).toEqual(zxc.trainDict(buildSamples(8)));
+    expect(d.huf).toEqual(zxc.trainDictHuf(buildSamples(8), d.content));
 
-    test('dictLoad rejects garbage', () => {
-        expect(() => zxc.dictLoad(Buffer.from('not a zxd file at all'))).toThrow();
-    });
+    const original = Buffer.from(
+      "the quick brown fox jumps over the lazy dog #obj".repeat(4),
+    );
+    const compressed = zxc.compress(original, { dict: d });
+    expect(zxc.decompress(compressed, { dict: d })).toEqual(original);
+
+    // The archive id binds (content, table): decoding with the raw
+    // content but no table is rejected.
+    expect(() => zxc.decompress(compressed, { dict: d.content })).toThrow();
+  });
 });
 
-describe('Dictionary object', () => {
-    test('train / save / load roundtrip and compress with {dict: Dictionary}', () => {
-        const d = zxc.Dictionary.train(buildSamples(8));
-        expect(Buffer.isBuffer(d.content)).toBe(true);
-        expect(d.content.length).toBeGreaterThan(0);
-        expect(d.huf.length).toBe(128);
-        expect(d.id).not.toBe(0);
+describe("seekable with dictionary", () => {
+  const dict = zxc.trainDict(buildSamples(8));
 
-        // save() -> load() preserves the (content, table, id) triple.
-        const reloaded = zxc.Dictionary.load(d.save());
-        expect(reloaded.content).toEqual(d.content);
-        expect(reloaded.huf).toEqual(d.huf);
-        expect(reloaded.id).toBe(d.id);
-
-        // One-call train matches the primitive 2-step training.
-        expect(d.content).toEqual(zxc.trainDict(buildSamples(8)));
-        expect(d.huf).toEqual(zxc.trainDictHuf(buildSamples(8), d.content));
-
-        const original = Buffer.from(
-            'the quick brown fox jumps over the lazy dog #obj'.repeat(4),
-        );
-        const compressed = zxc.compress(original, { dict: d });
-        expect(zxc.decompress(compressed, { dict: d })).toEqual(original);
-
-        // The archive id binds (content, table): decoding with the raw
-        // content but no table is rejected.
-        expect(() => zxc.decompress(compressed, { dict: d.content })).toThrow();
-    });
-});
-
-describe('seekable with dictionary', () => {
-    const dict = zxc.trainDict(buildSamples(8));
-
-    // A payload large enough to span multiple blocks, full of dictionary-ish
-    // patterns so the dictionary is actually engaged.
-    function buildPayload() {
-        const parts = [];
-        // > 512 KB so the seekable archive spans multiple blocks, exercising
-        // cross-block random access with a dictionary attached.
-        for (let i = 0; i < 24000; i++) {
-            parts.push(`the quick brown fox jumps over the lazy dog #${i} active reader writer admin\n`);
-        }
-        return Buffer.from(parts.join(''));
+  // A payload large enough to span multiple blocks, full of dictionary-ish
+  // patterns so the dictionary is actually engaged.
+  function buildPayload() {
+    const parts = [];
+    // > 512 KB so the seekable archive spans multiple blocks, exercising
+    // cross-block random access with a dictionary attached.
+    for (let i = 0; i < 24000; i++) {
+      parts.push(
+        `the quick brown fox jumps over the lazy dog #${i} active reader writer admin\n`,
+      );
     }
+    return Buffer.from(parts.join(""));
+  }
 
-    test('setDict + decompressRange roundtrip on a dict-compressed seekable archive', () => {
-        const payload = buildPayload();
-        const compressed = zxc.compress(payload, { seekable: true, dict });
-        expect(zxc.getDictId(compressed)).toBe(zxc.dictId(dict));
+  test("setDict + decompressRange roundtrip on a dict-compressed seekable archive", () => {
+    const payload = buildPayload();
+    const compressed = zxc.compress(payload, { seekable: true, dict });
+    expect(zxc.getDictId(compressed)).toBe(zxc.dictId(dict));
 
-        const s = new zxc.Seekable(compressed);
-        try {
-            expect(s.numBlocks()).toBeGreaterThan(1);
-            s.setDict(dict);
-            // Full-range round trip.
-            const full = s.decompressRange(0, payload.length);
-            expect(full).toEqual(payload);
+    const s = new zxc.Seekable(compressed);
+    try {
+      expect(s.numBlocks()).toBeGreaterThan(1);
+      s.setDict(dict);
+      // Full-range round trip.
+      const full = s.decompressRange(0, payload.length);
+      expect(full).toEqual(payload);
 
-            // A sub-range somewhere in the middle, crossing a block boundary.
-            const off = 600000;
-            const len = 4096;
-            const slice = s.decompressRange(off, len);
-            expect(slice).toEqual(payload.subarray(off, off + len));
-        } finally {
-            s.close();
-        }
-    });
+      // A sub-range somewhere in the middle, crossing a block boundary.
+      const off = 600000;
+      const len = 4096;
+      const slice = s.decompressRange(off, len);
+      expect(slice).toEqual(payload.subarray(off, off + len));
+    } finally {
+      s.close();
+    }
+  });
 });

--- a/wrappers/nodejs/test/zxc.seekable.test.js
+++ b/wrappers/nodejs/test/zxc.seekable.test.js
@@ -5,186 +5,190 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-'use strict';
+"use strict";
 
-const zxc = require('../lib/index');
+const zxc = require("../lib/index");
 
 // =============================================================================
 // Seekable random-access decompression
 // =============================================================================
 
 function buildPayload(size) {
-    const buf = Buffer.alloc(size);
-    for (let i = 0; i < size; i++) buf[i] = (i * 31) & 0xFF;
-    return buf;
+  const buf = Buffer.alloc(size);
+  for (let i = 0; i < size; i++) buf[i] = (i * 31) & 0xff;
+  return buf;
 }
 
 function buildSeekableArchive(payload) {
-    return zxc.compress(payload, { seekable: true, checksum: true });
+  return zxc.compress(payload, { seekable: true, checksum: true });
 }
 
-describe('Seekable: queries', () => {
-    const payload = buildPayload(64 * 1024);
-    const compressed = buildSeekableArchive(payload);
+describe("Seekable: queries", () => {
+  const payload = buildPayload(64 * 1024);
+  const compressed = buildSeekableArchive(payload);
 
-    test('reports total decompressed size and at least one block', () => {
-        const s = new zxc.Seekable(compressed);
-        try {
-            expect(s.decompressedSize()).toBe(payload.length);
-            expect(s.numBlocks()).toBeGreaterThanOrEqual(1);
-        } finally {
-            s.close();
-        }
-    });
+  test("reports total decompressed size and at least one block", () => {
+    const s = new zxc.Seekable(compressed);
+    try {
+      expect(s.decompressedSize()).toBe(payload.length);
+      expect(s.numBlocks()).toBeGreaterThanOrEqual(1);
+    } finally {
+      s.close();
+    }
+  });
 
-    test('reports per-block sizes and rejects out-of-range indices', () => {
-        const s = new zxc.Seekable(compressed);
-        try {
-            const numBlocks = s.numBlocks();
-            expect(s.blockCompressedSize(0)).toBeGreaterThan(0);
-            expect(s.blockDecompressedSize(0)).toBeGreaterThan(0);
-            expect(s.blockCompressedSize(numBlocks)).toBeNull();
-            expect(s.blockDecompressedSize(numBlocks)).toBeNull();
-        } finally {
-            s.close();
-        }
-    });
+  test("reports per-block sizes and rejects out-of-range indices", () => {
+    const s = new zxc.Seekable(compressed);
+    try {
+      const numBlocks = s.numBlocks();
+      expect(s.blockCompressedSize(0)).toBeGreaterThan(0);
+      expect(s.blockDecompressedSize(0)).toBeGreaterThan(0);
+      expect(s.blockCompressedSize(numBlocks)).toBeNull();
+      expect(s.blockDecompressedSize(numBlocks)).toBeNull();
+    } finally {
+      s.close();
+    }
+  });
 });
 
-describe('Seekable: decompressRange', () => {
-    const payload = buildPayload(64 * 1024);
-    const compressed = buildSeekableArchive(payload);
+describe("Seekable: decompressRange", () => {
+  const payload = buildPayload(64 * 1024);
+  const compressed = buildSeekableArchive(payload);
 
-    test('full-range round trip', () => {
-        const s = new zxc.Seekable(compressed);
-        try {
-            const out = s.decompressRange(0, payload.length);
-            expect(out.length).toBe(payload.length);
-            expect(out.equals(payload)).toBe(true);
-        } finally {
-            s.close();
-        }
-    });
+  test("full-range round trip", () => {
+    const s = new zxc.Seekable(compressed);
+    try {
+      const out = s.decompressRange(0, payload.length);
+      expect(out.length).toBe(payload.length);
+      expect(out.equals(payload)).toBe(true);
+    } finally {
+      s.close();
+    }
+  });
 
-    test('mid-range slice is byte-exact', () => {
-        const s = new zxc.Seekable(compressed);
-        try {
-            const off = 1024;
-            const len = 8192;
-            const out = s.decompressRange(off, len);
-            expect(out.length).toBe(len);
-            expect(out.equals(payload.subarray(off, off + len))).toBe(true);
-        } finally {
-            s.close();
-        }
-    });
+  test("mid-range slice is byte-exact", () => {
+    const s = new zxc.Seekable(compressed);
+    try {
+      const off = 1024;
+      const len = 8192;
+      const out = s.decompressRange(off, len);
+      expect(out.length).toBe(len);
+      expect(out.equals(payload.subarray(off, off + len))).toBe(true);
+    } finally {
+      s.close();
+    }
+  });
 
-    test('zero-length range returns empty buffer', () => {
-        const s = new zxc.Seekable(compressed);
-        try {
-            const out = s.decompressRange(0, 0);
-            expect(out.length).toBe(0);
-        } finally {
-            s.close();
-        }
-    });
+  test("zero-length range returns empty buffer", () => {
+    const s = new zxc.Seekable(compressed);
+    try {
+      const out = s.decompressRange(0, 0);
+      expect(out.length).toBe(0);
+    } finally {
+      s.close();
+    }
+  });
 });
 
-describe('Seekable: error handling', () => {
-    test('constructor throws on garbage buffer', () => {
-        expect(() => new zxc.Seekable(Buffer.from([1, 2, 3, 4, 5, 6, 7, 8]))).toThrow();
-    });
+describe("Seekable: error handling", () => {
+  test("constructor throws on garbage buffer", () => {
+    expect(
+      () => new zxc.Seekable(Buffer.from([1, 2, 3, 4, 5, 6, 7, 8])),
+    ).toThrow();
+  });
 
-    test('constructor throws on empty buffer', () => {
-        expect(() => new zxc.Seekable(Buffer.alloc(0))).toThrow();
-    });
+  test("constructor throws on empty buffer", () => {
+    expect(() => new zxc.Seekable(Buffer.alloc(0))).toThrow();
+  });
 
-    test('methods after close throw', () => {
-        const s = new zxc.Seekable(buildSeekableArchive(buildPayload(4096)));
-        s.close();
-        expect(() => s.numBlocks()).toThrow();
-        // close is idempotent
-        expect(() => s.close()).not.toThrow();
-    });
+  test("methods after close throw", () => {
+    const s = new zxc.Seekable(buildSeekableArchive(buildPayload(4096)));
+    s.close();
+    expect(() => s.numBlocks()).toThrow();
+    // close is idempotent
+    expect(() => s.close()).not.toThrow();
+  });
 });
 
-describe('Seekable: reader callback', () => {
-    const payload = buildPayload(128 * 1024);
-    const compressed = buildSeekableArchive(payload);
+describe("Seekable: reader callback", () => {
+  const payload = buildPayload(128 * 1024);
+  const compressed = buildSeekableArchive(payload);
 
-    test('roundtrip via in-memory readAt', () => {
-        let calls = 0;
-        const reader = {
-            size: compressed.length,
-            readAt(dst, offset) {
-                calls++;
-                compressed.copy(dst, 0, offset, offset + dst.length);
-            },
-        };
-        const s = new zxc.Seekable(reader);
-        try {
-            // 3 reads at open: header, footer, seek table.
-            expect(calls).toBe(3);
-            expect(s.decompressedSize()).toBe(payload.length);
-            const out = s.decompressRange(0, payload.length);
-            expect(Buffer.compare(out, payload)).toBe(0);
+  test("roundtrip via in-memory readAt", () => {
+    let calls = 0;
+    const reader = {
+      size: compressed.length,
+      readAt(dst, offset) {
+        calls++;
+        compressed.copy(dst, 0, offset, offset + dst.length);
+      },
+    };
+    const s = new zxc.Seekable(reader);
+    try {
+      // 3 reads at open: header, footer, seek table.
+      expect(calls).toBe(3);
+      expect(s.decompressedSize()).toBe(payload.length);
+      const out = s.decompressRange(0, payload.length);
+      expect(Buffer.compare(out, payload)).toBe(0);
 
-            const before = calls;
-            const chunk = s.decompressRange(2048, 1024);
-            expect(Buffer.compare(chunk, payload.subarray(2048, 2048 + 1024))).toBe(0);
-            // Single-block sub-range must trigger exactly one extra read.
-            expect(calls - before).toBe(1);
-        } finally {
-            s.close();
-        }
-    });
+      const before = calls;
+      const chunk = s.decompressRange(2048, 1024);
+      expect(Buffer.compare(chunk, payload.subarray(2048, 2048 + 1024))).toBe(
+        0,
+      );
+      // Single-block sub-range must trigger exactly one extra read.
+      expect(calls - before).toBe(1);
+    } finally {
+      s.close();
+    }
+  });
 
-    test('readAt throwing maps to decompress_range error', () => {
-        let attempted = 0;
-        const reader = {
-            size: compressed.length,
-            readAt(dst, offset) {
-                attempted++;
-                if (attempted > 3) throw new Error('boom');
-                compressed.copy(dst, 0, offset, offset + dst.length);
-            },
-        };
-        const s = new zxc.Seekable(reader);
-        try {
-            expect(() => s.decompressRange(0, payload.length)).toThrow();
-        } finally {
-            s.close();
-        }
-    });
+  test("readAt throwing maps to decompress_range error", () => {
+    let attempted = 0;
+    const reader = {
+      size: compressed.length,
+      readAt(dst, offset) {
+        attempted++;
+        if (attempted > 3) throw new Error("boom");
+        compressed.copy(dst, 0, offset, offset + dst.length);
+      },
+    };
+    const s = new zxc.Seekable(reader);
+    try {
+      expect(() => s.decompressRange(0, payload.length)).toThrow();
+    } finally {
+      s.close();
+    }
+  });
 
-    test('rejects missing size / readAt', () => {
-        expect(() => new zxc.Seekable({})).toThrow();
-        expect(() => new zxc.Seekable({ size: 100 })).toThrow();
-        expect(() => new zxc.Seekable({ readAt: () => {} })).toThrow();
-        expect(() => new zxc.Seekable({ size: 0, readAt: () => {} })).toThrow();
-    });
+  test("rejects missing size / readAt", () => {
+    expect(() => new zxc.Seekable({})).toThrow();
+    expect(() => new zxc.Seekable({ size: 100 })).toThrow();
+    expect(() => new zxc.Seekable({ readAt: () => {} })).toThrow();
+    expect(() => new zxc.Seekable({ size: 0, readAt: () => {} })).toThrow();
+  });
 
-    test('rejects garbage reader', () => {
-        const reader = {
-            size: 64,
-            readAt(dst /* , offset */) {
-                dst.fill(0);
-            },
-        };
-        expect(() => new zxc.Seekable(reader)).toThrow();
-    });
+  test("rejects garbage reader", () => {
+    const reader = {
+      size: 64,
+      readAt(dst /* , offset */) {
+        dst.fill(0);
+      },
+    };
+    expect(() => new zxc.Seekable(reader)).toThrow();
+  });
 });
 
-describe('Seekable: low-level seek table helpers', () => {
-    test('seekTableSize / writeSeekTable round trip', () => {
-        const compSizes = [128, 256, 200, 4];
-        const sz = zxc.seekTableSize(compSizes.length);
-        expect(sz).toBeGreaterThan(0);
-        const buf = zxc.writeSeekTable(compSizes);
-        expect(buf.length).toBe(sz);
-    });
+describe("Seekable: low-level seek table helpers", () => {
+  test("seekTableSize / writeSeekTable round trip", () => {
+    const compSizes = [128, 256, 200, 4];
+    const sz = zxc.seekTableSize(compSizes.length);
+    expect(sz).toBeGreaterThan(0);
+    const buf = zxc.writeSeekTable(compSizes);
+    expect(buf.length).toBe(sz);
+  });
 
-    test('writeSeekTable rejects empty array', () => {
-        expect(() => zxc.writeSeekTable([])).toThrow();
-    });
+  test("writeSeekTable rejects empty array", () => {
+    expect(() => zxc.writeSeekTable([])).toThrow();
+  });
 });

--- a/wrappers/nodejs/test/zxc.streams.test.js
+++ b/wrappers/nodejs/test/zxc.streams.test.js
@@ -7,130 +7,130 @@
  * Tests for the stream.Transform adapters and detectZxc helper.
  */
 
-'use strict';
+"use strict";
 
-const { Readable, PassThrough } = require('node:stream');
-const { pipeline } = require('node:stream/promises');
-const zxc = require('../lib/index');
+const { Readable, PassThrough } = require("node:stream");
+const { pipeline } = require("node:stream/promises");
+const zxc = require("../lib/index");
 
 async function gather(stream) {
-    const chunks = [];
-    for await (const c of stream) chunks.push(c);
-    return Buffer.concat(chunks);
+  const chunks = [];
+  for await (const c of stream) chunks.push(c);
+  return Buffer.concat(chunks);
 }
 
 async function roundtripPipeline(data, opts = {}) {
-    const compressed = await gather(
-        Readable.from([data]).pipe(zxc.createCompressStream(opts)),
-    );
-    const decompressed = await gather(
-        Readable.from([compressed]).pipe(zxc.createDecompressStream(opts)),
-    );
-    return decompressed;
+  const compressed = await gather(
+    Readable.from([data]).pipe(zxc.createCompressStream(opts)),
+  );
+  const decompressed = await gather(
+    Readable.from([compressed]).pipe(zxc.createDecompressStream(opts)),
+  );
+  return decompressed;
 }
 
-describe('CompressStream / DecompressStream roundtrip', () => {
-    test('small buffer', async () => {
-        const data = Buffer.from('Hello stream.Transform bridge over ZXC!');
-        const got = await roundtripPipeline(data);
-        expect(Buffer.compare(got, data)).toBe(0);
-    });
+describe("CompressStream / DecompressStream roundtrip", () => {
+  test("small buffer", async () => {
+    const data = Buffer.from("Hello stream.Transform bridge over ZXC!");
+    const got = await roundtripPipeline(data);
+    expect(Buffer.compare(got, data)).toBe(0);
+  });
 
-    test('large 2 MB buffer', async () => {
-        const data = Buffer.alloc(2 * 1024 * 1024);
-        for (let i = 0; i < data.length; i++) data[i] = (i * 13) % 251;
-        const got = await roundtripPipeline(data);
-        expect(got.length).toBe(data.length);
-        expect(Buffer.compare(got, data)).toBe(0);
-    });
+  test("large 2 MB buffer", async () => {
+    const data = Buffer.alloc(2 * 1024 * 1024);
+    for (let i = 0; i < data.length; i++) data[i] = (i * 13) % 251;
+    const got = await roundtripPipeline(data);
+    expect(got.length).toBe(data.length);
+    expect(Buffer.compare(got, data)).toBe(0);
+  });
 
-    test('many small chunks fed sequentially', async () => {
-        const want = Buffer.alloc(64 * 1024);
-        for (let i = 0; i < want.length; i++) want[i] = (i ^ 0x5A) & 0xFF;
+  test("many small chunks fed sequentially", async () => {
+    const want = Buffer.alloc(64 * 1024);
+    for (let i = 0; i < want.length; i++) want[i] = (i ^ 0x5a) & 0xff;
 
-        // Feed 257-byte chunks to exercise buffering boundaries.
-        const chunks = [];
-        for (let i = 0; i < want.length; i += 257) {
-            chunks.push(want.subarray(i, Math.min(i + 257, want.length)));
-        }
-        const compressed = await gather(
-            Readable.from(chunks).pipe(zxc.createCompressStream()),
-        );
-        const got = await gather(
-            Readable.from([compressed]).pipe(zxc.createDecompressStream()),
-        );
-        expect(Buffer.compare(got, want)).toBe(0);
-    });
+    // Feed 257-byte chunks to exercise buffering boundaries.
+    const chunks = [];
+    for (let i = 0; i < want.length; i += 257) {
+      chunks.push(want.subarray(i, Math.min(i + 257, want.length)));
+    }
+    const compressed = await gather(
+      Readable.from(chunks).pipe(zxc.createCompressStream()),
+    );
+    const got = await gather(
+      Readable.from([compressed]).pipe(zxc.createDecompressStream()),
+    );
+    expect(Buffer.compare(got, want)).toBe(0);
+  });
 
-    test('with checksum option', async () => {
-        const data = Buffer.alloc(32 * 1024);
-        for (let i = 0; i < data.length; i++) data[i] = i & 0xFF;
-        const got = await roundtripPipeline(data, { checksum: true });
-        expect(Buffer.compare(got, data)).toBe(0);
-    });
+  test("with checksum option", async () => {
+    const data = Buffer.alloc(32 * 1024);
+    for (let i = 0; i < data.length; i++) data[i] = i & 0xff;
+    const got = await roundtripPipeline(data, { checksum: true });
+    expect(Buffer.compare(got, data)).toBe(0);
+  });
 
-    test('via pipeline()', async () => {
-        const data = Buffer.from('pipeline integration smoke test'.repeat(100));
-        const intermediate = new PassThrough();
-        const finalSink = new PassThrough();
-        const collected = gather(finalSink);
+  test("via pipeline()", async () => {
+    const data = Buffer.from("pipeline integration smoke test".repeat(100));
+    const intermediate = new PassThrough();
+    const finalSink = new PassThrough();
+    const collected = gather(finalSink);
 
-        await pipeline(
-            Readable.from([data]),
-            zxc.createCompressStream(),
-            intermediate,
-            zxc.createDecompressStream(),
-            finalSink,
-        );
+    await pipeline(
+      Readable.from([data]),
+      zxc.createCompressStream(),
+      intermediate,
+      zxc.createDecompressStream(),
+      finalSink,
+    );
 
-        expect(Buffer.compare(await collected, data)).toBe(0);
-    });
+    expect(Buffer.compare(await collected, data)).toBe(0);
+  });
 });
 
-describe('DecompressStream error paths', () => {
-    test('truncated frame emits ZXC_TRUNCATED', async () => {
-        const data = Buffer.alloc(32 * 1024, 0x41);
-        const compressed = await gather(
-            Readable.from([data]).pipe(zxc.createCompressStream()),
-        );
-        const truncated = compressed.subarray(0, Math.floor(compressed.length / 2));
+describe("DecompressStream error paths", () => {
+  test("truncated frame emits ZXC_TRUNCATED", async () => {
+    const data = Buffer.alloc(32 * 1024, 0x41);
+    const compressed = await gather(
+      Readable.from([data]).pipe(zxc.createCompressStream()),
+    );
+    const truncated = compressed.subarray(0, Math.floor(compressed.length / 2));
 
-        await expect(
-            gather(Readable.from([truncated]).pipe(zxc.createDecompressStream())),
-        ).rejects.toMatchObject({ code: 'ZXC_TRUNCATED' });
-    });
+    await expect(
+      gather(Readable.from([truncated]).pipe(zxc.createDecompressStream())),
+    ).rejects.toMatchObject({ code: "ZXC_TRUNCATED" });
+  });
 });
 
-describe('detectZxc', () => {
-    test('detects a frame produced by compress()', () => {
-        const frame = zxc.compress(Buffer.from('sniff me'));
-        expect(zxc.detectZxc(frame)).toBe(true);
-    });
+describe("detectZxc", () => {
+  test("detects a frame produced by compress()", () => {
+    const frame = zxc.compress(Buffer.from("sniff me"));
+    expect(zxc.detectZxc(frame)).toBe(true);
+  });
 
-    test('detects a frame produced by CompressStream', async () => {
-        const frame = await gather(
-            Readable.from([Buffer.from('hi')]).pipe(zxc.createCompressStream()),
-        );
-        expect(zxc.detectZxc(frame)).toBe(true);
-    });
+  test("detects a frame produced by CompressStream", async () => {
+    const frame = await gather(
+      Readable.from([Buffer.from("hi")]).pipe(zxc.createCompressStream()),
+    );
+    expect(zxc.detectZxc(frame)).toBe(true);
+  });
 
-    test.each([
-        ['empty', Buffer.alloc(0)],
-        ['too short', Buffer.from([0xF5, 0x2E, 0xB0])],
-        ['zeros', Buffer.alloc(4)],
-        ['random text', Buffer.from('not a zxc frame at all')],
-    ])('rejects %s', (_name, buf) => {
-        expect(zxc.detectZxc(buf)).toBe(false);
-    });
+  test.each([
+    ["empty", Buffer.alloc(0)],
+    ["too short", Buffer.from([0xf5, 0x2e, 0xb0])],
+    ["zeros", Buffer.alloc(4)],
+    ["random text", Buffer.from("not a zxc frame at all")],
+  ])("rejects %s", (_name, buf) => {
+    expect(zxc.detectZxc(buf)).toBe(false);
+  });
 
-    test('accepts Uint8Array', () => {
-        const frame = zxc.compress(Buffer.from('x'));
-        const u8 = new Uint8Array(frame);
-        expect(zxc.detectZxc(u8)).toBe(true);
-    });
+  test("accepts Uint8Array", () => {
+    const frame = zxc.compress(Buffer.from("x"));
+    const u8 = new Uint8Array(frame);
+    expect(zxc.detectZxc(u8)).toBe(true);
+  });
 
-    test('returns false for null/undefined', () => {
-        expect(zxc.detectZxc(null)).toBe(false);
-        expect(zxc.detectZxc(undefined)).toBe(false);
-    });
+  test("returns false for null/undefined", () => {
+    expect(zxc.detectZxc(null)).toBe(false);
+    expect(zxc.detectZxc(undefined)).toBe(false);
+  });
 });

--- a/wrappers/nodejs/test/zxc.test.js
+++ b/wrappers/nodejs/test/zxc.test.js
@@ -5,186 +5,190 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-'use strict';
+"use strict";
 
-const zxc = require('../lib/index');
+const zxc = require("../lib/index");
 
 // =============================================================================
 // Roundtrip tests
 // =============================================================================
 
-describe('compress/decompress roundtrip', () => {
-    const testCases = [
-        { name: 'normal data',  data: Buffer.from('hello world'.repeat(10)) },
-        { name: 'single byte',  data: Buffer.from('a') },
-        { name: 'empty buffer', data: Buffer.alloc(0) },
-        { name: 'large 10 MB',  data: Buffer.alloc(10_000_000, 0x42) },
-    ];
+describe("compress/decompress roundtrip", () => {
+  const testCases = [
+    { name: "normal data", data: Buffer.from("hello world".repeat(10)) },
+    { name: "single byte", data: Buffer.from("a") },
+    { name: "empty buffer", data: Buffer.alloc(0) },
+    { name: "large 10 MB", data: Buffer.alloc(10_000_000, 0x42) },
+  ];
 
-    for (const { name, data } of testCases) {
-        test(`roundtrip: ${name}`, () => {
-            for (let level = zxc.LEVEL_FASTEST; level <= zxc.LEVEL_ULTRA; level++) {
-                const compressed = zxc.compress(data, { level });
-                const size = zxc.getDecompressedSize(compressed);
-                const decompressed = zxc.decompress(compressed, { size });
-
-                expect(decompressed.length).toBe(data.length);
-                expect(Buffer.compare(decompressed, data)).toBe(0);
-            }
-        });
-    }
-
-    test('roundtrip with auto-size detection', () => {
-        const data = Buffer.from('auto size detection test'.repeat(100));
-        const compressed = zxc.compress(data);
-        const decompressed = zxc.decompress(compressed);
+  for (const { name, data } of testCases) {
+    test(`roundtrip: ${name}`, () => {
+      for (let level = zxc.LEVEL_FASTEST; level <= zxc.LEVEL_ULTRA; level++) {
+        const compressed = zxc.compress(data, { level });
+        const size = zxc.getDecompressedSize(compressed);
+        const decompressed = zxc.decompress(compressed, { size });
 
         expect(decompressed.length).toBe(data.length);
         expect(Buffer.compare(decompressed, data)).toBe(0);
+      }
+    });
+  }
+
+  test("roundtrip with auto-size detection", () => {
+    const data = Buffer.from("auto size detection test".repeat(100));
+    const compressed = zxc.compress(data);
+    const decompressed = zxc.decompress(compressed);
+
+    expect(decompressed.length).toBe(data.length);
+    expect(Buffer.compare(decompressed, data)).toBe(0);
+  });
+
+  test("oversized size hint returns exactly the real payload", () => {
+    // Regression: the full hint-sized buffer used to be returned, with an
+    // uninitialized (allocUnsafe) tail past the real decompressed size.
+    const data = Buffer.from("oversized hint test".repeat(50));
+    const compressed = zxc.compress(data);
+    const decompressed = zxc.decompress(compressed, {
+      size: data.length + 4096,
     });
 
-    test('oversized size hint returns exactly the real payload', () => {
-        // Regression: the full hint-sized buffer used to be returned, with an
-        // uninitialized (allocUnsafe) tail past the real decompressed size.
-        const data = Buffer.from('oversized hint test'.repeat(50));
-        const compressed = zxc.compress(data);
-        const decompressed = zxc.decompress(compressed, { size: data.length + 4096 });
-
-        expect(decompressed.length).toBe(data.length);
-        expect(Buffer.compare(decompressed, data)).toBe(0);
-    });
+    expect(decompressed.length).toBe(data.length);
+    expect(Buffer.compare(decompressed, data)).toBe(0);
+  });
 });
 
 // =============================================================================
 // compressBound
 // =============================================================================
 
-describe('compressBound', () => {
-    test('returns a value >= input size', () => {
-        const bound = zxc.compressBound(1024);
-        expect(bound).toBeGreaterThanOrEqual(1024);
-    });
+describe("compressBound", () => {
+  test("returns a value >= input size", () => {
+    const bound = zxc.compressBound(1024);
+    expect(bound).toBeGreaterThanOrEqual(1024);
+  });
 
-    test('returns 0-based bound for size 0', () => {
-        const bound = zxc.compressBound(0);
-        expect(bound).toBeGreaterThanOrEqual(0);
-    });
+  test("returns 0-based bound for size 0", () => {
+    const bound = zxc.compressBound(0);
+    expect(bound).toBeGreaterThanOrEqual(0);
+  });
 });
 
 // =============================================================================
 // Corruption detection
 // =============================================================================
 
-describe('corruption detection', () => {
-    test('detects corrupted data with checksum', () => {
-        const data = Buffer.from('hello world'.repeat(10));
-        const compressed = zxc.compress(data, { checksum: true });
+describe("corruption detection", () => {
+  test("detects corrupted data with checksum", () => {
+    const data = Buffer.from("hello world".repeat(10));
+    const compressed = zxc.compress(data, { checksum: true });
 
-        // Corrupt last byte
-        const corrupted = Buffer.from(compressed);
-        corrupted[corrupted.length - 1] ^= 0x01;
+    // Corrupt last byte
+    const corrupted = Buffer.from(compressed);
+    corrupted[corrupted.length - 1] ^= 0x01;
 
-        expect(() => {
-            zxc.decompress(corrupted, { size: data.length, checksum: true });
-        }).toThrow();
-    });
+    expect(() => {
+      zxc.decompress(corrupted, { size: data.length, checksum: true });
+    }).toThrow();
+  });
 
-    test('throws on truncated compressed input', () => {
-        expect(() => {
-            zxc.decompress(Buffer.from([0x01, 0x02, 0x03]), { size: 100 });
-        }).toThrow();
-    });
+  test("throws on truncated compressed input", () => {
+    expect(() => {
+      zxc.decompress(Buffer.from([0x01, 0x02, 0x03]), { size: 100 });
+    }).toThrow();
+  });
 });
 
 // =============================================================================
 // Invalid input types
 // =============================================================================
 
-describe('invalid input handling', () => {
-    test('compress rejects non-Buffer', () => {
-        expect(() => zxc.compress('string')).toThrow(TypeError);
-        expect(() => zxc.compress(123)).toThrow(TypeError);
-        expect(() => zxc.compress(null)).toThrow(TypeError);
-    });
+describe("invalid input handling", () => {
+  test("compress rejects non-Buffer", () => {
+    expect(() => zxc.compress("string")).toThrow(TypeError);
+    expect(() => zxc.compress(123)).toThrow(TypeError);
+    expect(() => zxc.compress(null)).toThrow(TypeError);
+  });
 
-    test('decompress rejects non-Buffer', () => {
-        expect(() => zxc.decompress('string')).toThrow(TypeError);
-        expect(() => zxc.decompress(123)).toThrow(TypeError);
-    });
+  test("decompress rejects non-Buffer", () => {
+    expect(() => zxc.decompress("string")).toThrow(TypeError);
+    expect(() => zxc.decompress(123)).toThrow(TypeError);
+  });
 
-    test('getDecompressedSize rejects non-Buffer', () => {
-        expect(() => zxc.getDecompressedSize('string')).toThrow(TypeError);
-    });
+  test("getDecompressedSize rejects non-Buffer", () => {
+    expect(() => zxc.getDecompressedSize("string")).toThrow(TypeError);
+  });
 
-    test('compressBound rejects non-number', () => {
-        expect(() => zxc.compressBound('abc')).toThrow(TypeError);
-    });
+  test("compressBound rejects non-number", () => {
+    expect(() => zxc.compressBound("abc")).toThrow(TypeError);
+  });
 });
 
 // =============================================================================
 // Constants
 // =============================================================================
 
-describe('constants', () => {
-    test('compression levels are defined', () => {
-        expect(zxc.LEVEL_FASTEST).toBe(1);
-        expect(zxc.LEVEL_FAST).toBe(2);
-        expect(zxc.LEVEL_DEFAULT).toBe(3);
-        expect(zxc.LEVEL_BALANCED).toBe(4);
-        expect(zxc.LEVEL_COMPACT).toBe(5);
-        expect(zxc.LEVEL_DENSITY).toBe(6);
-        expect(zxc.LEVEL_ULTRA).toBe(7);
-    });
+describe("constants", () => {
+  test("compression levels are defined", () => {
+    expect(zxc.LEVEL_FASTEST).toBe(1);
+    expect(zxc.LEVEL_FAST).toBe(2);
+    expect(zxc.LEVEL_DEFAULT).toBe(3);
+    expect(zxc.LEVEL_BALANCED).toBe(4);
+    expect(zxc.LEVEL_COMPACT).toBe(5);
+    expect(zxc.LEVEL_DENSITY).toBe(6);
+    expect(zxc.LEVEL_ULTRA).toBe(7);
+  });
 });
 
 // =============================================================================
 // Error Handling
 // =============================================================================
 
-describe('error handling', () => {
-    test('error constants are defined', () => {
-        expect(zxc.ERROR_MEMORY).toBe(-1);
-        expect(zxc.ERROR_DST_TOO_SMALL).toBe(-2);
-        expect(zxc.ERROR_SRC_TOO_SMALL).toBe(-3);
-        expect(zxc.ERROR_BAD_MAGIC).toBe(-4);
-        expect(zxc.ERROR_BAD_VERSION).toBe(-5);
-        expect(zxc.ERROR_BAD_HEADER).toBe(-6);
-        expect(zxc.ERROR_BAD_CHECKSUM).toBe(-7);
-        expect(zxc.ERROR_CORRUPT_DATA).toBe(-8);
-        expect(zxc.ERROR_BAD_OFFSET).toBe(-9);
-        expect(zxc.ERROR_OVERFLOW).toBe(-10);
-        expect(zxc.ERROR_IO).toBe(-11);
-        expect(zxc.ERROR_NULL_INPUT).toBe(-12);
-        expect(zxc.ERROR_BAD_BLOCK_TYPE).toBe(-13);
-        expect(zxc.ERROR_BAD_BLOCK_SIZE).toBe(-14);
-    });
+describe("error handling", () => {
+  test("error constants are defined", () => {
+    expect(zxc.ERROR_MEMORY).toBe(-1);
+    expect(zxc.ERROR_DST_TOO_SMALL).toBe(-2);
+    expect(zxc.ERROR_SRC_TOO_SMALL).toBe(-3);
+    expect(zxc.ERROR_BAD_MAGIC).toBe(-4);
+    expect(zxc.ERROR_BAD_VERSION).toBe(-5);
+    expect(zxc.ERROR_BAD_HEADER).toBe(-6);
+    expect(zxc.ERROR_BAD_CHECKSUM).toBe(-7);
+    expect(zxc.ERROR_CORRUPT_DATA).toBe(-8);
+    expect(zxc.ERROR_BAD_OFFSET).toBe(-9);
+    expect(zxc.ERROR_OVERFLOW).toBe(-10);
+    expect(zxc.ERROR_IO).toBe(-11);
+    expect(zxc.ERROR_NULL_INPUT).toBe(-12);
+    expect(zxc.ERROR_BAD_BLOCK_TYPE).toBe(-13);
+    expect(zxc.ERROR_BAD_BLOCK_SIZE).toBe(-14);
+  });
 
-    test('errorName works', () => {
-        expect(zxc.errorName(zxc.ERROR_DST_TOO_SMALL)).toBe('ZXC_ERROR_DST_TOO_SMALL');
-        expect(zxc.errorName(-999)).toBe('ZXC_UNKNOWN_ERROR');
-    });
+  test("errorName works", () => {
+    expect(zxc.errorName(zxc.ERROR_DST_TOO_SMALL)).toBe(
+      "ZXC_ERROR_DST_TOO_SMALL",
+    );
+    expect(zxc.errorName(-999)).toBe("ZXC_UNKNOWN_ERROR");
+  });
 
-    test('thrown errors have code property', () => {
-        try {
-            zxc.decompress(Buffer.from([0x01, 0x02, 0x03]), { size: 100 });
-            throw new Error('Should have thrown');
-        } catch (err) {
-            expect(err.code).toBe(zxc.ERROR_NULL_INPUT);
-            expect(err.message).toBe('ZXC_ERROR_NULL_INPUT');
-        }
-    });
+  test("thrown errors have code property", () => {
+    try {
+      zxc.decompress(Buffer.from([0x01, 0x02, 0x03]), { size: 100 });
+      throw new Error("Should have thrown");
+    } catch (err) {
+      expect(err.code).toBe(zxc.ERROR_NULL_INPUT);
+      expect(err.message).toBe("ZXC_ERROR_NULL_INPUT");
+    }
+  });
 
-    test('detects bad magic with correct code', () => {
-        try {
-            // Provide enough bytes (16 for header) but fake magic
-            const fakeHeader = Buffer.alloc(32);
-            fakeHeader.write('FAKE', 0, 'utf8');
-            zxc.decompress(fakeHeader, { size: 100 });
-            throw new Error('Should have thrown');
-        } catch (err) {
-            expect(err.code).toBe(zxc.ERROR_BAD_HEADER);
-        }
-    });
+  test("detects bad magic with correct code", () => {
+    try {
+      // Provide enough bytes (16 for header) but fake magic
+      const fakeHeader = Buffer.alloc(32);
+      fakeHeader.write("FAKE", 0, "utf8");
+      zxc.decompress(fakeHeader, { size: 100 });
+      throw new Error("Should have thrown");
+    } catch (err) {
+      expect(err.code).toBe(zxc.ERROR_BAD_HEADER);
+    }
+  });
 });
 
 // =============================================================================
@@ -192,79 +196,84 @@ describe('error handling', () => {
 // =============================================================================
 
 function pstreamRoundtrip(data, { level, checksum } = {}) {
-    const cs = new zxc.CStream({ level, checksum });
-    const compressedChunks = [];
-    // Feed in 17-byte slices to exercise the buffering/state machine.
-    const step = Math.max(1, Math.min(17, data.length));
-    for (let i = 0; i < data.length; i += step) {
-        compressedChunks.push(cs.compress(data.subarray(i, i + step)));
-    }
-    compressedChunks.push(cs.end());
-    cs.close();
-    const compressed = Buffer.concat(compressedChunks);
+  const cs = new zxc.CStream({ level, checksum });
+  const compressedChunks = [];
+  // Feed in 17-byte slices to exercise the buffering/state machine.
+  const step = Math.max(1, Math.min(17, data.length));
+  for (let i = 0; i < data.length; i += step) {
+    compressedChunks.push(cs.compress(data.subarray(i, i + step)));
+  }
+  compressedChunks.push(cs.end());
+  cs.close();
+  const compressed = Buffer.concat(compressedChunks);
 
-    const ds = new zxc.DStream({ checksum });
-    const outChunks = [];
-    const dstep = Math.max(1, Math.min(31, compressed.length));
-    for (let i = 0; i < compressed.length; i += dstep) {
-        outChunks.push(ds.decompress(compressed.subarray(i, i + dstep)));
-    }
-    expect(ds.finished()).toBe(true);
-    ds.close();
-    return Buffer.concat(outChunks);
+  const ds = new zxc.DStream({ checksum });
+  const outChunks = [];
+  const dstep = Math.max(1, Math.min(31, compressed.length));
+  for (let i = 0; i < compressed.length; i += dstep) {
+    outChunks.push(ds.decompress(compressed.subarray(i, i + dstep)));
+  }
+  expect(ds.finished()).toBe(true);
+  ds.close();
+  return Buffer.concat(outChunks);
 }
 
-describe('pstream roundtrip', () => {
-    test('small payload', () => {
-        const data = Buffer.from('Hello pstream! Round-trip through the Node.js push API.');
-        expect(pstreamRoundtrip(data).equals(data)).toBe(true);
-    });
+describe("pstream roundtrip", () => {
+  test("small payload", () => {
+    const data = Buffer.from(
+      "Hello pstream! Round-trip through the Node.js push API.",
+    );
+    expect(pstreamRoundtrip(data).equals(data)).toBe(true);
+  });
 
-    test('with checksum', () => {
-        const data = Buffer.alloc(32 * 1024);
-        for (let i = 0; i < data.length; i++) data[i] = i % 251;
-        expect(pstreamRoundtrip(data, { checksum: true }).equals(data)).toBe(true);
-    });
+  test("with checksum", () => {
+    const data = Buffer.alloc(32 * 1024);
+    for (let i = 0; i < data.length; i++) data[i] = i % 251;
+    expect(pstreamRoundtrip(data, { checksum: true }).equals(data)).toBe(true);
+  });
 
-    test('multi-block (>512 KB)', () => {
-        const data = Buffer.alloc(1536 * 1024);
-        for (let i = 0; i < data.length; i++) data[i] = (i * 7) % 256;
-        expect(pstreamRoundtrip(data).equals(data)).toBe(true);
-    });
+  test("multi-block (>512 KB)", () => {
+    const data = Buffer.alloc(1536 * 1024);
+    for (let i = 0; i < data.length; i++) data[i] = (i * 7) % 256;
+    expect(pstreamRoundtrip(data).equals(data)).toBe(true);
+  });
 });
 
-describe('pstream lifecycle', () => {
-    test('size hints non-zero', () => {
-        const cs = new zxc.CStream();
-        expect(cs.inSize()).toBeGreaterThan(0);
-        expect(cs.outSize()).toBeGreaterThan(0);
-        cs.close();
+describe("pstream lifecycle", () => {
+  test("size hints non-zero", () => {
+    const cs = new zxc.CStream();
+    expect(cs.inSize()).toBeGreaterThan(0);
+    expect(cs.outSize()).toBeGreaterThan(0);
+    cs.close();
 
-        const ds = new zxc.DStream();
-        expect(ds.inSize()).toBeGreaterThan(0);
-        expect(ds.outSize()).toBeGreaterThan(0);
-        expect(ds.finished()).toBe(false);
-        ds.close();
-    });
+    const ds = new zxc.DStream();
+    expect(ds.inSize()).toBeGreaterThan(0);
+    expect(ds.outSize()).toBeGreaterThan(0);
+    expect(ds.finished()).toBe(false);
+    ds.close();
+  });
 
-    test('use after close throws', () => {
-        const cs = new zxc.CStream();
-        cs.close();
-        expect(() => cs.compress(Buffer.from('x'))).toThrow(/closed/);
+  test("use after close throws", () => {
+    const cs = new zxc.CStream();
+    cs.close();
+    expect(() => cs.compress(Buffer.from("x"))).toThrow(/closed/);
 
-        const ds = new zxc.DStream();
-        ds.close();
-        expect(() => ds.decompress(Buffer.from('x'))).toThrow(/closed/);
-    });
+    const ds = new zxc.DStream();
+    ds.close();
+    expect(() => ds.decompress(Buffer.from("x"))).toThrow(/closed/);
+  });
 
-    test('truncated stream not finished', () => {
-        const cs = new zxc.CStream();
-        const compressed = Buffer.concat([cs.compress(Buffer.from('hello '.repeat(1000))), cs.end()]);
-        cs.close();
+  test("truncated stream not finished", () => {
+    const cs = new zxc.CStream();
+    const compressed = Buffer.concat([
+      cs.compress(Buffer.from("hello ".repeat(1000))),
+      cs.end(),
+    ]);
+    cs.close();
 
-        const ds = new zxc.DStream();
-        ds.decompress(compressed.subarray(0, compressed.length - 5));
-        expect(ds.finished()).toBe(false);
-        ds.close();
-    });
+    const ds = new zxc.DStream();
+    ds.decompress(compressed.subarray(0, compressed.length - 5));
+    expect(ds.finished()).toBe(false);
+    ds.close();
+  });
 });

--- a/wrappers/python/src/zxc/__init__.py
+++ b/wrappers/python/src/zxc/__init__.py
@@ -82,7 +82,7 @@ try:
     from ._version import __version__
 except ImportError:
     __version__ = "0.0.0-dev"
-    
+
 __all__ = [
     # Functions
     "compress",
@@ -90,7 +90,6 @@ __all__ = [
     "stream_compress",
     "stream_decompress",
     "get_decompressed_size",
-
     # Dictionary
     "train_dict",
     "dict_id",
@@ -101,27 +100,22 @@ __all__ = [
     "train_dict_huf",
     "dict_huf",
     "Dictionary",
-
     # Push streaming
     "CStream",
     "DStream",
-
     # Seekable random-access decompression
     "Seekable",
     "seek_table_size",
     "write_seek_table",
-
     # io.RawIOBase adapters
     "ZxcReader",
     "ZxcWriter",
     "detect_zxc",
-
     # Library info helpers
     "min_level",
     "max_level",
     "default_level",
     "library_version",
-
     # Constants
     "LEVEL_FASTEST",
     "LEVEL_FAST",
@@ -130,7 +124,6 @@ __all__ = [
     "LEVEL_COMPACT",
     "LEVEL_DENSITY",
     "LEVEL_ULTRA",
-
     # Error Constants
     "ERROR_MEMORY",
     "ERROR_DST_TOO_SMALL",
@@ -151,6 +144,7 @@ __all__ = [
     "ERROR_DICT_TOO_LARGE",
     "ERROR_BAD_LEVEL",
 ]
+
 
 def min_level() -> int:
     """Return the minimum supported compression level (currently 1)."""
@@ -280,8 +274,11 @@ class Dictionary:
         return dict_save(self.content, self.huf)
 
     def __eq__(self, other):
-        return (isinstance(other, Dictionary) and self.content == other.content
-                and self.huf == other.huf)
+        return (
+            isinstance(other, Dictionary)
+            and self.content == other.content
+            and self.huf == other.huf
+        )
 
     def __repr__(self):
         return f"Dictionary(id=0x{self.id:08X}, content={len(self.content)} bytes)"
@@ -294,7 +291,9 @@ def _split_dict_arg(dict, dict_huf):
     return dict, dict_huf
 
 
-def compress(data, level = LEVEL_DEFAULT, checksum = False, dict = None, dict_huf = None) -> bytes:
+def compress(
+    data, level=LEVEL_DEFAULT, checksum=False, dict=None, dict_huf=None
+) -> bytes:
     """Compress a bytes object.
 
     Args:
@@ -333,7 +332,9 @@ def get_decompressed_size(data: bytes) -> int:
     return pyzxc_get_decompressed_size(data)
 
 
-def decompress(data, decompress_size=None, checksum=False, dict=None, dict_huf=None) -> bytes:
+def decompress(
+    data, decompress_size=None, checksum=False, dict=None, dict_huf=None
+) -> bytes:
     """Decompress a bytes object.
 
     Args:
@@ -355,7 +356,17 @@ def decompress(data, decompress_size=None, checksum=False, dict=None, dict_huf=N
     dict, dict_huf = _split_dict_arg(dict, dict_huf)
     return pyzxc_decompress(data, decompress_size, checksum, dict, dict_huf)
 
-def stream_compress(src, dst, n_threads=0, level=LEVEL_DEFAULT, checksum=False, seekable=False, dict=None, dict_huf=None) -> int:
+
+def stream_compress(
+    src,
+    dst,
+    n_threads=0,
+    level=LEVEL_DEFAULT,
+    checksum=False,
+    seekable=False,
+    dict=None,
+    dict_huf=None,
+) -> int:
     """Compress data from src to dst (file-like objects).
 
     Args:
@@ -395,7 +406,10 @@ def stream_compress(src, dst, n_threads=0, level=LEVEL_DEFAULT, checksum=False, 
         dst.flush()
 
     dict, dict_huf = _split_dict_arg(dict, dict_huf)
-    return pyzxc_stream_compress(src, dst, n_threads, level, checksum, seekable, dict, dict_huf)
+    return pyzxc_stream_compress(
+        src, dst, n_threads, level, checksum, seekable, dict, dict_huf
+    )
+
 
 def stream_decompress(src, dst, n_threads=0, checksum=False) -> int:
     """Decompress data from src to dst (file-like objects).
@@ -505,7 +519,9 @@ class Seekable:
         dict, dict_huf = _split_dict_arg(dict, dict_huf)
         pyzxc_seekable_set_dict(self._handle, dict, dict_huf)
 
-    def decompress_range(self, offset: int, length: int, *, n_threads: int = 0) -> bytes:
+    def decompress_range(
+        self, offset: int, length: int, *, n_threads: int = 0
+    ) -> bytes:
         self._ensure_open()
         return pyzxc_seekable_decompress_range(self._handle, offset, length, n_threads)
 
@@ -573,7 +589,9 @@ class CStream:
 
     __slots__ = ("_handle",)
 
-    def __init__(self, level: int = LEVEL_DEFAULT, checksum: bool = False, block_size: int = 0):
+    def __init__(
+        self, level: int = LEVEL_DEFAULT, checksum: bool = False, block_size: int = 0
+    ):
         self._handle = pyzxc_cstream_create(level, checksum, block_size)
 
     def compress(self, data) -> bytes:
@@ -744,7 +762,7 @@ class ZxcReader(_io.RawIOBase):
         if buffer_size <= 0:
             buffer_size = self._ds.in_size
         self._bufsize = buffer_size
-        self._pending = b""    # decompressed bytes not yet returned
+        self._pending = b""  # decompressed bytes not yet returned
         self._eof_src = False  # True once src.read() returned empty bytes
 
     def readable(self) -> bool:

--- a/wrappers/python/src/zxc/__init__.pyi
+++ b/wrappers/python/src/zxc/__init__.pyi
@@ -39,11 +39,12 @@ ERROR_BAD_LEVEL: int
 # ---------- types ----------
 class FileLike(Protocol):
     """File-like object with a file descriptor.
-    
+
     Note:
         This excludes in-memory streams like io.BytesIO.
         Use real file objects or objects wrapping OS file descriptors.
     """
+
     def fileno(self) -> int: ...
     def readable(self) -> bool: ...
     def writable(self) -> bool: ...
@@ -54,17 +55,15 @@ def compress(
     level: int = LEVEL_DEFAULT,
     checksum: bool = False,
     dict: Optional[bytes] = None,
-    dict_huf: Optional[bytes] = None
+    dict_huf: Optional[bytes] = None,
 ) -> bytes: ...
-
 def decompress(
     data: bytes,
     decompress_size: Optional[int] = None,
     checksum: bool = False,
     dict: Optional[bytes] = None,
-    dict_huf: Optional[bytes] = None
+    dict_huf: Optional[bytes] = None,
 ) -> bytes: ...
-
 def stream_compress(
     src: FileLike,
     dst: FileLike,
@@ -73,16 +72,11 @@ def stream_compress(
     checksum: bool = False,
     seekable: bool = False,
     dict: Optional[bytes] = None,
-    dict_huf: Optional[bytes] = None
+    dict_huf: Optional[bytes] = None,
 ) -> int: ...
-
 def stream_decompress(
-    src: FileLike,
-    dst: FileLike,
-    n_threads: int = 0,
-    checksum: bool = False
+    src: FileLike, dst: FileLike, n_threads: int = 0, checksum: bool = False
 ) -> int: ...
-
 def get_decompressed_size(data: bytes) -> int: ...
 
 # ---------- pre-trained dictionaries ----------
@@ -114,6 +108,7 @@ def library_version() -> str: ...
 # ---------- seekable random-access decompression ----------
 class Seekable:
     """Random-access decompression of a seekable ZXC archive."""
+
     def __init__(self, source: bytes | bytearray | memoryview | object) -> None: ...
     @property
     def num_blocks(self) -> int: ...
@@ -122,7 +117,9 @@ class Seekable:
     def block_compressed_size(self, block_idx: int) -> Optional[int]: ...
     def block_decompressed_size(self, block_idx: int) -> Optional[int]: ...
     def set_dict(self, dict: bytes, dict_huf: Optional[bytes] = None) -> None: ...
-    def decompress_range(self, offset: int, length: int, *, n_threads: int = 0) -> bytes: ...
+    def decompress_range(
+        self, offset: int, length: int, *, n_threads: int = 0
+    ) -> bytes: ...
     def close(self) -> None: ...
     def __enter__(self) -> "Seekable": ...
     def __exit__(self, exc_type, exc, tb) -> bool: ...
@@ -133,7 +130,10 @@ def write_seek_table(comp_sizes: list[int]) -> bytes: ...
 # ---------- push streaming ----------
 class CStream:
     """Push-based, single-threaded compression stream."""
-    def __init__(self, level: int = LEVEL_DEFAULT, checksum: bool = False, block_size: int = 0) -> None: ...
+
+    def __init__(
+        self, level: int = LEVEL_DEFAULT, checksum: bool = False, block_size: int = 0
+    ) -> None: ...
     def compress(self, data: bytes) -> bytes: ...
     def end(self) -> bytes: ...
     @property
@@ -146,6 +146,7 @@ class CStream:
 
 class DStream:
     """Push-based, single-threaded decompression stream."""
+
     def __init__(self, checksum: bool = False) -> None: ...
     def decompress(self, data: bytes) -> bytes: ...
     @property
@@ -166,6 +167,7 @@ def detect_zxc(data: bytes) -> bool: ...
 
 class ZxcReader(_io.RawIOBase):
     """Decompresses a ZXC frame read from a binary file-like object."""
+
     def __init__(
         self,
         fileobj: IO[bytes],
@@ -179,6 +181,7 @@ class ZxcReader(_io.RawIOBase):
 
 class ZxcWriter(_io.RawIOBase):
     """Compresses bytes written to it into a binary file-like object."""
+
     def __init__(
         self,
         fileobj: IO[bytes],

--- a/wrappers/python/tests/test_buffer.py
+++ b/wrappers/python/tests/test_buffer.py
@@ -8,14 +8,17 @@ SPDX-License-Identifier: BSD-3-Clause
 import pytest
 import zxc
 
-@pytest.mark.parametrize("data", [
-    None,
-    "string",
-    123,
-    12.5,
-    object(),
-])
 
+@pytest.mark.parametrize(
+    "data",
+    [
+        None,
+        "string",
+        123,
+        12.5,
+        object(),
+    ],
+)
 def test_compress_invalid_type(data):
     with pytest.raises(TypeError):
         zxc.compress(data)
@@ -24,8 +27,8 @@ def test_compress_invalid_type(data):
 @pytest.mark.parametrize(
     "data,corrupt_func,exc",
     [
-        (b"hello world" * 10, lambda x: x[:-1] + b"\x01", RuntimeError),  
-        (b"a" * 10, lambda x: b"", RuntimeError),                     
+        (b"hello world" * 10, lambda x: x[:-1] + b"\x01", RuntimeError),
+        (b"a" * 10, lambda x: b"", RuntimeError),
     ],
     ids=["corrupted_data", "invalid_header"],
 )
@@ -40,10 +43,10 @@ def test_compress_corruption(data, corrupt_func, exc):
 @pytest.mark.parametrize(
     "data",
     [
-        b"hello world" * 10,   # default
-        b"a",                  # single byte 
+        b"hello world" * 10,  # default
+        b"a",  # single byte
         b"",
-        b"a" * 10_000_000,     # large data 
+        b"a" * 10_000_000,  # large data
     ],
     ids=[
         "normal_data",
@@ -52,7 +55,6 @@ def test_compress_corruption(data, corrupt_func, exc):
         "large_10mb",
     ],
 )
-
 def test_compress_roundtrip(data):
     # test all compression levels (1..LEVEL_ULTRA)
     for level in range(zxc.LEVEL_FASTEST, zxc.LEVEL_ULTRA + 1):
@@ -62,5 +64,3 @@ def test_compress_roundtrip(data):
         decompressed = zxc.decompress(compressed, out_size)
         assert len(data) == len(decompressed)
         assert data == decompressed
-    
-

--- a/wrappers/python/tests/test_dict.py
+++ b/wrappers/python/tests/test_dict.py
@@ -184,7 +184,7 @@ class TestSeekableDict:
             assert s.decompressed_size == len(payload)
             # mid-range slice
             chunk = s.decompress_range(500, 1234)
-            assert chunk == payload[500:500 + 1234]
+            assert chunk == payload[500 : 500 + 1234]
             # full range
             full = s.decompress_range(0, s.decompressed_size)
             assert full == payload

--- a/wrappers/python/tests/test_io_adapters.py
+++ b/wrappers/python/tests/test_io_adapters.py
@@ -138,6 +138,7 @@ def test_reader_underlying_not_closed():
 # detect_zxc
 # ---------------------------------------------------------------------------
 
+
 def test_detect_zxc_positive_compress():
     frame = zxc.compress(b"sniff me")
     assert zxc.detect_zxc(frame)

--- a/wrappers/python/tests/test_seekable.py
+++ b/wrappers/python/tests/test_seekable.py
@@ -31,6 +31,7 @@ def build_seekable_archive_stream(payload, tmp_path, level=zxc.LEVEL_DEFAULT):
 # Queries
 # =========================================================================
 
+
 class TestSeekableQueries:
     def test_reports_size_and_blocks(self, tmp_path):
         payload = build_payload(64 * 1024)
@@ -54,6 +55,7 @@ class TestSeekableQueries:
 # decompress_range
 # =========================================================================
 
+
 class TestDecompressRange:
     def test_full_range_roundtrip(self, tmp_path):
         payload = build_payload(64 * 1024)
@@ -68,7 +70,7 @@ class TestDecompressRange:
         with zxc.Seekable(compressed) as s:
             off, length = 1024, 8192
             out = s.decompress_range(off, length)
-            assert out == payload[off:off + length]
+            assert out == payload[off : off + length]
 
     def test_zero_length(self, tmp_path):
         payload = build_payload(4096)
@@ -87,6 +89,7 @@ class TestDecompressRange:
 # =========================================================================
 # Error handling
 # =========================================================================
+
 
 class TestSeekableErrors:
     def test_garbage_buffer(self):
@@ -122,6 +125,7 @@ class TestSeekableErrors:
 # Reader callback
 # =========================================================================
 
+
 class TestSeekableReader:
     def test_roundtrip_via_reader(self, tmp_path):
         payload = build_payload(128 * 1024)
@@ -133,7 +137,7 @@ class TestSeekableReader:
 
             def read_at(self, length, offset):
                 calls[0] += 1
-                return compressed[offset:offset + length]
+                return compressed[offset : offset + length]
 
         with zxc.Seekable(Reader()) as s:
             assert calls[0] == 3  # header, footer, seek table
@@ -143,7 +147,7 @@ class TestSeekableReader:
 
             before = calls[0]
             chunk = s.decompress_range(2048, 1024)
-            assert chunk == payload[2048:2048 + 1024]
+            assert chunk == payload[2048 : 2048 + 1024]
             assert calls[0] - before == 1
 
     def test_reader_exception_propagates(self, tmp_path):
@@ -160,7 +164,7 @@ class TestSeekableReader:
                 attempted[0] += 1
                 if attempted[0] > 3:
                     raise IOError("boom")
-                return compressed[offset:offset + length]
+                return compressed[offset : offset + length]
 
         with zxc.Seekable(BadReader()) as s:
             with pytest.raises(IOError, match="boom"):
@@ -177,7 +181,7 @@ class TestSeekableReader:
             size = len(compressed)
 
             def read_at(self, length, offset):
-                return compressed[offset:offset + length]
+                return compressed[offset : offset + length]
 
         with zxc.Seekable(Reader()) as s:
             assert s.num_blocks >= 2
@@ -202,6 +206,7 @@ class TestSeekableReader:
 # =========================================================================
 # Low-level seek table helpers
 # =========================================================================
+
 
 class TestSeekTableHelpers:
     def test_roundtrip(self):

--- a/wrappers/python/tests/test_stream.py
+++ b/wrappers/python/tests/test_stream.py
@@ -9,13 +9,29 @@ import pytest
 import zxc
 import io
 
+
 @pytest.mark.parametrize(
     "src,dst,expected_error,match",
     [
-        ("not a file", io.BytesIO(), ValueError, "src and dst must be open file-like objects"),
-        (io.BytesIO(b"data"), "not a file", ValueError, "src and dst must be open file-like objects"),
+        (
+            "not a file",
+            io.BytesIO(),
+            ValueError,
+            "src and dst must be open file-like objects",
+        ),
+        (
+            io.BytesIO(b"data"),
+            "not a file",
+            ValueError,
+            "src and dst must be open file-like objects",
+        ),
         (io.BytesIO(b"data"), io.BytesIO(), ValueError, "Source file must be readable"),
-        (io.BytesIO(b"data"), io.BytesIO(), ValueError, "Destination file must be writable"),
+        (
+            io.BytesIO(b"data"),
+            io.BytesIO(),
+            ValueError,
+            "Destination file must be writable",
+        ),
         (None, None, None, "valid_file"),
     ],
     ids=[
@@ -24,7 +40,7 @@ import io
         "src_not_readable",
         "dst_not_writable",
         "valid_file",
-    ]
+    ],
 )
 def test_stream_invalid_src_dst(tmp_path, src, dst, expected_error, match):
     # Helper class to mock fileno behavior
@@ -89,17 +105,22 @@ def test_stream_compress_corruption(tmp_path, data, corrupt_func, exc):
     compressed_file_path.write_bytes(corrupted_bytes)
 
     with pytest.raises(exc):
-        with open(compressed_file_path, "rb") as src, open(decompressed_file_path, "wb") as dst:
+        with open(compressed_file_path, "rb") as src, open(
+            decompressed_file_path, "wb"
+        ) as dst:
             zxc.stream_decompress(src, dst, checksum=True)
 
 
-@pytest.mark.parametrize("data", [
-    b"hello world" * 10,   # normal
-    b"a",                  # single byte
-    b"",                   # empty
-    b"a" * 10_000_000,     # large
-], ids=["normal", "single_byte", "empty", "large_10mb"])
-
+@pytest.mark.parametrize(
+    "data",
+    [
+        b"hello world" * 10,  # normal
+        b"a",  # single byte
+        b"",  # empty
+        b"a" * 10_000_000,  # large
+    ],
+    ids=["normal", "single_byte", "empty", "large_10mb"],
+)
 def test_stream_roundtrip(tmp_path, data):
     src_file_path = tmp_path / "src.txt"
     compressed_file_path = tmp_path / "compressed.zxc"
@@ -108,12 +129,14 @@ def test_stream_roundtrip(tmp_path, data):
     src_file_path.write_bytes(data)
 
     for level in range(zxc.LEVEL_FASTEST, zxc.LEVEL_ULTRA + 1):
-        with open(src_file_path, "rb") as src, \
-            open(compressed_file_path, "wb") as compressed:
+        with open(src_file_path, "rb") as src, open(
+            compressed_file_path, "wb"
+        ) as compressed:
             zxc.stream_compress(src, compressed, level=level)
 
-        with open(compressed_file_path, "rb") as compressed, \
-            open(decompressed_file_path, "wb") as decompressed:
+        with open(compressed_file_path, "rb") as compressed, open(
+            decompressed_file_path, "wb"
+        ) as decompressed:
             zxc.stream_decompress(compressed, decompressed)
 
         decompressed_data = decompressed_file_path.read_bytes()

--- a/wrappers/rust/zxc-sys/build.rs
+++ b/wrappers/rust/zxc-sys/build.rs
@@ -20,16 +20,15 @@ use std::path::{Path, PathBuf};
 /// Extract version constants from zxc_constants.h
 fn extract_version(include_dir: &Path) -> (u32, u32, u32) {
     let header_path = include_dir.join("zxc_constants.h");
-    let content = fs::read_to_string(&header_path)
-        .expect("Failed to read zxc_constants.h");
-    
+    let content = fs::read_to_string(&header_path).expect("Failed to read zxc_constants.h");
+
     let mut major = None;
     let mut minor = None;
     let mut patch = None;
 
     for line in content.lines() {
         let trimmed = line.trim();
-        
+
         // Parse lines like: #define ZXC_VERSION_MAJOR 0
         if trimmed.starts_with("#define") {
             let parts: Vec<&str> = trimmed.split_whitespace().collect();
@@ -54,8 +53,7 @@ fn extract_version(include_dir: &Path) -> (u32, u32, u32) {
 /// Extract compression level constants from zxc_constants.h
 fn extract_compression_levels(include_dir: &Path) -> (i32, i32, i32, i32, i32, i32, i32) {
     let header_path = include_dir.join("zxc_constants.h");
-    let content = fs::read_to_string(&header_path)
-        .expect("Failed to read zxc_constants.h");
+    let content = fs::read_to_string(&header_path).expect("Failed to read zxc_constants.h");
 
     let mut fastest = None;
     let mut fast = None;
@@ -139,7 +137,9 @@ fn main() {
         (src_lib, include_dir)
     } else {
         // Try direct path from workspace root
-        let zxc_root = manifest_dir.join("../../..").canonicalize()
+        let zxc_root = manifest_dir
+            .join("../../..")
+            .canonicalize()
             .expect("Failed to find ZXC root directory");
         (zxc_root.join("src/lib"), zxc_root.join("include"))
     };

--- a/wrappers/rust/zxc-sys/src/lib.rs
+++ b/wrappers/rust/zxc-sys/src/lib.rs
@@ -1133,7 +1133,10 @@ mod tests {
             );
             assert!(compressed_size > 0, "Compression failed");
             // Highly repetitive data should compress significantly
-            assert!((compressed_size as usize) < input.len() / 2, "Data should compress well");
+            assert!(
+                (compressed_size as usize) < input.len() / 2,
+                "Data should compress well"
+            );
 
             // Get decompressed size
             let decompressed_size = zxc_get_decompressed_size(
@@ -1190,11 +1193,7 @@ mod tests {
                     compressed.len(),
                     &copts,
                 );
-                assert!(
-                    compressed_size > 0,
-                    "Compression failed at level {}",
-                    level
-                );
+                assert!(compressed_size > 0, "Compression failed at level {}", level);
             }
         }
     }

--- a/wrappers/rust/zxc/examples/file_compression.rs
+++ b/wrappers/rust/zxc/examples/file_compression.rs
@@ -48,7 +48,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Get compressed file size
     let compressed_size = fs::metadata(compressed_path)?.len();
     let ratio = 100.0 * compressed_size as f64 / original_size as f64;
-    println!("  Compressed file size: {} bytes ({:.1}%)", compressed_size, ratio);
+    println!(
+        "  Compressed file size: {} bytes ({:.1}%)",
+        compressed_size, ratio
+    );
 
     // Query the decompressed size from the file
     let reported_size = zxc::file_decompressed_size(compressed_path)?;

--- a/wrappers/rust/zxc/examples/simple.rs
+++ b/wrappers/rust/zxc/examples/simple.rs
@@ -9,7 +9,7 @@
 //!
 //! Run with: `cargo run --example simple`
 
-use zxc::{compress, decompress, decompressed_size, version_string, Level};
+use zxc::{Level, compress, decompress, decompressed_size, version_string};
 
 fn main() -> Result<(), zxc::Error> {
     println!("ZXC Rust Wrapper v{}\n", version_string());

--- a/wrappers/rust/zxc/src/dict.rs
+++ b/wrappers/rust/zxc/src/dict.rs
@@ -45,7 +45,7 @@
 
 use std::ffi::c_void;
 
-pub use zxc_sys::{ZXC_HUF_TABLE_SIZE, ZXC_DICT_SIZE_MAX};
+pub use zxc_sys::{ZXC_DICT_SIZE_MAX, ZXC_HUF_TABLE_SIZE};
 
 use crate::error::error_from_code;
 use crate::{Error, Result};
@@ -66,7 +66,10 @@ use crate::{Error, Result};
 pub fn train_dict(samples: &[&[u8]], max_size: usize) -> Result<Vec<u8>> {
     let cap = max_size.clamp(1, ZXC_DICT_SIZE_MAX);
 
-    let ptrs: Vec<*const c_void> = samples.iter().map(|s| s.as_ptr() as *const c_void).collect();
+    let ptrs: Vec<*const c_void> = samples
+        .iter()
+        .map(|s| s.as_ptr() as *const c_void)
+        .collect();
     let sizes: Vec<usize> = samples.iter().map(|s| s.len()).collect();
 
     let mut buf = vec![0u8; cap];
@@ -129,7 +132,10 @@ pub fn dict_get_id(zxd: &[u8]) -> u32 {
 ///
 /// Returns an [`Error`] if training fails (e.g. no usable samples).
 pub fn train_dict_huf(samples: &[&[u8]], dict: &[u8]) -> Result<[u8; ZXC_HUF_TABLE_SIZE]> {
-    let ptrs: Vec<*const c_void> = samples.iter().map(|s| s.as_ptr() as *const c_void).collect();
+    let ptrs: Vec<*const c_void> = samples
+        .iter()
+        .map(|s| s.as_ptr() as *const c_void)
+        .collect();
     let sizes: Vec<usize> = samples.iter().map(|s| s.len()).collect();
 
     let mut huf = [0u8; ZXC_HUF_TABLE_SIZE];
@@ -191,9 +197,7 @@ pub fn dict_huf(zxd: &[u8]) -> Option<[u8; ZXC_HUF_TABLE_SIZE]> {
     }
     let mut huf = [0u8; ZXC_HUF_TABLE_SIZE];
     // The pointer aims into `zxd` (zero-copy); copy out for an owned result.
-    huf.copy_from_slice(unsafe {
-        std::slice::from_raw_parts(p as *const u8, ZXC_HUF_TABLE_SIZE)
-    });
+    huf.copy_from_slice(unsafe { std::slice::from_raw_parts(p as *const u8, ZXC_HUF_TABLE_SIZE) });
     Some(huf)
 }
 
@@ -229,8 +233,10 @@ pub struct Dictionary {
 impl Dictionary {
     /// Trains a complete dictionary (content + shared table) from samples.
     pub fn train(samples: &[&[u8]]) -> Result<Self> {
-        let ptrs: Vec<*const c_void> =
-            samples.iter().map(|s| s.as_ptr() as *const c_void).collect();
+        let ptrs: Vec<*const c_void> = samples
+            .iter()
+            .map(|s| s.as_ptr() as *const c_void)
+            .collect();
         let sizes: Vec<usize> = samples.iter().map(|s| s.len()).collect();
 
         let cap = unsafe { zxc_sys::zxc_dict_save_bound(ZXC_DICT_SIZE_MAX) };
@@ -245,7 +251,11 @@ impl Dictionary {
             )
         };
         if written <= 0 {
-            return Err(if written < 0 { error_from_code(written) } else { Error::InvalidData });
+            return Err(if written < 0 {
+                error_from_code(written)
+            } else {
+                Error::InvalidData
+            });
         }
         zxd.truncate(written as usize);
         Self::load(&zxd)
@@ -314,7 +324,7 @@ impl Dictionary {
 mod tests {
     use super::*;
     use crate::{
-        compress_with_options, decompress_with_options, CompressOptions, DecompressOptions,
+        CompressOptions, DecompressOptions, compress_with_options, decompress_with_options,
     };
 
     fn sample_corpus() -> Vec<Vec<u8>> {
@@ -436,8 +446,7 @@ mod tests {
 
         // Options take the bundle in one call; round-trip + id binding.
         let sample = corpus[3].clone();
-        let copts = crate::CompressOptions::with_level(crate::Level::Density)
-            .with_dictionary(&d);
+        let copts = crate::CompressOptions::with_level(crate::Level::Density).with_dictionary(&d);
         let archive = compress_with_options(&sample, &copts).expect("compress");
         let dopts = DecompressOptions::default().with_dictionary(&d);
         let restored = decompress_with_options(&archive, &dopts).expect("decompress");

--- a/wrappers/rust/zxc/src/lib.rs
+++ b/wrappers/rust/zxc/src/lib.rs
@@ -47,14 +47,32 @@
 #![warn(rust_2018_idioms)]
 
 pub use zxc_sys::{
-    ZXC_LEVEL_BALANCED, ZXC_LEVEL_COMPACT, ZXC_LEVEL_DEFAULT, ZXC_LEVEL_DENSITY, ZXC_LEVEL_FAST,
-    ZXC_LEVEL_FASTEST, ZXC_LEVEL_ULTRA, ZXC_VERSION_MAJOR, ZXC_VERSION_MINOR, ZXC_VERSION_PATCH,
-    // Error codes
-    ZXC_OK, ZXC_ERROR_MEMORY, ZXC_ERROR_DST_TOO_SMALL, ZXC_ERROR_SRC_TOO_SMALL,
-    ZXC_ERROR_BAD_MAGIC, ZXC_ERROR_BAD_VERSION, ZXC_ERROR_BAD_HEADER,
-    ZXC_ERROR_BAD_CHECKSUM, ZXC_ERROR_CORRUPT_DATA, ZXC_ERROR_BAD_OFFSET,
-    ZXC_ERROR_OVERFLOW, ZXC_ERROR_IO, ZXC_ERROR_NULL_INPUT, ZXC_ERROR_BAD_BLOCK_TYPE,
     ZXC_ERROR_BAD_BLOCK_SIZE,
+    ZXC_ERROR_BAD_BLOCK_TYPE,
+    ZXC_ERROR_BAD_CHECKSUM,
+    ZXC_ERROR_BAD_HEADER,
+    ZXC_ERROR_BAD_MAGIC,
+    ZXC_ERROR_BAD_OFFSET,
+    ZXC_ERROR_BAD_VERSION,
+    ZXC_ERROR_CORRUPT_DATA,
+    ZXC_ERROR_DST_TOO_SMALL,
+    ZXC_ERROR_IO,
+    ZXC_ERROR_MEMORY,
+    ZXC_ERROR_NULL_INPUT,
+    ZXC_ERROR_OVERFLOW,
+    ZXC_ERROR_SRC_TOO_SMALL,
+    ZXC_LEVEL_BALANCED,
+    ZXC_LEVEL_COMPACT,
+    ZXC_LEVEL_DEFAULT,
+    ZXC_LEVEL_DENSITY,
+    ZXC_LEVEL_FAST,
+    ZXC_LEVEL_FASTEST,
+    ZXC_LEVEL_ULTRA,
+    // Error codes
+    ZXC_OK,
+    ZXC_VERSION_MAJOR,
+    ZXC_VERSION_MINOR,
+    ZXC_VERSION_PATCH,
 };
 
 // =============================================================================
@@ -276,23 +294,23 @@ pub mod seekable;
 mod stdio;
 
 pub use dict::{
-    dict_get_id, dict_huf, dict_id, dict_load, dict_save, get_dict_id, train_dict, train_dict_huf,
-    Dictionary,
+    Dictionary, dict_get_id, dict_huf, dict_id, dict_load, dict_save, get_dict_id, train_dict,
+    train_dict_huf,
 };
-pub use zxc_sys::{ZXC_HUF_TABLE_SIZE, ZXC_DICT_SIZE_MAX};
+pub use zxc_sys::{ZXC_DICT_SIZE_MAX, ZXC_HUF_TABLE_SIZE};
 
+pub use ctx::{Cctx, Dctx, compress_block_bound, decompress_block_bound};
 pub use error::{Error, Result};
+pub use file::{
+    StreamCompressOptions, StreamDecompressOptions, StreamError, StreamResult, compress_file,
+    compress_file_with_options, decompress_file, decompress_file_with_options,
+    file_decompressed_size,
+};
 pub use oneshot::{
     compress, compress_bound, compress_to, compress_with_options, decompress, decompress_to,
     decompress_with_options, decompressed_size, default_level, max_level, min_level,
     runtime_version, version, version_string,
 };
-pub use ctx::{compress_block_bound, decompress_block_bound, Cctx, Dctx};
-pub use file::{
-    compress_file, compress_file_with_options, decompress_file, decompress_file_with_options,
-    file_decompressed_size, StreamCompressOptions, StreamDecompressOptions, StreamError,
-    StreamResult,
-};
 pub use pstream::{CStream, CStreamProgress, DStream, DStreamProgress};
-pub use seekable::{seek_table_size, write_seek_table, Seekable};
-pub use stdio::{detect_zxc, Decoder, Encoder};
+pub use seekable::{Seekable, seek_table_size, write_seek_table};
+pub use stdio::{Decoder, Encoder, detect_zxc};

--- a/wrappers/rust/zxc/src/oneshot.rs
+++ b/wrappers/rust/zxc/src/oneshot.rs
@@ -81,8 +81,7 @@ pub fn compress_with_options(data: &[u8], options: &CompressOptions) -> Result<V
     let bound = compress_bound(data.len()) as usize;
     let mut output = Vec::with_capacity(bound);
 
-    let written =
-        unsafe { impl_compress(data, output.as_mut_ptr(), output.capacity(), options)? };
+    let written = unsafe { impl_compress(data, output.as_mut_ptr(), output.capacity(), options)? };
 
     unsafe {
         output.set_len(written);
@@ -213,10 +212,7 @@ pub fn decompress(compressed: &[u8]) -> Result<Vec<u8>> {
 }
 
 /// Decompresses data with full options control.
-pub fn decompress_with_options(
-    compressed: &[u8],
-    options: &DecompressOptions,
-) -> Result<Vec<u8>> {
+pub fn decompress_with_options(compressed: &[u8], options: &DecompressOptions) -> Result<Vec<u8>> {
     // `decompressed_size` returns None for an ambiguous 0 (a valid empty-payload
     // archive or invalid input); fall back to 0 and let the C decoder validate
     // the frame (it returns a negative error code on genuinely corrupt input).

--- a/wrappers/rust/zxc/src/seekable.rs
+++ b/wrappers/rust/zxc/src/seekable.rs
@@ -31,7 +31,7 @@
 //! by this crate yet; the underlying `zxc_seekable_decompress_range_mt`
 //! symbol is reserved for a future addition.
 
-use std::ffi::{c_void, CString};
+use std::ffi::{CString, c_void};
 use std::path::Path;
 use std::ptr::NonNull;
 
@@ -71,9 +71,7 @@ impl Seekable {
     /// The buffer is held alive for the lifetime of the returned handle.
     /// Use this when the archive is already in memory.
     pub fn from_bytes(data: Vec<u8>) -> Result<Self> {
-        let ptr = unsafe {
-            zxc_sys::zxc_seekable_open(data.as_ptr() as *const c_void, data.len())
-        };
+        let ptr = unsafe { zxc_sys::zxc_seekable_open(data.as_ptr() as *const c_void, data.len()) };
         let inner = NonNull::new(ptr).ok_or(Error::InvalidData)?;
         Ok(Self {
             inner,
@@ -183,9 +181,8 @@ impl Seekable {
         if block_idx >= self.num_blocks() {
             return None;
         }
-        let sz = unsafe {
-            zxc_sys::zxc_seekable_get_block_comp_size(self.inner.as_ptr(), block_idx)
-        };
+        let sz =
+            unsafe { zxc_sys::zxc_seekable_get_block_comp_size(self.inner.as_ptr(), block_idx) };
         Some(sz)
     }
 
@@ -196,9 +193,8 @@ impl Seekable {
         if block_idx >= self.num_blocks() {
             return None;
         }
-        let sz = unsafe {
-            zxc_sys::zxc_seekable_get_block_decomp_size(self.inner.as_ptr(), block_idx)
-        };
+        let sz =
+            unsafe { zxc_sys::zxc_seekable_get_block_decomp_size(self.inner.as_ptr(), block_idx) };
         Some(sz)
     }
 
@@ -240,12 +236,7 @@ impl Seekable {
     ///
     /// Only the blocks overlapping the requested range are read and
     /// decompressed. Returns the number of bytes actually written.
-    pub fn decompress_range(
-        &mut self,
-        dst: &mut [u8],
-        offset: u64,
-        len: usize,
-    ) -> Result<usize> {
+    pub fn decompress_range(&mut self, dst: &mut [u8], offset: u64, len: usize) -> Result<usize> {
         let res = unsafe {
             zxc_sys::zxc_seekable_decompress_range(
                 self.inner.as_ptr(),
@@ -390,7 +381,7 @@ fn path_to_cstring(path: &Path) -> Result<CString> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{compress_with_options, CompressOptions, Level};
+    use crate::{CompressOptions, Level, compress_with_options};
 
     fn build_archive(data: &[u8]) -> Vec<u8> {
         let opts = CompressOptions {
@@ -470,7 +461,10 @@ mod tests {
         fn read_at(&self, dst: &mut [u8], offset: u64) -> std::io::Result<()> {
             self.calls.set(self.calls.get() + 1);
             let off = offset as usize;
-            if off.checked_add(dst.len()).map_or(true, |end| end > self.data.len()) {
+            if off
+                .checked_add(dst.len())
+                .map_or(true, |end| end > self.data.len())
+            {
                 return Err(std::io::Error::new(
                     std::io::ErrorKind::UnexpectedEof,
                     "out of bounds",
@@ -522,7 +516,7 @@ mod tests {
 
     #[test]
     fn set_dict_range_roundtrip() {
-        use crate::{train_dict, ZXC_DICT_SIZE_MAX};
+        use crate::{ZXC_DICT_SIZE_MAX, train_dict};
 
         // Train a dictionary from repetitive records, then build a seekable,
         // dict-compressed archive over many such records.

--- a/wrappers/rust/zxc/src/stdio.rs
+++ b/wrappers/rust/zxc/src/stdio.rs
@@ -319,8 +319,8 @@ fn map_err(e: Error) -> io::Error {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::compress;
     use crate::Level;
+    use crate::compress;
     use std::io::{Cursor, Read, Write};
 
     fn roundtrip(data: &[u8]) -> Vec<u8> {
@@ -342,7 +342,9 @@ mod tests {
 
     #[test]
     fn encoder_decoder_large_roundtrip() {
-        let data: Vec<u8> = (0..2 * 1024 * 1024).map(|i| ((i * 13) % 251) as u8).collect();
+        let data: Vec<u8> = (0..2 * 1024 * 1024)
+            .map(|i| ((i * 13) % 251) as u8)
+            .collect();
         assert_eq!(roundtrip(&data), data);
     }
 

--- a/wrappers/wasm/test.mjs
+++ b/wrappers/wasm/test.mjs
@@ -482,14 +482,14 @@ async function main() {
     }).pipeThrough(zxc.createDecompressTransformStream());
 
     let didThrow = false;
-    let errorCode;
+    let errorCode = "";
     try {
       for await (const _ of truncSource) {
         /* drain */
       }
     } catch (e) {
       didThrow = true;
-      errorCode = e?.code;
+      errorCode = e?.code ?? "";
     }
     assert(didThrow, "truncated frame throws an error");
     assert(

--- a/wrappers/wasm/test.mjs
+++ b/wrappers/wasm/test.mjs
@@ -11,547 +11,783 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-import { join, dirname, resolve } from 'path';
-import { fileURLToPath, pathToFileURL } from 'url';
+import { join, dirname, resolve } from "path";
+import { fileURLToPath, pathToFileURL } from "url";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 // Resolve BUILD_DIR relative to CWD (not the test file location)
 const buildDir = process.env.BUILD_DIR
-    ? resolve(process.cwd(), process.env.BUILD_DIR)
-    : join(__dirname, '..', '..', 'build-wasm');
+  ? resolve(process.cwd(), process.env.BUILD_DIR)
+  : join(__dirname, "..", "..", "build-wasm");
 
 // The module is built with -sEXPORT_ES6=1; import it as ESM.
-const ZXCModule = (await import(pathToFileURL(join(buildDir, 'zxc.js')))).default;
+const ZXCModule = (await import(pathToFileURL(join(buildDir, "zxc.js"))))
+  .default;
 
 let passed = 0;
 let failed = 0;
 
 function assert(cond, msg) {
-    if (!cond) {
-        console.error(`  ✗ FAIL: ${msg}`);
-        failed++;
-    } else {
-        console.log(`  ✓ ${msg}`);
-        passed++;
-    }
+  if (!cond) {
+    console.error(`  ✗ FAIL: ${msg}`);
+    failed++;
+  } else {
+    console.log(`  ✓ ${msg}`);
+    passed++;
+  }
 }
 
 function arraysEqual(a, b) {
-    if (a.length !== b.length) return false;
-    for (let i = 0; i < a.length; i++) {
-        if (a[i] !== b[i]) return false;
-    }
-    return true;
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) return false;
+  }
+  return true;
 }
 
 async function main() {
-    console.log('ZXC WASM Test Suite\n');
+  console.log("ZXC WASM Test Suite\n");
 
-    // --- 1. Module initialisation ---
-    console.log('1. Module Initialisation');
-    const Module = await ZXCModule();
-    assert(!!Module, 'Module loaded successfully');
+  // --- 1. Module initialisation ---
+  console.log("1. Module Initialisation");
+  const Module = await ZXCModule();
+  assert(!!Module, "Module loaded successfully");
 
-    // Wrap core functions
-    const _compress = Module.cwrap('zxc_compress', 'number',
-        ['number', 'number', 'number', 'number', 'number']);
-    const _decompress = Module.cwrap('zxc_decompress', 'number',
-        ['number', 'number', 'number', 'number', 'number']);
-    const _compress_bound = Module.cwrap('zxc_compress_bound', 'number', ['number']);
-    const _get_decompressed_size = Module.cwrap('zxc_get_decompressed_size', 'number',
-        ['number', 'number']);
-    const _version_string = Module.cwrap('zxc_version_string', 'string', []);
-    const _min_level = Module.cwrap('zxc_min_level', 'number', []);
-    const _max_level = Module.cwrap('zxc_max_level', 'number', []);
-    const _default_level = Module.cwrap('zxc_default_level', 'number', []);
-    const _error_name = Module.cwrap('zxc_error_name', 'string', ['number']);
+  // Wrap core functions
+  const _compress = Module.cwrap("zxc_compress", "number", [
+    "number",
+    "number",
+    "number",
+    "number",
+    "number",
+  ]);
+  const _decompress = Module.cwrap("zxc_decompress", "number", [
+    "number",
+    "number",
+    "number",
+    "number",
+    "number",
+  ]);
+  const _compress_bound = Module.cwrap("zxc_compress_bound", "number", [
+    "number",
+  ]);
+  const _get_decompressed_size = Module.cwrap(
+    "zxc_get_decompressed_size",
+    "number",
+    ["number", "number"],
+  );
+  const _version_string = Module.cwrap("zxc_version_string", "string", []);
+  const _min_level = Module.cwrap("zxc_min_level", "number", []);
+  const _max_level = Module.cwrap("zxc_max_level", "number", []);
+  const _default_level = Module.cwrap("zxc_default_level", "number", []);
+  const _error_name = Module.cwrap("zxc_error_name", "string", ["number"]);
 
-    // --- 2. Library info ---
-    console.log('\n2. Library Info');
-    const version = _version_string();
-    assert(typeof version === 'string' && version.length > 0, `Version: ${version}`);
-    assert(_min_level() === 1, `Min level: ${_min_level()}`);
-    assert(_max_level() === 7, `Max level: ${_max_level()}`);
-    assert(_default_level() === 3, `Default level: ${_default_level()}`);
+  // --- 2. Library info ---
+  console.log("\n2. Library Info");
+  const version = _version_string();
+  assert(
+    typeof version === "string" && version.length > 0,
+    `Version: ${version}`,
+  );
+  assert(_min_level() === 1, `Min level: ${_min_level()}`);
+  assert(_max_level() === 7, `Max level: ${_max_level()}`);
+  assert(_default_level() === 3, `Default level: ${_default_level()}`);
 
-    // --- 3. Compress bound ---
-    console.log('\n3. Compress Bound');
-    const bound1k = _compress_bound(1024);
-    assert(bound1k > 1024, `Bound for 1KB: ${bound1k}`);
-    const bound0 = _compress_bound(0);
-    assert(bound0 > 0, `Bound for 0 bytes: ${bound0}`);
+  // --- 3. Compress bound ---
+  console.log("\n3. Compress Bound");
+  const bound1k = _compress_bound(1024);
+  assert(bound1k > 1024, `Bound for 1KB: ${bound1k}`);
+  const bound0 = _compress_bound(0);
+  assert(bound0 > 0, `Bound for 0 bytes: ${bound0}`);
 
-    // --- 4. Roundtrip: simple string ---
-    console.log('\n4. Roundtrip: Simple String');
-    {
-        const input = new TextEncoder().encode('Hello, ZXC WebAssembly! '.repeat(100));
-        const bound = _compress_bound(input.length);
+  // --- 4. Roundtrip: simple string ---
+  console.log("\n4. Roundtrip: Simple String");
+  {
+    const input = new TextEncoder().encode(
+      "Hello, ZXC WebAssembly! ".repeat(100),
+    );
+    const bound = _compress_bound(input.length);
 
-        const srcPtr = Module._malloc(input.length);
-        const dstPtr = Module._malloc(bound);
-        Module.HEAPU8.set(input, srcPtr);
+    const srcPtr = Module._malloc(input.length);
+    const dstPtr = Module._malloc(bound);
+    Module.HEAPU8.set(input, srcPtr);
 
-        const csize = _compress(srcPtr, input.length, dstPtr, bound, 0);
-        assert(csize > 0, `Compressed ${input.length} -> ${csize} bytes`);
-        assert(csize < input.length, `Compression ratio: ${(input.length / csize).toFixed(2)}x`);
+    const csize = _compress(srcPtr, input.length, dstPtr, bound, 0);
+    assert(csize > 0, `Compressed ${input.length} -> ${csize} bytes`);
+    assert(
+      csize < input.length,
+      `Compression ratio: ${(input.length / csize).toFixed(2)}x`,
+    );
 
-        // Read back compressed data
-        const compressed = new Uint8Array(Module.HEAPU8.buffer, dstPtr, csize).slice();
+    // Read back compressed data
+    const compressed = new Uint8Array(
+      Module.HEAPU8.buffer,
+      dstPtr,
+      csize,
+    ).slice();
 
-        // Get decompressed size
-        const csrcPtr = Module._malloc(compressed.length);
-        Module.HEAPU8.set(compressed, csrcPtr);
-        const origSize = _get_decompressed_size(csrcPtr, compressed.length);
-        assert(origSize === input.length, `Decompressed size: ${origSize} (expected ${input.length})`);
+    // Get decompressed size
+    const csrcPtr = Module._malloc(compressed.length);
+    Module.HEAPU8.set(compressed, csrcPtr);
+    const origSize = _get_decompressed_size(csrcPtr, compressed.length);
+    assert(
+      origSize === input.length,
+      `Decompressed size: ${origSize} (expected ${input.length})`,
+    );
 
-        // Decompress
-        const outPtr = Module._malloc(origSize);
-        const dsize = _decompress(csrcPtr, compressed.length, outPtr, origSize, 0);
-        assert(dsize === input.length, `Decompressed ${dsize} bytes`);
+    // Decompress
+    const outPtr = Module._malloc(origSize);
+    const dsize = _decompress(csrcPtr, compressed.length, outPtr, origSize, 0);
+    assert(dsize === input.length, `Decompressed ${dsize} bytes`);
 
-        const output = new Uint8Array(Module.HEAPU8.buffer, outPtr, dsize).slice();
-        assert(arraysEqual(input, output), 'Roundtrip byte-exact match');
+    const output = new Uint8Array(Module.HEAPU8.buffer, outPtr, dsize).slice();
+    assert(arraysEqual(input, output), "Roundtrip byte-exact match");
 
-        Module._free(srcPtr);
-        Module._free(dstPtr);
-        Module._free(csrcPtr);
-        Module._free(outPtr);
+    Module._free(srcPtr);
+    Module._free(dstPtr);
+    Module._free(csrcPtr);
+    Module._free(outPtr);
+  }
+
+  // --- 5. Roundtrip: all compression levels ---
+  console.log("\n5. Roundtrip: All Compression Levels");
+  {
+    const input = new Uint8Array(4096);
+    // Fill with semi-compressible pattern
+    for (let i = 0; i < input.length; i++) {
+      input[i] = (i * 7 + 13) & 0xff;
+    }
+    const bound = _compress_bound(input.length);
+
+    for (let level = 1; level <= 7; level++) {
+      const srcPtr = Module._malloc(input.length);
+      const dstPtr = Module._malloc(bound);
+      Module.HEAPU8.set(input, srcPtr);
+
+      // Build opts struct (full 40-byte zxc_compress_opts_t so the
+      // dict/progress fields the library reads are zeroed, not heap
+      // garbage): {n_threads=0, level, block_size=0, checksum=1, ...}
+      const optsPtr = Module._malloc(40);
+      for (let i = 0; i < 40; i++) Module.HEAPU8[optsPtr + i] = 0;
+      Module.HEAP32[(optsPtr >> 2) + 1] = level; // level
+      Module.HEAP32[(optsPtr >> 2) + 3] = 1; // checksum_enabled
+
+      const csize = _compress(srcPtr, input.length, dstPtr, bound, optsPtr);
+      assert(csize > 0, `Level ${level}: compressed to ${csize} bytes`);
+
+      // Decompress with checksum verification (28-byte zxc_decompress_opts_t)
+      const compressed = new Uint8Array(
+        Module.HEAPU8.buffer,
+        dstPtr,
+        csize,
+      ).slice();
+      const csrcPtr = Module._malloc(compressed.length);
+      Module.HEAPU8.set(compressed, csrcPtr);
+
+      const dOptsPtr = Module._malloc(28);
+      for (let i = 0; i < 28; i++) Module.HEAPU8[dOptsPtr + i] = 0;
+      Module.HEAP32[(dOptsPtr >> 2) + 1] = 1; // checksum_enabled
+
+      const outPtr = Module._malloc(input.length);
+      const dsize = _decompress(
+        csrcPtr,
+        compressed.length,
+        outPtr,
+        input.length,
+        dOptsPtr,
+      );
+      const output = new Uint8Array(
+        Module.HEAPU8.buffer,
+        outPtr,
+        dsize,
+      ).slice();
+      assert(arraysEqual(input, output), `Level ${level}: roundtrip OK`);
+
+      Module._free(srcPtr);
+      Module._free(dstPtr);
+      Module._free(optsPtr);
+      Module._free(csrcPtr);
+      Module._free(dOptsPtr);
+      Module._free(outPtr);
+    }
+  }
+
+  // --- 6. Reusable context API ---
+  console.log("\n6. Reusable Context API");
+  {
+    const _create_cctx = Module.cwrap("zxc_create_cctx", "number", ["number"]);
+    const _free_cctx = Module.cwrap("zxc_free_cctx", "void", ["number"]);
+    const _compress_cctx = Module.cwrap("zxc_compress_cctx", "number", [
+      "number",
+      "number",
+      "number",
+      "number",
+      "number",
+      "number",
+    ]);
+    const _create_dctx = Module.cwrap("zxc_create_dctx", "number", []);
+    const _free_dctx = Module.cwrap("zxc_free_dctx", "void", ["number"]);
+    const _decompress_dctx = Module.cwrap("zxc_decompress_dctx", "number", [
+      "number",
+      "number",
+      "number",
+      "number",
+      "number",
+      "number",
+    ]);
+
+    const cctx = _create_cctx(0);
+    assert(cctx !== 0, "Created compression context");
+
+    const dctx = _create_dctx();
+    assert(dctx !== 0, "Created decompression context");
+
+    // Compress two different payloads with same context
+    for (let trial = 0; trial < 3; trial++) {
+      const input = new TextEncoder().encode(
+        `Trial ${trial}: ${"ABCDEFGH".repeat(200)}`,
+      );
+      const bound = _compress_bound(input.length);
+
+      const srcPtr = Module._malloc(input.length);
+      const dstPtr = Module._malloc(bound);
+      Module.HEAPU8.set(input, srcPtr);
+
+      const csize = _compress_cctx(
+        cctx,
+        srcPtr,
+        input.length,
+        dstPtr,
+        bound,
+        0,
+      );
+      assert(csize > 0, `Context compress trial ${trial}: ${csize} bytes`);
+
+      const compressed = new Uint8Array(
+        Module.HEAPU8.buffer,
+        dstPtr,
+        csize,
+      ).slice();
+      const csrcPtr = Module._malloc(compressed.length);
+      Module.HEAPU8.set(compressed, csrcPtr);
+
+      const outPtr = Module._malloc(input.length);
+      const dsize = _decompress_dctx(
+        dctx,
+        csrcPtr,
+        compressed.length,
+        outPtr,
+        input.length,
+        0,
+      );
+      const output = new Uint8Array(
+        Module.HEAPU8.buffer,
+        outPtr,
+        dsize,
+      ).slice();
+      assert(
+        arraysEqual(input, output),
+        `Context roundtrip trial ${trial}: OK`,
+      );
+
+      Module._free(srcPtr);
+      Module._free(dstPtr);
+      Module._free(csrcPtr);
+      Module._free(outPtr);
     }
 
-    // --- 5. Roundtrip: all compression levels ---
-    console.log('\n5. Roundtrip: All Compression Levels');
+    _free_cctx(cctx);
+    _free_dctx(dctx);
+    console.log("  Contexts freed.");
+  }
+
+  // --- 7. Error handling ---
+  console.log("\n7. Error Handling");
+  {
+    const errorName = _error_name(-1);
+    assert(typeof errorName === "string", `Error name for -1: ${errorName}`);
+
+    // Attempt to decompress garbage
+    const garbage = new Uint8Array([0, 1, 2, 3, 4, 5, 6, 7]);
+    const gPtr = Module._malloc(garbage.length);
+    const outPtr = Module._malloc(1024);
+    Module.HEAPU8.set(garbage, gPtr);
+    const result = _decompress(gPtr, garbage.length, outPtr, 1024, 0);
+    assert(
+      result < 0,
+      `Garbage decompression returns error: ${result} (${_error_name(result)})`,
+    );
+    Module._free(gPtr);
+    Module._free(outPtr);
+  }
+
+  // --- 8. Push streaming API (high-level wrapper) -----------------------
+  console.log("\n8. Push Streaming API (CStream / DStream)");
+  {
+    const { default: createZXC } = await import("./zxc_wasm.js");
+    const zxc = await createZXC({}, ZXCModule);
+
+    const cs = zxc.createCStream({ checksum: true });
+    assert(
+      cs.inSize() > 0 && cs.outSize() > 0,
+      `cstream size hints: in=${cs.inSize()} out=${cs.outSize()}`,
+    );
+
+    // Multi-block payload to exercise > 1 block.
+    const data = new Uint8Array(512 * 1024);
+    for (let i = 0; i < data.length; i++) data[i] = (i * 7) & 0xff;
+
+    const chunks = [];
+    let totalC = 0;
+    const step = 17_000;
+    for (let i = 0; i < data.length; i += step) {
+      const c = cs.compress(data.subarray(i, Math.min(i + step, data.length)));
+      chunks.push(c);
+      totalC += c.length;
+    }
+    const tail = cs.end();
+    chunks.push(tail);
+    totalC += tail.length;
+    cs.free();
+
+    const compressed = new Uint8Array(totalC);
+    let off = 0;
+    for (const c of chunks) {
+      compressed.set(c, off);
+      off += c.length;
+    }
+    assert(
+      compressed.length > 0,
+      `pstream compressed ${data.length} -> ${compressed.length} bytes`,
+    );
+
+    const ds = zxc.createDStream({ checksum: true });
+    const outChunks = [];
+    let totalD = 0;
+    const dstep = 31_000;
+    for (let i = 0; i < compressed.length; i += dstep) {
+      const o = ds.decompress(
+        compressed.subarray(i, Math.min(i + dstep, compressed.length)),
+      );
+      outChunks.push(o);
+      totalD += o.length;
+    }
+    assert(ds.finished(), "dstream finished after full input");
+    ds.free();
+
+    const decoded = new Uint8Array(totalD);
+    off = 0;
+    for (const c of outChunks) {
+      decoded.set(c, off);
+      off += c.length;
+    }
+    assert(
+      decoded.length === data.length,
+      `pstream decoded ${decoded.length} bytes (expected ${data.length})`,
+    );
+    assert(arraysEqual(data, decoded), "pstream roundtrip byte-exact match");
+  }
+
+  // --- 9. WHATWG TransformStream adapters -------------------------------
+  console.log("\n9. WHATWG TransformStream adapters + detectZxc");
+  {
+    const { default: createZXC, detectZxc } = await import("./zxc_wasm.js");
+    const zxc = await createZXC({}, ZXCModule);
+
+    // detectZxc: works without WASM init too (pure JS), but check both
+    // call sites as they share the same implementation.
+    assert(
+      detectZxc === zxc.detectZxc,
+      "detectZxc exported at module + API level",
+    );
+    assert(!detectZxc(null), "detectZxc(null) === false");
+    assert(
+      !detectZxc(new Uint8Array([0xf5, 0x2e, 0xb0])),
+      "detectZxc rejects 3-byte input",
+    );
+    assert(!detectZxc(new Uint8Array(4)), "detectZxc rejects zero buffer");
+
+    // Build a frame with the buffer API and sniff it.
+    const frame = zxc.compress(new Uint8Array([1, 2, 3, 4, 5]));
+    assert(detectZxc(frame), "detectZxc accepts compress() output");
+    assert(detectZxc(frame.buffer), "detectZxc accepts ArrayBuffer");
+
+    // TransformStream roundtrip via pipeThrough().
+    const data = new Uint8Array(64 * 1024);
+    for (let i = 0; i < data.length; i++) data[i] = (i ^ 0x5a) & 0xff;
+
+    const sourceCompressed = new ReadableStream({
+      start(c) {
+        c.enqueue(data);
+        c.close();
+      },
+    }).pipeThrough(zxc.createCompressTransformStream());
+
+    const compressedChunks = [];
+    let cTotal = 0;
+    for await (const c of sourceCompressed) {
+      compressedChunks.push(c);
+      cTotal += c.length;
+    }
+    const compressed = new Uint8Array(cTotal);
     {
-        const input = new Uint8Array(4096);
-        // Fill with semi-compressible pattern
-        for (let i = 0; i < input.length; i++) {
-            input[i] = (i * 7 + 13) & 0xFF;
-        }
-        const bound = _compress_bound(input.length);
+      let off = 0;
+      for (const c of compressedChunks) {
+        compressed.set(c, off);
+        off += c.length;
+      }
+    }
+    assert(
+      detectZxc(compressed),
+      "TransformStream output is a valid ZXC frame",
+    );
 
-        for (let level = 1; level <= 7; level++) {
-            const srcPtr = Module._malloc(input.length);
-            const dstPtr = Module._malloc(bound);
-            Module.HEAPU8.set(input, srcPtr);
+    const sourceDecompressed = new ReadableStream({
+      start(c) {
+        c.enqueue(compressed);
+        c.close();
+      },
+    }).pipeThrough(zxc.createDecompressTransformStream());
 
-            // Build opts struct (full 40-byte zxc_compress_opts_t so the
-            // dict/progress fields the library reads are zeroed, not heap
-            // garbage): {n_threads=0, level, block_size=0, checksum=1, ...}
-            const optsPtr = Module._malloc(40);
-            for (let i = 0; i < 40; i++) Module.HEAPU8[optsPtr + i] = 0;
-            Module.HEAP32[(optsPtr >> 2) + 1] = level;  // level
-            Module.HEAP32[(optsPtr >> 2) + 3] = 1;      // checksum_enabled
+    const outChunks = [];
+    let dTotal = 0;
+    for await (const c of sourceDecompressed) {
+      outChunks.push(c);
+      dTotal += c.length;
+    }
+    const decoded = new Uint8Array(dTotal);
+    {
+      let off = 0;
+      for (const c of outChunks) {
+        decoded.set(c, off);
+        off += c.length;
+      }
+    }
+    assert(
+      decoded.length === data.length,
+      `TransformStream decoded ${decoded.length} bytes (expected ${data.length})`,
+    );
+    assert(
+      arraysEqual(data, decoded),
+      "TransformStream roundtrip byte-exact match",
+    );
 
-            const csize = _compress(srcPtr, input.length, dstPtr, bound, optsPtr);
-            assert(csize > 0, `Level ${level}: compressed to ${csize} bytes`);
+    // Truncated frame must error the decode stream.
+    const truncated = compressed.subarray(0, Math.floor(compressed.length / 2));
+    const truncSource = new ReadableStream({
+      start(c) {
+        c.enqueue(truncated);
+        c.close();
+      },
+    }).pipeThrough(zxc.createDecompressTransformStream());
 
-            // Decompress with checksum verification (28-byte zxc_decompress_opts_t)
-            const compressed = new Uint8Array(Module.HEAPU8.buffer, dstPtr, csize).slice();
-            const csrcPtr = Module._malloc(compressed.length);
-            Module.HEAPU8.set(compressed, csrcPtr);
+    let didThrow = false;
+    let errorCode;
+    try {
+      for await (const _ of truncSource) {
+        /* drain */
+      }
+    } catch (e) {
+      didThrow = true;
+      errorCode = e?.code;
+    }
+    assert(didThrow, "truncated frame throws an error");
+    assert(
+      errorCode === "ZXC_TRUNCATED",
+      "truncated frame error code is ZXC_TRUNCATED",
+    );
+  }
 
-            const dOptsPtr = Module._malloc(28);
-            for (let i = 0; i < 28; i++) Module.HEAPU8[dOptsPtr + i] = 0;
-            Module.HEAP32[(dOptsPtr >> 2) + 1] = 1; // checksum_enabled
+  // --- 10. Seekable API (random-access decompression) -------------------
+  console.log("\n10. Seekable API");
+  {
+    const { default: createZXC } = await import("./zxc_wasm.js");
+    const zxc = await createZXC({}, ZXCModule);
 
-            const outPtr = Module._malloc(input.length);
-            const dsize = _decompress(csrcPtr, compressed.length, outPtr, input.length, dOptsPtr);
-            const output = new Uint8Array(Module.HEAPU8.buffer, outPtr, dsize).slice();
-            assert(arraysEqual(input, output), `Level ${level}: roundtrip OK`);
+    // Build a payload that exercises both block-level and intra-block ranges.
+    const payload = new Uint8Array(64 * 1024);
+    for (let i = 0; i < payload.length; i++) payload[i] = (i * 31) & 0xff;
 
-            Module._free(srcPtr);
-            Module._free(dstPtr);
-            Module._free(optsPtr);
-            Module._free(csrcPtr);
-            Module._free(dOptsPtr);
-            Module._free(outPtr);
-        }
+    const compressed = zxc.compress(payload, {
+      seekable: true,
+      checksum: true,
+    });
+    assert(
+      compressed.length > 0,
+      `seekable archive compressed to ${compressed.length} bytes`,
+    );
+
+    const s = zxc.createSeekable(compressed);
+    try {
+      assert(
+        s.decompressedSize() === payload.length,
+        `decompressedSize=${s.decompressedSize()} (expected ${payload.length})`,
+      );
+      assert(s.numBlocks() >= 1, `numBlocks=${s.numBlocks()}`);
+
+      const cs0 = s.blockCompressedSize(0);
+      const ds0 = s.blockDecompressedSize(0);
+      assert(
+        typeof cs0 === "number" && cs0 > 0,
+        `block 0 compressed size=${cs0}`,
+      );
+      assert(
+        typeof ds0 === "number" && ds0 > 0,
+        `block 0 decompressed size=${ds0}`,
+      );
+      assert(
+        s.blockCompressedSize(s.numBlocks()) === null,
+        "out-of-range block index returns null",
+      );
+
+      // Full-range round-trip.
+      const full = s.decompressRange(0, payload.length);
+      assert(
+        full.length === payload.length,
+        `full range length=${full.length}`,
+      );
+      assert(
+        arraysEqual(full, payload),
+        "seekable full-range byte-exact match",
+      );
+
+      // Mid-range slice.
+      const off = 1024,
+        len = 8192;
+      const mid = s.decompressRange(off, len);
+      assert(mid.length === len, `mid range length=${mid.length}`);
+      assert(
+        arraysEqual(mid, payload.subarray(off, off + len)),
+        "seekable mid-range byte-exact match",
+      );
+    } finally {
+      s.free();
     }
 
-    // --- 6. Reusable context API ---
-    console.log('\n6. Reusable Context API');
-    {
-        const _create_cctx = Module.cwrap('zxc_create_cctx', 'number', ['number']);
-        const _free_cctx = Module.cwrap('zxc_free_cctx', 'void', ['number']);
-        const _compress_cctx = Module.cwrap('zxc_compress_cctx', 'number',
-            ['number', 'number', 'number', 'number', 'number', 'number']);
-        const _create_dctx = Module.cwrap('zxc_create_dctx', 'number', []);
-        const _free_dctx = Module.cwrap('zxc_free_dctx', 'void', ['number']);
-        const _decompress_dctx = Module.cwrap('zxc_decompress_dctx', 'number',
-            ['number', 'number', 'number', 'number', 'number', 'number']);
+    // Invalid archive throws.
+    let didThrow = false;
+    try {
+      zxc.createSeekable(new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]));
+    } catch (_) {
+      didThrow = true;
+    }
+    assert(didThrow, "createSeekable on garbage throws");
 
-        const cctx = _create_cctx(0);
-        assert(cctx !== 0, 'Created compression context');
+    // Low-level seek table helpers.
+    const compSizes = [128, 256, 200, 4];
+    const tableSize = zxc.seekTableSize(compSizes.length);
+    const table = zxc.writeSeekTable(compSizes);
+    assert(
+      table.length === tableSize,
+      `writeSeekTable bytes=${table.length} (expected ${tableSize})`,
+    );
+  }
 
-        const dctx = _create_dctx();
-        assert(dctx !== 0, 'Created decompression context');
+  // --- 11. Dictionary API ----------------------------------------------
+  console.log("\n11. Dictionary API");
+  {
+    const { default: createZXC } = await import("./zxc_wasm.js");
+    const zxc = await createZXC({}, ZXCModule);
 
-        // Compress two different payloads with same context
-        for (let trial = 0; trial < 3; trial++) {
-            const input = new TextEncoder().encode(`Trial ${trial}: ${'ABCDEFGH'.repeat(200)}`);
-            const bound = _compress_bound(input.length);
-
-            const srcPtr = Module._malloc(input.length);
-            const dstPtr = Module._malloc(bound);
-            Module.HEAPU8.set(input, srcPtr);
-
-            const csize = _compress_cctx(cctx, srcPtr, input.length, dstPtr, bound, 0);
-            assert(csize > 0, `Context compress trial ${trial}: ${csize} bytes`);
-
-            const compressed = new Uint8Array(Module.HEAPU8.buffer, dstPtr, csize).slice();
-            const csrcPtr = Module._malloc(compressed.length);
-            Module.HEAPU8.set(compressed, csrcPtr);
-
-            const outPtr = Module._malloc(input.length);
-            const dsize = _decompress_dctx(dctx, csrcPtr, compressed.length, outPtr, input.length, 0);
-            const output = new Uint8Array(Module.HEAPU8.buffer, outPtr, dsize).slice();
-            assert(arraysEqual(input, output), `Context roundtrip trial ${trial}: OK`);
-
-            Module._free(srcPtr);
-            Module._free(dstPtr);
-            Module._free(csrcPtr);
-            Module._free(outPtr);
-        }
-
-        _free_cctx(cctx);
-        _free_dctx(dctx);
-        console.log('  Contexts freed.');
+    // Build a corpus of similar JSON-like samples so training has shared
+    // structure to extract.
+    const samples = [];
+    for (let k = 0; k < 16; k++) {
+      const s = `{"id":${k},"type":"event","payload":{"user":"alice","action":"login","region":"eu-west"}}`;
+      samples.push(new TextEncoder().encode(s));
     }
 
-    // --- 7. Error handling ---
-    console.log('\n7. Error Handling');
-    {
-        const errorName = _error_name(-1);
-        assert(typeof errorName === 'string', `Error name for -1: ${errorName}`);
+    const dict = zxc.trainDict(samples);
+    assert(
+      dict instanceof Uint8Array && dict.length > 0,
+      `trainDict produced ${dict.length}-byte dictionary`,
+    );
 
-        // Attempt to decompress garbage
-        const garbage = new Uint8Array([0, 1, 2, 3, 4, 5, 6, 7]);
-        const gPtr = Module._malloc(garbage.length);
-        const outPtr = Module._malloc(1024);
-        Module.HEAPU8.set(garbage, gPtr);
-        const result = _decompress(gPtr, garbage.length, outPtr, 1024, 0);
-        assert(result < 0, `Garbage decompression returns error: ${result} (${_error_name(result)})`);
-        Module._free(gPtr);
-        Module._free(outPtr);
+    // Compress a fresh similar payload with the dict, decompress with it.
+    const payload = new TextEncoder().encode(
+      '{"id":999,"type":"event","payload":{"user":"alice","action":"login","region":"eu-west"}}',
+    );
+    const compressed = zxc.compress(payload, { dict });
+    assert(
+      compressed.length > 0,
+      `dict-compressed to ${compressed.length} bytes`,
+    );
+
+    const decoded = zxc.decompress(compressed, { dict });
+    assert(
+      arraysEqual(decoded, payload),
+      "dict compress/decompress byte-exact roundtrip",
+    );
+
+    // Decompressing a dict archive WITHOUT the dict must fail.
+    let threwNoDict = false;
+    try {
+      zxc.decompress(compressed);
+    } catch (_) {
+      threwNoDict = true;
+    }
+    assert(threwNoDict, "decompress of dict archive without dict throws");
+
+    // ID consistency: dictId(content) == getDictId(archive) == dictGetId(.zxd).
+    const idContent = zxc.dictId(dict);
+    const idArchive = zxc.getDictId(compressed);
+    assert(idContent !== 0, `dictId(content)=${idContent}`);
+    assert(
+      idContent === idArchive,
+      `dictId == getDictId(archive) (${idContent} == ${idArchive})`,
+    );
+
+    // trainDictHuf -> dictSave -> dictGetId / dictLoad / dictHuf roundtrip.
+    const huf = zxc.trainDictHuf(samples, dict);
+    assert(
+      huf instanceof Uint8Array && huf.length === 128,
+      `trainDictHuf produced ${huf.length}-byte table`,
+    );
+    const zxd = zxc.dictSave(dict, huf);
+    assert(
+      zxd instanceof Uint8Array && zxd.length > dict.length,
+      `dictSave produced ${zxd.length}-byte .zxd`,
+    );
+    const idZxd = zxc.dictGetId(zxd);
+    // The .zxd id binds (content, table): non-zero, distinct from the
+    // content-only id.
+    assert(
+      idZxd !== 0 && idZxd !== idContent,
+      `dictGetId(.zxd) binds the table (${idZxd} != ${idContent})`,
+    );
+    assert(
+      arraysEqual(zxc.dictHuf(zxd), huf),
+      "dictHuf(.zxd) returns the stored table",
+    );
+
+    const loaded = zxc.dictLoad(zxd);
+    assert(loaded.id === idZxd, `dictLoad id matches (${loaded.id})`);
+    assert(
+      arraysEqual(loaded.content, dict),
+      "dictSave -> dictLoad content roundtrip",
+    );
+    assert(
+      arraysEqual(loaded.huf, huf),
+      "dictLoad returns the stored huf table",
+    );
+
+    // dictTrain one-call creator: byte-identical to the 3-step sequence.
+    const zxdOneCall = zxc.dictTrain(samples);
+    assert(
+      arraysEqual(zxdOneCall, zxd),
+      "dictTrain == trainDict+trainDictHuf+dictSave",
+    );
+
+    // Dictionary object: train / save / load roundtrip, options routing.
+    const d = zxc.Dictionary.train(samples);
+    assert(
+      arraysEqual(d.content, dict) && arraysEqual(d.huf, huf) && d.id === idZxd,
+      "Dictionary.train carries (content, huf, id)",
+    );
+    const dReloaded = zxc.Dictionary.load(d.save());
+    assert(
+      arraysEqual(dReloaded.content, d.content) &&
+        arraysEqual(dReloaded.huf, d.huf) &&
+        dReloaded.id === d.id,
+      "Dictionary save/load roundtrip",
+    );
+    const cObj = zxc.compress(payload, { dict: d });
+    assert(
+      arraysEqual(zxc.decompress(cObj, { dict: d }), payload),
+      "compress/decompress with {dict: Dictionary} roundtrip",
+    );
+    let objRejected = false;
+    try {
+      zxc.decompress(cObj, { dict: d.content });
+    } catch (e) {
+      objRejected = true;
+    }
+    assert(
+      objRejected,
+      "Dictionary archive rejects content-only decode (id binding)",
+    );
+
+    // dictHuf round through compress/decompress (id binding both ways).
+    const cHuf = zxc.compress(payload, { dict, dictHuf: huf });
+    assert(
+      arraysEqual(zxc.decompress(cHuf, { dict, dictHuf: huf }), payload),
+      "compress/decompress with dictHuf roundtrip",
+    );
+    let rejected = false;
+    try {
+      zxc.decompress(cHuf, { dict });
+    } catch (e) {
+      rejected = true;
+    }
+    assert(rejected, "decompress without dictHuf is rejected (id binding)");
+
+    // Seekable + setDict + range roundtrip on a dict-compressed archive.
+    const bigPayload = new Uint8Array(48 * 1024);
+    {
+      const unit = new TextEncoder().encode(
+        '{"user":"alice","action":"login","region":"eu-west"}',
+      );
+      for (let i = 0; i < bigPayload.length; i++)
+        bigPayload[i] = unit[i % unit.length];
+    }
+    const seekArchive = zxc.compress(bigPayload, { dict, seekable: true });
+    const s = zxc.createSeekable(seekArchive);
+    try {
+      s.setDict(dict);
+      const full = s.decompressRange(0, bigPayload.length);
+      assert(
+        arraysEqual(full, bigPayload),
+        "seekable+dict full-range byte-exact",
+      );
+      const off = 4096,
+        len = 8192;
+      const mid = s.decompressRange(off, len);
+      assert(
+        arraysEqual(mid, bigPayload.subarray(off, off + len)),
+        "seekable+dict mid-range byte-exact",
+      );
+    } finally {
+      s.free();
+      s.free(); // idempotent: second call must be a no-op
     }
 
-    // --- 8. Push streaming API (high-level wrapper) -----------------------
-    console.log('\n8. Push Streaming API (CStream / DStream)');
-    {
-        const { default: createZXC } = await import('./zxc_wasm.js');
-        const zxc = await createZXC({}, ZXCModule);
-
-        const cs = zxc.createCStream({ checksum: true });
-        assert(cs.inSize() > 0 && cs.outSize() > 0, `cstream size hints: in=${cs.inSize()} out=${cs.outSize()}`);
-
-        // Multi-block payload to exercise > 1 block.
-        const data = new Uint8Array(512 * 1024);
-        for (let i = 0; i < data.length; i++) data[i] = (i * 7) & 0xff;
-
-        const chunks = [];
-        let totalC = 0;
-        const step = 17_000;
-        for (let i = 0; i < data.length; i += step) {
-            const c = cs.compress(data.subarray(i, Math.min(i + step, data.length)));
-            chunks.push(c);
-            totalC += c.length;
-        }
-        const tail = cs.end();
-        chunks.push(tail);
-        totalC += tail.length;
-        cs.free();
-
-        const compressed = new Uint8Array(totalC);
-        let off = 0;
-        for (const c of chunks) { compressed.set(c, off); off += c.length; }
-        assert(compressed.length > 0, `pstream compressed ${data.length} -> ${compressed.length} bytes`);
-
-        const ds = zxc.createDStream({ checksum: true });
-        const outChunks = [];
-        let totalD = 0;
-        const dstep = 31_000;
-        for (let i = 0; i < compressed.length; i += dstep) {
-            const o = ds.decompress(compressed.subarray(i, Math.min(i + dstep, compressed.length)));
-            outChunks.push(o);
-            totalD += o.length;
-        }
-        assert(ds.finished(), 'dstream finished after full input');
-        ds.free();
-
-        const decoded = new Uint8Array(totalD);
-        off = 0;
-        for (const c of outChunks) { decoded.set(c, off); off += c.length; }
-        assert(decoded.length === data.length, `pstream decoded ${decoded.length} bytes (expected ${data.length})`);
-        assert(arraysEqual(data, decoded), 'pstream roundtrip byte-exact match');
+    // Seekable + Dictionary (content + huf table): regression for setDict
+    // dropping the table argument, which made every (dict, huf)-bound
+    // archive fail range decode with DICT_MISMATCH.
+    const seekArchiveHuf = zxc.compress(bigPayload, {
+      dict: d,
+      seekable: true,
+    });
+    const sh = zxc.createSeekable(seekArchiveHuf);
+    try {
+      sh.setDict(d);
+      const full = sh.decompressRange(0, bigPayload.length);
+      assert(
+        arraysEqual(full, bigPayload),
+        "seekable+Dictionary(huf) full-range byte-exact",
+      );
+      let hufRejected = false;
+      try {
+        sh.setDict(d.content);
+      } catch (e) {
+        hufRejected = true;
+      }
+      assert(
+        hufRejected,
+        "seekable setDict(content-only) rejected on a Dictionary archive",
+      );
+    } finally {
+      sh.free();
     }
+  }
 
-    // --- 9. WHATWG TransformStream adapters -------------------------------
-    console.log('\n9. WHATWG TransformStream adapters + detectZxc');
-    {
-        const { default: createZXC, detectZxc } = await import('./zxc_wasm.js');
-        const zxc = await createZXC({}, ZXCModule);
-
-        // detectZxc: works without WASM init too (pure JS), but check both
-        // call sites as they share the same implementation.
-        assert(detectZxc === zxc.detectZxc, 'detectZxc exported at module + API level');
-        assert(!detectZxc(null), 'detectZxc(null) === false');
-        assert(!detectZxc(new Uint8Array([0xF5, 0x2E, 0xB0])), 'detectZxc rejects 3-byte input');
-        assert(!detectZxc(new Uint8Array(4)), 'detectZxc rejects zero buffer');
-
-        // Build a frame with the buffer API and sniff it.
-        const frame = zxc.compress(new Uint8Array([1, 2, 3, 4, 5]));
-        assert(detectZxc(frame), 'detectZxc accepts compress() output');
-        assert(detectZxc(frame.buffer), 'detectZxc accepts ArrayBuffer');
-
-        // TransformStream roundtrip via pipeThrough().
-        const data = new Uint8Array(64 * 1024);
-        for (let i = 0; i < data.length; i++) data[i] = (i ^ 0x5A) & 0xFF;
-
-        const sourceCompressed = new ReadableStream({
-            start(c) { c.enqueue(data); c.close(); }
-        }).pipeThrough(zxc.createCompressTransformStream());
-
-        const compressedChunks = [];
-        let cTotal = 0;
-        for await (const c of sourceCompressed) {
-            compressedChunks.push(c);
-            cTotal += c.length;
-        }
-        const compressed = new Uint8Array(cTotal);
-        {
-            let off = 0;
-            for (const c of compressedChunks) { compressed.set(c, off); off += c.length; }
-        }
-        assert(detectZxc(compressed), 'TransformStream output is a valid ZXC frame');
-
-        const sourceDecompressed = new ReadableStream({
-            start(c) { c.enqueue(compressed); c.close(); }
-        }).pipeThrough(zxc.createDecompressTransformStream());
-
-        const outChunks = [];
-        let dTotal = 0;
-        for await (const c of sourceDecompressed) {
-            outChunks.push(c);
-            dTotal += c.length;
-        }
-        const decoded = new Uint8Array(dTotal);
-        {
-            let off = 0;
-            for (const c of outChunks) { decoded.set(c, off); off += c.length; }
-        }
-        assert(decoded.length === data.length, `TransformStream decoded ${decoded.length} bytes (expected ${data.length})`);
-        assert(arraysEqual(data, decoded), 'TransformStream roundtrip byte-exact match');
-
-        // Truncated frame must error the decode stream.
-        const truncated = compressed.subarray(0, Math.floor(compressed.length / 2));
-        const truncSource = new ReadableStream({
-            start(c) { c.enqueue(truncated); c.close(); }
-        }).pipeThrough(zxc.createDecompressTransformStream());
-
-        let didThrow = false;
-        let errorCode;
-        try {
-            for await (const _ of truncSource) { /* drain */ }
-        } catch (e) {
-            didThrow = true;
-            errorCode = e?.code;
-        }
-        assert(didThrow, 'truncated frame throws an error');
-        assert(errorCode === 'ZXC_TRUNCATED', 'truncated frame error code is ZXC_TRUNCATED');
-    }
-
-    // --- 10. Seekable API (random-access decompression) -------------------
-    console.log('\n10. Seekable API');
-    {
-        const { default: createZXC } = await import('./zxc_wasm.js');
-        const zxc = await createZXC({}, ZXCModule);
-
-        // Build a payload that exercises both block-level and intra-block ranges.
-        const payload = new Uint8Array(64 * 1024);
-        for (let i = 0; i < payload.length; i++) payload[i] = (i * 31) & 0xFF;
-
-        const compressed = zxc.compress(payload, { seekable: true, checksum: true });
-        assert(compressed.length > 0, `seekable archive compressed to ${compressed.length} bytes`);
-
-        const s = zxc.createSeekable(compressed);
-        try {
-            assert(s.decompressedSize() === payload.length,
-                `decompressedSize=${s.decompressedSize()} (expected ${payload.length})`);
-            assert(s.numBlocks() >= 1, `numBlocks=${s.numBlocks()}`);
-
-            const cs0 = s.blockCompressedSize(0);
-            const ds0 = s.blockDecompressedSize(0);
-            assert(typeof cs0 === 'number' && cs0 > 0, `block 0 compressed size=${cs0}`);
-            assert(typeof ds0 === 'number' && ds0 > 0, `block 0 decompressed size=${ds0}`);
-            assert(s.blockCompressedSize(s.numBlocks()) === null,
-                'out-of-range block index returns null');
-
-            // Full-range round-trip.
-            const full = s.decompressRange(0, payload.length);
-            assert(full.length === payload.length, `full range length=${full.length}`);
-            assert(arraysEqual(full, payload), 'seekable full-range byte-exact match');
-
-            // Mid-range slice.
-            const off = 1024, len = 8192;
-            const mid = s.decompressRange(off, len);
-            assert(mid.length === len, `mid range length=${mid.length}`);
-            assert(arraysEqual(mid, payload.subarray(off, off + len)),
-                'seekable mid-range byte-exact match');
-        } finally {
-            s.free();
-        }
-
-        // Invalid archive throws.
-        let didThrow = false;
-        try {
-            zxc.createSeekable(new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]));
-        } catch (_) {
-            didThrow = true;
-        }
-        assert(didThrow, 'createSeekable on garbage throws');
-
-        // Low-level seek table helpers.
-        const compSizes = [128, 256, 200, 4];
-        const tableSize = zxc.seekTableSize(compSizes.length);
-        const table = zxc.writeSeekTable(compSizes);
-        assert(table.length === tableSize, `writeSeekTable bytes=${table.length} (expected ${tableSize})`);
-    }
-
-    // --- 11. Dictionary API ----------------------------------------------
-    console.log('\n11. Dictionary API');
-    {
-        const { default: createZXC } = await import('./zxc_wasm.js');
-        const zxc = await createZXC({}, ZXCModule);
-
-        // Build a corpus of similar JSON-like samples so training has shared
-        // structure to extract.
-        const samples = [];
-        for (let k = 0; k < 16; k++) {
-            const s = `{"id":${k},"type":"event","payload":{"user":"alice","action":"login","region":"eu-west"}}`;
-            samples.push(new TextEncoder().encode(s));
-        }
-
-        const dict = zxc.trainDict(samples);
-        assert(dict instanceof Uint8Array && dict.length > 0,
-            `trainDict produced ${dict.length}-byte dictionary`);
-
-        // Compress a fresh similar payload with the dict, decompress with it.
-        const payload = new TextEncoder().encode(
-            '{"id":999,"type":"event","payload":{"user":"alice","action":"login","region":"eu-west"}}');
-        const compressed = zxc.compress(payload, { dict });
-        assert(compressed.length > 0, `dict-compressed to ${compressed.length} bytes`);
-
-        const decoded = zxc.decompress(compressed, { dict });
-        assert(arraysEqual(decoded, payload), 'dict compress/decompress byte-exact roundtrip');
-
-        // Decompressing a dict archive WITHOUT the dict must fail.
-        let threwNoDict = false;
-        try {
-            zxc.decompress(compressed);
-        } catch (_) {
-            threwNoDict = true;
-        }
-        assert(threwNoDict, 'decompress of dict archive without dict throws');
-
-        // ID consistency: dictId(content) == getDictId(archive) == dictGetId(.zxd).
-        const idContent = zxc.dictId(dict);
-        const idArchive = zxc.getDictId(compressed);
-        assert(idContent !== 0, `dictId(content)=${idContent}`);
-        assert(idContent === idArchive,
-            `dictId == getDictId(archive) (${idContent} == ${idArchive})`);
-
-        // trainDictHuf -> dictSave -> dictGetId / dictLoad / dictHuf roundtrip.
-        const huf = zxc.trainDictHuf(samples, dict);
-        assert(huf instanceof Uint8Array && huf.length === 128,
-            `trainDictHuf produced ${huf.length}-byte table`);
-        const zxd = zxc.dictSave(dict, huf);
-        assert(zxd instanceof Uint8Array && zxd.length > dict.length,
-            `dictSave produced ${zxd.length}-byte .zxd`);
-        const idZxd = zxc.dictGetId(zxd);
-        // The .zxd id binds (content, table): non-zero, distinct from the
-        // content-only id.
-        assert(idZxd !== 0 && idZxd !== idContent,
-            `dictGetId(.zxd) binds the table (${idZxd} != ${idContent})`);
-        assert(arraysEqual(zxc.dictHuf(zxd), huf), 'dictHuf(.zxd) returns the stored table');
-
-        const loaded = zxc.dictLoad(zxd);
-        assert(loaded.id === idZxd, `dictLoad id matches (${loaded.id})`);
-        assert(arraysEqual(loaded.content, dict), 'dictSave -> dictLoad content roundtrip');
-        assert(arraysEqual(loaded.huf, huf), 'dictLoad returns the stored huf table');
-
-        // dictTrain one-call creator: byte-identical to the 3-step sequence.
-        const zxdOneCall = zxc.dictTrain(samples);
-        assert(arraysEqual(zxdOneCall, zxd), 'dictTrain == trainDict+trainDictHuf+dictSave');
-
-        // Dictionary object: train / save / load roundtrip, options routing.
-        const d = zxc.Dictionary.train(samples);
-        assert(arraysEqual(d.content, dict) && arraysEqual(d.huf, huf) && d.id === idZxd,
-            'Dictionary.train carries (content, huf, id)');
-        const dReloaded = zxc.Dictionary.load(d.save());
-        assert(arraysEqual(dReloaded.content, d.content) && arraysEqual(dReloaded.huf, d.huf)
-            && dReloaded.id === d.id, 'Dictionary save/load roundtrip');
-        const cObj = zxc.compress(payload, { dict: d });
-        assert(arraysEqual(zxc.decompress(cObj, { dict: d }), payload),
-            'compress/decompress with {dict: Dictionary} roundtrip');
-        let objRejected = false;
-        try { zxc.decompress(cObj, { dict: d.content }); } catch (e) { objRejected = true; }
-        assert(objRejected, 'Dictionary archive rejects content-only decode (id binding)');
-
-        // dictHuf round through compress/decompress (id binding both ways).
-        const cHuf = zxc.compress(payload, { dict, dictHuf: huf });
-        assert(arraysEqual(zxc.decompress(cHuf, { dict, dictHuf: huf }), payload),
-            'compress/decompress with dictHuf roundtrip');
-        let rejected = false;
-        try { zxc.decompress(cHuf, { dict }); } catch (e) { rejected = true; }
-        assert(rejected, 'decompress without dictHuf is rejected (id binding)');
-
-        // Seekable + setDict + range roundtrip on a dict-compressed archive.
-        const bigPayload = new Uint8Array(48 * 1024);
-        {
-            const unit = new TextEncoder().encode(
-                '{"user":"alice","action":"login","region":"eu-west"}');
-            for (let i = 0; i < bigPayload.length; i++) bigPayload[i] = unit[i % unit.length];
-        }
-        const seekArchive = zxc.compress(bigPayload, { dict, seekable: true });
-        const s = zxc.createSeekable(seekArchive);
-        try {
-            s.setDict(dict);
-            const full = s.decompressRange(0, bigPayload.length);
-            assert(arraysEqual(full, bigPayload), 'seekable+dict full-range byte-exact');
-            const off = 4096, len = 8192;
-            const mid = s.decompressRange(off, len);
-            assert(arraysEqual(mid, bigPayload.subarray(off, off + len)),
-                'seekable+dict mid-range byte-exact');
-        } finally {
-            s.free();
-            s.free(); // idempotent: second call must be a no-op
-        }
-
-        // Seekable + Dictionary (content + huf table): regression for setDict
-        // dropping the table argument, which made every (dict, huf)-bound
-        // archive fail range decode with DICT_MISMATCH.
-        const seekArchiveHuf = zxc.compress(bigPayload, { dict: d, seekable: true });
-        const sh = zxc.createSeekable(seekArchiveHuf);
-        try {
-            sh.setDict(d);
-            const full = sh.decompressRange(0, bigPayload.length);
-            assert(arraysEqual(full, bigPayload),
-                'seekable+Dictionary(huf) full-range byte-exact');
-            let hufRejected = false;
-            try { sh.setDict(d.content); } catch (e) { hufRejected = true; }
-            assert(hufRejected,
-                'seekable setDict(content-only) rejected on a Dictionary archive');
-        } finally {
-            sh.free();
-        }
-    }
-
-    // --- Summary ---
-    console.log(`\n${'='.repeat(40)}`);
-    console.log(`Results: ${passed} passed, ${failed} failed`);
-    process.exit(failed > 0 ? 1 : 0);
+  // --- Summary ---
+  console.log(`\n${"=".repeat(40)}`);
+  console.log(`Results: ${passed} passed, ${failed} failed`);
+  process.exit(failed > 0 ? 1 : 0);
 }
 
-main().catch(err => {
-    console.error('Fatal error:', err);
-    process.exit(1);
+main().catch((err) => {
+  console.error("Fatal error:", err);
+  process.exit(1);
 });

--- a/wrappers/wasm/zxc_wasm.js
+++ b/wrappers/wasm/zxc_wasm.js
@@ -19,10 +19,12 @@
  * @returns {boolean}
  */
 export function detectZxc(buf) {
-    if (!buf) return false;
-    const view = buf instanceof ArrayBuffer ? new Uint8Array(buf) : buf;
-    if (!view || view.length < 4) return false;
-    return view[0] === 0xF5 && view[1] === 0x2E && view[2] === 0xB0 && view[3] === 0x9C;
+  if (!buf) return false;
+  const view = buf instanceof ArrayBuffer ? new Uint8Array(buf) : buf;
+  if (!view || view.length < 4) return false;
+  return (
+    view[0] === 0xf5 && view[1] === 0x2e && view[2] === 0xb0 && view[3] === 0x9c
+  );
 }
 
 /**
@@ -35,1258 +37,1522 @@ export function detectZxc(buf) {
  * @returns {Promise<ZXC>} Resolved API object.
  */
 export default async function createZXC(moduleOverrides, factory) {
-    let ZXCModule = factory;
-    if (!ZXCModule) {
-        ZXCModule = (await import('./zxc.js')).default;
-        if (typeof ZXCModule !== 'function') {
-            try {
-                const { createRequire } = await import('node:module');
-                ZXCModule = createRequire(import.meta.url)('./zxc.js');
-            } catch (_) {
-                throw new Error(
-                    'ZXC: could not load ./zxc.js as a module factory; ' +
-                    'pass the Emscripten factory explicitly: createZXC({}, factory)');
-            }
-        }
+  let ZXCModule = factory;
+  if (!ZXCModule) {
+    ZXCModule = (await import("./zxc.js")).default;
+    if (typeof ZXCModule !== "function") {
+      try {
+        const { createRequire } = await import("node:module");
+        ZXCModule = createRequire(import.meta.url)("./zxc.js");
+      } catch (_) {
+        throw new Error(
+          "ZXC: could not load ./zxc.js as a module factory; " +
+            "pass the Emscripten factory explicitly: createZXC({}, factory)",
+        );
+      }
     }
-    const Module = await ZXCModule(moduleOverrides || {});
+  }
+  const Module = await ZXCModule(moduleOverrides || {});
 
-    // --- Wrap C functions via cwrap ------------------------------------------
-    const _compress = Module.cwrap('zxc_compress', 'number',
-        ['number', 'number', 'number', 'number', 'number']);
-    const _decompress = Module.cwrap('zxc_decompress', 'number',
-        ['number', 'number', 'number', 'number', 'number']);
-    const _compress_bound = Module.cwrap('zxc_compress_bound', 'number', ['number']);
-    const _get_decompressed_size = Module.cwrap('zxc_get_decompressed_size', 'number',
-        ['number', 'number']);
+  // --- Wrap C functions via cwrap ------------------------------------------
+  const _compress = Module.cwrap("zxc_compress", "number", [
+    "number",
+    "number",
+    "number",
+    "number",
+    "number",
+  ]);
+  const _decompress = Module.cwrap("zxc_decompress", "number", [
+    "number",
+    "number",
+    "number",
+    "number",
+    "number",
+  ]);
+  const _compress_bound = Module.cwrap("zxc_compress_bound", "number", [
+    "number",
+  ]);
+  const _get_decompressed_size = Module.cwrap(
+    "zxc_get_decompressed_size",
+    "number",
+    ["number", "number"],
+  );
 
-    const _create_cctx = Module.cwrap('zxc_create_cctx', 'number', ['number']);
-    const _free_cctx   = Module.cwrap('zxc_free_cctx', 'void', ['number']);
-    const _compress_cctx = Module.cwrap('zxc_compress_cctx', 'number',
-        ['number', 'number', 'number', 'number', 'number', 'number']);
+  const _create_cctx = Module.cwrap("zxc_create_cctx", "number", ["number"]);
+  const _free_cctx = Module.cwrap("zxc_free_cctx", "void", ["number"]);
+  const _compress_cctx = Module.cwrap("zxc_compress_cctx", "number", [
+    "number",
+    "number",
+    "number",
+    "number",
+    "number",
+    "number",
+  ]);
 
-    const _create_dctx = Module.cwrap('zxc_create_dctx', 'number', []);
-    const _free_dctx   = Module.cwrap('zxc_free_dctx', 'void', ['number']);
-    const _decompress_dctx = Module.cwrap('zxc_decompress_dctx', 'number',
-        ['number', 'number', 'number', 'number', 'number', 'number']);
+  const _create_dctx = Module.cwrap("zxc_create_dctx", "number", []);
+  const _free_dctx = Module.cwrap("zxc_free_dctx", "void", ["number"]);
+  const _decompress_dctx = Module.cwrap("zxc_decompress_dctx", "number", [
+    "number",
+    "number",
+    "number",
+    "number",
+    "number",
+    "number",
+  ]);
 
-    // Push streaming API
-    const _cstream_create   = Module.cwrap('zxc_cstream_create', 'number', ['number']);
-    const _cstream_free     = Module.cwrap('zxc_cstream_free', 'void', ['number']);
-    const _cstream_compress = Module.cwrap('zxc_cstream_compress', 'number',
-        ['number', 'number', 'number']);
-    const _cstream_end      = Module.cwrap('zxc_cstream_end', 'number', ['number', 'number']);
-    const _cstream_in_size  = Module.cwrap('zxc_cstream_in_size', 'number', ['number']);
-    const _cstream_out_size = Module.cwrap('zxc_cstream_out_size', 'number', ['number']);
+  // Push streaming API
+  const _cstream_create = Module.cwrap("zxc_cstream_create", "number", [
+    "number",
+  ]);
+  const _cstream_free = Module.cwrap("zxc_cstream_free", "void", ["number"]);
+  const _cstream_compress = Module.cwrap("zxc_cstream_compress", "number", [
+    "number",
+    "number",
+    "number",
+  ]);
+  const _cstream_end = Module.cwrap("zxc_cstream_end", "number", [
+    "number",
+    "number",
+  ]);
+  const _cstream_in_size = Module.cwrap("zxc_cstream_in_size", "number", [
+    "number",
+  ]);
+  const _cstream_out_size = Module.cwrap("zxc_cstream_out_size", "number", [
+    "number",
+  ]);
 
-    const _dstream_create     = Module.cwrap('zxc_dstream_create', 'number', ['number']);
-    const _dstream_free       = Module.cwrap('zxc_dstream_free', 'void', ['number']);
-    const _dstream_decompress = Module.cwrap('zxc_dstream_decompress', 'number',
-        ['number', 'number', 'number']);
-    const _dstream_finished   = Module.cwrap('zxc_dstream_finished', 'number', ['number']);
-    const _dstream_in_size    = Module.cwrap('zxc_dstream_in_size', 'number', ['number']);
-    const _dstream_out_size   = Module.cwrap('zxc_dstream_out_size', 'number', ['number']);
+  const _dstream_create = Module.cwrap("zxc_dstream_create", "number", [
+    "number",
+  ]);
+  const _dstream_free = Module.cwrap("zxc_dstream_free", "void", ["number"]);
+  const _dstream_decompress = Module.cwrap("zxc_dstream_decompress", "number", [
+    "number",
+    "number",
+    "number",
+  ]);
+  const _dstream_finished = Module.cwrap("zxc_dstream_finished", "number", [
+    "number",
+  ]);
+  const _dstream_in_size = Module.cwrap("zxc_dstream_in_size", "number", [
+    "number",
+  ]);
+  const _dstream_out_size = Module.cwrap("zxc_dstream_out_size", "number", [
+    "number",
+  ]);
 
-    // Seekable API (random-access decompression, single-threaded)
-    const _seekable_open      = Module.cwrap('zxc_seekable_open', 'number', ['number', 'number']);
-    const _seekable_free      = Module.cwrap('zxc_seekable_free', 'void', ['number']);
-    const _seekable_num_blocks         = Module.cwrap('zxc_seekable_get_num_blocks', 'number', ['number']);
-    const _seekable_decompressed_size  = Module.cwrap('zxc_seekable_get_decompressed_size', 'number', ['number']);
-    const _seekable_block_comp_size    = Module.cwrap('zxc_seekable_get_block_comp_size', 'number', ['number', 'number']);
-    const _seekable_block_decomp_size  = Module.cwrap('zxc_seekable_get_block_decomp_size', 'number', ['number', 'number']);
-    // Use the i32-offset shim from wasm_entry.c: cwrap cannot pass a uint64_t
-    // argument without -sWASM_BIGINT=1, and the wasm32 heap is itself bounded
-    // to 4 GiB, so a 32-bit offset is enough for any in-memory archive.
-    const _seekable_decompress_range   = Module.cwrap('zxcw_seekable_decompress_range', 'number',
-        ['number', 'number', 'number', 'number', 'number']);
-    const _seek_table_size  = Module.cwrap('zxc_seek_table_size', 'number', ['number']);
-    const _write_seek_table = Module.cwrap('zxc_write_seek_table', 'number',
-        ['number', 'number', 'number', 'number']);
-    const _seekable_set_dict = Module.cwrap('zxc_seekable_set_dict', 'number',
-        ['number', 'number', 'number', 'number']);
+  // Seekable API (random-access decompression, single-threaded)
+  const _seekable_open = Module.cwrap("zxc_seekable_open", "number", [
+    "number",
+    "number",
+  ]);
+  const _seekable_free = Module.cwrap("zxc_seekable_free", "void", ["number"]);
+  const _seekable_num_blocks = Module.cwrap(
+    "zxc_seekable_get_num_blocks",
+    "number",
+    ["number"],
+  );
+  const _seekable_decompressed_size = Module.cwrap(
+    "zxc_seekable_get_decompressed_size",
+    "number",
+    ["number"],
+  );
+  const _seekable_block_comp_size = Module.cwrap(
+    "zxc_seekable_get_block_comp_size",
+    "number",
+    ["number", "number"],
+  );
+  const _seekable_block_decomp_size = Module.cwrap(
+    "zxc_seekable_get_block_decomp_size",
+    "number",
+    ["number", "number"],
+  );
+  // Use the i32-offset shim from wasm_entry.c: cwrap cannot pass a uint64_t
+  // argument without -sWASM_BIGINT=1, and the wasm32 heap is itself bounded
+  // to 4 GiB, so a 32-bit offset is enough for any in-memory archive.
+  const _seekable_decompress_range = Module.cwrap(
+    "zxcw_seekable_decompress_range",
+    "number",
+    ["number", "number", "number", "number", "number"],
+  );
+  const _seek_table_size = Module.cwrap("zxc_seek_table_size", "number", [
+    "number",
+  ]);
+  const _write_seek_table = Module.cwrap("zxc_write_seek_table", "number", [
+    "number",
+    "number",
+    "number",
+    "number",
+  ]);
+  const _seekable_set_dict = Module.cwrap("zxc_seekable_set_dict", "number", [
+    "number",
+    "number",
+    "number",
+    "number",
+  ]);
 
-    // Dictionary API. zxc_train_dict / zxc_dict_save / zxc_dict_load return
-    // int64_t; on wasm32 cwrap('number') reads the low 32 bits, which is
-    // sufficient since results are bounded by ZXC_DICT_SIZE_MAX (65535) and
-    // pointers are 32-bit.
-    const _train_dict      = Module.cwrap('zxc_train_dict', 'number',
-        ['number', 'number', 'number', 'number', 'number']);
-    const _dict_id         = Module.cwrap('zxc_dict_id', 'number',
-        ['number', 'number', 'number']);
-    const _get_dict_id     = Module.cwrap('zxc_get_dict_id', 'number', ['number', 'number']);
-    const _dict_get_id     = Module.cwrap('zxc_dict_get_id', 'number', ['number', 'number']);
-    const _dict_save       = Module.cwrap('zxc_dict_save', 'number',
-        ['number', 'number', 'number', 'number', 'number']);
-    const _train_dict_huf  = Module.cwrap('zxc_train_dict_huf', 'number',
-        ['number', 'number', 'number', 'number', 'number', 'number']);
-    const _dict_huf        = Module.cwrap('zxc_dict_huf', 'number', ['number', 'number']);
-    const _dict_save_bound = Module.cwrap('zxc_dict_save_bound', 'number', ['number']);
-    const _dict_load       = Module.cwrap('zxc_dict_load', 'number',
-        ['number', 'number', 'number', 'number', 'number', 'number']);
-    const _dict_train      = Module.cwrap('zxc_dict_train', 'number',
-        ['number', 'number', 'number', 'number', 'number']);
+  // Dictionary API. zxc_train_dict / zxc_dict_save / zxc_dict_load return
+  // int64_t; on wasm32 cwrap('number') reads the low 32 bits, which is
+  // sufficient since results are bounded by ZXC_DICT_SIZE_MAX (65535) and
+  // pointers are 32-bit.
+  const _train_dict = Module.cwrap("zxc_train_dict", "number", [
+    "number",
+    "number",
+    "number",
+    "number",
+    "number",
+  ]);
+  const _dict_id = Module.cwrap("zxc_dict_id", "number", [
+    "number",
+    "number",
+    "number",
+  ]);
+  const _get_dict_id = Module.cwrap("zxc_get_dict_id", "number", [
+    "number",
+    "number",
+  ]);
+  const _dict_get_id = Module.cwrap("zxc_dict_get_id", "number", [
+    "number",
+    "number",
+  ]);
+  const _dict_save = Module.cwrap("zxc_dict_save", "number", [
+    "number",
+    "number",
+    "number",
+    "number",
+    "number",
+  ]);
+  const _train_dict_huf = Module.cwrap("zxc_train_dict_huf", "number", [
+    "number",
+    "number",
+    "number",
+    "number",
+    "number",
+    "number",
+  ]);
+  const _dict_huf = Module.cwrap("zxc_dict_huf", "number", [
+    "number",
+    "number",
+  ]);
+  const _dict_save_bound = Module.cwrap("zxc_dict_save_bound", "number", [
+    "number",
+  ]);
+  const _dict_load = Module.cwrap("zxc_dict_load", "number", [
+    "number",
+    "number",
+    "number",
+    "number",
+    "number",
+    "number",
+  ]);
+  const _dict_train = Module.cwrap("zxc_dict_train", "number", [
+    "number",
+    "number",
+    "number",
+    "number",
+    "number",
+  ]);
 
-    const ZXC_DICT_SIZE_MAX = 65535;
-    const ZXC_HUF_TABLE_SIZE = 128;
+  const ZXC_DICT_SIZE_MAX = 65535;
+  const ZXC_HUF_TABLE_SIZE = 128;
 
-    const _version_string = Module.cwrap('zxc_version_string', 'string', []);
-    const _error_name     = Module.cwrap('zxc_error_name', 'string', ['number']);
-    const _min_level      = Module.cwrap('zxc_min_level', 'number', []);
-    const _max_level      = Module.cwrap('zxc_max_level', 'number', []);
-    const _default_level  = Module.cwrap('zxc_default_level', 'number', []);
+  const _version_string = Module.cwrap("zxc_version_string", "string", []);
+  const _error_name = Module.cwrap("zxc_error_name", "string", ["number"]);
+  const _min_level = Module.cwrap("zxc_min_level", "number", []);
+  const _max_level = Module.cwrap("zxc_max_level", "number", []);
+  const _default_level = Module.cwrap("zxc_default_level", "number", []);
 
-    const _malloc = Module._malloc;
-    const _free   = Module._free;
+  const _malloc = Module._malloc;
+  const _free = Module._free;
 
-    const _getTempRet0 =
-        typeof Module.getTempRet0 === 'function' ? Module.getTempRet0 : null;
-    function _u64(low) {
-        const lo = low >>> 0;
-        const hi = _getTempRet0 ? (_getTempRet0() >>> 0) : 0;
-        return hi * 0x100000000 + lo;
+  const _getTempRet0 =
+    typeof Module.getTempRet0 === "function" ? Module.getTempRet0 : null;
+  function _u64(low) {
+    const lo = low >>> 0;
+    const hi = _getTempRet0 ? _getTempRet0() >>> 0 : 0;
+    return hi * 0x100000000 + lo;
+  }
+
+  // --- Options struct layout -----------------------------------------------
+  // zxc_compress_opts_t (WASM32 layout, all fields 4-byte aligned):
+  //   int n_threads (off 0)  | int level (4)  | size_t block_size (8)
+  //   int checksum_enabled (12) | int seekable (16)
+  //   const void* dict (20) | size_t dict_size (24) | const void* dict_huf (28)
+  //   ptr progress_cb (32) | ptr user_data (36)
+  // Total: 40 bytes in WASM32
+  const COMPRESS_OPTS_SIZE = 40;
+
+  // zxc_decompress_opts_t:
+  //   int n_threads (0) | int checksum_enabled (4)
+  //   const void* dict (8) | size_t dict_size (12) | const void* dict_huf (16)
+  //   ptr progress_cb (20) | ptr user_data (24)
+  // Total: 28 bytes in WASM32
+  const DECOMPRESS_OPTS_SIZE = 28;
+
+  // Layout guard: the offsets above are hand-mirrored from zxc_opts.h. The
+  // library exports its compiled sizeof()s; a mismatch means the C structs
+  // changed without this file being updated -- fail loudly at load time
+  // instead of silently reading fields at wrong offsets.
+  {
+    const _copts_size = Module.cwrap("zxc_compress_opts_size", "number", []);
+    const _dopts_size = Module.cwrap("zxc_decompress_opts_size", "number", []);
+    const cSize = _copts_size();
+    const dSize = _dopts_size();
+    if (cSize !== COMPRESS_OPTS_SIZE || dSize !== DECOMPRESS_OPTS_SIZE) {
+      throw new Error(
+        `ZXC: options struct layout drift detected -- ` +
+          `zxc_compress_opts_t is ${cSize} bytes (wrapper assumes ${COMPRESS_OPTS_SIZE}), ` +
+          `zxc_decompress_opts_t is ${dSize} bytes (wrapper assumes ${DECOMPRESS_OPTS_SIZE}). ` +
+          `Update the struct layout section of zxc_wasm.js.`,
+      );
     }
+  }
 
-    // --- Options struct layout -----------------------------------------------
-    // zxc_compress_opts_t (WASM32 layout, all fields 4-byte aligned):
-    //   int n_threads (off 0)  | int level (4)  | size_t block_size (8)
-    //   int checksum_enabled (12) | int seekable (16)
-    //   const void* dict (20) | size_t dict_size (24) | const void* dict_huf (28)
-    //   ptr progress_cb (32) | ptr user_data (36)
-    // Total: 40 bytes in WASM32
-    const COMPRESS_OPTS_SIZE = 40;
+  // zxc_inbuf_t / zxc_outbuf_t (WASM32 layout):
+  //   ptr src/dst (4) | size_t size (4) | size_t pos (4)
+  // Total: 12 bytes in WASM32
+  const IO_BUF_SIZE = 12;
 
-    // zxc_decompress_opts_t:
-    //   int n_threads (0) | int checksum_enabled (4)
-    //   const void* dict (8) | size_t dict_size (12) | const void* dict_huf (16)
-    //   ptr progress_cb (20) | ptr user_data (24)
-    // Total: 28 bytes in WASM32
-    const DECOMPRESS_OPTS_SIZE = 28;
+  /**
+   * Write a zxc_compress_opts_t struct into WASM memory.
+   * @returns {number} Pointer to the struct (caller must free).
+   */
+  function _writeCompressOpts(
+    level,
+    checksum,
+    seekable,
+    dictPtr,
+    dictSize,
+    dictHufPtr,
+  ) {
+    const ptr = _malloc(COMPRESS_OPTS_SIZE);
+    // Zero-fill covers n_threads (0), block_size (8, default),
+    // progress_cb (32) and user_data (36).
+    Module.HEAPU8.fill(0, ptr, ptr + COMPRESS_OPTS_SIZE);
+    // level (offset 4)
+    Module.HEAP32[(ptr >> 2) + 1] = level;
+    // checksum_enabled (offset 12)
+    Module.HEAP32[(ptr >> 2) + 3] = checksum ? 1 : 0;
+    // seekable (offset 16)
+    Module.HEAP32[(ptr >> 2) + 4] = seekable ? 1 : 0;
+    // dict (offset 20), dict_size (offset 24), dict_huf (offset 28)
+    Module.HEAPU32[(ptr >> 2) + 5] = dictPtr || 0;
+    Module.HEAPU32[(ptr >> 2) + 6] = dictSize || 0;
+    Module.HEAPU32[(ptr >> 2) + 7] = dictHufPtr || 0;
+    return ptr;
+  }
 
-    // Layout guard: the offsets above are hand-mirrored from zxc_opts.h. The
-    // library exports its compiled sizeof()s; a mismatch means the C structs
-    // changed without this file being updated -- fail loudly at load time
-    // instead of silently reading fields at wrong offsets.
-    {
-        const _copts_size = Module.cwrap('zxc_compress_opts_size', 'number', []);
-        const _dopts_size = Module.cwrap('zxc_decompress_opts_size', 'number', []);
-        const cSize = _copts_size();
-        const dSize = _dopts_size();
-        if (cSize !== COMPRESS_OPTS_SIZE || dSize !== DECOMPRESS_OPTS_SIZE) {
-            throw new Error(
-                `ZXC: options struct layout drift detected -- ` +
-                `zxc_compress_opts_t is ${cSize} bytes (wrapper assumes ${COMPRESS_OPTS_SIZE}), ` +
-                `zxc_decompress_opts_t is ${dSize} bytes (wrapper assumes ${DECOMPRESS_OPTS_SIZE}). ` +
-                `Update the struct layout section of zxc_wasm.js.`);
-        }
+  /**
+   * Write a zxc_decompress_opts_t struct into WASM memory.
+   * @returns {number} Pointer to the struct (caller must free).
+   */
+  function _writeDecompressOpts(checksum, dictPtr, dictSize, dictHufPtr) {
+    const ptr = _malloc(DECOMPRESS_OPTS_SIZE);
+    // Zero-fill covers n_threads (0), progress_cb (20) and user_data (24).
+    Module.HEAPU8.fill(0, ptr, ptr + DECOMPRESS_OPTS_SIZE);
+    // checksum_enabled (offset 4)
+    Module.HEAP32[(ptr >> 2) + 1] = checksum ? 1 : 0;
+    // dict (offset 8), dict_size (offset 12), dict_huf (offset 16)
+    Module.HEAPU32[(ptr >> 2) + 2] = dictPtr || 0;
+    Module.HEAPU32[(ptr >> 2) + 3] = dictSize || 0;
+    Module.HEAPU32[(ptr >> 2) + 4] = dictHufPtr || 0;
+    return ptr;
+  }
+
+  // --- Public API ----------------------------------------------------------
+
+  /**
+   * Accept a {@link Dictionary} or raw `(dict, dictHuf)` pieces in options.
+   * @returns {{dict: Uint8Array|null, dictHuf: Uint8Array|null}}
+   */
+  function _splitDictOption(opts) {
+    const d = (opts && opts.dict) || null;
+    if (d instanceof Dictionary) {
+      return { dict: d.content, dictHuf: d.huf };
     }
-
-    // zxc_inbuf_t / zxc_outbuf_t (WASM32 layout):
-    //   ptr src/dst (4) | size_t size (4) | size_t pos (4)
-    // Total: 12 bytes in WASM32
-    const IO_BUF_SIZE = 12;
-
-    /**
-     * Write a zxc_compress_opts_t struct into WASM memory.
-     * @returns {number} Pointer to the struct (caller must free).
-     */
-    function _writeCompressOpts(level, checksum, seekable, dictPtr, dictSize, dictHufPtr) {
-        const ptr = _malloc(COMPRESS_OPTS_SIZE);
-        // Zero-fill covers n_threads (0), block_size (8, default),
-        // progress_cb (32) and user_data (36).
-        Module.HEAPU8.fill(0, ptr, ptr + COMPRESS_OPTS_SIZE);
-        // level (offset 4)
-        Module.HEAP32[(ptr >> 2) + 1] = level;
-        // checksum_enabled (offset 12)
-        Module.HEAP32[(ptr >> 2) + 3] = checksum ? 1 : 0;
-        // seekable (offset 16)
-        Module.HEAP32[(ptr >> 2) + 4] = seekable ? 1 : 0;
-        // dict (offset 20), dict_size (offset 24), dict_huf (offset 28)
-        Module.HEAPU32[(ptr >> 2) + 5] = dictPtr || 0;
-        Module.HEAPU32[(ptr >> 2) + 6] = dictSize || 0;
-        Module.HEAPU32[(ptr >> 2) + 7] = dictHufPtr || 0;
-        return ptr;
+    const dictHuf = (opts && opts.dictHuf) || null;
+    if (dictHuf && dictHuf.length !== ZXC_HUF_TABLE_SIZE) {
+      throw new Error("ZXC: dictHuf must be exactly 128 bytes");
     }
+    return { dict: d, dictHuf };
+  }
 
-    /**
-     * Write a zxc_decompress_opts_t struct into WASM memory.
-     * @returns {number} Pointer to the struct (caller must free).
-     */
-    function _writeDecompressOpts(checksum, dictPtr, dictSize, dictHufPtr) {
-        const ptr = _malloc(DECOMPRESS_OPTS_SIZE);
-        // Zero-fill covers n_threads (0), progress_cb (20) and user_data (24).
-        Module.HEAPU8.fill(0, ptr, ptr + DECOMPRESS_OPTS_SIZE);
-        // checksum_enabled (offset 4)
-        Module.HEAP32[(ptr >> 2) + 1] = checksum ? 1 : 0;
-        // dict (offset 8), dict_size (offset 12), dict_huf (offset 16)
-        Module.HEAPU32[(ptr >> 2) + 2] = dictPtr || 0;
-        Module.HEAPU32[(ptr >> 2) + 3] = dictSize || 0;
-        Module.HEAPU32[(ptr >> 2) + 4] = dictHufPtr || 0;
-        return ptr;
+  /**
+   * Compress a Uint8Array.
+   *
+   * @param {Uint8Array} data - Input data to compress.
+   * @param {object} [opts] - Options.
+   * @param {number} [opts.level=3] - Compression level (1-7).
+   * @param {boolean} [opts.checksum=false] - Enable checksums.
+   * @param {boolean} [opts.seekable=false] - Append seek table for random-access.
+   * @param {Dictionary|Uint8Array} [opts.dict] - A {@link Dictionary}, or raw
+   *   pre-trained dictionary content.
+   * @param {Uint8Array} [opts.dictHuf] - Shared literal Huffman table
+   *   (128 bytes, from {@link trainDictHuf} or {@link dictHuf}); ignored
+   *   without `opts.dict`, redundant with a {@link Dictionary}.
+   * @returns {Uint8Array} Compressed data.
+   * @throws {Error} On compression failure.
+   */
+  function compress(data, opts) {
+    const level = (opts && opts.level) || _default_level();
+    const checksum = (opts && opts.checksum) || false;
+    const seekable = (opts && opts.seekable) || false;
+    const { dict, dictHuf } = _splitDictOption(opts);
+
+    const bound = _compress_bound(data.length);
+    if (bound === 0) throw new Error("ZXC: compress_bound returned 0");
+
+    const srcPtr = _malloc(data.length);
+    const dstPtr = _malloc(bound);
+    const dictPtr = dict && dict.length > 0 ? _malloc(dict.length) : 0;
+    if (dictPtr) Module.HEAPU8.set(dict, dictPtr);
+    const dictHufPtr = dictHuf ? _malloc(ZXC_HUF_TABLE_SIZE) : 0;
+    if (dictHufPtr) Module.HEAPU8.set(dictHuf, dictHufPtr);
+    const optsPtr = _writeCompressOpts(
+      level,
+      checksum,
+      seekable,
+      dictPtr,
+      dict ? dict.length : 0,
+      dictHufPtr,
+    );
+
+    try {
+      Module.HEAPU8.set(data, srcPtr);
+      const result = _compress(srcPtr, data.length, dstPtr, bound, optsPtr);
+      if (result < 0) {
+        throw new Error(
+          `ZXC compress error: ${_error_name(result)} (${result})`,
+        );
+      }
+      return new Uint8Array(Module.HEAPU8.buffer, dstPtr, result).slice();
+    } finally {
+      _free(srcPtr);
+      _free(dstPtr);
+      _free(optsPtr);
+      if (dictPtr) _free(dictPtr);
+      if (dictHufPtr) _free(dictHufPtr);
     }
+  }
 
-    // --- Public API ----------------------------------------------------------
+  /**
+   * Decompress a Uint8Array.
+   *
+   * @param {Uint8Array} data - Compressed data.
+   * @param {object} [opts] - Options.
+   * @param {boolean} [opts.checksum=false] - Verify checksums.
+   * @param {Dictionary|Uint8Array} [opts.dict] - A {@link Dictionary}, or raw
+   *   pre-trained dictionary content.
+   * @param {Uint8Array} [opts.dictHuf] - Shared literal Huffman table
+   *   (128 bytes) when the archive was compressed with one; redundant with a
+   *   {@link Dictionary}.
+   * @returns {Uint8Array} Decompressed data.
+   * @throws {Error} On decompression failure.
+   */
+  function decompress(data, opts) {
+    const checksum = (opts && opts.checksum) || false;
+    const { dict, dictHuf } = _splitDictOption(opts);
 
-    /**
-     * Accept a {@link Dictionary} or raw `(dict, dictHuf)` pieces in options.
-     * @returns {{dict: Uint8Array|null, dictHuf: Uint8Array|null}}
-     */
-    function _splitDictOption(opts) {
-        const d = (opts && opts.dict) || null;
-        if (d instanceof Dictionary) {
-            return { dict: d.content, dictHuf: d.huf };
-        }
-        const dictHuf = (opts && opts.dictHuf) || null;
-        if (dictHuf && dictHuf.length !== ZXC_HUF_TABLE_SIZE) {
-            throw new Error('ZXC: dictHuf must be exactly 128 bytes');
-        }
-        return { dict: d, dictHuf };
+    // Read decompressed size from footer
+    const srcPtr = _malloc(data.length);
+    Module.HEAPU8.set(data, srcPtr);
+
+    const origSize = _u64(_get_decompressed_size(srcPtr, data.length));
+    if (origSize > 0x7fffffff) {
+      // A wasm32 heap cannot address it; fail clearly instead of
+      // aborting inside malloc.
+      _free(srcPtr);
+      throw new Error(
+        `ZXC: decompressed size (${origSize} bytes) exceeds wasm32 addressable memory`,
+      );
     }
+    const dstPtr = _malloc(origSize || 1);
+    const dictPtr = dict && dict.length > 0 ? _malloc(dict.length) : 0;
+    if (dictPtr) Module.HEAPU8.set(dict, dictPtr);
+    const dictHufPtr = dictHuf ? _malloc(ZXC_HUF_TABLE_SIZE) : 0;
+    if (dictHufPtr) Module.HEAPU8.set(dictHuf, dictHufPtr);
+    const optsPtr = _writeDecompressOpts(
+      checksum,
+      dictPtr,
+      dict ? dict.length : 0,
+      dictHufPtr,
+    );
 
-    /**
-     * Compress a Uint8Array.
-     *
-     * @param {Uint8Array} data - Input data to compress.
-     * @param {object} [opts] - Options.
-     * @param {number} [opts.level=3] - Compression level (1-7).
-     * @param {boolean} [opts.checksum=false] - Enable checksums.
-     * @param {boolean} [opts.seekable=false] - Append seek table for random-access.
-     * @param {Dictionary|Uint8Array} [opts.dict] - A {@link Dictionary}, or raw
-     *   pre-trained dictionary content.
-     * @param {Uint8Array} [opts.dictHuf] - Shared literal Huffman table
-     *   (128 bytes, from {@link trainDictHuf} or {@link dictHuf}); ignored
-     *   without `opts.dict`, redundant with a {@link Dictionary}.
-     * @returns {Uint8Array} Compressed data.
-     * @throws {Error} On compression failure.
-     */
-    function compress(data, opts) {
-        const level    = (opts && opts.level)    || _default_level();
-        const checksum = (opts && opts.checksum) || false;
-        const seekable = (opts && opts.seekable) || false;
-        const { dict, dictHuf } = _splitDictOption(opts);
+    try {
+      const result = _decompress(
+        srcPtr,
+        data.length,
+        dstPtr,
+        origSize,
+        optsPtr,
+      );
+      if (result < 0) {
+        throw new Error(
+          `ZXC decompress error: ${_error_name(result)} (${result})`,
+        );
+      }
+      return new Uint8Array(Module.HEAPU8.buffer, dstPtr, result).slice();
+    } finally {
+      _free(srcPtr);
+      _free(dstPtr);
+      _free(optsPtr);
+      if (dictPtr) _free(dictPtr);
+      if (dictHufPtr) _free(dictHufPtr);
+    }
+  }
 
+  /**
+   * Returns the maximum compressed output size for a given input size.
+   * @param {number} inputSize
+   * @returns {number}
+   */
+  function compressBound(inputSize) {
+    return _compress_bound(inputSize);
+  }
+
+  /**
+   * Reads the decompressed size from a compressed buffer without decompressing.
+   * @param {Uint8Array} data - Compressed data.
+   * @returns {number} Original uncompressed size, or 0 if invalid.
+   */
+  function getDecompressedSize(data) {
+    const ptr = _malloc(data.length);
+    try {
+      Module.HEAPU8.set(data, ptr);
+      return _u64(_get_decompressed_size(ptr, data.length));
+    } finally {
+      _free(ptr);
+    }
+  }
+
+  /**
+   * Create a reusable compression context for high-frequency usage.
+   * Call .free() when done to release WASM memory.
+   *
+   * @param {object} [opts] - Default options.
+   * @param {number} [opts.level=3] - Default compression level.
+   * @param {boolean} [opts.checksum=false] - Default checksum setting.
+   * @returns {{ compress: Function, free: Function }}
+   */
+  function createCompressContext(opts) {
+    const level = (opts && opts.level) || _default_level();
+    const checksum = (opts && opts.checksum) || false;
+    const seekable = (opts && opts.seekable) || false;
+
+    const optsPtr = _writeCompressOpts(level, checksum, seekable);
+    let cctx = _create_cctx(optsPtr);
+    _free(optsPtr);
+
+    if (cctx === 0)
+      throw new Error("ZXC: failed to create compression context");
+
+    return {
+      /**
+       * Compress data using this reusable context.
+       * @param {Uint8Array} data
+       * @returns {Uint8Array}
+       */
+      compress(data) {
         const bound = _compress_bound(data.length);
-        if (bound === 0) throw new Error('ZXC: compress_bound returned 0');
-
         const srcPtr = _malloc(data.length);
         const dstPtr = _malloc(bound);
-        const dictPtr = dict && dict.length > 0 ? _malloc(dict.length) : 0;
-        if (dictPtr) Module.HEAPU8.set(dict, dictPtr);
-        const dictHufPtr = dictHuf ? _malloc(ZXC_HUF_TABLE_SIZE) : 0;
-        if (dictHufPtr) Module.HEAPU8.set(dictHuf, dictHufPtr);
-        const optsPtr = _writeCompressOpts(level, checksum, seekable,
-            dictPtr, dict ? dict.length : 0, dictHufPtr);
-
         try {
-            Module.HEAPU8.set(data, srcPtr);
-            const result = _compress(srcPtr, data.length, dstPtr, bound, optsPtr);
-            if (result < 0) {
-                throw new Error(`ZXC compress error: ${_error_name(result)} (${result})`);
-            }
-            return new Uint8Array(Module.HEAPU8.buffer, dstPtr, result).slice();
+          Module.HEAPU8.set(data, srcPtr);
+          const result = _compress_cctx(
+            cctx,
+            srcPtr,
+            data.length,
+            dstPtr,
+            bound,
+            0,
+          );
+          if (result < 0) {
+            throw new Error(
+              `ZXC cctx compress error: ${_error_name(result)} (${result})`,
+            );
+          }
+          return new Uint8Array(Module.HEAPU8.buffer, dstPtr, result).slice();
         } finally {
-            _free(srcPtr);
-            _free(dstPtr);
-            _free(optsPtr);
-            if (dictPtr) _free(dictPtr);
-            if (dictHufPtr) _free(dictHufPtr);
+          _free(srcPtr);
+          _free(dstPtr);
         }
-    }
+      },
+      /** Free the context and release WASM memory. Idempotent. */
+      free() {
+        if (!cctx) return;
+        _free_cctx(cctx);
+        cctx = 0;
+      },
+    };
+  }
 
-    /**
-     * Decompress a Uint8Array.
-     *
-     * @param {Uint8Array} data - Compressed data.
-     * @param {object} [opts] - Options.
-     * @param {boolean} [opts.checksum=false] - Verify checksums.
-     * @param {Dictionary|Uint8Array} [opts.dict] - A {@link Dictionary}, or raw
-     *   pre-trained dictionary content.
-     * @param {Uint8Array} [opts.dictHuf] - Shared literal Huffman table
-     *   (128 bytes) when the archive was compressed with one; redundant with a
-     *   {@link Dictionary}.
-     * @returns {Uint8Array} Decompressed data.
-     * @throws {Error} On decompression failure.
-     */
-    function decompress(data, opts) {
-        const checksum = (opts && opts.checksum) || false;
-        const { dict, dictHuf } = _splitDictOption(opts);
+  /**
+   * Create a reusable decompression context for high-frequency usage.
+   * Call .free() when done to release WASM memory.
+   *
+   * @returns {{ decompress: Function, free: Function }}
+   */
+  function createDecompressContext() {
+    let dctx = _create_dctx();
+    if (dctx === 0)
+      throw new Error("ZXC: failed to create decompression context");
 
-        // Read decompressed size from footer
+    return {
+      /**
+       * Decompress data using this reusable context.
+       * @param {Uint8Array} data
+       * @returns {Uint8Array}
+       */
+      decompress(data) {
         const srcPtr = _malloc(data.length);
         Module.HEAPU8.set(data, srcPtr);
-
         const origSize = _u64(_get_decompressed_size(srcPtr, data.length));
-        if (origSize > 0x7FFFFFFF) {
-            // A wasm32 heap cannot address it; fail clearly instead of
-            // aborting inside malloc.
-            _free(srcPtr);
-            throw new Error(
-                `ZXC: decompressed size (${origSize} bytes) exceeds wasm32 addressable memory`);
+        if (origSize > 0x7fffffff) {
+          _free(srcPtr);
+          throw new Error(
+            `ZXC: decompressed size (${origSize} bytes) exceeds wasm32 addressable memory`,
+          );
         }
         const dstPtr = _malloc(origSize || 1);
-        const dictPtr = dict && dict.length > 0 ? _malloc(dict.length) : 0;
-        if (dictPtr) Module.HEAPU8.set(dict, dictPtr);
-        const dictHufPtr = dictHuf ? _malloc(ZXC_HUF_TABLE_SIZE) : 0;
-        if (dictHufPtr) Module.HEAPU8.set(dictHuf, dictHufPtr);
-        const optsPtr = _writeDecompressOpts(checksum, dictPtr, dict ? dict.length : 0,
-            dictHufPtr);
-
         try {
-            const result = _decompress(srcPtr, data.length, dstPtr, origSize, optsPtr);
-            if (result < 0) {
-                throw new Error(`ZXC decompress error: ${_error_name(result)} (${result})`);
-            }
-            return new Uint8Array(Module.HEAPU8.buffer, dstPtr, result).slice();
+          const result = _decompress_dctx(
+            dctx,
+            srcPtr,
+            data.length,
+            dstPtr,
+            origSize,
+            0,
+          );
+          if (result < 0) {
+            throw new Error(
+              `ZXC dctx decompress error: ${_error_name(result)} (${result})`,
+            );
+          }
+          return new Uint8Array(Module.HEAPU8.buffer, dstPtr, result).slice();
         } finally {
-            _free(srcPtr);
-            _free(dstPtr);
-            _free(optsPtr);
-            if (dictPtr) _free(dictPtr);
-            if (dictHufPtr) _free(dictHufPtr);
+          _free(srcPtr);
+          _free(dstPtr);
         }
+      },
+      /** Free the context and release WASM memory. Idempotent. */
+      free() {
+        if (!dctx) return;
+        _free_dctx(dctx);
+        dctx = 0;
+      },
+    };
+  }
+
+  // --- Push streaming helpers ----------------------------------------------
+
+  /** Write a zxc_inbuf_t at `bufPtr` pointing to `srcPtr` (size bytes, pos=0). */
+  function _writeInbuf(bufPtr, srcPtr, size) {
+    Module.HEAP32[(bufPtr >> 2) + 0] = srcPtr;
+    Module.HEAPU32[(bufPtr >> 2) + 1] = size;
+    Module.HEAPU32[(bufPtr >> 2) + 2] = 0;
+  }
+  /** Write a zxc_outbuf_t at `bufPtr` pointing to `dstPtr` (size bytes, pos=0). */
+  function _writeOutbuf(bufPtr, dstPtr, size) {
+    Module.HEAP32[(bufPtr >> 2) + 0] = dstPtr;
+    Module.HEAPU32[(bufPtr >> 2) + 1] = size;
+    Module.HEAPU32[(bufPtr >> 2) + 2] = 0;
+  }
+  function _readPos(bufPtr) {
+    return Module.HEAPU32[(bufPtr >> 2) + 2];
+  }
+
+  /* Concatenate JS-side slices into a single Uint8Array. A single chunk is
+   * the common case (the staging buffer holds a full block): return it
+   * as-is and skip the concat copy (chunks are already heap-independent
+   * .slice() copies). */
+  function _concatChunks(chunks, totalLen) {
+    if (chunks.length === 1) return chunks[0];
+    const out = new Uint8Array(totalLen);
+    let off = 0;
+    for (const c of chunks) {
+      out.set(c, off);
+      off += c.length;
+    }
+    return out;
+  }
+
+  /**
+   * Create a push-based, single-threaded compression stream.
+   * @param {object} [opts]
+   * @param {number} [opts.level=3]
+   * @param {boolean} [opts.checksum=false]
+   * @returns {{ compress(Uint8Array): Uint8Array, end(): Uint8Array, free(): void, inSize(): number, outSize(): number }}
+   */
+  function createCStream(opts) {
+    const level = (opts && opts.level) || _default_level();
+    const checksum = (opts && opts.checksum) || false;
+
+    const optsPtr = _writeCompressOpts(level, checksum, false);
+    let cs = _cstream_create(optsPtr);
+    _free(optsPtr);
+    if (cs === 0) throw new Error("ZXC: failed to create cstream");
+
+    // Reusable scratch buffers in the WASM heap. The compress/end calls
+    // never reallocate, so these pointers stay valid for the stream's
+    // lifetime even if the heap grows (cwrap re-reads HEAPU8 internally).
+    const inDescPtr = _malloc(IO_BUF_SIZE);
+    const outDescPtr = _malloc(IO_BUF_SIZE);
+    const stageCap = Math.max(_cstream_out_size(cs), 64 * 1024);
+    const stagePtr = _malloc(stageCap);
+
+    function drainCompress(srcPtr, srcLen) {
+      const chunks = [];
+      let total = 0;
+      _writeInbuf(inDescPtr, srcPtr, srcLen);
+      for (;;) {
+        _writeOutbuf(outDescPtr, stagePtr, stageCap);
+        const r = _cstream_compress(cs, outDescPtr, inDescPtr);
+        if (r < 0) {
+          throw new Error(
+            `ZXC cstream compress error: ${_error_name(r)} (${r})`,
+          );
+        }
+        const produced = _readPos(outDescPtr);
+        if (produced > 0) {
+          chunks.push(
+            new Uint8Array(Module.HEAPU8.buffer, stagePtr, produced).slice(),
+          );
+          total += produced;
+        }
+        if (r === 0 && _readPos(inDescPtr) === srcLen) break;
+      }
+      return _concatChunks(chunks, total);
     }
 
-    /**
-     * Returns the maximum compressed output size for a given input size.
-     * @param {number} inputSize
-     * @returns {number}
-     */
-    function compressBound(inputSize) {
-        return _compress_bound(inputSize);
+    function drainEnd() {
+      const chunks = [];
+      let total = 0;
+      for (;;) {
+        _writeOutbuf(outDescPtr, stagePtr, stageCap);
+        const r = _cstream_end(cs, outDescPtr);
+        if (r < 0) {
+          throw new Error(`ZXC cstream end error: ${_error_name(r)} (${r})`);
+        }
+        const produced = _readPos(outDescPtr);
+        if (produced > 0) {
+          chunks.push(
+            new Uint8Array(Module.HEAPU8.buffer, stagePtr, produced).slice(),
+          );
+          total += produced;
+        }
+        if (r === 0) break;
+      }
+      return _concatChunks(chunks, total);
     }
 
-    /**
-     * Reads the decompressed size from a compressed buffer without decompressing.
-     * @param {Uint8Array} data - Compressed data.
-     * @returns {number} Original uncompressed size, or 0 if invalid.
-     */
-    function getDecompressedSize(data) {
-        const ptr = _malloc(data.length);
+    return {
+      /** Push input and return any compressed bytes produced. */
+      compress(data) {
+        if (data.length === 0) return drainCompress(stagePtr, 0);
+        const srcPtr = _malloc(data.length);
         try {
-            Module.HEAPU8.set(data, ptr);
-            return _u64(_get_decompressed_size(ptr, data.length));
+          Module.HEAPU8.set(data, srcPtr);
+          return drainCompress(srcPtr, data.length);
         } finally {
-            _free(ptr);
+          _free(srcPtr);
         }
-    }
+      },
+      /** Finalise: residual block + EOF + footer. */
+      end() {
+        return drainEnd();
+      },
+      /** Free the stream and its scratch buffers. Idempotent. */
+      free() {
+        if (!cs) return;
+        _cstream_free(cs);
+        _free(inDescPtr);
+        _free(outDescPtr);
+        _free(stagePtr);
+        cs = 0;
+      },
+      inSize() {
+        return _cstream_in_size(cs);
+      },
+      outSize() {
+        return _cstream_out_size(cs);
+      },
+    };
+  }
 
-    /**
-     * Create a reusable compression context for high-frequency usage.
-     * Call .free() when done to release WASM memory.
-     *
-     * @param {object} [opts] - Default options.
-     * @param {number} [opts.level=3] - Default compression level.
-     * @param {boolean} [opts.checksum=false] - Default checksum setting.
-     * @returns {{ compress: Function, free: Function }}
-     */
-    function createCompressContext(opts) {
-        const level    = (opts && opts.level)    || _default_level();
-        const checksum = (opts && opts.checksum) || false;
-        const seekable = (opts && opts.seekable) || false;
+  /**
+   * Create a push-based, single-threaded decompression stream.
+   * @param {object} [opts]
+   * @param {boolean} [opts.checksum=false]
+   * @returns {{ decompress(Uint8Array): Uint8Array, finished(): boolean, free(): void, inSize(): number, outSize(): number }}
+   */
+  function createDStream(opts) {
+    const checksum = (opts && opts.checksum) || false;
+    const optsPtr = _writeDecompressOpts(checksum);
+    let ds = _dstream_create(optsPtr);
+    _free(optsPtr);
+    if (ds === 0) throw new Error("ZXC: failed to create dstream");
 
-        const optsPtr = _writeCompressOpts(level, checksum, seekable);
-        let cctx = _create_cctx(optsPtr);
-        _free(optsPtr);
+    const inDescPtr = _malloc(IO_BUF_SIZE);
+    const outDescPtr = _malloc(IO_BUF_SIZE);
+    const stageCap = Math.max(_dstream_out_size(ds), 4096);
+    const stagePtr = _malloc(stageCap);
 
-        if (cctx === 0) throw new Error('ZXC: failed to create compression context');
-
-        return {
-            /**
-             * Compress data using this reusable context.
-             * @param {Uint8Array} data
-             * @returns {Uint8Array}
-             */
-            compress(data) {
-                const bound = _compress_bound(data.length);
-                const srcPtr = _malloc(data.length);
-                const dstPtr = _malloc(bound);
-                try {
-                    Module.HEAPU8.set(data, srcPtr);
-                    const result = _compress_cctx(cctx, srcPtr, data.length, dstPtr, bound, 0);
-                    if (result < 0) {
-                        throw new Error(`ZXC cctx compress error: ${_error_name(result)} (${result})`);
-                    }
-                    return new Uint8Array(Module.HEAPU8.buffer, dstPtr, result).slice();
-                } finally {
-                    _free(srcPtr);
-                    _free(dstPtr);
-                }
-            },
-            /** Free the context and release WASM memory. Idempotent. */
-            free() {
-                if (!cctx) return;
-                _free_cctx(cctx);
-                cctx = 0;
-            }
-        };
-    }
-
-    /**
-     * Create a reusable decompression context for high-frequency usage.
-     * Call .free() when done to release WASM memory.
-     *
-     * @returns {{ decompress: Function, free: Function }}
-     */
-    function createDecompressContext() {
-        let dctx = _create_dctx();
-        if (dctx === 0) throw new Error('ZXC: failed to create decompression context');
-
-        return {
-            /**
-             * Decompress data using this reusable context.
-             * @param {Uint8Array} data
-             * @returns {Uint8Array}
-             */
-            decompress(data) {
-                const srcPtr = _malloc(data.length);
-                Module.HEAPU8.set(data, srcPtr);
-                const origSize = _u64(_get_decompressed_size(srcPtr, data.length));
-                if (origSize > 0x7FFFFFFF) {
-                    _free(srcPtr);
-                    throw new Error(
-                        `ZXC: decompressed size (${origSize} bytes) exceeds wasm32 addressable memory`);
-                }
-                const dstPtr = _malloc(origSize || 1);
-                try {
-                    const result = _decompress_dctx(dctx, srcPtr, data.length, dstPtr, origSize, 0);
-                    if (result < 0) {
-                        throw new Error(`ZXC dctx decompress error: ${_error_name(result)} (${result})`);
-                    }
-                    return new Uint8Array(Module.HEAPU8.buffer, dstPtr, result).slice();
-                } finally {
-                    _free(srcPtr);
-                    _free(dstPtr);
-                }
-            },
-            /** Free the context and release WASM memory. Idempotent. */
-            free() {
-                if (!dctx) return;
-                _free_dctx(dctx);
-                dctx = 0;
-            }
-        };
-    }
-
-    // --- Push streaming helpers ----------------------------------------------
-
-    /** Write a zxc_inbuf_t at `bufPtr` pointing to `srcPtr` (size bytes, pos=0). */
-    function _writeInbuf(bufPtr, srcPtr, size) {
-        Module.HEAP32[(bufPtr >> 2) + 0] = srcPtr;
-        Module.HEAPU32[(bufPtr >> 2) + 1] = size;
-        Module.HEAPU32[(bufPtr >> 2) + 2] = 0;
-    }
-    /** Write a zxc_outbuf_t at `bufPtr` pointing to `dstPtr` (size bytes, pos=0). */
-    function _writeOutbuf(bufPtr, dstPtr, size) {
-        Module.HEAP32[(bufPtr >> 2) + 0] = dstPtr;
-        Module.HEAPU32[(bufPtr >> 2) + 1] = size;
-        Module.HEAPU32[(bufPtr >> 2) + 2] = 0;
-    }
-    function _readPos(bufPtr) {
-        return Module.HEAPU32[(bufPtr >> 2) + 2];
-    }
-
-    /* Concatenate JS-side slices into a single Uint8Array. A single chunk is
-     * the common case (the staging buffer holds a full block): return it
-     * as-is and skip the concat copy (chunks are already heap-independent
-     * .slice() copies). */
-    function _concatChunks(chunks, totalLen) {
-        if (chunks.length === 1) return chunks[0];
-        const out = new Uint8Array(totalLen);
-        let off = 0;
-        for (const c of chunks) {
-            out.set(c, off);
-            off += c.length;
-        }
-        return out;
-    }
-
-    /**
-     * Create a push-based, single-threaded compression stream.
-     * @param {object} [opts]
-     * @param {number} [opts.level=3]
-     * @param {boolean} [opts.checksum=false]
-     * @returns {{ compress(Uint8Array): Uint8Array, end(): Uint8Array, free(): void, inSize(): number, outSize(): number }}
-     */
-    function createCStream(opts) {
-        const level    = (opts && opts.level)    || _default_level();
-        const checksum = (opts && opts.checksum) || false;
-
-        const optsPtr = _writeCompressOpts(level, checksum, false);
-        let cs = _cstream_create(optsPtr);
-        _free(optsPtr);
-        if (cs === 0) throw new Error('ZXC: failed to create cstream');
-
-        // Reusable scratch buffers in the WASM heap. The compress/end calls
-        // never reallocate, so these pointers stay valid for the stream's
-        // lifetime even if the heap grows (cwrap re-reads HEAPU8 internally).
-        const inDescPtr  = _malloc(IO_BUF_SIZE);
-        const outDescPtr = _malloc(IO_BUF_SIZE);
-        const stageCap   = Math.max(_cstream_out_size(cs), 64 * 1024);
-        const stagePtr   = _malloc(stageCap);
-
-        function drainCompress(srcPtr, srcLen) {
-            const chunks = [];
-            let total = 0;
-            _writeInbuf(inDescPtr, srcPtr, srcLen);
-            for (;;) {
-                _writeOutbuf(outDescPtr, stagePtr, stageCap);
-                const r = _cstream_compress(cs, outDescPtr, inDescPtr);
-                if (r < 0) {
-                    throw new Error(`ZXC cstream compress error: ${_error_name(r)} (${r})`);
-                }
-                const produced = _readPos(outDescPtr);
-                if (produced > 0) {
-                    chunks.push(new Uint8Array(Module.HEAPU8.buffer, stagePtr, produced).slice());
-                    total += produced;
-                }
-                if (r === 0 && _readPos(inDescPtr) === srcLen) break;
-            }
-            return _concatChunks(chunks, total);
-        }
-
-        function drainEnd() {
-            const chunks = [];
-            let total = 0;
-            for (;;) {
-                _writeOutbuf(outDescPtr, stagePtr, stageCap);
-                const r = _cstream_end(cs, outDescPtr);
-                if (r < 0) {
-                    throw new Error(`ZXC cstream end error: ${_error_name(r)} (${r})`);
-                }
-                const produced = _readPos(outDescPtr);
-                if (produced > 0) {
-                    chunks.push(new Uint8Array(Module.HEAPU8.buffer, stagePtr, produced).slice());
-                    total += produced;
-                }
-                if (r === 0) break;
-            }
-            return _concatChunks(chunks, total);
-        }
-
-        return {
-            /** Push input and return any compressed bytes produced. */
-            compress(data) {
-                if (data.length === 0) return drainCompress(stagePtr, 0);
-                const srcPtr = _malloc(data.length);
-                try {
-                    Module.HEAPU8.set(data, srcPtr);
-                    return drainCompress(srcPtr, data.length);
-                } finally {
-                    _free(srcPtr);
-                }
-            },
-            /** Finalise: residual block + EOF + footer. */
-            end() {
-                return drainEnd();
-            },
-            /** Free the stream and its scratch buffers. Idempotent. */
-            free() {
-                if (!cs) return;
-                _cstream_free(cs);
-                _free(inDescPtr);
-                _free(outDescPtr);
-                _free(stagePtr);
-                cs = 0;
-            },
-            inSize()  { return _cstream_in_size(cs); },
-            outSize() { return _cstream_out_size(cs); }
-        };
-    }
-
-    /**
-     * Create a push-based, single-threaded decompression stream.
-     * @param {object} [opts]
-     * @param {boolean} [opts.checksum=false]
-     * @returns {{ decompress(Uint8Array): Uint8Array, finished(): boolean, free(): void, inSize(): number, outSize(): number }}
-     */
-    function createDStream(opts) {
-        const checksum = (opts && opts.checksum) || false;
-        const optsPtr  = _writeDecompressOpts(checksum);
-        let ds = _dstream_create(optsPtr);
-        _free(optsPtr);
-        if (ds === 0) throw new Error('ZXC: failed to create dstream');
-
-        const inDescPtr  = _malloc(IO_BUF_SIZE);
-        const outDescPtr = _malloc(IO_BUF_SIZE);
-        const stageCap   = Math.max(_dstream_out_size(ds), 4096);
-        const stagePtr   = _malloc(stageCap);
-
-        return {
-            /** Push compressed bytes; return any decompressed bytes produced. */
-            decompress(data) {
-                const srcPtr = data.length > 0 ? _malloc(data.length) : 0;
-                try {
-                    if (srcPtr) Module.HEAPU8.set(data, srcPtr);
-                    _writeInbuf(inDescPtr, srcPtr, data.length);
-
-                    const chunks = [];
-                    let total = 0;
-                    let exhausted = data.length === 0;
-                    for (;;) {
-                        const beforeIn = _readPos(inDescPtr);
-                        _writeOutbuf(outDescPtr, stagePtr, stageCap);
-                        const r = _dstream_decompress(ds, outDescPtr, inDescPtr);
-                        if (r < 0) {
-                            throw new Error(`ZXC dstream error: ${_error_name(r)} (${r})`);
-                        }
-                        const produced = _readPos(outDescPtr);
-                        if (produced > 0) {
-                            chunks.push(new Uint8Array(Module.HEAPU8.buffer, stagePtr, produced).slice());
-                            total += produced;
-                        }
-                        const afterIn = _readPos(inDescPtr);
-                        // Stop only when the call made no progress at all
-                        // (no input consumed AND no output produced).
-                        if (afterIn === beforeIn && produced === 0) break;
-                        if (!exhausted && afterIn === data.length) {
-                            _writeInbuf(inDescPtr, 0, 0);
-                            exhausted = true;
-                        }
-                    }
-                    return _concatChunks(chunks, total);
-                } finally {
-                    if (srcPtr) _free(srcPtr);
-                }
-            },
-            /** True iff the file footer has been consumed and validated. */
-            finished() { return _dstream_finished(ds) !== 0; },
-            /** Free the stream and its scratch buffers. Idempotent. */
-            free() {
-                if (!ds) return;
-                _dstream_free(ds);
-                _free(inDescPtr);
-                _free(outDescPtr);
-                _free(stagePtr);
-                ds = 0;
-            },
-            inSize()  { return _dstream_in_size(ds); },
-            outSize() { return _dstream_out_size(ds); }
-        };
-    }
-
-    // --- Seekable API --------------------------------------------------------
-
-    /**
-     * Open a seekable ZXC archive for random-access decompression.
-     *
-     * The compressed buffer is copied into the WASM heap and held alive
-     * for the lifetime of the handle. Call `.free()` to release both the
-     * native handle and the WASM-side copy.
-     *
-     * Throws on invalid archives (bad magic, truncated seek table, ...).
-     *
-     * @param {Uint8Array} data - Compressed buffer, ideally produced with
-     *        `{ seekable: true }` so it carries an embedded seek table.
-     * @returns {{
-     *   numBlocks(): number,
-     *   decompressedSize(): number,
-     *   blockCompressedSize(idx: number): (number | null),
-     *   blockDecompressedSize(idx: number): (number | null),
-     *   decompressRange(offset: number, length: number): Uint8Array,
-     *   free(): void
-     * }}
-     */
-    function createSeekable(data) {
-        if (!data || data.length === 0) {
-            throw new Error('ZXC: createSeekable requires a non-empty buffer');
-        }
-
-        const srcLen = data.length;
-        const srcPtr = _malloc(srcLen);
-        if (!srcPtr) throw new Error('ZXC: malloc failed for seekable buffer');
-        Module.HEAPU8.set(data, srcPtr);
-
-        let handle = _seekable_open(srcPtr, srcLen);
-        if (handle === 0) {
-            _free(srcPtr);
-            throw new Error('ZXC: invalid seekable archive');
-        }
-
-        return {
-            numBlocks() { return _seekable_num_blocks(handle); },
-            decompressedSize() { return _u64(_seekable_decompressed_size(handle)); },
-            blockCompressedSize(idx) {
-                if (idx < 0 || idx >= _seekable_num_blocks(handle)) return null;
-                return _seekable_block_comp_size(handle, idx);
-            },
-            blockDecompressedSize(idx) {
-                if (idx < 0 || idx >= _seekable_num_blocks(handle)) return null;
-                return _seekable_block_decomp_size(handle, idx);
-            },
-            /**
-             * Attach a pre-trained dictionary to this seekable handle.
-             * Must be called before any decompressRange() call.
-             *
-             * When the archive was compressed with a shared literal Huffman
-             * table (or with a {@link Dictionary}), the same table must be
-             * supplied: the archive's dict_id binds the (content, table)
-             * pair, so content alone would be rejected with DICT_MISMATCH.
-             *
-             * @param {Dictionary|Uint8Array} dict - A {@link Dictionary}, or
-             *        raw dictionary content.
-             * @param {Uint8Array} [dictHuf] - Shared literal Huffman table
-             *        (128 bytes); redundant when `dict` is a {@link Dictionary}.
-             */
-            setDict(dict, dictHuf) {
-                if (dict instanceof Dictionary) {
-                    dictHuf = dict.huf;
-                    dict = dict.content;
-                }
-                if (!dict || dict.length === 0) {
-                    throw new Error('ZXC: setDict requires a non-empty dictionary');
-                }
-                if (dictHuf && dictHuf.length !== ZXC_HUF_TABLE_SIZE) {
-                    throw new Error('ZXC: dictHuf must be exactly 128 bytes');
-                }
-                const dictPtr = _malloc(dict.length);
-                if (!dictPtr) throw new Error('ZXC: malloc failed for dictionary');
-                const hufPtr = dictHuf ? _malloc(ZXC_HUF_TABLE_SIZE) : 0;
-                try {
-                    Module.HEAPU8.set(dict, dictPtr);
-                    if (hufPtr) Module.HEAPU8.set(dictHuf, hufPtr);
-                    const r = _seekable_set_dict(handle, dictPtr, dict.length, hufPtr);
-                    if (r < 0) {
-                        throw new Error(`ZXC seekable set_dict error: ${_error_name(r)} (${r})`);
-                    }
-                } finally {
-                    _free(dictPtr);
-                    if (hufPtr) _free(hufPtr);
-                }
-            },
-            decompressRange(offset, length) {
-                if (length < 0) throw new Error('ZXC: length must be non-negative');
-                // The wasm shim carries the offset as a uint32 (no BigInt);
-                // values outside [0, 2^32-1] would silently wrap and return
-                // data from the wrong position.
-                if (!Number.isInteger(offset) || offset < 0 || offset > 0xFFFFFFFF) {
-                    throw new Error('ZXC: offset must be an integer in [0, 2^32-1]');
-                }
-                if (length === 0) return new Uint8Array(0);
-                const dstPtr = _malloc(length);
-                if (!dstPtr) throw new Error('ZXC: malloc failed for output buffer');
-                try {
-                    const r = _seekable_decompress_range(handle, dstPtr, length, offset, length);
-                    if (r < 0) {
-                        throw new Error(`ZXC seekable decompress error: ${_error_name(r)} (${r})`);
-                    }
-                    return new Uint8Array(Module.HEAPU8.buffer, dstPtr, r).slice();
-                } finally {
-                    _free(dstPtr);
-                }
-            },
-            /** Release the native handle and the WASM-side copy. Idempotent. */
-            free() {
-                if (!handle) return;
-                _seekable_free(handle);
-                _free(srcPtr);
-                handle = 0;
-            },
-        };
-    }
-
-    /**
-     * Encoded byte size of a seek table covering `numBlocks` data blocks.
-     * Use this to size a destination buffer for [writeSeekTable].
-     * @param {number} numBlocks
-     * @returns {number}
-     */
-    function seekTableSize(numBlocks) {
-        return _seek_table_size(numBlocks >>> 0);
-    }
-
-    /**
-     * Low-level: write a seek table (header + entries) for the given
-     * per-block on-disk compressed sizes.
-     *
-     * Most callers do not need this directly; the buffer and streaming
-     * APIs emit a seek table when `seekable: true` is set.
-     *
-     * @param {ArrayLike<number>} compSizes - Per-block compressed sizes,
-     *        in order. Each entry is treated as an unsigned 32-bit value.
-     * @returns {Uint8Array} The encoded seek table.
-     */
-    function writeSeekTable(compSizes) {
-        if (!compSizes || compSizes.length === 0) {
-            throw new Error('ZXC: compSizes must be non-empty');
-        }
-        const numBlocks = compSizes.length;
-        const sz = _seek_table_size(numBlocks);
-        const dstPtr = _malloc(sz);
-        if (!dstPtr) throw new Error('ZXC: malloc failed for seek table');
-
-        const csPtr = _malloc(numBlocks * 4);
-        if (!csPtr) {
-            _free(dstPtr);
-            throw new Error('ZXC: malloc failed for compSizes scratch');
-        }
-
+    return {
+      /** Push compressed bytes; return any decompressed bytes produced. */
+      decompress(data) {
+        const srcPtr = data.length > 0 ? _malloc(data.length) : 0;
         try {
-            for (let i = 0; i < numBlocks; i++) {
-                Module.HEAPU32[(csPtr >> 2) + i] = compSizes[i] >>> 0;
-            }
-            const r = _write_seek_table(dstPtr, sz, csPtr, numBlocks);
+          if (srcPtr) Module.HEAPU8.set(data, srcPtr);
+          _writeInbuf(inDescPtr, srcPtr, data.length);
+
+          const chunks = [];
+          let total = 0;
+          let exhausted = data.length === 0;
+          for (;;) {
+            const beforeIn = _readPos(inDescPtr);
+            _writeOutbuf(outDescPtr, stagePtr, stageCap);
+            const r = _dstream_decompress(ds, outDescPtr, inDescPtr);
             if (r < 0) {
-                throw new Error(`ZXC write_seek_table error: ${_error_name(r)} (${r})`);
+              throw new Error(`ZXC dstream error: ${_error_name(r)} (${r})`);
             }
-            return new Uint8Array(Module.HEAPU8.buffer, dstPtr, r).slice();
-        } finally {
-            _free(dstPtr);
-            _free(csPtr);
-        }
-    }
-
-    // --- Dictionary API ------------------------------------------------------
-
-    /**
-     * Train a dictionary from a corpus of samples.
-     *
-     * @param {Uint8Array[]} samples - Array of sample buffers (similar payloads).
-     * @param {number} [maxSize=65535] - Maximum dictionary size in bytes
-     *        (capped at ZXC_DICT_SIZE_MAX).
-     * @returns {Uint8Array} Raw trained dictionary content.
-     * @throws {Error} On training failure.
-     */
-    function trainDict(samples, maxSize = ZXC_DICT_SIZE_MAX) {
-        if (!samples || samples.length === 0) {
-            throw new Error('ZXC: trainDict requires at least one sample');
-        }
-        const cap = Math.min(maxSize >>> 0, ZXC_DICT_SIZE_MAX);
-        const n = samples.length;
-
-        // Heap arrays: pointers (4 bytes each) + sizes (size_t = 4 bytes on wasm32).
-        const ptrsPtr  = _malloc(n * 4);
-        const sizesPtr = _malloc(n * 4);
-        const samplePtrs = [];
-        const dictPtr = _malloc(cap);
-
-        try {
-            for (let i = 0; i < n; i++) {
-                const s = samples[i];
-                const sp = s.length > 0 ? _malloc(s.length) : _malloc(1);
-                if (s.length > 0) Module.HEAPU8.set(s, sp);
-                samplePtrs.push(sp);
-                Module.HEAPU32[(ptrsPtr >> 2) + i] = sp;
-                Module.HEAPU32[(sizesPtr >> 2) + i] = s.length;
+            const produced = _readPos(outDescPtr);
+            if (produced > 0) {
+              chunks.push(
+                new Uint8Array(
+                  Module.HEAPU8.buffer,
+                  stagePtr,
+                  produced,
+                ).slice(),
+              );
+              total += produced;
             }
-            const r = _train_dict(ptrsPtr, sizesPtr, n, dictPtr, cap);
-            if (r < 0) {
-                throw new Error(`ZXC train_dict error: ${_error_name(r)} (${r})`);
+            const afterIn = _readPos(inDescPtr);
+            // Stop only when the call made no progress at all
+            // (no input consumed AND no output produced).
+            if (afterIn === beforeIn && produced === 0) break;
+            if (!exhausted && afterIn === data.length) {
+              _writeInbuf(inDescPtr, 0, 0);
+              exhausted = true;
             }
-            return new Uint8Array(Module.HEAPU8.buffer, dictPtr, r).slice();
+          }
+          return _concatChunks(chunks, total);
         } finally {
-            for (const sp of samplePtrs) _free(sp);
-            _free(ptrsPtr);
-            _free(sizesPtr);
-            _free(dictPtr);
+          if (srcPtr) _free(srcPtr);
         }
+      },
+      /** True iff the file footer has been consumed and validated. */
+      finished() {
+        return _dstream_finished(ds) !== 0;
+      },
+      /** Free the stream and its scratch buffers. Idempotent. */
+      free() {
+        if (!ds) return;
+        _dstream_free(ds);
+        _free(inDescPtr);
+        _free(outDescPtr);
+        _free(stagePtr);
+        ds = 0;
+      },
+      inSize() {
+        return _dstream_in_size(ds);
+      },
+      outSize() {
+        return _dstream_out_size(ds);
+      },
+    };
+  }
+
+  // --- Seekable API --------------------------------------------------------
+
+  /**
+   * Open a seekable ZXC archive for random-access decompression.
+   *
+   * The compressed buffer is copied into the WASM heap and held alive
+   * for the lifetime of the handle. Call `.free()` to release both the
+   * native handle and the WASM-side copy.
+   *
+   * Throws on invalid archives (bad magic, truncated seek table, ...).
+   *
+   * @param {Uint8Array} data - Compressed buffer, ideally produced with
+   *        `{ seekable: true }` so it carries an embedded seek table.
+   * @returns {{
+   *   numBlocks(): number,
+   *   decompressedSize(): number,
+   *   blockCompressedSize(idx: number): (number | null),
+   *   blockDecompressedSize(idx: number): (number | null),
+   *   decompressRange(offset: number, length: number): Uint8Array,
+   *   free(): void
+   * }}
+   */
+  function createSeekable(data) {
+    if (!data || data.length === 0) {
+      throw new Error("ZXC: createSeekable requires a non-empty buffer");
     }
 
-    /* Shared helper: copy a Uint8Array into the heap and call an id getter. */
-    function _callIdOnBuffer(fn, data) {
-        if (!data || data.length === 0) return 0;
-        const ptr = _malloc(data.length);
-        try {
-            Module.HEAPU8.set(data, ptr);
-            return fn(ptr, data.length) >>> 0;
-        } finally {
-            _free(ptr);
-        }
+    const srcLen = data.length;
+    const srcPtr = _malloc(srcLen);
+    if (!srcPtr) throw new Error("ZXC: malloc failed for seekable buffer");
+    Module.HEAPU8.set(data, srcPtr);
+
+    let handle = _seekable_open(srcPtr, srcLen);
+    if (handle === 0) {
+      _free(srcPtr);
+      throw new Error("ZXC: invalid seekable archive");
     }
 
-    /**
-     * Compute the 32-bit dictionary ID for raw dictionary content.
-     * @param {Uint8Array} content
-     * @returns {number} Unsigned 32-bit ID (0 if empty).
-     */
-    function dictId(content) {
-        // Third arg: NULL huf table -> content-only id.
-        return _callIdOnBuffer((ptr, len) => _dict_id(ptr, len, 0), content);
-    }
-
-    /**
-     * Read the dictionary ID referenced by a compressed `.zxc` archive.
-     * @param {Uint8Array} archive
-     * @returns {number} Unsigned 32-bit ID (0 if no dictionary required).
-     */
-    function getDictId(archive) {
-        return _callIdOnBuffer(_get_dict_id, archive);
-    }
-
-    /**
-     * Read the dictionary ID stored in a serialized `.zxd` file buffer.
-     * @param {Uint8Array} zxd
-     * @returns {number} Unsigned 32-bit ID (0 if not a valid .zxd).
-     */
-    function dictGetId(zxd) {
-        return _callIdOnBuffer(_dict_get_id, zxd);
-    }
-
-    /**
-     * Serialize dictionary content and its shared literal Huffman table
-     * (128 bytes, from {@link trainDictHuf}) to the `.zxd` file format.
-     * The stored dictionary ID covers both content and table.
-     * @param {Uint8Array} content - Raw dictionary content.
-     * @param {Uint8Array} hufLengths - 128-byte packed code-lengths table.
-     * @returns {Uint8Array} The encoded `.zxd` file.
-     * @throws {Error} On failure.
-     */
-    function dictSave(content, hufLengths) {
-        if (!content || content.length === 0) {
-            throw new Error('ZXC: dictSave requires non-empty content');
-        }
-        if (!hufLengths || hufLengths.length !== ZXC_HUF_TABLE_SIZE) {
-            throw new Error('ZXC: dictSave requires a 128-byte hufLengths table');
-        }
-        const cap = _dict_save_bound(content.length);
-        const contentPtr = _malloc(content.length);
-        const hufPtr = _malloc(ZXC_HUF_TABLE_SIZE);
-        const bufPtr = _malloc(cap);
-        try {
-            Module.HEAPU8.set(content, contentPtr);
-            Module.HEAPU8.set(hufLengths, hufPtr);
-            const r = _dict_save(contentPtr, content.length, hufPtr, bufPtr, cap);
-            if (r < 0) {
-                throw new Error(`ZXC dict_save error: ${_error_name(r)} (${r})`);
-            }
-            return new Uint8Array(Module.HEAPU8.buffer, bufPtr, r).slice();
-        } finally {
-            _free(contentPtr);
-            _free(hufPtr);
-            _free(bufPtr);
-        }
-    }
-
-    /**
-     * Train the shared literal Huffman table for an already-trained
-     * dictionary (see {@link trainDict}).
-     * @param {Uint8Array[]} samples - Training corpus.
-     * @param {Uint8Array} dict - Trained dictionary content.
-     * @returns {Uint8Array} 128-byte packed table for {@link dictSave} /
-     *   `opts.dictHuf`.
-     * @throws {Error} On failure.
-     */
-    function trainDictHuf(samples, dict) {
-        if (!samples || samples.length === 0) {
-            throw new Error('ZXC: trainDictHuf requires at least one sample');
+    return {
+      numBlocks() {
+        return _seekable_num_blocks(handle);
+      },
+      decompressedSize() {
+        return _u64(_seekable_decompressed_size(handle));
+      },
+      blockCompressedSize(idx) {
+        if (idx < 0 || idx >= _seekable_num_blocks(handle)) return null;
+        return _seekable_block_comp_size(handle, idx);
+      },
+      blockDecompressedSize(idx) {
+        if (idx < 0 || idx >= _seekable_num_blocks(handle)) return null;
+        return _seekable_block_decomp_size(handle, idx);
+      },
+      /**
+       * Attach a pre-trained dictionary to this seekable handle.
+       * Must be called before any decompressRange() call.
+       *
+       * When the archive was compressed with a shared literal Huffman
+       * table (or with a {@link Dictionary}), the same table must be
+       * supplied: the archive's dict_id binds the (content, table)
+       * pair, so content alone would be rejected with DICT_MISMATCH.
+       *
+       * @param {Dictionary|Uint8Array} dict - A {@link Dictionary}, or
+       *        raw dictionary content.
+       * @param {Uint8Array} [dictHuf] - Shared literal Huffman table
+       *        (128 bytes); redundant when `dict` is a {@link Dictionary}.
+       */
+      setDict(dict, dictHuf) {
+        if (dict instanceof Dictionary) {
+          dictHuf = dict.huf;
+          dict = dict.content;
         }
         if (!dict || dict.length === 0) {
-            throw new Error('ZXC: trainDictHuf requires a non-empty dictionary');
+          throw new Error("ZXC: setDict requires a non-empty dictionary");
         }
-        const n = samples.length;
-        const ptrsPtr  = _malloc(n * 4);
-        const sizesPtr = _malloc(n * 4);
-        const samplePtrs = [];
+        if (dictHuf && dictHuf.length !== ZXC_HUF_TABLE_SIZE) {
+          throw new Error("ZXC: dictHuf must be exactly 128 bytes");
+        }
         const dictPtr = _malloc(dict.length);
-        const hufPtr = _malloc(ZXC_HUF_TABLE_SIZE);
+        if (!dictPtr) throw new Error("ZXC: malloc failed for dictionary");
+        const hufPtr = dictHuf ? _malloc(ZXC_HUF_TABLE_SIZE) : 0;
         try {
-            for (let i = 0; i < n; i++) {
-                const sp = _malloc(samples[i].length || 1);
-                samplePtrs.push(sp);
-                if (samples[i].length > 0) Module.HEAPU8.set(samples[i], sp);
-                Module.HEAPU32[(ptrsPtr >> 2) + i]  = sp;
-                Module.HEAPU32[(sizesPtr >> 2) + i] = samples[i].length;
-            }
-            Module.HEAPU8.set(dict, dictPtr);
-            const r = _train_dict_huf(ptrsPtr, sizesPtr, n, dictPtr, dict.length, hufPtr);
-            if (r < 0) {
-                throw new Error(`ZXC train_dict_huf error: ${_error_name(r)} (${r})`);
-            }
-            return new Uint8Array(Module.HEAPU8.buffer, hufPtr, ZXC_HUF_TABLE_SIZE).slice();
+          Module.HEAPU8.set(dict, dictPtr);
+          if (hufPtr) Module.HEAPU8.set(dictHuf, hufPtr);
+          const r = _seekable_set_dict(handle, dictPtr, dict.length, hufPtr);
+          if (r < 0) {
+            throw new Error(
+              `ZXC seekable set_dict error: ${_error_name(r)} (${r})`,
+            );
+          }
         } finally {
-            for (const sp of samplePtrs) _free(sp);
-            _free(ptrsPtr);
-            _free(sizesPtr);
-            _free(dictPtr);
-            _free(hufPtr);
+          _free(dictPtr);
+          if (hufPtr) _free(hufPtr);
         }
-    }
-
-    /**
-     * Return the 128-byte shared Huffman table stored in a `.zxd` file, or
-     * `null` if the buffer is not a valid `.zxd` file.
-     * @param {Uint8Array} zxd - The `.zxd` file bytes.
-     * @returns {Uint8Array | null}
-     */
-    function dictHuf(zxd) {
-        if (!zxd || zxd.length === 0) return null;
-        const bufPtr = _malloc(zxd.length);
+      },
+      decompressRange(offset, length) {
+        if (length < 0) throw new Error("ZXC: length must be non-negative");
+        // The wasm shim carries the offset as a uint32 (no BigInt);
+        // values outside [0, 2^32-1] would silently wrap and return
+        // data from the wrong position.
+        if (!Number.isInteger(offset) || offset < 0 || offset > 0xffffffff) {
+          throw new Error("ZXC: offset must be an integer in [0, 2^32-1]");
+        }
+        if (length === 0) return new Uint8Array(0);
+        const dstPtr = _malloc(length);
+        if (!dstPtr) throw new Error("ZXC: malloc failed for output buffer");
         try {
-            Module.HEAPU8.set(zxd, bufPtr);
-            const p = _dict_huf(bufPtr, zxd.length);
-            if (!p) return null;
-            return new Uint8Array(Module.HEAPU8.buffer, p, ZXC_HUF_TABLE_SIZE).slice();
+          const r = _seekable_decompress_range(
+            handle,
+            dstPtr,
+            length,
+            offset,
+            length,
+          );
+          if (r < 0) {
+            throw new Error(
+              `ZXC seekable decompress error: ${_error_name(r)} (${r})`,
+            );
+          }
+          return new Uint8Array(Module.HEAPU8.buffer, dstPtr, r).slice();
         } finally {
-            _free(bufPtr);
+          _free(dstPtr);
         }
+      },
+      /** Release the native handle and the WASM-side copy. Idempotent. */
+      free() {
+        if (!handle) return;
+        _seekable_free(handle);
+        _free(srcPtr);
+        handle = 0;
+      },
+    };
+  }
+
+  /**
+   * Encoded byte size of a seek table covering `numBlocks` data blocks.
+   * Use this to size a destination buffer for [writeSeekTable].
+   * @param {number} numBlocks
+   * @returns {number}
+   */
+  function seekTableSize(numBlocks) {
+    return _seek_table_size(numBlocks >>> 0);
+  }
+
+  /**
+   * Low-level: write a seek table (header + entries) for the given
+   * per-block on-disk compressed sizes.
+   *
+   * Most callers do not need this directly; the buffer and streaming
+   * APIs emit a seek table when `seekable: true` is set.
+   *
+   * @param {ArrayLike<number>} compSizes - Per-block compressed sizes,
+   *        in order. Each entry is treated as an unsigned 32-bit value.
+   * @returns {Uint8Array} The encoded seek table.
+   */
+  function writeSeekTable(compSizes) {
+    if (!compSizes || compSizes.length === 0) {
+      throw new Error("ZXC: compSizes must be non-empty");
+    }
+    const numBlocks = compSizes.length;
+    const sz = _seek_table_size(numBlocks);
+    const dstPtr = _malloc(sz);
+    if (!dstPtr) throw new Error("ZXC: malloc failed for seek table");
+
+    const csPtr = _malloc(numBlocks * 4);
+    if (!csPtr) {
+      _free(dstPtr);
+      throw new Error("ZXC: malloc failed for compSizes scratch");
+    }
+
+    try {
+      for (let i = 0; i < numBlocks; i++) {
+        Module.HEAPU32[(csPtr >> 2) + i] = compSizes[i] >>> 0;
+      }
+      const r = _write_seek_table(dstPtr, sz, csPtr, numBlocks);
+      if (r < 0) {
+        throw new Error(`ZXC write_seek_table error: ${_error_name(r)} (${r})`);
+      }
+      return new Uint8Array(Module.HEAPU8.buffer, dstPtr, r).slice();
+    } finally {
+      _free(dstPtr);
+      _free(csPtr);
+    }
+  }
+
+  // --- Dictionary API ------------------------------------------------------
+
+  /**
+   * Train a dictionary from a corpus of samples.
+   *
+   * @param {Uint8Array[]} samples - Array of sample buffers (similar payloads).
+   * @param {number} [maxSize=65535] - Maximum dictionary size in bytes
+   *        (capped at ZXC_DICT_SIZE_MAX).
+   * @returns {Uint8Array} Raw trained dictionary content.
+   * @throws {Error} On training failure.
+   */
+  function trainDict(samples, maxSize = ZXC_DICT_SIZE_MAX) {
+    if (!samples || samples.length === 0) {
+      throw new Error("ZXC: trainDict requires at least one sample");
+    }
+    const cap = Math.min(maxSize >>> 0, ZXC_DICT_SIZE_MAX);
+    const n = samples.length;
+
+    // Heap arrays: pointers (4 bytes each) + sizes (size_t = 4 bytes on wasm32).
+    const ptrsPtr = _malloc(n * 4);
+    const sizesPtr = _malloc(n * 4);
+    const samplePtrs = [];
+    const dictPtr = _malloc(cap);
+
+    try {
+      for (let i = 0; i < n; i++) {
+        const s = samples[i];
+        const sp = s.length > 0 ? _malloc(s.length) : _malloc(1);
+        if (s.length > 0) Module.HEAPU8.set(s, sp);
+        samplePtrs.push(sp);
+        Module.HEAPU32[(ptrsPtr >> 2) + i] = sp;
+        Module.HEAPU32[(sizesPtr >> 2) + i] = s.length;
+      }
+      const r = _train_dict(ptrsPtr, sizesPtr, n, dictPtr, cap);
+      if (r < 0) {
+        throw new Error(`ZXC train_dict error: ${_error_name(r)} (${r})`);
+      }
+      return new Uint8Array(Module.HEAPU8.buffer, dictPtr, r).slice();
+    } finally {
+      for (const sp of samplePtrs) _free(sp);
+      _free(ptrsPtr);
+      _free(sizesPtr);
+      _free(dictPtr);
+    }
+  }
+
+  /* Shared helper: copy a Uint8Array into the heap and call an id getter. */
+  function _callIdOnBuffer(fn, data) {
+    if (!data || data.length === 0) return 0;
+    const ptr = _malloc(data.length);
+    try {
+      Module.HEAPU8.set(data, ptr);
+      return fn(ptr, data.length) >>> 0;
+    } finally {
+      _free(ptr);
+    }
+  }
+
+  /**
+   * Compute the 32-bit dictionary ID for raw dictionary content.
+   * @param {Uint8Array} content
+   * @returns {number} Unsigned 32-bit ID (0 if empty).
+   */
+  function dictId(content) {
+    // Third arg: NULL huf table -> content-only id.
+    return _callIdOnBuffer((ptr, len) => _dict_id(ptr, len, 0), content);
+  }
+
+  /**
+   * Read the dictionary ID referenced by a compressed `.zxc` archive.
+   * @param {Uint8Array} archive
+   * @returns {number} Unsigned 32-bit ID (0 if no dictionary required).
+   */
+  function getDictId(archive) {
+    return _callIdOnBuffer(_get_dict_id, archive);
+  }
+
+  /**
+   * Read the dictionary ID stored in a serialized `.zxd` file buffer.
+   * @param {Uint8Array} zxd
+   * @returns {number} Unsigned 32-bit ID (0 if not a valid .zxd).
+   */
+  function dictGetId(zxd) {
+    return _callIdOnBuffer(_dict_get_id, zxd);
+  }
+
+  /**
+   * Serialize dictionary content and its shared literal Huffman table
+   * (128 bytes, from {@link trainDictHuf}) to the `.zxd` file format.
+   * The stored dictionary ID covers both content and table.
+   * @param {Uint8Array} content - Raw dictionary content.
+   * @param {Uint8Array} hufLengths - 128-byte packed code-lengths table.
+   * @returns {Uint8Array} The encoded `.zxd` file.
+   * @throws {Error} On failure.
+   */
+  function dictSave(content, hufLengths) {
+    if (!content || content.length === 0) {
+      throw new Error("ZXC: dictSave requires non-empty content");
+    }
+    if (!hufLengths || hufLengths.length !== ZXC_HUF_TABLE_SIZE) {
+      throw new Error("ZXC: dictSave requires a 128-byte hufLengths table");
+    }
+    const cap = _dict_save_bound(content.length);
+    const contentPtr = _malloc(content.length);
+    const hufPtr = _malloc(ZXC_HUF_TABLE_SIZE);
+    const bufPtr = _malloc(cap);
+    try {
+      Module.HEAPU8.set(content, contentPtr);
+      Module.HEAPU8.set(hufLengths, hufPtr);
+      const r = _dict_save(contentPtr, content.length, hufPtr, bufPtr, cap);
+      if (r < 0) {
+        throw new Error(`ZXC dict_save error: ${_error_name(r)} (${r})`);
+      }
+      return new Uint8Array(Module.HEAPU8.buffer, bufPtr, r).slice();
+    } finally {
+      _free(contentPtr);
+      _free(hufPtr);
+      _free(bufPtr);
+    }
+  }
+
+  /**
+   * Train the shared literal Huffman table for an already-trained
+   * dictionary (see {@link trainDict}).
+   * @param {Uint8Array[]} samples - Training corpus.
+   * @param {Uint8Array} dict - Trained dictionary content.
+   * @returns {Uint8Array} 128-byte packed table for {@link dictSave} /
+   *   `opts.dictHuf`.
+   * @throws {Error} On failure.
+   */
+  function trainDictHuf(samples, dict) {
+    if (!samples || samples.length === 0) {
+      throw new Error("ZXC: trainDictHuf requires at least one sample");
+    }
+    if (!dict || dict.length === 0) {
+      throw new Error("ZXC: trainDictHuf requires a non-empty dictionary");
+    }
+    const n = samples.length;
+    const ptrsPtr = _malloc(n * 4);
+    const sizesPtr = _malloc(n * 4);
+    const samplePtrs = [];
+    const dictPtr = _malloc(dict.length);
+    const hufPtr = _malloc(ZXC_HUF_TABLE_SIZE);
+    try {
+      for (let i = 0; i < n; i++) {
+        const sp = _malloc(samples[i].length || 1);
+        samplePtrs.push(sp);
+        if (samples[i].length > 0) Module.HEAPU8.set(samples[i], sp);
+        Module.HEAPU32[(ptrsPtr >> 2) + i] = sp;
+        Module.HEAPU32[(sizesPtr >> 2) + i] = samples[i].length;
+      }
+      Module.HEAPU8.set(dict, dictPtr);
+      const r = _train_dict_huf(
+        ptrsPtr,
+        sizesPtr,
+        n,
+        dictPtr,
+        dict.length,
+        hufPtr,
+      );
+      if (r < 0) {
+        throw new Error(`ZXC train_dict_huf error: ${_error_name(r)} (${r})`);
+      }
+      return new Uint8Array(
+        Module.HEAPU8.buffer,
+        hufPtr,
+        ZXC_HUF_TABLE_SIZE,
+      ).slice();
+    } finally {
+      for (const sp of samplePtrs) _free(sp);
+      _free(ptrsPtr);
+      _free(sizesPtr);
+      _free(dictPtr);
+      _free(hufPtr);
+    }
+  }
+
+  /**
+   * Return the 128-byte shared Huffman table stored in a `.zxd` file, or
+   * `null` if the buffer is not a valid `.zxd` file.
+   * @param {Uint8Array} zxd - The `.zxd` file bytes.
+   * @returns {Uint8Array | null}
+   */
+  function dictHuf(zxd) {
+    if (!zxd || zxd.length === 0) return null;
+    const bufPtr = _malloc(zxd.length);
+    try {
+      Module.HEAPU8.set(zxd, bufPtr);
+      const p = _dict_huf(bufPtr, zxd.length);
+      if (!p) return null;
+      return new Uint8Array(
+        Module.HEAPU8.buffer,
+        p,
+        ZXC_HUF_TABLE_SIZE,
+      ).slice();
+    } finally {
+      _free(bufPtr);
+    }
+  }
+
+  /**
+   * Load and validate a `.zxd` file buffer.
+   * @param {Uint8Array} zxd - The `.zxd` file bytes.
+   * @returns {{ content: Uint8Array, huf: Uint8Array, id: number }}
+   * @throws {Error} On invalid input.
+   */
+  function dictLoad(zxd) {
+    if (!zxd || zxd.length === 0) {
+      throw new Error("ZXC: dictLoad requires a non-empty buffer");
+    }
+    const bufPtr = _malloc(zxd.length);
+    // out params: content ptr (4), content size (4), huf ptr (4), dict id (4)
+    const contentOutPtr = _malloc(4);
+    const sizeOutPtr = _malloc(4);
+    const hufOutPtr = _malloc(4);
+    const idOutPtr = _malloc(4);
+    try {
+      Module.HEAPU8.set(zxd, bufPtr);
+      const r = _dict_load(
+        bufPtr,
+        zxd.length,
+        contentOutPtr,
+        sizeOutPtr,
+        hufOutPtr,
+        idOutPtr,
+      );
+      if (r < 0) {
+        throw new Error(`ZXC dict_load error: ${_error_name(r)} (${r})`);
+      }
+      const contentPtr = Module.HEAPU32[contentOutPtr >> 2];
+      const contentSize = Module.HEAPU32[sizeOutPtr >> 2];
+      const hufPtr = Module.HEAPU32[hufOutPtr >> 2];
+      const id = Module.HEAPU32[idOutPtr >> 2] >>> 0;
+      // content/huf point into bufPtr (zero-copy); copy out before freeing.
+      const content = new Uint8Array(
+        Module.HEAPU8.buffer,
+        contentPtr,
+        contentSize,
+      ).slice();
+      const huf = new Uint8Array(
+        Module.HEAPU8.buffer,
+        hufPtr,
+        ZXC_HUF_TABLE_SIZE,
+      ).slice();
+      return { content, huf, id };
+    } finally {
+      _free(bufPtr);
+      _free(contentOutPtr);
+      _free(sizeOutPtr);
+      _free(hufOutPtr);
+      _free(idOutPtr);
+    }
+  }
+
+  /**
+   * Train a complete dictionary (content + shared Huffman table) and
+   * serialize it to `.zxd` bytes in one call. One-call equivalent of
+   * {@link trainDict} + {@link trainDictHuf} + {@link dictSave}.
+   * @param {Uint8Array[]} samples - Training corpus.
+   * @returns {Uint8Array} The encoded `.zxd` file.
+   * @throws {Error} On failure.
+   */
+  function dictTrain(samples) {
+    if (!samples || samples.length === 0) {
+      throw new Error("ZXC: dictTrain requires at least one sample");
+    }
+    const n = samples.length;
+    const ptrsPtr = _malloc(n * 4);
+    const sizesPtr = _malloc(n * 4);
+    const samplePtrs = [];
+    const cap = _dict_save_bound(ZXC_DICT_SIZE_MAX);
+    const zxdPtr = _malloc(cap);
+    try {
+      for (let i = 0; i < n; i++) {
+        const s = samples[i];
+        const sp = _malloc(s.length || 1);
+        if (s.length > 0) Module.HEAPU8.set(s, sp);
+        samplePtrs.push(sp);
+        Module.HEAPU32[(ptrsPtr >> 2) + i] = sp;
+        Module.HEAPU32[(sizesPtr >> 2) + i] = s.length;
+      }
+      const r = _dict_train(ptrsPtr, sizesPtr, n, zxdPtr, cap);
+      if (r < 0) {
+        throw new Error(`ZXC dict_train error: ${_error_name(r)} (${r})`);
+      }
+      return new Uint8Array(Module.HEAPU8.buffer, zxdPtr, r).slice();
+    } finally {
+      for (const sp of samplePtrs) _free(sp);
+      _free(ptrsPtr);
+      _free(sizesPtr);
+      _free(zxdPtr);
+    }
+  }
+
+  /**
+   * A trained dictionary: content bytes, its shared literal Huffman table
+   * and the ID binding the pair. Pass an instance as `opts.dict` to
+   * `compress` / `decompress` instead of juggling `dict` + `dictHuf`.
+   */
+  class Dictionary {
+    /**
+     * @param {Uint8Array} content - Raw LZ-window content bytes.
+     * @param {Uint8Array} huf - 128-byte shared literal Huffman table.
+     * @param {number} id - Dictionary ID binding the (content, table) pair.
+     */
+    constructor(content, huf, id) {
+      if (!content || !huf || huf.length !== ZXC_HUF_TABLE_SIZE) {
+        throw new Error(
+          "ZXC: Dictionary requires (content, 128-byte huf table)",
+        );
+      }
+      this.content = content;
+      this.huf = huf;
+      this.id = id >>> 0;
     }
 
     /**
-     * Load and validate a `.zxd` file buffer.
-     * @param {Uint8Array} zxd - The `.zxd` file bytes.
-     * @returns {{ content: Uint8Array, huf: Uint8Array, id: number }}
-     * @throws {Error} On invalid input.
+     * Train a complete dictionary (content + shared table) from samples.
+     * @param {Uint8Array[]} samples
+     * @returns {Dictionary}
      */
-    function dictLoad(zxd) {
-        if (!zxd || zxd.length === 0) {
-            throw new Error('ZXC: dictLoad requires a non-empty buffer');
-        }
-        const bufPtr = _malloc(zxd.length);
-        // out params: content ptr (4), content size (4), huf ptr (4), dict id (4)
-        const contentOutPtr = _malloc(4);
-        const sizeOutPtr    = _malloc(4);
-        const hufOutPtr     = _malloc(4);
-        const idOutPtr      = _malloc(4);
+    static train(samples) {
+      return Dictionary.load(dictTrain(samples));
+    }
+
+    /**
+     * Parse `.zxd` bytes into a Dictionary (owned copies).
+     * @param {Uint8Array} zxd
+     * @returns {Dictionary}
+     */
+    static load(zxd) {
+      const { content, huf, id } = dictLoad(zxd);
+      return new Dictionary(content, huf, id);
+    }
+
+    /**
+     * Serialize back to `.zxd` file bytes.
+     * @returns {Uint8Array}
+     */
+    save() {
+      return dictSave(this.content, this.huf);
+    }
+  }
+
+  // --- WHATWG TransformStream adapters -------------------------------------
+  //
+  // Mirror of the wrappers shipped by the Go, Rust, Python and Node bindings:
+  // turn a CStream / DStream pair into a `TransformStream` so ZXC can be
+  // wired into fetch pipelines, Service Workers, Deno, Bun, Node ≥18 — any
+  // host that exposes the Streams API. Useful for OCI use cases such as
+  // streaming a compressed layer through `fetch().body.pipeThrough(...)`.
+
+  /**
+   * Returns a WHATWG TransformStream that compresses bytes through a ZXC
+   * frame. Pipe a ReadableStream<Uint8Array> through it to produce a
+   * compressed ReadableStream<Uint8Array>.
+   *
+   * @param {object} [opts]
+   * @param {number} [opts.level]
+   * @param {boolean} [opts.checksum]
+   * @returns {TransformStream<Uint8Array, Uint8Array>}
+   */
+  function createCompressTransformStream(opts) {
+    let cs;
+    return new TransformStream({
+      start() {
+        cs = createCStream(opts);
+      },
+      transform(chunk, controller) {
         try {
-            Module.HEAPU8.set(zxd, bufPtr);
-            const r = _dict_load(bufPtr, zxd.length, contentOutPtr, sizeOutPtr,
-                hufOutPtr, idOutPtr);
-            if (r < 0) {
-                throw new Error(`ZXC dict_load error: ${_error_name(r)} (${r})`);
-            }
-            const contentPtr  = Module.HEAPU32[contentOutPtr >> 2];
-            const contentSize = Module.HEAPU32[sizeOutPtr >> 2];
-            const hufPtr      = Module.HEAPU32[hufOutPtr >> 2];
-            const id          = Module.HEAPU32[idOutPtr >> 2] >>> 0;
-            // content/huf point into bufPtr (zero-copy); copy out before freeing.
-            const content = new Uint8Array(Module.HEAPU8.buffer, contentPtr, contentSize).slice();
-            const huf = new Uint8Array(Module.HEAPU8.buffer, hufPtr,
-                ZXC_HUF_TABLE_SIZE).slice();
-            return { content, huf, id };
-        } finally {
-            _free(bufPtr);
-            _free(contentOutPtr);
-            _free(sizeOutPtr);
-            _free(hufOutPtr);
-            _free(idOutPtr);
+          const out = cs.compress(chunk);
+          if (out.length > 0) controller.enqueue(out);
+        } catch (e) {
+          controller.error(e);
+          try {
+            cs.free();
+          } catch (_) {
+            /* idempotent */
+          }
         }
-    }
-
-    /**
-     * Train a complete dictionary (content + shared Huffman table) and
-     * serialize it to `.zxd` bytes in one call. One-call equivalent of
-     * {@link trainDict} + {@link trainDictHuf} + {@link dictSave}.
-     * @param {Uint8Array[]} samples - Training corpus.
-     * @returns {Uint8Array} The encoded `.zxd` file.
-     * @throws {Error} On failure.
-     */
-    function dictTrain(samples) {
-        if (!samples || samples.length === 0) {
-            throw new Error('ZXC: dictTrain requires at least one sample');
-        }
-        const n = samples.length;
-        const ptrsPtr  = _malloc(n * 4);
-        const sizesPtr = _malloc(n * 4);
-        const samplePtrs = [];
-        const cap = _dict_save_bound(ZXC_DICT_SIZE_MAX);
-        const zxdPtr = _malloc(cap);
+      },
+      flush(controller) {
         try {
-            for (let i = 0; i < n; i++) {
-                const s = samples[i];
-                const sp = _malloc(s.length || 1);
-                if (s.length > 0) Module.HEAPU8.set(s, sp);
-                samplePtrs.push(sp);
-                Module.HEAPU32[(ptrsPtr >> 2) + i]  = sp;
-                Module.HEAPU32[(sizesPtr >> 2) + i] = s.length;
-            }
-            const r = _dict_train(ptrsPtr, sizesPtr, n, zxdPtr, cap);
-            if (r < 0) {
-                throw new Error(`ZXC dict_train error: ${_error_name(r)} (${r})`);
-            }
-            return new Uint8Array(Module.HEAPU8.buffer, zxdPtr, r).slice();
+          const tail = cs.end();
+          if (tail.length > 0) controller.enqueue(tail);
+        } catch (e) {
+          controller.error(e);
         } finally {
-            for (const sp of samplePtrs) _free(sp);
-            _free(ptrsPtr);
-            _free(sizesPtr);
-            _free(zxdPtr);
+          try {
+            cs.free();
+          } catch (_) {
+            /* idempotent */
+          }
         }
-    }
-
-    /**
-     * A trained dictionary: content bytes, its shared literal Huffman table
-     * and the ID binding the pair. Pass an instance as `opts.dict` to
-     * `compress` / `decompress` instead of juggling `dict` + `dictHuf`.
-     */
-    class Dictionary {
-        /**
-         * @param {Uint8Array} content - Raw LZ-window content bytes.
-         * @param {Uint8Array} huf - 128-byte shared literal Huffman table.
-         * @param {number} id - Dictionary ID binding the (content, table) pair.
-         */
-        constructor(content, huf, id) {
-            if (!content || !huf || huf.length !== ZXC_HUF_TABLE_SIZE) {
-                throw new Error(
-                    'ZXC: Dictionary requires (content, 128-byte huf table)');
-            }
-            this.content = content;
-            this.huf = huf;
-            this.id = id >>> 0;
+      },
+      // Reader cancelled / writable aborted: flush() never runs, so the
+      // wasm stream context and staging buffers must be freed here.
+      cancel() {
+        try {
+          cs.free();
+        } catch (_) {
+          /* idempotent */
         }
-
-        /**
-         * Train a complete dictionary (content + shared table) from samples.
-         * @param {Uint8Array[]} samples
-         * @returns {Dictionary}
-         */
-        static train(samples) {
-            return Dictionary.load(dictTrain(samples));
-        }
-
-        /**
-         * Parse `.zxd` bytes into a Dictionary (owned copies).
-         * @param {Uint8Array} zxd
-         * @returns {Dictionary}
-         */
-        static load(zxd) {
-            const { content, huf, id } = dictLoad(zxd);
-            return new Dictionary(content, huf, id);
-        }
-
-        /**
-         * Serialize back to `.zxd` file bytes.
-         * @returns {Uint8Array}
-         */
-        save() {
-            return dictSave(this.content, this.huf);
-        }
-    }
-
-    // --- WHATWG TransformStream adapters -------------------------------------
-    //
-    // Mirror of the wrappers shipped by the Go, Rust, Python and Node bindings:
-    // turn a CStream / DStream pair into a `TransformStream` so ZXC can be
-    // wired into fetch pipelines, Service Workers, Deno, Bun, Node ≥18 — any
-    // host that exposes the Streams API. Useful for OCI use cases such as
-    // streaming a compressed layer through `fetch().body.pipeThrough(...)`.
-
-    /**
-     * Returns a WHATWG TransformStream that compresses bytes through a ZXC
-     * frame. Pipe a ReadableStream<Uint8Array> through it to produce a
-     * compressed ReadableStream<Uint8Array>.
-     *
-     * @param {object} [opts]
-     * @param {number} [opts.level]
-     * @param {boolean} [opts.checksum]
-     * @returns {TransformStream<Uint8Array, Uint8Array>}
-     */
-    function createCompressTransformStream(opts) {
-        let cs;
-        return new TransformStream({
-            start() {
-                cs = createCStream(opts);
-            },
-            transform(chunk, controller) {
-                try {
-                    const out = cs.compress(chunk);
-                    if (out.length > 0) controller.enqueue(out);
-                } catch (e) {
-                    controller.error(e);
-                    try { cs.free(); } catch (_) { /* idempotent */ }
-                }
-            },
-            flush(controller) {
-                try {
-                    const tail = cs.end();
-                    if (tail.length > 0) controller.enqueue(tail);
-                } catch (e) {
-                    controller.error(e);
-                } finally {
-                    try { cs.free(); } catch (_) { /* idempotent */ }
-                }
-            },
-            // Reader cancelled / writable aborted: flush() never runs, so the
-            // wasm stream context and staging buffers must be freed here.
-            cancel() {
-                try { cs.free(); } catch (_) { /* idempotent */ }
-            },
-        });
-    }
-
-    /**
-     * Returns a WHATWG TransformStream that decompresses a ZXC frame.
-     *
-     * Errors the stream with a `'ZXC_TRUNCATED'`-tagged Error if the input
-     * ends before the footer is reached.
-     *
-     * @param {object} [opts]
-     * @param {boolean} [opts.checksum]
-     * @returns {TransformStream<Uint8Array, Uint8Array>}
-     */
-    function createDecompressTransformStream(opts) {
-        let ds;
-        return new TransformStream({
-            start() {
-                ds = createDStream(opts);
-            },
-            transform(chunk, controller) {
-                try {
-                    const out = ds.decompress(chunk);
-                    if (out.length > 0) controller.enqueue(out);
-                } catch (e) {
-                    controller.error(e);
-                    try { ds.free(); } catch (_) { /* idempotent */ }
-                }
-            },
-            flush(controller) {
-                try {
-                    if (!ds.finished()) {
-                        const err = new Error(
-                            'ZXC: input drained before footer (truncated frame)');
-                        err.code = 'ZXC_TRUNCATED';
-                        controller.error(err);
-                        return;
-                    }
-                } catch (e) {
-                    controller.error(e);
-                } finally {
-                    try { ds.free(); } catch (_) { /* idempotent */ }
-                }
-            },
-            // Reader cancelled / writable aborted: flush() never runs, so the
-            // wasm stream context and staging buffers must be freed here.
-            cancel() {
-                try { ds.free(); } catch (_) { /* idempotent */ }
-            },
-        });
-    }
-
-    // --- Exposed API object --------------------------------------------------
-    return Object.freeze({
-        compress,
-        decompress,
-        compressBound,
-        getDecompressedSize,
-        createCompressContext,
-        createDecompressContext,
-        createCStream,
-        createDStream,
-        createCompressTransformStream,
-        createDecompressTransformStream,
-        createSeekable,
-        seekTableSize,
-        writeSeekTable,
-        detectZxc,
-
-        // Dictionary API
-        Dictionary,
-        dictTrain,
-        trainDict,
-        trainDictHuf,
-        dictId,
-        getDictId,
-        dictGetId,
-        dictSave,
-        dictLoad,
-        dictHuf,
-
-        /** Library version string (e.g. "0.13.1"). */
-        version: _version_string(),
-        /** Minimum compression level. */
-        minLevel: _min_level(),
-        /** Maximum compression level. */
-        maxLevel: _max_level(),
-        /** Default compression level. */
-        defaultLevel: _default_level(),
-
-        /** Raw Emscripten Module (for advanced use). */
-        _module: Module,
+      },
     });
+  }
+
+  /**
+   * Returns a WHATWG TransformStream that decompresses a ZXC frame.
+   *
+   * Errors the stream with a `'ZXC_TRUNCATED'`-tagged Error if the input
+   * ends before the footer is reached.
+   *
+   * @param {object} [opts]
+   * @param {boolean} [opts.checksum]
+   * @returns {TransformStream<Uint8Array, Uint8Array>}
+   */
+  function createDecompressTransformStream(opts) {
+    let ds;
+    return new TransformStream({
+      start() {
+        ds = createDStream(opts);
+      },
+      transform(chunk, controller) {
+        try {
+          const out = ds.decompress(chunk);
+          if (out.length > 0) controller.enqueue(out);
+        } catch (e) {
+          controller.error(e);
+          try {
+            ds.free();
+          } catch (_) {
+            /* idempotent */
+          }
+        }
+      },
+      flush(controller) {
+        try {
+          if (!ds.finished()) {
+            const err = new Error(
+              "ZXC: input drained before footer (truncated frame)",
+            );
+            err.code = "ZXC_TRUNCATED";
+            controller.error(err);
+            return;
+          }
+        } catch (e) {
+          controller.error(e);
+        } finally {
+          try {
+            ds.free();
+          } catch (_) {
+            /* idempotent */
+          }
+        }
+      },
+      // Reader cancelled / writable aborted: flush() never runs, so the
+      // wasm stream context and staging buffers must be freed here.
+      cancel() {
+        try {
+          ds.free();
+        } catch (_) {
+          /* idempotent */
+        }
+      },
+    });
+  }
+
+  // --- Exposed API object --------------------------------------------------
+  return Object.freeze({
+    compress,
+    decompress,
+    compressBound,
+    getDecompressedSize,
+    createCompressContext,
+    createDecompressContext,
+    createCStream,
+    createDStream,
+    createCompressTransformStream,
+    createDecompressTransformStream,
+    createSeekable,
+    seekTableSize,
+    writeSeekTable,
+    detectZxc,
+
+    // Dictionary API
+    Dictionary,
+    dictTrain,
+    trainDict,
+    trainDictHuf,
+    dictId,
+    getDictId,
+    dictGetId,
+    dictSave,
+    dictLoad,
+    dictHuf,
+
+    /** Library version string (e.g. "0.13.1"). */
+    version: _version_string(),
+    /** Minimum compression level. */
+    minLevel: _min_level(),
+    /** Maximum compression level. */
+    maxLevel: _max_level(),
+    /** Default compression level. */
+    defaultLevel: _default_level(),
+
+    /** Raw Emscripten Module (for advanced use). */
+    _module: Module,
+  });
 }


### PR DESCRIPTION
- Adds a quality job for each wrapper to ensure source code formatting, and reformats the wrappers so those jobs pass: rustfmt, black and prettier had never been run (go was already clean).
- Unify the wrapper workflow names by language