### PR TITLE
build: Remove duplicate SSE2/NEON FMV variants, drop -mfma, harden x86 dispatch gates

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Clone LZbench
         run: |
           # git clone --depth 1 https://github.com/inikep/lzbench "${LZBENCH_DIR}"
-          git clone -b zxc-0.13.0 https://github.com/hellobertrand/lzbench "${LZBENCH_DIR}"
+          git clone -b zxc-0.13.2 https://github.com/hellobertrand/lzbench "${LZBENCH_DIR}"
 
       - name: Copy Lib ZXC
         run: |

--- a/.github/workflows/multiarch.yml
+++ b/.github/workflows/multiarch.yml
@@ -285,10 +285,13 @@ jobs:
   # TCG re-translation) and, unlike QEMU's TCG, can execute AVX-512. One native
   # build per job carries all per-ISA variants; the emulated CPU model makes the
   # runtime dispatcher select that job's tier:
-  #   -mrm  Merom (Core 2)  -> SSE2 tier    (== old core2duo)
-  #   -hsw  Haswell         -> AVX2 tier     (== old Haswell)
-  #   -icx  Ice Lake Server -> AVX-512 tier  (F+BW+VBMI2; VBMI2 is required by
-  #                            ZXC's AVX-512 gate, which Skylake-Server lacks)
+  #   -mrm  Merom (Core 2)  -> SSE2 tier    (sub-AVX2 detection -> _default,
+  #                            which carries the SSE2 paths: x86-64 baseline)
+  #   -hsw  Haswell         -> AVX2 tier     (gate = AVX2+BMI1+BMI2+LZCNT,
+  #                            all present on Haswell; Merom has none)
+  #   -icx  Ice Lake Server -> AVX-512 tier  (F+BW+VBMI2 plus BMI1/BMI2/LZCNT;
+  #                            VBMI2 is required by ZXC's AVX-512 gate, which
+  #                            Skylake-Server lacks)
   # ===========================================================================
   build-tier2-amd64-sde:
     name: "Tier 2: Linux amd64 (${{ matrix.tier }})"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -179,32 +179,23 @@ if(ZXC_DISABLE_SIMD)
 else()
 if(CMAKE_SYSTEM_PROCESSOR MATCHES "amd64|x86_64|AMD64")
     message(STATUS "Building x86_64 AVX2 and AVX512 variants...")
+    # No _sse2 variant: SSE2 is the x86-64 baseline, so _default already
+    # compiles the SSE2 code paths (ZXC_USE_SSE2 in zxc_internal.h).
     if(MSVC)
-        # SSE2 for MSVC: SSE2 is the x86-64 baseline
-        zxc_add_variant(_sse2 "/D__SSE2__")
         # AVX2 for MSVC (Enables AVX2/BMI1/BMI2 sets)
         zxc_add_variant(_avx2 "/arch:AVX2;/D__BMI__;/D__BMI2__;/D__LZCNT__")
         # AVX512 for MSVC (VS2019 16.10+ supports /arch:AVX512)
         zxc_add_variant(_avx512 "/arch:AVX512;/D__BMI__;/D__BMI2__;/D__LZCNT__")
     else()
-        # SSE2 for GCC/Clang (x86-64 baseline)
-        zxc_add_variant(_sse2 "-msse2")
         # AVX2 for GCC/Clang
-        zxc_add_variant(_avx2 "-mavx2;-mfma;-mbmi;-mbmi2;-mlzcnt")
+        zxc_add_variant(_avx2 "-mavx2;-mbmi;-mbmi2;-mlzcnt")
         # AVX512 for GCC/Clang
         zxc_add_variant(_avx512
                         "-mavx512f;-mavx512bw;-mavx512vbmi;-mavx512vbmi2;-mbmi;-mbmi2;-mlzcnt")
     endif()
 
 elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|arm64|ARM64")
-    message(STATUS "Building AArch64 NEON variant...")
-    if(MSVC)
-        # MSVC for ARM64 implies NEON support by default.
-        zxc_add_variant(_neon "")
-    else()
-        # NEON is usually default on AArch64, but we add a specific variant for structure
-        zxc_add_variant(_neon "-march=armv8-a+simd")
-    endif()
+    message(STATUS "AArch64: NEON is baseline; no dedicated SIMD variant needed.")
 
 elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "^arm")
     message(STATUS "Building ARM NEON variant...")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -198,8 +198,8 @@ elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|arm64|ARM64")
     message(STATUS "AArch64: NEON is baseline; no dedicated SIMD variant needed.")
 
 elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "^arm")
-    message(STATUS "Building ARM NEON variant...")
-    zxc_add_variant(_neon "-march=armv7-a;-mfpu=neon")
+    message(STATUS "Building ARMv7 NEON32 variant...")
+    zxc_add_variant(_neon32 "-march=armv7-a;-mfpu=neon")
 endif()
 endif()
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -91,7 +91,7 @@ libzxc uses an **opt-in** export strategy:
 
 | Build type | How symbols are exposed |
 |-----------|------------------------|
-| **Shared library** | Default visibility is `hidden`.  Only functions annotated with `ZXC_EXPORT` are exported.  Internal FMV variants (`_default`, `_neon`, `_avx2`, `_avx512`) are hidden. |
+| **Shared library** | Default visibility is `hidden`.  Only functions annotated with `ZXC_EXPORT` are exported.  Internal FMV variants (`_default`, `_neon32`, `_avx2`, `_avx512`) are hidden. |
 | **Static library** | Define `ZXC_STATIC_DEFINE` (set automatically by CMake) to disable import/export annotations. |
 
 ### Macros
@@ -1583,5 +1583,5 @@ The shared library exports **47 symbols** (verified with `nm -gU`):
 | 61 | `zxc_seekable_set_dict` | Seekable | `zxc_seekable.h` |
 
 No internal symbols leak into the public ABI. FMV dispatch variants
-(`_default`, `_neon`, `_avx2`, `_avx512`) are compiled with
+(`_default`, `_neon32`, `_avx2`, `_avx512`) are compiled with
 `-fvisibility=hidden` and are not exported.

--- a/docs/abi/libzxc-linux-x86_64.abi.xml
+++ b/docs/abi/libzxc-linux-x86_64.abi.xml
@@ -1,4 +1,4 @@
-<abi-corpus version='2.2' path='build/libzxc.so.0.13.1' architecture='elf-amd-x86_64' soname='libzxc.so.4'>
+<abi-corpus version='2.2' path='/tmp/babi/libzxc.so.0.13.1' architecture='elf-amd-x86_64' soname='libzxc.so.4'>
   <elf-needed>
     <dependency name='libc.so.6'/>
   </elf-needed>
@@ -71,13 +71,13 @@
     <elf-symbol name='zxc_version_string' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='zxc_write_seek_table' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
   </elf-function-symbols>
-  <abi-instr address-size='64' path='/src/src/lib/zxc_common.c' comp-dir-path='/src/build' language='LANG_C11'>
+  <abi-instr address-size='64' path='/src/src/lib/zxc_common.c' comp-dir-path='/tmp/babi' language='LANG_C11'>
     <qualified-type-def type-id='type-id-1' restrict='yes' id='type-id-2'/>
     <pointer-type-def type-id='type-id-3' size-in-bits='64' id='type-id-4'/>
     <qualified-type-def type-id='type-id-4' restrict='yes' id='type-id-5'/>
     <pointer-type-def type-id='type-id-6' size-in-bits='64' id='type-id-7'/>
     <qualified-type-def type-id='type-id-7' restrict='yes' id='type-id-8'/>
-    <function-decl name='zxc_huf_dict_tree_build' filepath='/src/src/lib/zxc_internal.h' line='1514' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='zxc_huf_dict_tree_build' filepath='/src/src/lib/zxc_internal.h' line='1515' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-2'/>
       <parameter type-id='type-id-8'/>
       <parameter type-id='type-id-9'/>
@@ -85,45 +85,45 @@
       <parameter type-id='type-id-5'/>
       <return type-id='type-id-11'/>
     </function-decl>
-    <function-decl name='free' filepath='/src/usr/include/stdlib.h' line='687' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='free' filepath='/usr/include/stdlib.h' line='687' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-12'/>
       <return type-id='type-id-13'/>
     </function-decl>
-    <function-decl name='posix_memalign' filepath='/src/usr/lib/gcc/x86_64-linux-gnu/13/include/mm_malloc.h' line='32' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='posix_memalign' filepath='/usr/lib/gcc/x86_64-linux-gnu/13/include/mm_malloc.h' line='32' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-14'/>
       <parameter type-id='type-id-15'/>
       <parameter type-id='type-id-15'/>
       <return type-id='type-id-11'/>
     </function-decl>
   </abi-instr>
-  <abi-instr address-size='64' path='/src/src/lib/zxc_compress.c' comp-dir-path='/src/build' language='LANG_C11'>
-    <class-decl name='zxc_gnr_header_t' size-in-bits='96' is-struct='yes' naming-typedef-id='type-id-16' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='982' column='1' id='type-id-17'>
+  <abi-instr address-size='64' path='/src/src/lib/zxc_compress.c' comp-dir-path='/tmp/babi' language='LANG_C11'>
+    <class-decl name='zxc_gnr_header_t' size-in-bits='96' is-struct='yes' naming-typedef-id='type-id-16' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='983' column='1' id='type-id-17'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='n_sequences' type-id='type-id-18' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='983' column='1'/>
+        <var-decl name='n_sequences' type-id='type-id-18' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='984' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='n_literals' type-id='type-id-18' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='984' column='1'/>
+        <var-decl name='n_literals' type-id='type-id-18' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='985' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='enc_lit' type-id='type-id-19' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='985' column='1'/>
+        <var-decl name='enc_lit' type-id='type-id-19' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='986' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='72'>
-        <var-decl name='enc_litlen' type-id='type-id-19' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='986' column='1'/>
+        <var-decl name='enc_litlen' type-id='type-id-19' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='987' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='80'>
-        <var-decl name='enc_mlen' type-id='type-id-19' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='987' column='1'/>
+        <var-decl name='enc_mlen' type-id='type-id-19' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='988' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='88'>
-        <var-decl name='enc_off' type-id='type-id-19' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='988' column='1'/>
+        <var-decl name='enc_off' type-id='type-id-19' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='989' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='zxc_section_desc_t' size-in-bits='64' is-struct='yes' naming-typedef-id='type-id-20' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='998' column='1' id='type-id-21'>
+    <class-decl name='zxc_section_desc_t' size-in-bits='64' is-struct='yes' naming-typedef-id='type-id-20' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='999' column='1' id='type-id-21'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='sizes' type-id='type-id-22' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='999' column='1'/>
+        <var-decl name='sizes' type-id='type-id-22' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='1000' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='zxc_gnr_header_t' type-id='type-id-17' filepath='/src/src/lib/zxc_internal.h' line='989' column='1' id='type-id-16'/>
-    <typedef-decl name='zxc_section_desc_t' type-id='type-id-21' filepath='/src/src/lib/zxc_internal.h' line='1000' column='1' id='type-id-20'/>
+    <typedef-decl name='zxc_gnr_header_t' type-id='type-id-17' filepath='/src/src/lib/zxc_internal.h' line='990' column='1' id='type-id-16'/>
+    <typedef-decl name='zxc_section_desc_t' type-id='type-id-21' filepath='/src/src/lib/zxc_internal.h' line='1001' column='1' id='type-id-20'/>
     <qualified-type-def type-id='type-id-16' const='yes' id='type-id-23'/>
     <pointer-type-def type-id='type-id-23' size-in-bits='64' id='type-id-24'/>
     <qualified-type-def type-id='type-id-24' restrict='yes' id='type-id-25'/>
@@ -132,332 +132,274 @@
     <qualified-type-def type-id='type-id-12' restrict='yes' id='type-id-28'/>
     <qualified-type-def type-id='type-id-12' restrict='yes' id='type-id-29'/>
     <qualified-type-def type-id='type-id-12' restrict='yes' id='type-id-30'/>
-    <qualified-type-def type-id='type-id-12' restrict='yes' id='type-id-31'/>
-    <function-decl name='zxc_write_glo_header_and_desc' filepath='/src/src/lib/zxc_internal.h' line='1392' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-10'/>
-      <parameter type-id='type-id-32'/>
-      <parameter type-id='type-id-25'/>
-      <parameter type-id='type-id-27'/>
-      <return type-id='type-id-11'/>
-    </function-decl>
-    <function-decl name='zxc_write_ghi_header_and_desc' filepath='/src/src/lib/zxc_internal.h' line='1423' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-10'/>
-      <parameter type-id='type-id-32'/>
-      <parameter type-id='type-id-25'/>
-      <parameter type-id='type-id-27'/>
-      <return type-id='type-id-11'/>
-    </function-decl>
-    <function-decl name='zxc_huf_build_code_lengths_avx2' filepath='/src/src/lib/zxc_internal.h' line='1472' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-33'/>
-      <parameter type-id='type-id-10'/>
-      <parameter type-id='type-id-30'/>
-      <parameter type-id='type-id-11'/>
-      <return type-id='type-id-11'/>
-    </function-decl>
-    <function-decl name='zxc_huf_build_code_lengths_avx512' filepath='/src/src/lib/zxc_internal.h' line='1472' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-33'/>
+    <function-decl name='zxc_write_glo_header_and_desc' filepath='/src/src/lib/zxc_internal.h' line='1393' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-10'/>
       <parameter type-id='type-id-31'/>
-      <parameter type-id='type-id-11'/>
+      <parameter type-id='type-id-25'/>
+      <parameter type-id='type-id-27'/>
       <return type-id='type-id-11'/>
     </function-decl>
-    <function-decl name='zxc_huf_build_code_lengths_default' filepath='/src/src/lib/zxc_internal.h' line='1472' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-33'/>
+    <function-decl name='zxc_write_ghi_header_and_desc' filepath='/src/src/lib/zxc_internal.h' line='1424' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-10'/>
-      <parameter type-id='type-id-28'/>
-      <parameter type-id='type-id-11'/>
+      <parameter type-id='type-id-31'/>
+      <parameter type-id='type-id-25'/>
+      <parameter type-id='type-id-27'/>
       <return type-id='type-id-11'/>
     </function-decl>
-    <function-decl name='zxc_huf_build_code_lengths_sse2' filepath='/src/src/lib/zxc_internal.h' line='1472' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-33'/>
+    <function-decl name='zxc_huf_build_code_lengths_avx2' filepath='/src/src/lib/zxc_internal.h' line='1473' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-32'/>
       <parameter type-id='type-id-10'/>
       <parameter type-id='type-id-29'/>
       <parameter type-id='type-id-11'/>
       <return type-id='type-id-11'/>
     </function-decl>
-    <function-decl name='zxc_huf_calc_size_avx2' filepath='/src/src/lib/zxc_internal.h' line='1502' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-33'/>
-      <parameter type-id='type-id-2'/>
-      <parameter type-id='type-id-11'/>
-      <return type-id='type-id-15'/>
-    </function-decl>
-    <function-decl name='zxc_huf_calc_size_avx512' filepath='/src/src/lib/zxc_internal.h' line='1502' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-33'/>
-      <parameter type-id='type-id-2'/>
-      <parameter type-id='type-id-11'/>
-      <return type-id='type-id-15'/>
-    </function-decl>
-    <function-decl name='zxc_huf_calc_size_default' filepath='/src/src/lib/zxc_internal.h' line='1502' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-33'/>
-      <parameter type-id='type-id-2'/>
-      <parameter type-id='type-id-11'/>
-      <return type-id='type-id-15'/>
-    </function-decl>
-    <function-decl name='zxc_huf_calc_size_sse2' filepath='/src/src/lib/zxc_internal.h' line='1502' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-33'/>
-      <parameter type-id='type-id-2'/>
-      <parameter type-id='type-id-11'/>
-      <return type-id='type-id-15'/>
-    </function-decl>
-    <function-decl name='zxc_huf_encode_section_avx2' filepath='/src/src/lib/zxc_internal.h' line='1506' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-2'/>
-      <parameter type-id='type-id-15'/>
-      <parameter type-id='type-id-33'/>
-      <parameter type-id='type-id-2'/>
-      <parameter type-id='type-id-10'/>
-      <parameter type-id='type-id-15'/>
-      <return type-id='type-id-11'/>
-    </function-decl>
-    <function-decl name='zxc_huf_encode_section_avx512' filepath='/src/src/lib/zxc_internal.h' line='1506' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-2'/>
-      <parameter type-id='type-id-15'/>
-      <parameter type-id='type-id-33'/>
-      <parameter type-id='type-id-2'/>
-      <parameter type-id='type-id-10'/>
-      <parameter type-id='type-id-15'/>
-      <return type-id='type-id-11'/>
-    </function-decl>
-    <function-decl name='zxc_huf_encode_section_default' filepath='/src/src/lib/zxc_internal.h' line='1506' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-2'/>
-      <parameter type-id='type-id-15'/>
-      <parameter type-id='type-id-33'/>
-      <parameter type-id='type-id-2'/>
-      <parameter type-id='type-id-10'/>
-      <parameter type-id='type-id-15'/>
-      <return type-id='type-id-11'/>
-    </function-decl>
-    <function-decl name='zxc_huf_encode_section_sse2' filepath='/src/src/lib/zxc_internal.h' line='1506' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-2'/>
-      <parameter type-id='type-id-15'/>
-      <parameter type-id='type-id-33'/>
-      <parameter type-id='type-id-2'/>
-      <parameter type-id='type-id-10'/>
-      <parameter type-id='type-id-15'/>
-      <return type-id='type-id-11'/>
-    </function-decl>
-    <function-decl name='zxc_huf_calc_size_dict_avx2' filepath='/src/src/lib/zxc_internal.h' line='1519' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-33'/>
-      <parameter type-id='type-id-2'/>
-      <parameter type-id='type-id-34'/>
-      <return type-id='type-id-15'/>
-    </function-decl>
-    <function-decl name='zxc_huf_calc_size_dict_avx512' filepath='/src/src/lib/zxc_internal.h' line='1519' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-33'/>
-      <parameter type-id='type-id-2'/>
-      <parameter type-id='type-id-34'/>
-      <return type-id='type-id-15'/>
-    </function-decl>
-    <function-decl name='zxc_huf_calc_size_dict_default' filepath='/src/src/lib/zxc_internal.h' line='1519' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-33'/>
-      <parameter type-id='type-id-2'/>
-      <parameter type-id='type-id-34'/>
-      <return type-id='type-id-15'/>
-    </function-decl>
-    <function-decl name='zxc_huf_calc_size_dict_sse2' filepath='/src/src/lib/zxc_internal.h' line='1519' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-33'/>
-      <parameter type-id='type-id-2'/>
-      <parameter type-id='type-id-34'/>
-      <return type-id='type-id-15'/>
-    </function-decl>
-    <function-decl name='zxc_huf_encode_section_dict_avx2' filepath='/src/src/lib/zxc_internal.h' line='1523' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-2'/>
-      <parameter type-id='type-id-15'/>
-      <parameter type-id='type-id-33'/>
-      <parameter type-id='type-id-2'/>
-      <parameter type-id='type-id-34'/>
-      <parameter type-id='type-id-33'/>
-      <parameter type-id='type-id-10'/>
-      <parameter type-id='type-id-15'/>
-      <return type-id='type-id-11'/>
-    </function-decl>
-    <function-decl name='zxc_huf_encode_section_dict_avx512' filepath='/src/src/lib/zxc_internal.h' line='1523' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-2'/>
-      <parameter type-id='type-id-15'/>
-      <parameter type-id='type-id-33'/>
-      <parameter type-id='type-id-2'/>
-      <parameter type-id='type-id-34'/>
-      <parameter type-id='type-id-33'/>
-      <parameter type-id='type-id-10'/>
-      <parameter type-id='type-id-15'/>
-      <return type-id='type-id-11'/>
-    </function-decl>
-    <function-decl name='zxc_huf_encode_section_dict_default' filepath='/src/src/lib/zxc_internal.h' line='1523' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-2'/>
-      <parameter type-id='type-id-15'/>
-      <parameter type-id='type-id-33'/>
-      <parameter type-id='type-id-2'/>
-      <parameter type-id='type-id-34'/>
-      <parameter type-id='type-id-33'/>
-      <parameter type-id='type-id-10'/>
-      <parameter type-id='type-id-15'/>
-      <return type-id='type-id-11'/>
-    </function-decl>
-    <function-decl name='zxc_huf_encode_section_dict_sse2' filepath='/src/src/lib/zxc_internal.h' line='1523' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-2'/>
-      <parameter type-id='type-id-15'/>
-      <parameter type-id='type-id-33'/>
-      <parameter type-id='type-id-2'/>
-      <parameter type-id='type-id-34'/>
-      <parameter type-id='type-id-33'/>
-      <parameter type-id='type-id-10'/>
-      <parameter type-id='type-id-15'/>
-      <return type-id='type-id-11'/>
-    </function-decl>
-    <function-decl name='zxc_write_block_header' filepath='/src/src/lib/zxc_internal.h' line='1867' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-10'/>
+    <function-decl name='zxc_huf_build_code_lengths_avx512' filepath='/src/src/lib/zxc_internal.h' line='1473' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-32'/>
-      <parameter type-id='type-id-35'/>
+      <parameter type-id='type-id-10'/>
+      <parameter type-id='type-id-30'/>
+      <parameter type-id='type-id-11'/>
+      <return type-id='type-id-11'/>
+    </function-decl>
+    <function-decl name='zxc_huf_build_code_lengths_default' filepath='/src/src/lib/zxc_internal.h' line='1473' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-32'/>
+      <parameter type-id='type-id-10'/>
+      <parameter type-id='type-id-28'/>
+      <parameter type-id='type-id-11'/>
+      <return type-id='type-id-11'/>
+    </function-decl>
+    <function-decl name='zxc_huf_calc_size_avx2' filepath='/src/src/lib/zxc_internal.h' line='1503' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-32'/>
+      <parameter type-id='type-id-2'/>
+      <parameter type-id='type-id-11'/>
+      <return type-id='type-id-15'/>
+    </function-decl>
+    <function-decl name='zxc_huf_calc_size_avx512' filepath='/src/src/lib/zxc_internal.h' line='1503' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-32'/>
+      <parameter type-id='type-id-2'/>
+      <parameter type-id='type-id-11'/>
+      <return type-id='type-id-15'/>
+    </function-decl>
+    <function-decl name='zxc_huf_calc_size_default' filepath='/src/src/lib/zxc_internal.h' line='1503' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-32'/>
+      <parameter type-id='type-id-2'/>
+      <parameter type-id='type-id-11'/>
+      <return type-id='type-id-15'/>
+    </function-decl>
+    <function-decl name='zxc_huf_encode_section_avx2' filepath='/src/src/lib/zxc_internal.h' line='1507' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-2'/>
+      <parameter type-id='type-id-15'/>
+      <parameter type-id='type-id-32'/>
+      <parameter type-id='type-id-2'/>
+      <parameter type-id='type-id-10'/>
+      <parameter type-id='type-id-15'/>
+      <return type-id='type-id-11'/>
+    </function-decl>
+    <function-decl name='zxc_huf_encode_section_avx512' filepath='/src/src/lib/zxc_internal.h' line='1507' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-2'/>
+      <parameter type-id='type-id-15'/>
+      <parameter type-id='type-id-32'/>
+      <parameter type-id='type-id-2'/>
+      <parameter type-id='type-id-10'/>
+      <parameter type-id='type-id-15'/>
+      <return type-id='type-id-11'/>
+    </function-decl>
+    <function-decl name='zxc_huf_encode_section_default' filepath='/src/src/lib/zxc_internal.h' line='1507' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-2'/>
+      <parameter type-id='type-id-15'/>
+      <parameter type-id='type-id-32'/>
+      <parameter type-id='type-id-2'/>
+      <parameter type-id='type-id-10'/>
+      <parameter type-id='type-id-15'/>
+      <return type-id='type-id-11'/>
+    </function-decl>
+    <function-decl name='zxc_huf_calc_size_dict_avx2' filepath='/src/src/lib/zxc_internal.h' line='1520' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-32'/>
+      <parameter type-id='type-id-2'/>
+      <parameter type-id='type-id-33'/>
+      <return type-id='type-id-15'/>
+    </function-decl>
+    <function-decl name='zxc_huf_calc_size_dict_avx512' filepath='/src/src/lib/zxc_internal.h' line='1520' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-32'/>
+      <parameter type-id='type-id-2'/>
+      <parameter type-id='type-id-33'/>
+      <return type-id='type-id-15'/>
+    </function-decl>
+    <function-decl name='zxc_huf_calc_size_dict_default' filepath='/src/src/lib/zxc_internal.h' line='1520' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-32'/>
+      <parameter type-id='type-id-2'/>
+      <parameter type-id='type-id-33'/>
+      <return type-id='type-id-15'/>
+    </function-decl>
+    <function-decl name='zxc_huf_encode_section_dict_avx2' filepath='/src/src/lib/zxc_internal.h' line='1524' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-2'/>
+      <parameter type-id='type-id-15'/>
+      <parameter type-id='type-id-32'/>
+      <parameter type-id='type-id-2'/>
+      <parameter type-id='type-id-33'/>
+      <parameter type-id='type-id-32'/>
+      <parameter type-id='type-id-10'/>
+      <parameter type-id='type-id-15'/>
+      <return type-id='type-id-11'/>
+    </function-decl>
+    <function-decl name='zxc_huf_encode_section_dict_avx512' filepath='/src/src/lib/zxc_internal.h' line='1524' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-2'/>
+      <parameter type-id='type-id-15'/>
+      <parameter type-id='type-id-32'/>
+      <parameter type-id='type-id-2'/>
+      <parameter type-id='type-id-33'/>
+      <parameter type-id='type-id-32'/>
+      <parameter type-id='type-id-10'/>
+      <parameter type-id='type-id-15'/>
+      <return type-id='type-id-11'/>
+    </function-decl>
+    <function-decl name='zxc_huf_encode_section_dict_default' filepath='/src/src/lib/zxc_internal.h' line='1524' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-2'/>
+      <parameter type-id='type-id-15'/>
+      <parameter type-id='type-id-32'/>
+      <parameter type-id='type-id-2'/>
+      <parameter type-id='type-id-33'/>
+      <parameter type-id='type-id-32'/>
+      <parameter type-id='type-id-10'/>
+      <parameter type-id='type-id-15'/>
+      <return type-id='type-id-11'/>
+    </function-decl>
+    <function-decl name='zxc_write_block_header' filepath='/src/src/lib/zxc_internal.h' line='1868' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-10'/>
+      <parameter type-id='type-id-31'/>
+      <parameter type-id='type-id-34'/>
       <return type-id='type-id-11'/>
     </function-decl>
   </abi-instr>
-  <abi-instr address-size='64' path='/src/src/lib/zxc_decompress.c' comp-dir-path='/src/build' language='LANG_C11'>
-    <pointer-type-def type-id='type-id-16' size-in-bits='64' id='type-id-36'/>
-    <qualified-type-def type-id='type-id-36' restrict='yes' id='type-id-37'/>
-    <pointer-type-def type-id='type-id-20' size-in-bits='64' id='type-id-38'/>
-    <function-decl name='zxc_read_glo_header_and_desc' filepath='/src/src/lib/zxc_internal.h' line='1409' column='1' visibility='default' binding='global' size-in-bits='64'>
+  <abi-instr address-size='64' path='/src/src/lib/zxc_decompress.c' comp-dir-path='/tmp/babi' language='LANG_C11'>
+    <pointer-type-def type-id='type-id-16' size-in-bits='64' id='type-id-35'/>
+    <qualified-type-def type-id='type-id-35' restrict='yes' id='type-id-36'/>
+    <pointer-type-def type-id='type-id-20' size-in-bits='64' id='type-id-37'/>
+    <function-decl name='zxc_read_glo_header_and_desc' filepath='/src/src/lib/zxc_internal.h' line='1410' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-2'/>
-      <parameter type-id='type-id-32'/>
+      <parameter type-id='type-id-31'/>
+      <parameter type-id='type-id-36'/>
       <parameter type-id='type-id-37'/>
-      <parameter type-id='type-id-38'/>
       <return type-id='type-id-11'/>
     </function-decl>
-    <function-decl name='zxc_read_ghi_header_and_desc' filepath='/src/src/lib/zxc_internal.h' line='1441' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='zxc_read_ghi_header_and_desc' filepath='/src/src/lib/zxc_internal.h' line='1442' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-2'/>
-      <parameter type-id='type-id-32'/>
+      <parameter type-id='type-id-31'/>
+      <parameter type-id='type-id-36'/>
       <parameter type-id='type-id-37'/>
+      <return type-id='type-id-11'/>
+    </function-decl>
+    <function-decl name='zxc_huf_decode_section_avx2' filepath='/src/src/lib/zxc_internal.h' line='1532' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-2'/>
+      <parameter type-id='type-id-15'/>
+      <parameter type-id='type-id-10'/>
+      <parameter type-id='type-id-15'/>
+      <parameter type-id='type-id-10'/>
+      <return type-id='type-id-11'/>
+    </function-decl>
+    <function-decl name='zxc_huf_decode_section_avx512' filepath='/src/src/lib/zxc_internal.h' line='1532' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-2'/>
+      <parameter type-id='type-id-15'/>
+      <parameter type-id='type-id-10'/>
+      <parameter type-id='type-id-15'/>
+      <parameter type-id='type-id-10'/>
+      <return type-id='type-id-11'/>
+    </function-decl>
+    <function-decl name='zxc_huf_decode_section_default' filepath='/src/src/lib/zxc_internal.h' line='1532' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-2'/>
+      <parameter type-id='type-id-15'/>
+      <parameter type-id='type-id-10'/>
+      <parameter type-id='type-id-15'/>
+      <parameter type-id='type-id-10'/>
+      <return type-id='type-id-11'/>
+    </function-decl>
+    <function-decl name='zxc_huf_decode_section_dict_avx2' filepath='/src/src/lib/zxc_internal.h' line='1537' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-2'/>
+      <parameter type-id='type-id-15'/>
+      <parameter type-id='type-id-10'/>
+      <parameter type-id='type-id-15'/>
+      <parameter type-id='type-id-33'/>
       <parameter type-id='type-id-38'/>
+      <parameter type-id='type-id-10'/>
       <return type-id='type-id-11'/>
     </function-decl>
-    <function-decl name='zxc_huf_decode_section_avx2' filepath='/src/src/lib/zxc_internal.h' line='1531' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='zxc_huf_decode_section_dict_avx512' filepath='/src/src/lib/zxc_internal.h' line='1537' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-2'/>
       <parameter type-id='type-id-15'/>
       <parameter type-id='type-id-10'/>
       <parameter type-id='type-id-15'/>
+      <parameter type-id='type-id-33'/>
+      <parameter type-id='type-id-38'/>
       <parameter type-id='type-id-10'/>
       <return type-id='type-id-11'/>
     </function-decl>
-    <function-decl name='zxc_huf_decode_section_avx512' filepath='/src/src/lib/zxc_internal.h' line='1531' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='zxc_huf_decode_section_dict_default' filepath='/src/src/lib/zxc_internal.h' line='1537' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-2'/>
       <parameter type-id='type-id-15'/>
       <parameter type-id='type-id-10'/>
       <parameter type-id='type-id-15'/>
+      <parameter type-id='type-id-33'/>
+      <parameter type-id='type-id-38'/>
       <parameter type-id='type-id-10'/>
       <return type-id='type-id-11'/>
     </function-decl>
-    <function-decl name='zxc_huf_decode_section_default' filepath='/src/src/lib/zxc_internal.h' line='1531' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-2'/>
-      <parameter type-id='type-id-15'/>
-      <parameter type-id='type-id-10'/>
-      <parameter type-id='type-id-15'/>
-      <parameter type-id='type-id-10'/>
-      <return type-id='type-id-11'/>
-    </function-decl>
-    <function-decl name='zxc_huf_decode_section_sse2' filepath='/src/src/lib/zxc_internal.h' line='1531' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-2'/>
-      <parameter type-id='type-id-15'/>
-      <parameter type-id='type-id-10'/>
-      <parameter type-id='type-id-15'/>
-      <parameter type-id='type-id-10'/>
-      <return type-id='type-id-11'/>
-    </function-decl>
-    <function-decl name='zxc_huf_decode_section_dict_avx2' filepath='/src/src/lib/zxc_internal.h' line='1536' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-2'/>
-      <parameter type-id='type-id-15'/>
-      <parameter type-id='type-id-10'/>
-      <parameter type-id='type-id-15'/>
-      <parameter type-id='type-id-34'/>
+    <function-decl name='zxc_cctx_alloc_entropy_scratch' filepath='/src/src/lib/zxc_internal.h' line='1730' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-39'/>
-      <parameter type-id='type-id-10'/>
-      <return type-id='type-id-11'/>
-    </function-decl>
-    <function-decl name='zxc_huf_decode_section_dict_avx512' filepath='/src/src/lib/zxc_internal.h' line='1536' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-2'/>
-      <parameter type-id='type-id-15'/>
-      <parameter type-id='type-id-10'/>
-      <parameter type-id='type-id-15'/>
-      <parameter type-id='type-id-34'/>
-      <parameter type-id='type-id-39'/>
-      <parameter type-id='type-id-10'/>
-      <return type-id='type-id-11'/>
-    </function-decl>
-    <function-decl name='zxc_huf_decode_section_dict_default' filepath='/src/src/lib/zxc_internal.h' line='1536' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-2'/>
-      <parameter type-id='type-id-15'/>
-      <parameter type-id='type-id-10'/>
-      <parameter type-id='type-id-15'/>
-      <parameter type-id='type-id-34'/>
-      <parameter type-id='type-id-39'/>
-      <parameter type-id='type-id-10'/>
-      <return type-id='type-id-11'/>
-    </function-decl>
-    <function-decl name='zxc_huf_decode_section_dict_sse2' filepath='/src/src/lib/zxc_internal.h' line='1536' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-2'/>
-      <parameter type-id='type-id-15'/>
-      <parameter type-id='type-id-10'/>
-      <parameter type-id='type-id-15'/>
-      <parameter type-id='type-id-34'/>
-      <parameter type-id='type-id-39'/>
-      <parameter type-id='type-id-10'/>
-      <return type-id='type-id-11'/>
-    </function-decl>
-    <function-decl name='zxc_cctx_alloc_entropy_scratch' filepath='/src/src/lib/zxc_internal.h' line='1729' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-40'/>
       <return type-id='type-id-11'/>
     </function-decl>
   </abi-instr>
-  <abi-instr address-size='64' path='/src/src/lib/zxc_dict.c' comp-dir-path='/src/build' language='LANG_C11'>
-    <qualified-type-def type-id='type-id-41' restrict='yes' id='type-id-33'/>
-    <pointer-type-def type-id='type-id-42' size-in-bits='64' id='type-id-40'/>
-    <qualified-type-def type-id='type-id-40' restrict='yes' id='type-id-43'/>
+  <abi-instr address-size='64' path='/src/src/lib/zxc_dict.c' comp-dir-path='/tmp/babi' language='LANG_C11'>
+    <qualified-type-def type-id='type-id-40' restrict='yes' id='type-id-32'/>
+    <pointer-type-def type-id='type-id-41' size-in-bits='64' id='type-id-39'/>
+    <qualified-type-def type-id='type-id-39' restrict='yes' id='type-id-42'/>
     <function-decl name='zxc_compress_bound' filepath='/src/src/lib/../../include/zxc_buffer.h' line='114' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-32'/>
+      <parameter type-id='type-id-31'/>
       <return type-id='type-id-22'/>
     </function-decl>
-    <function-decl name='zxc_huf_build_code_lengths' filepath='/src/src/lib/zxc_internal.h' line='1472' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-33'/>
+    <function-decl name='zxc_huf_build_code_lengths' filepath='/src/src/lib/zxc_internal.h' line='1473' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-32'/>
       <parameter type-id='type-id-10'/>
-      <parameter type-id='type-id-44'/>
+      <parameter type-id='type-id-43'/>
       <parameter type-id='type-id-11'/>
       <return type-id='type-id-11'/>
     </function-decl>
-    <function-decl name='zxc_huf_pack_lengths' filepath='/src/src/lib/zxc_internal.h' line='1478' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='zxc_huf_pack_lengths' filepath='/src/src/lib/zxc_internal.h' line='1479' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-2'/>
       <parameter type-id='type-id-10'/>
       <return type-id='type-id-13'/>
     </function-decl>
-    <function-decl name='zxc_cctx_init' filepath='/src/src/lib/zxc_internal.h' line='1647' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-40'/>
-      <parameter type-id='type-id-32'/>
-      <parameter type-id='type-id-45'/>
-      <parameter type-id='type-id-45'/>
-      <parameter type-id='type-id-45'/>
-      <parameter type-id='type-id-32'/>
+    <function-decl name='zxc_cctx_init' filepath='/src/src/lib/zxc_internal.h' line='1648' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-39'/>
+      <parameter type-id='type-id-31'/>
+      <parameter type-id='type-id-44'/>
+      <parameter type-id='type-id-44'/>
+      <parameter type-id='type-id-44'/>
+      <parameter type-id='type-id-31'/>
       <return type-id='type-id-11'/>
     </function-decl>
-    <function-decl name='zxc_cctx_free' filepath='/src/src/lib/zxc_internal.h' line='1739' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-40'/>
+    <function-decl name='zxc_cctx_free' filepath='/src/src/lib/zxc_internal.h' line='1740' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-39'/>
       <return type-id='type-id-13'/>
     </function-decl>
-    <function-decl name='zxc_compress_chunk_wrapper' filepath='/src/src/lib/zxc_internal.h' line='1786' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-43'/>
+    <function-decl name='zxc_compress_chunk_wrapper' filepath='/src/src/lib/zxc_internal.h' line='1787' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-42'/>
       <parameter type-id='type-id-2'/>
-      <parameter type-id='type-id-32'/>
+      <parameter type-id='type-id-31'/>
       <parameter type-id='type-id-10'/>
-      <parameter type-id='type-id-32'/>
+      <parameter type-id='type-id-31'/>
       <return type-id='type-id-11'/>
     </function-decl>
-    <function-decl name='malloc' filepath='/src/usr/include/stdlib.h' line='672' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='malloc' filepath='/usr/include/stdlib.h' line='672' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-15'/>
       <return type-id='type-id-12'/>
     </function-decl>
   </abi-instr>
-  <abi-instr address-size='64' path='/src/src/lib/zxc_dispatch.c' comp-dir-path='/src/build' language='LANG_C11'>
-    <qualified-type-def type-id='type-id-3' const='yes' id='type-id-46'/>
-    <pointer-type-def type-id='type-id-46' size-in-bits='64' id='type-id-47'/>
-    <qualified-type-def type-id='type-id-47' restrict='yes' id='type-id-39'/>
-    <qualified-type-def type-id='type-id-6' const='yes' id='type-id-48'/>
-    <pointer-type-def type-id='type-id-48' size-in-bits='64' id='type-id-49'/>
-    <qualified-type-def type-id='type-id-49' restrict='yes' id='type-id-34'/>
+  <abi-instr address-size='64' path='/src/src/lib/zxc_dispatch.c' comp-dir-path='/tmp/babi' language='LANG_C11'>
+    <qualified-type-def type-id='type-id-3' const='yes' id='type-id-45'/>
+    <pointer-type-def type-id='type-id-45' size-in-bits='64' id='type-id-46'/>
+    <qualified-type-def type-id='type-id-46' restrict='yes' id='type-id-38'/>
+    <qualified-type-def type-id='type-id-6' const='yes' id='type-id-47'/>
+    <pointer-type-def type-id='type-id-47' size-in-bits='64' id='type-id-48'/>
+    <qualified-type-def type-id='type-id-48' restrict='yes' id='type-id-33'/>
     <function-decl name='zxc_dict_id' filepath='/src/src/lib/../../include/zxc_dict.h' line='76' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-12'/>
       <parameter type-id='type-id-15'/>
@@ -465,567 +407,527 @@
       <return type-id='type-id-18'/>
     </function-decl>
     <function-decl name='zxc_write_seek_table' filepath='/src/src/lib/../../include/zxc_seekable.h' line='269' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-49'/>
+      <parameter type-id='type-id-31'/>
+      <parameter type-id='type-id-40'/>
       <parameter type-id='type-id-50'/>
-      <parameter type-id='type-id-32'/>
-      <parameter type-id='type-id-41'/>
-      <parameter type-id='type-id-51'/>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-51'/>
     </function-decl>
-    <function-decl name='zxc_decompress_chunk_wrapper_default' filepath='/src/src/lib/zxc_dispatch.c' line='51' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-53'/>
+    <function-decl name='zxc_decompress_chunk_wrapper_default' filepath='/src/src/lib/zxc_dispatch.c' line='57' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-52'/>
       <parameter type-id='type-id-2'/>
-      <parameter type-id='type-id-32'/>
+      <parameter type-id='type-id-31'/>
       <parameter type-id='type-id-10'/>
-      <parameter type-id='type-id-32'/>
+      <parameter type-id='type-id-31'/>
       <return type-id='type-id-11'/>
     </function-decl>
-    <function-decl name='zxc_decompress_chunk_wrapper_dict_default' filepath='/src/src/lib/zxc_dispatch.c' line='54' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-53'/>
+    <function-decl name='zxc_decompress_chunk_wrapper_dict_default' filepath='/src/src/lib/zxc_dispatch.c' line='60' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-52'/>
       <parameter type-id='type-id-2'/>
-      <parameter type-id='type-id-32'/>
+      <parameter type-id='type-id-31'/>
       <parameter type-id='type-id-10'/>
-      <parameter type-id='type-id-32'/>
+      <parameter type-id='type-id-31'/>
       <return type-id='type-id-11'/>
     </function-decl>
-    <function-decl name='zxc_decompress_chunk_wrapper_safe_default' filepath='/src/src/lib/zxc_dispatch.c' line='57' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-53'/>
+    <function-decl name='zxc_decompress_chunk_wrapper_safe_default' filepath='/src/src/lib/zxc_dispatch.c' line='63' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-52'/>
       <parameter type-id='type-id-2'/>
-      <parameter type-id='type-id-32'/>
+      <parameter type-id='type-id-31'/>
       <parameter type-id='type-id-10'/>
-      <parameter type-id='type-id-32'/>
+      <parameter type-id='type-id-31'/>
       <return type-id='type-id-11'/>
     </function-decl>
-    <function-decl name='zxc_decompress_chunk_wrapper_avx2' filepath='/src/src/lib/zxc_dispatch.c' line='63' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-53'/>
+    <function-decl name='zxc_decompress_chunk_wrapper_avx2' filepath='/src/src/lib/zxc_dispatch.c' line='69' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-52'/>
       <parameter type-id='type-id-2'/>
-      <parameter type-id='type-id-32'/>
+      <parameter type-id='type-id-31'/>
       <parameter type-id='type-id-10'/>
-      <parameter type-id='type-id-32'/>
+      <parameter type-id='type-id-31'/>
       <return type-id='type-id-11'/>
     </function-decl>
-    <function-decl name='zxc_decompress_chunk_wrapper_dict_avx2' filepath='/src/src/lib/zxc_dispatch.c' line='66' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-53'/>
+    <function-decl name='zxc_decompress_chunk_wrapper_dict_avx2' filepath='/src/src/lib/zxc_dispatch.c' line='72' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-52'/>
       <parameter type-id='type-id-2'/>
-      <parameter type-id='type-id-32'/>
+      <parameter type-id='type-id-31'/>
       <parameter type-id='type-id-10'/>
-      <parameter type-id='type-id-32'/>
+      <parameter type-id='type-id-31'/>
       <return type-id='type-id-11'/>
     </function-decl>
-    <function-decl name='zxc_decompress_chunk_wrapper_avx512' filepath='/src/src/lib/zxc_dispatch.c' line='69' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-53'/>
+    <function-decl name='zxc_decompress_chunk_wrapper_avx512' filepath='/src/src/lib/zxc_dispatch.c' line='75' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-52'/>
       <parameter type-id='type-id-2'/>
-      <parameter type-id='type-id-32'/>
+      <parameter type-id='type-id-31'/>
       <parameter type-id='type-id-10'/>
-      <parameter type-id='type-id-32'/>
+      <parameter type-id='type-id-31'/>
       <return type-id='type-id-11'/>
     </function-decl>
-    <function-decl name='zxc_decompress_chunk_wrapper_dict_avx512' filepath='/src/src/lib/zxc_dispatch.c' line='72' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-53'/>
+    <function-decl name='zxc_decompress_chunk_wrapper_dict_avx512' filepath='/src/src/lib/zxc_dispatch.c' line='78' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-52'/>
       <parameter type-id='type-id-2'/>
-      <parameter type-id='type-id-32'/>
+      <parameter type-id='type-id-31'/>
       <parameter type-id='type-id-10'/>
-      <parameter type-id='type-id-32'/>
+      <parameter type-id='type-id-31'/>
       <return type-id='type-id-11'/>
     </function-decl>
-    <function-decl name='zxc_decompress_chunk_wrapper_safe_avx2' filepath='/src/src/lib/zxc_dispatch.c' line='75' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-53'/>
+    <function-decl name='zxc_decompress_chunk_wrapper_safe_avx2' filepath='/src/src/lib/zxc_dispatch.c' line='81' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-52'/>
       <parameter type-id='type-id-2'/>
-      <parameter type-id='type-id-32'/>
+      <parameter type-id='type-id-31'/>
       <parameter type-id='type-id-10'/>
-      <parameter type-id='type-id-32'/>
+      <parameter type-id='type-id-31'/>
       <return type-id='type-id-11'/>
     </function-decl>
-    <function-decl name='zxc_decompress_chunk_wrapper_safe_avx512' filepath='/src/src/lib/zxc_dispatch.c' line='78' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-53'/>
+    <function-decl name='zxc_decompress_chunk_wrapper_safe_avx512' filepath='/src/src/lib/zxc_dispatch.c' line='84' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-52'/>
       <parameter type-id='type-id-2'/>
-      <parameter type-id='type-id-32'/>
+      <parameter type-id='type-id-31'/>
       <parameter type-id='type-id-10'/>
-      <parameter type-id='type-id-32'/>
+      <parameter type-id='type-id-31'/>
       <return type-id='type-id-11'/>
     </function-decl>
-    <function-decl name='zxc_decompress_chunk_wrapper_sse2' filepath='/src/src/lib/zxc_dispatch.c' line='81' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-53'/>
+    <function-decl name='zxc_compress_chunk_wrapper_default' filepath='/src/src/lib/zxc_dispatch.c' line='101' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-42'/>
       <parameter type-id='type-id-2'/>
-      <parameter type-id='type-id-32'/>
+      <parameter type-id='type-id-31'/>
       <parameter type-id='type-id-10'/>
-      <parameter type-id='type-id-32'/>
+      <parameter type-id='type-id-31'/>
       <return type-id='type-id-11'/>
     </function-decl>
-    <function-decl name='zxc_decompress_chunk_wrapper_dict_sse2' filepath='/src/src/lib/zxc_dispatch.c' line='84' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-53'/>
-      <parameter type-id='type-id-2'/>
-      <parameter type-id='type-id-32'/>
-      <parameter type-id='type-id-10'/>
-      <parameter type-id='type-id-32'/>
-      <return type-id='type-id-11'/>
-    </function-decl>
-    <function-decl name='zxc_decompress_chunk_wrapper_safe_sse2' filepath='/src/src/lib/zxc_dispatch.c' line='87' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-53'/>
-      <parameter type-id='type-id-2'/>
-      <parameter type-id='type-id-32'/>
-      <parameter type-id='type-id-10'/>
-      <parameter type-id='type-id-32'/>
-      <return type-id='type-id-11'/>
-    </function-decl>
-    <function-decl name='zxc_compress_chunk_wrapper_default' filepath='/src/src/lib/zxc_dispatch.c' line='104' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-43'/>
-      <parameter type-id='type-id-2'/>
-      <parameter type-id='type-id-32'/>
-      <parameter type-id='type-id-10'/>
-      <parameter type-id='type-id-32'/>
-      <return type-id='type-id-11'/>
-    </function-decl>
-    <function-decl name='zxc_huf_dict_tree_build_default' filepath='/src/src/lib/zxc_dispatch.c' line='132' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-2'/>
-      <parameter type-id='type-id-8'/>
-      <parameter type-id='type-id-9'/>
-      <parameter type-id='type-id-10'/>
-      <parameter type-id='type-id-5'/>
-      <return type-id='type-id-11'/>
-    </function-decl>
-    <function-decl name='zxc_huf_pack_lengths_default' filepath='/src/src/lib/zxc_dispatch.c' line='139' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='zxc_huf_pack_lengths_default' filepath='/src/src/lib/zxc_dispatch.c' line='132' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-2'/>
       <parameter type-id='type-id-10'/>
       <return type-id='type-id-13'/>
     </function-decl>
-    <function-decl name='zxc_huf_unpack_lengths_default' filepath='/src/src/lib/zxc_dispatch.c' line='140' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='zxc_huf_unpack_lengths_default' filepath='/src/src/lib/zxc_dispatch.c' line='133' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-2'/>
       <parameter type-id='type-id-10'/>
       <return type-id='type-id-11'/>
     </function-decl>
-    <function-decl name='zxc_compress_chunk_wrapper_avx2' filepath='/src/src/lib/zxc_dispatch.c' line='143' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-43'/>
+    <function-decl name='zxc_compress_chunk_wrapper_avx2' filepath='/src/src/lib/zxc_dispatch.c' line='136' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-42'/>
       <parameter type-id='type-id-2'/>
-      <parameter type-id='type-id-32'/>
+      <parameter type-id='type-id-31'/>
       <parameter type-id='type-id-10'/>
-      <parameter type-id='type-id-32'/>
+      <parameter type-id='type-id-31'/>
       <return type-id='type-id-11'/>
     </function-decl>
-    <function-decl name='zxc_compress_chunk_wrapper_avx512' filepath='/src/src/lib/zxc_dispatch.c' line='146' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-43'/>
+    <function-decl name='zxc_compress_chunk_wrapper_avx512' filepath='/src/src/lib/zxc_dispatch.c' line='139' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-42'/>
       <parameter type-id='type-id-2'/>
-      <parameter type-id='type-id-32'/>
+      <parameter type-id='type-id-31'/>
       <parameter type-id='type-id-10'/>
-      <parameter type-id='type-id-32'/>
+      <parameter type-id='type-id-31'/>
       <return type-id='type-id-11'/>
     </function-decl>
-    <function-decl name='zxc_compress_chunk_wrapper_sse2' filepath='/src/src/lib/zxc_dispatch.c' line='149' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-43'/>
-      <parameter type-id='type-id-2'/>
-      <parameter type-id='type-id-32'/>
-      <parameter type-id='type-id-10'/>
-      <parameter type-id='type-id-32'/>
-      <return type-id='type-id-11'/>
-    </function-decl>
-    <function-decl name='zxc_cctx_attach_dict_huf' filepath='/src/src/lib/zxc_internal.h' line='1662' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-43'/>
+    <function-decl name='zxc_cctx_attach_dict_huf' filepath='/src/src/lib/zxc_internal.h' line='1663' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-42'/>
       <parameter type-id='type-id-2'/>
       <return type-id='type-id-11'/>
     </function-decl>
-    <function-decl name='zxc_cctx_compute_workspace_size' filepath='/src/src/lib/zxc_internal.h' line='1679' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-32'/>
-      <parameter type-id='type-id-45'/>
-      <parameter type-id='type-id-45'/>
-      <parameter type-id='type-id-32'/>
+    <function-decl name='zxc_cctx_compute_workspace_size' filepath='/src/src/lib/zxc_internal.h' line='1680' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-31'/>
+      <parameter type-id='type-id-44'/>
+      <parameter type-id='type-id-44'/>
+      <parameter type-id='type-id-31'/>
       <return type-id='type-id-15'/>
     </function-decl>
-    <function-decl name='zxc_cctx_init_in_workspace' filepath='/src/src/lib/zxc_internal.h' line='1714' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-43'/>
-      <parameter type-id='type-id-54'/>
-      <parameter type-id='type-id-32'/>
-      <parameter type-id='type-id-32'/>
-      <parameter type-id='type-id-45'/>
-      <parameter type-id='type-id-45'/>
-      <parameter type-id='type-id-45'/>
-      <parameter type-id='type-id-32'/>
-      <parameter type-id='type-id-45'/>
+    <function-decl name='zxc_cctx_init_in_workspace' filepath='/src/src/lib/zxc_internal.h' line='1715' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-42'/>
+      <parameter type-id='type-id-53'/>
+      <parameter type-id='type-id-31'/>
+      <parameter type-id='type-id-31'/>
+      <parameter type-id='type-id-44'/>
+      <parameter type-id='type-id-44'/>
+      <parameter type-id='type-id-44'/>
+      <parameter type-id='type-id-31'/>
+      <parameter type-id='type-id-44'/>
       <return type-id='type-id-11'/>
     </function-decl>
-    <function-decl name='zxc_write_file_header' filepath='/src/src/lib/zxc_internal.h' line='1828' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='zxc_write_file_header' filepath='/src/src/lib/zxc_internal.h' line='1829' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-10'/>
-      <parameter type-id='type-id-32'/>
-      <parameter type-id='type-id-32'/>
-      <parameter type-id='type-id-45'/>
-      <parameter type-id='type-id-51'/>
+      <parameter type-id='type-id-31'/>
+      <parameter type-id='type-id-31'/>
+      <parameter type-id='type-id-44'/>
+      <parameter type-id='type-id-50'/>
       <return type-id='type-id-11'/>
     </function-decl>
-    <function-decl name='zxc_read_file_header' filepath='/src/src/lib/zxc_internal.h' line='1850' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='zxc_read_file_header' filepath='/src/src/lib/zxc_internal.h' line='1851' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-2'/>
-      <parameter type-id='type-id-32'/>
+      <parameter type-id='type-id-31'/>
+      <parameter type-id='type-id-54'/>
       <parameter type-id='type-id-55'/>
       <parameter type-id='type-id-56'/>
+      <return type-id='type-id-11'/>
+    </function-decl>
+    <function-decl name='zxc_read_block_header' filepath='/src/src/lib/zxc_internal.h' line='1885' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-2'/>
+      <parameter type-id='type-id-31'/>
       <parameter type-id='type-id-57'/>
       <return type-id='type-id-11'/>
     </function-decl>
-    <function-decl name='zxc_read_block_header' filepath='/src/src/lib/zxc_internal.h' line='1884' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-2'/>
-      <parameter type-id='type-id-32'/>
-      <parameter type-id='type-id-58'/>
-      <return type-id='type-id-11'/>
-    </function-decl>
-    <function-decl name='zxc_write_file_footer' filepath='/src/src/lib/zxc_internal.h' line='1903' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='zxc_write_file_footer' filepath='/src/src/lib/zxc_internal.h' line='1904' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-10'/>
-      <parameter type-id='type-id-32'/>
-      <parameter type-id='type-id-59'/>
-      <parameter type-id='type-id-51'/>
-      <parameter type-id='type-id-45'/>
+      <parameter type-id='type-id-31'/>
+      <parameter type-id='type-id-58'/>
+      <parameter type-id='type-id-50'/>
+      <parameter type-id='type-id-44'/>
       <return type-id='type-id-11'/>
     </function-decl>
-    <function-decl name='calloc' filepath='/src/usr/include/stdlib.h' line='675' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='calloc' filepath='/usr/include/stdlib.h' line='675' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-15'/>
       <parameter type-id='type-id-15'/>
       <return type-id='type-id-12'/>
     </function-decl>
-    <function-decl name='realloc' filepath='/src/usr/include/stdlib.h' line='683' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='realloc' filepath='/usr/include/stdlib.h' line='683' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-12'/>
       <parameter type-id='type-id-15'/>
       <return type-id='type-id-12'/>
     </function-decl>
   </abi-instr>
-  <abi-instr address-size='64' path='/src/src/lib/zxc_driver.c' comp-dir-path='/src/build' language='LANG_C11'>
-    <array-type-def dimensions='1' type-id='type-id-60' size-in-bits='320' id='type-id-61'>
-      <subrange length='40' lower-bound='0' upper-bound='39' type-id='type-id-62' id='type-id-63'/>
+  <abi-instr address-size='64' path='/src/src/lib/zxc_driver.c' comp-dir-path='/tmp/babi' language='LANG_C11'>
+    <array-type-def dimensions='1' type-id='type-id-59' size-in-bits='320' id='type-id-60'>
+      <subrange length='40' lower-bound='0' upper-bound='39' type-id='type-id-61' id='type-id-62'/>
     </array-type-def>
-    <array-type-def dimensions='1' type-id='type-id-60' size-in-bits='384' id='type-id-64'>
-      <subrange length='48' lower-bound='0' upper-bound='47' type-id='type-id-62' id='type-id-65'/>
+    <array-type-def dimensions='1' type-id='type-id-59' size-in-bits='384' id='type-id-63'>
+      <subrange length='48' lower-bound='0' upper-bound='47' type-id='type-id-61' id='type-id-64'/>
     </array-type-def>
-    <array-type-def dimensions='1' type-id='type-id-60' size-in-bits='32' id='type-id-66'>
-      <subrange length='4' lower-bound='0' upper-bound='3' type-id='type-id-62' id='type-id-67'/>
+    <array-type-def dimensions='1' type-id='type-id-59' size-in-bits='32' id='type-id-65'>
+      <subrange length='4' lower-bound='0' upper-bound='3' type-id='type-id-61' id='type-id-66'/>
     </array-type-def>
-    <array-type-def dimensions='1' type-id='type-id-60' size-in-bits='448' id='type-id-68'>
-      <subrange length='56' lower-bound='0' upper-bound='55' type-id='type-id-62' id='type-id-69'/>
+    <array-type-def dimensions='1' type-id='type-id-59' size-in-bits='448' id='type-id-67'>
+      <subrange length='56' lower-bound='0' upper-bound='55' type-id='type-id-61' id='type-id-68'/>
     </array-type-def>
-    <type-decl name='long long int' size-in-bits='64' id='type-id-70'/>
-    <class-decl name='__pthread_cond_s' size-in-bits='384' is-struct='yes' visibility='default' filepath='/src/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='94' column='1' id='type-id-71'>
+    <type-decl name='long long int' size-in-bits='64' id='type-id-69'/>
+    <class-decl name='__pthread_cond_s' size-in-bits='384' is-struct='yes' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='94' column='1' id='type-id-70'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='__wseq' type-id='type-id-72' visibility='default' filepath='/src/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='96' column='1'/>
+        <var-decl name='__wseq' type-id='type-id-71' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='96' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='__g1_start' type-id='type-id-72' visibility='default' filepath='/src/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='97' column='1'/>
+        <var-decl name='__g1_start' type-id='type-id-71' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='97' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='__g_refs' type-id='type-id-73' visibility='default' filepath='/src/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='98' column='1'/>
+        <var-decl name='__g_refs' type-id='type-id-72' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='98' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='__g_size' type-id='type-id-73' visibility='default' filepath='/src/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='99' column='1'/>
+        <var-decl name='__g_size' type-id='type-id-72' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='99' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='__g1_orig_size' type-id='type-id-74' visibility='default' filepath='/src/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='100' column='1'/>
+        <var-decl name='__g1_orig_size' type-id='type-id-73' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='100' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='288'>
-        <var-decl name='__wrefs' type-id='type-id-74' visibility='default' filepath='/src/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='101' column='1'/>
+        <var-decl name='__wrefs' type-id='type-id-73' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='101' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='__g_signals' type-id='type-id-73' visibility='default' filepath='/src/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='102' column='1'/>
+        <var-decl name='__g_signals' type-id='type-id-72' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='102' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='__pthread_internal_list' size-in-bits='128' is-struct='yes' visibility='default' filepath='/src/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='51' column='1' id='type-id-75'>
+    <class-decl name='__pthread_internal_list' size-in-bits='128' is-struct='yes' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='51' column='1' id='type-id-74'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='__prev' type-id='type-id-76' visibility='default' filepath='/src/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='53' column='1'/>
+        <var-decl name='__prev' type-id='type-id-75' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='53' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='__next' type-id='type-id-76' visibility='default' filepath='/src/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='54' column='1'/>
+        <var-decl name='__next' type-id='type-id-75' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='54' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='__pthread_mutex_s' size-in-bits='320' is-struct='yes' visibility='default' filepath='/src/usr/include/x86_64-linux-gnu/bits/struct_mutex.h' line='22' column='1' id='type-id-77'>
+    <class-decl name='__pthread_mutex_s' size-in-bits='320' is-struct='yes' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/struct_mutex.h' line='22' column='1' id='type-id-76'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='__lock' type-id='type-id-11' visibility='default' filepath='/src/usr/include/x86_64-linux-gnu/bits/struct_mutex.h' line='24' column='1'/>
+        <var-decl name='__lock' type-id='type-id-11' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/struct_mutex.h' line='24' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='__count' type-id='type-id-74' visibility='default' filepath='/src/usr/include/x86_64-linux-gnu/bits/struct_mutex.h' line='25' column='1'/>
+        <var-decl name='__count' type-id='type-id-73' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/struct_mutex.h' line='25' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='__owner' type-id='type-id-11' visibility='default' filepath='/src/usr/include/x86_64-linux-gnu/bits/struct_mutex.h' line='26' column='1'/>
+        <var-decl name='__owner' type-id='type-id-11' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/struct_mutex.h' line='26' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='96'>
-        <var-decl name='__nusers' type-id='type-id-74' visibility='default' filepath='/src/usr/include/x86_64-linux-gnu/bits/struct_mutex.h' line='28' column='1'/>
+        <var-decl name='__nusers' type-id='type-id-73' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/struct_mutex.h' line='28' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='__kind' type-id='type-id-11' visibility='default' filepath='/src/usr/include/x86_64-linux-gnu/bits/struct_mutex.h' line='32' column='1'/>
+        <var-decl name='__kind' type-id='type-id-11' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/struct_mutex.h' line='32' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='160'>
-        <var-decl name='__spins' type-id='type-id-78' visibility='default' filepath='/src/usr/include/x86_64-linux-gnu/bits/struct_mutex.h' line='34' column='1'/>
+        <var-decl name='__spins' type-id='type-id-77' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/struct_mutex.h' line='34' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='176'>
-        <var-decl name='__elision' type-id='type-id-78' visibility='default' filepath='/src/usr/include/x86_64-linux-gnu/bits/struct_mutex.h' line='35' column='1'/>
+        <var-decl name='__elision' type-id='type-id-77' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/struct_mutex.h' line='35' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='__list' type-id='type-id-79' visibility='default' filepath='/src/usr/include/x86_64-linux-gnu/bits/struct_mutex.h' line='36' column='1'/>
+        <var-decl name='__list' type-id='type-id-78' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/struct_mutex.h' line='36' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='__anonymous_struct__' size-in-bits='64' is-struct='yes' is-anonymous='yes' visibility='default' filepath='/src/usr/include/x86_64-linux-gnu/bits/atomic_wide_counter.h' line='28' column='1' id='type-id-80'>
+    <class-decl name='__anonymous_struct__' size-in-bits='64' is-struct='yes' is-anonymous='yes' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/atomic_wide_counter.h' line='28' column='1' id='type-id-79'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='__low' type-id='type-id-74' visibility='default' filepath='/src/usr/include/x86_64-linux-gnu/bits/atomic_wide_counter.h' line='30' column='1'/>
+        <var-decl name='__low' type-id='type-id-73' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/atomic_wide_counter.h' line='30' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='__high' type-id='type-id-74' visibility='default' filepath='/src/usr/include/x86_64-linux-gnu/bits/atomic_wide_counter.h' line='31' column='1'/>
+        <var-decl name='__high' type-id='type-id-73' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/atomic_wide_counter.h' line='31' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='__atomic_wide_counter' type-id='type-id-81' filepath='/src/usr/include/x86_64-linux-gnu/bits/atomic_wide_counter.h' line='33' column='1' id='type-id-72'/>
-    <typedef-decl name='__pthread_list_t' type-id='type-id-75' filepath='/src/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='55' column='1' id='type-id-79'/>
-    <typedef-decl name='__ssize_t' type-id='type-id-82' filepath='/src/usr/include/x86_64-linux-gnu/bits/types.h' line='194' column='1' id='type-id-83'/>
-    <typedef-decl name='pthread_attr_t' type-id='type-id-84' filepath='/src/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='62' column='1' id='type-id-85'/>
-    <typedef-decl name='pthread_cond_t' type-id='type-id-86' filepath='/src/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='80' column='1' id='type-id-87'/>
-    <typedef-decl name='pthread_condattr_t' type-id='type-id-88' filepath='/src/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='45' column='1' id='type-id-89'/>
-    <typedef-decl name='pthread_mutex_t' type-id='type-id-90' filepath='/src/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='72' column='1' id='type-id-91'/>
-    <typedef-decl name='pthread_mutexattr_t' type-id='type-id-92' filepath='/src/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='36' column='1' id='type-id-93'/>
-    <typedef-decl name='pthread_t' type-id='type-id-62' filepath='/src/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='27' column='1' id='type-id-94'/>
-    <typedef-decl name='ssize_t' type-id='type-id-83' filepath='/src/usr/include/stdio.h' line='78' column='1' id='type-id-95'/>
-    <union-decl name='__atomic_wide_counter' size-in-bits='64' naming-typedef-id='type-id-72' visibility='default' filepath='/src/usr/include/x86_64-linux-gnu/bits/atomic_wide_counter.h' line='25' column='1' id='type-id-81'>
+    <typedef-decl name='__atomic_wide_counter' type-id='type-id-80' filepath='/usr/include/x86_64-linux-gnu/bits/atomic_wide_counter.h' line='33' column='1' id='type-id-71'/>
+    <typedef-decl name='__pthread_list_t' type-id='type-id-74' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='55' column='1' id='type-id-78'/>
+    <typedef-decl name='__ssize_t' type-id='type-id-81' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='194' column='1' id='type-id-82'/>
+    <typedef-decl name='pthread_attr_t' type-id='type-id-83' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='62' column='1' id='type-id-84'/>
+    <typedef-decl name='pthread_cond_t' type-id='type-id-85' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='80' column='1' id='type-id-86'/>
+    <typedef-decl name='pthread_condattr_t' type-id='type-id-87' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='45' column='1' id='type-id-88'/>
+    <typedef-decl name='pthread_mutex_t' type-id='type-id-89' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='72' column='1' id='type-id-90'/>
+    <typedef-decl name='pthread_mutexattr_t' type-id='type-id-91' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='36' column='1' id='type-id-92'/>
+    <typedef-decl name='pthread_t' type-id='type-id-61' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='27' column='1' id='type-id-93'/>
+    <typedef-decl name='ssize_t' type-id='type-id-82' filepath='/usr/include/stdio.h' line='78' column='1' id='type-id-94'/>
+    <union-decl name='__atomic_wide_counter' size-in-bits='64' naming-typedef-id='type-id-71' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/atomic_wide_counter.h' line='25' column='1' id='type-id-80'>
       <data-member access='public'>
-        <var-decl name='__value64' type-id='type-id-96' visibility='default' filepath='/src/usr/include/x86_64-linux-gnu/bits/atomic_wide_counter.h' line='27' column='1'/>
+        <var-decl name='__value64' type-id='type-id-95' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/atomic_wide_counter.h' line='27' column='1'/>
       </data-member>
       <data-member access='public'>
-        <var-decl name='__value32' type-id='type-id-80' visibility='default' filepath='/src/usr/include/x86_64-linux-gnu/bits/atomic_wide_counter.h' line='32' column='1'/>
-      </data-member>
-    </union-decl>
-    <union-decl name='pthread_attr_t' size-in-bits='448' visibility='default' filepath='/src/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='56' column='1' id='type-id-84'>
-      <data-member access='public'>
-        <var-decl name='__size' type-id='type-id-68' visibility='default' filepath='/src/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='58' column='1'/>
-      </data-member>
-      <data-member access='public'>
-        <var-decl name='__align' type-id='type-id-82' visibility='default' filepath='/src/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='59' column='1'/>
+        <var-decl name='__value32' type-id='type-id-79' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/atomic_wide_counter.h' line='32' column='1'/>
       </data-member>
     </union-decl>
-    <union-decl name='pthread_cond_t' size-in-bits='384' naming-typedef-id='type-id-87' visibility='default' filepath='/src/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='75' column='1' id='type-id-86'>
+    <union-decl name='pthread_attr_t' size-in-bits='448' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='56' column='1' id='type-id-83'>
       <data-member access='public'>
-        <var-decl name='__data' type-id='type-id-71' visibility='default' filepath='/src/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='77' column='1'/>
+        <var-decl name='__size' type-id='type-id-67' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='58' column='1'/>
       </data-member>
       <data-member access='public'>
-        <var-decl name='__size' type-id='type-id-64' visibility='default' filepath='/src/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='78' column='1'/>
-      </data-member>
-      <data-member access='public'>
-        <var-decl name='__align' type-id='type-id-70' visibility='default' filepath='/src/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='79' column='1'/>
+        <var-decl name='__align' type-id='type-id-81' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='59' column='1'/>
       </data-member>
     </union-decl>
-    <union-decl name='pthread_condattr_t' size-in-bits='32' naming-typedef-id='type-id-89' visibility='default' filepath='/src/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='41' column='1' id='type-id-88'>
+    <union-decl name='pthread_cond_t' size-in-bits='384' naming-typedef-id='type-id-86' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='75' column='1' id='type-id-85'>
       <data-member access='public'>
-        <var-decl name='__size' type-id='type-id-66' visibility='default' filepath='/src/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='43' column='1'/>
+        <var-decl name='__data' type-id='type-id-70' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='77' column='1'/>
       </data-member>
       <data-member access='public'>
-        <var-decl name='__align' type-id='type-id-11' visibility='default' filepath='/src/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='44' column='1'/>
-      </data-member>
-    </union-decl>
-    <union-decl name='pthread_mutex_t' size-in-bits='320' naming-typedef-id='type-id-91' visibility='default' filepath='/src/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='67' column='1' id='type-id-90'>
-      <data-member access='public'>
-        <var-decl name='__data' type-id='type-id-77' visibility='default' filepath='/src/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='69' column='1'/>
+        <var-decl name='__size' type-id='type-id-63' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='78' column='1'/>
       </data-member>
       <data-member access='public'>
-        <var-decl name='__size' type-id='type-id-61' visibility='default' filepath='/src/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='70' column='1'/>
-      </data-member>
-      <data-member access='public'>
-        <var-decl name='__align' type-id='type-id-82' visibility='default' filepath='/src/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='71' column='1'/>
+        <var-decl name='__align' type-id='type-id-69' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='79' column='1'/>
       </data-member>
     </union-decl>
-    <union-decl name='pthread_mutexattr_t' size-in-bits='32' naming-typedef-id='type-id-93' visibility='default' filepath='/src/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='32' column='1' id='type-id-92'>
+    <union-decl name='pthread_condattr_t' size-in-bits='32' naming-typedef-id='type-id-88' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='41' column='1' id='type-id-87'>
       <data-member access='public'>
-        <var-decl name='__size' type-id='type-id-66' visibility='default' filepath='/src/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='34' column='1'/>
+        <var-decl name='__size' type-id='type-id-65' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='43' column='1'/>
       </data-member>
       <data-member access='public'>
-        <var-decl name='__align' type-id='type-id-11' visibility='default' filepath='/src/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='35' column='1'/>
+        <var-decl name='__align' type-id='type-id-11' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='44' column='1'/>
       </data-member>
     </union-decl>
-    <array-type-def dimensions='1' type-id='type-id-74' size-in-bits='64' id='type-id-73'>
-      <subrange length='2' lower-bound='0' upper-bound='1' type-id='type-id-62' id='type-id-97'/>
+    <union-decl name='pthread_mutex_t' size-in-bits='320' naming-typedef-id='type-id-90' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='67' column='1' id='type-id-89'>
+      <data-member access='public'>
+        <var-decl name='__data' type-id='type-id-76' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='69' column='1'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='__size' type-id='type-id-60' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='70' column='1'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='__align' type-id='type-id-81' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='71' column='1'/>
+      </data-member>
+    </union-decl>
+    <union-decl name='pthread_mutexattr_t' size-in-bits='32' naming-typedef-id='type-id-92' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='32' column='1' id='type-id-91'>
+      <data-member access='public'>
+        <var-decl name='__size' type-id='type-id-65' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='34' column='1'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='__align' type-id='type-id-11' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='35' column='1'/>
+      </data-member>
+    </union-decl>
+    <array-type-def dimensions='1' type-id='type-id-73' size-in-bits='64' id='type-id-72'>
+      <subrange length='2' lower-bound='0' upper-bound='1' type-id='type-id-61' id='type-id-96'/>
     </array-type-def>
-    <type-decl name='unsigned long long int' size-in-bits='64' id='type-id-96'/>
-    <qualified-type-def type-id='type-id-98' restrict='yes' id='type-id-99'/>
-    <pointer-type-def type-id='type-id-75' size-in-bits='64' id='type-id-76'/>
-    <qualified-type-def type-id='type-id-85' const='yes' id='type-id-100'/>
-    <pointer-type-def type-id='type-id-100' size-in-bits='64' id='type-id-101'/>
-    <qualified-type-def type-id='type-id-101' restrict='yes' id='type-id-102'/>
-    <qualified-type-def type-id='type-id-89' const='yes' id='type-id-103'/>
-    <pointer-type-def type-id='type-id-103' size-in-bits='64' id='type-id-104'/>
-    <qualified-type-def type-id='type-id-104' restrict='yes' id='type-id-105'/>
-    <qualified-type-def type-id='type-id-93' const='yes' id='type-id-106'/>
-    <pointer-type-def type-id='type-id-106' size-in-bits='64' id='type-id-107'/>
-    <qualified-type-def type-id='type-id-108' const='yes' id='type-id-109'/>
-    <pointer-type-def type-id='type-id-109' size-in-bits='64' id='type-id-35'/>
-    <qualified-type-def type-id='type-id-42' const='yes' id='type-id-110'/>
-    <pointer-type-def type-id='type-id-110' size-in-bits='64' id='type-id-111'/>
-    <qualified-type-def type-id='type-id-111' restrict='yes' id='type-id-53'/>
-    <pointer-type-def type-id='type-id-11' size-in-bits='64' id='type-id-56'/>
-    <pointer-type-def type-id='type-id-87' size-in-bits='64' id='type-id-112'/>
-    <qualified-type-def type-id='type-id-112' restrict='yes' id='type-id-113'/>
-    <pointer-type-def type-id='type-id-91' size-in-bits='64' id='type-id-114'/>
-    <qualified-type-def type-id='type-id-114' restrict='yes' id='type-id-115'/>
-    <pointer-type-def type-id='type-id-94' size-in-bits='64' id='type-id-116'/>
-    <qualified-type-def type-id='type-id-116' restrict='yes' id='type-id-117'/>
-    <pointer-type-def type-id='type-id-118' size-in-bits='64' id='type-id-119'/>
-    <pointer-type-def type-id='type-id-108' size-in-bits='64' id='type-id-58'/>
+    <type-decl name='unsigned long long int' size-in-bits='64' id='type-id-95'/>
+    <qualified-type-def type-id='type-id-97' restrict='yes' id='type-id-98'/>
+    <pointer-type-def type-id='type-id-74' size-in-bits='64' id='type-id-75'/>
+    <qualified-type-def type-id='type-id-84' const='yes' id='type-id-99'/>
+    <pointer-type-def type-id='type-id-99' size-in-bits='64' id='type-id-100'/>
+    <qualified-type-def type-id='type-id-100' restrict='yes' id='type-id-101'/>
+    <qualified-type-def type-id='type-id-88' const='yes' id='type-id-102'/>
+    <pointer-type-def type-id='type-id-102' size-in-bits='64' id='type-id-103'/>
+    <qualified-type-def type-id='type-id-103' restrict='yes' id='type-id-104'/>
+    <qualified-type-def type-id='type-id-92' const='yes' id='type-id-105'/>
+    <pointer-type-def type-id='type-id-105' size-in-bits='64' id='type-id-106'/>
+    <qualified-type-def type-id='type-id-107' const='yes' id='type-id-108'/>
+    <pointer-type-def type-id='type-id-108' size-in-bits='64' id='type-id-34'/>
+    <qualified-type-def type-id='type-id-41' const='yes' id='type-id-109'/>
+    <pointer-type-def type-id='type-id-109' size-in-bits='64' id='type-id-110'/>
+    <qualified-type-def type-id='type-id-110' restrict='yes' id='type-id-52'/>
+    <pointer-type-def type-id='type-id-11' size-in-bits='64' id='type-id-55'/>
+    <pointer-type-def type-id='type-id-86' size-in-bits='64' id='type-id-111'/>
+    <qualified-type-def type-id='type-id-111' restrict='yes' id='type-id-112'/>
+    <pointer-type-def type-id='type-id-90' size-in-bits='64' id='type-id-113'/>
+    <qualified-type-def type-id='type-id-113' restrict='yes' id='type-id-114'/>
+    <pointer-type-def type-id='type-id-93' size-in-bits='64' id='type-id-115'/>
+    <qualified-type-def type-id='type-id-115' restrict='yes' id='type-id-116'/>
+    <pointer-type-def type-id='type-id-117' size-in-bits='64' id='type-id-118'/>
+    <pointer-type-def type-id='type-id-107' size-in-bits='64' id='type-id-57'/>
+    <qualified-type-def type-id='type-id-12' restrict='yes' id='type-id-119'/>
     <qualified-type-def type-id='type-id-12' restrict='yes' id='type-id-120'/>
-    <qualified-type-def type-id='type-id-12' restrict='yes' id='type-id-121'/>
     <function-decl name='zxc_seekable_open_reader' filepath='/src/src/lib/../../include/zxc_seekable.h' line='140' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-122'/>
-      <return type-id='type-id-123'/>
+      <parameter type-id='type-id-121'/>
+      <return type-id='type-id-122'/>
     </function-decl>
     <function-decl name='zxc_seek_table_size' filepath='/src/src/lib/../../include/zxc_seekable.h' line='278' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-51'/>
+      <parameter type-id='type-id-50'/>
       <return type-id='type-id-15'/>
     </function-decl>
-    <function-decl name='zxc_aligned_malloc' filepath='/src/src/lib/zxc_internal.h' line='1302' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-32'/>
-      <parameter type-id='type-id-32'/>
+    <function-decl name='zxc_aligned_malloc' filepath='/src/src/lib/zxc_internal.h' line='1303' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-31'/>
+      <parameter type-id='type-id-31'/>
       <return type-id='type-id-12'/>
     </function-decl>
-    <function-decl name='zxc_aligned_free' filepath='/src/src/lib/zxc_internal.h' line='1314' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='zxc_aligned_free' filepath='/src/src/lib/zxc_internal.h' line='1315' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-12'/>
       <return type-id='type-id-13'/>
     </function-decl>
-    <function-decl name='zxc_decompress_chunk_wrapper' filepath='/src/src/lib/zxc_internal.h' line='1761' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-53'/>
+    <function-decl name='zxc_decompress_chunk_wrapper' filepath='/src/src/lib/zxc_internal.h' line='1762' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-52'/>
       <parameter type-id='type-id-2'/>
-      <parameter type-id='type-id-32'/>
+      <parameter type-id='type-id-31'/>
       <parameter type-id='type-id-10'/>
-      <parameter type-id='type-id-32'/>
+      <parameter type-id='type-id-31'/>
       <return type-id='type-id-11'/>
     </function-decl>
-    <function-decl name='zxc_seekable_attach_owned_ctx' filepath='/src/src/lib/zxc_internal.h' line='1924' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-123'/>
+    <function-decl name='zxc_seekable_attach_owned_ctx' filepath='/src/src/lib/zxc_internal.h' line='1925' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-122'/>
       <parameter type-id='type-id-12'/>
       <return type-id='type-id-13'/>
     </function-decl>
-    <function-decl name='pthread_create' filepath='/src/usr/include/pthread.h' line='202' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-117'/>
-      <parameter type-id='type-id-102'/>
+    <function-decl name='pthread_create' filepath='/usr/include/pthread.h' line='202' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-116'/>
+      <parameter type-id='type-id-101'/>
+      <parameter type-id='type-id-118'/>
       <parameter type-id='type-id-119'/>
-      <parameter type-id='type-id-120'/>
       <return type-id='type-id-11'/>
     </function-decl>
-    <function-decl name='pthread_join' filepath='/src/usr/include/pthread.h' line='219' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-94'/>
+    <function-decl name='pthread_join' filepath='/usr/include/pthread.h' line='219' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-93'/>
       <parameter type-id='type-id-14'/>
       <return type-id='type-id-11'/>
     </function-decl>
-    <function-decl name='pthread_mutex_init' filepath='/src/usr/include/pthread.h' line='781' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-114'/>
-      <parameter type-id='type-id-107'/>
-      <return type-id='type-id-11'/>
-    </function-decl>
-    <function-decl name='pthread_mutex_destroy' filepath='/src/usr/include/pthread.h' line='786' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-114'/>
-      <return type-id='type-id-11'/>
-    </function-decl>
-    <function-decl name='pthread_mutex_lock' filepath='/src/usr/include/pthread.h' line='794' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-114'/>
-      <return type-id='type-id-11'/>
-    </function-decl>
-    <function-decl name='pthread_mutex_unlock' filepath='/src/usr/include/pthread.h' line='835' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-114'/>
-      <return type-id='type-id-11'/>
-    </function-decl>
-    <function-decl name='pthread_cond_init' filepath='/src/usr/include/pthread.h' line='1112' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='pthread_mutex_init' filepath='/usr/include/pthread.h' line='781' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-113'/>
-      <parameter type-id='type-id-105'/>
+      <parameter type-id='type-id-106'/>
       <return type-id='type-id-11'/>
     </function-decl>
-    <function-decl name='pthread_cond_destroy' filepath='/src/usr/include/pthread.h' line='1117' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-112'/>
-      <return type-id='type-id-11'/>
-    </function-decl>
-    <function-decl name='pthread_cond_signal' filepath='/src/usr/include/pthread.h' line='1121' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-112'/>
-      <return type-id='type-id-11'/>
-    </function-decl>
-    <function-decl name='pthread_cond_broadcast' filepath='/src/usr/include/pthread.h' line='1125' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-112'/>
-      <return type-id='type-id-11'/>
-    </function-decl>
-    <function-decl name='pthread_cond_wait' filepath='/src/usr/include/pthread.h' line='1133' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='pthread_mutex_destroy' filepath='/usr/include/pthread.h' line='786' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-113'/>
-      <parameter type-id='type-id-115'/>
       <return type-id='type-id-11'/>
     </function-decl>
-    <function-decl name='fwrite' filepath='/src/usr/include/stdio.h' line='745' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-121'/>
-      <parameter type-id='type-id-15'/>
-      <parameter type-id='type-id-15'/>
-      <parameter type-id='type-id-99'/>
-      <return type-id='type-id-15'/>
-    </function-decl>
-    <function-decl name='fileno' filepath='/src/usr/include/stdio.h' line='883' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-98'/>
+    <function-decl name='pthread_mutex_lock' filepath='/usr/include/pthread.h' line='794' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-113'/>
       <return type-id='type-id-11'/>
     </function-decl>
-    <function-decl name='sysconf' filepath='/src/usr/include/unistd.h' line='640' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-11'/>
-      <return type-id='type-id-82'/>
+    <function-decl name='pthread_mutex_unlock' filepath='/usr/include/pthread.h' line='835' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-113'/>
+      <return type-id='type-id-11'/>
     </function-decl>
-    <function-decl name='__fread_chk' filepath='/src/usr/include/x86_64-linux-gnu/bits/stdio2-decl.h' line='122' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='pthread_cond_init' filepath='/usr/include/pthread.h' line='1112' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-112'/>
+      <parameter type-id='type-id-104'/>
+      <return type-id='type-id-11'/>
+    </function-decl>
+    <function-decl name='pthread_cond_destroy' filepath='/usr/include/pthread.h' line='1117' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-111'/>
+      <return type-id='type-id-11'/>
+    </function-decl>
+    <function-decl name='pthread_cond_signal' filepath='/usr/include/pthread.h' line='1121' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-111'/>
+      <return type-id='type-id-11'/>
+    </function-decl>
+    <function-decl name='pthread_cond_broadcast' filepath='/usr/include/pthread.h' line='1125' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-111'/>
+      <return type-id='type-id-11'/>
+    </function-decl>
+    <function-decl name='pthread_cond_wait' filepath='/usr/include/pthread.h' line='1133' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-112'/>
+      <parameter type-id='type-id-114'/>
+      <return type-id='type-id-11'/>
+    </function-decl>
+    <function-decl name='fwrite' filepath='/usr/include/stdio.h' line='745' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-120'/>
       <parameter type-id='type-id-15'/>
       <parameter type-id='type-id-15'/>
-      <parameter type-id='type-id-15'/>
-      <parameter type-id='type-id-99'/>
+      <parameter type-id='type-id-98'/>
       <return type-id='type-id-15'/>
     </function-decl>
-    <function-decl name='__pread64_chk' filepath='/src/usr/include/x86_64-linux-gnu/bits/unistd-decl.h' line='42' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='fileno' filepath='/usr/include/stdio.h' line='883' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-97'/>
+      <return type-id='type-id-11'/>
+    </function-decl>
+    <function-decl name='sysconf' filepath='/usr/include/unistd.h' line='640' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-11'/>
+      <return type-id='type-id-81'/>
+    </function-decl>
+    <function-decl name='__fread_chk' filepath='/usr/include/x86_64-linux-gnu/bits/stdio2-decl.h' line='122' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-119'/>
+      <parameter type-id='type-id-15'/>
+      <parameter type-id='type-id-15'/>
+      <parameter type-id='type-id-15'/>
+      <parameter type-id='type-id-98'/>
+      <return type-id='type-id-15'/>
+    </function-decl>
+    <function-decl name='__pread64_chk' filepath='/usr/include/x86_64-linux-gnu/bits/unistd-decl.h' line='42' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-11'/>
       <parameter type-id='type-id-12'/>
       <parameter type-id='type-id-15'/>
-      <parameter type-id='type-id-124'/>
+      <parameter type-id='type-id-123'/>
       <parameter type-id='type-id-15'/>
-      <return type-id='type-id-95'/>
+      <return type-id='type-id-94'/>
     </function-decl>
-    <function-type size-in-bits='64' id='type-id-118'>
+    <function-type size-in-bits='64' id='type-id-117'>
       <parameter type-id='type-id-12'/>
       <return type-id='type-id-12'/>
     </function-type>
-    <function-type size-in-bits='64' id='type-id-125'>
+    <function-type size-in-bits='64' id='type-id-124'>
       <parameter type-id='type-id-12'/>
       <parameter type-id='type-id-12'/>
       <parameter type-id='type-id-15'/>
       <parameter type-id='type-id-22'/>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-51'/>
     </function-type>
   </abi-instr>
-  <abi-instr address-size='64' path='/src/src/lib/zxc_huffman.c' comp-dir-path='/src/build' language='LANG_C11'>
+  <abi-instr address-size='64' path='/src/src/lib/zxc_huffman.c' comp-dir-path='/tmp/babi' language='LANG_C11'>
   </abi-instr>
-  <abi-instr address-size='64' path='/src/src/lib/zxc_pstream.c' comp-dir-path='/src/build' language='LANG_C11'>
+  <abi-instr address-size='64' path='/src/src/lib/zxc_pstream.c' comp-dir-path='/tmp/babi' language='LANG_C11'>
     <function-decl name='zxc_compress_block_bound' filepath='/src/src/lib/../../include/zxc_buffer.h' line='288' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-15'/>
       <return type-id='type-id-22'/>
     </function-decl>
     <function-decl name='zxc_compress_block' filepath='/src/src/lib/../../include/zxc_buffer.h' line='343' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-125'/>
+      <parameter type-id='type-id-12'/>
+      <parameter type-id='type-id-15'/>
+      <parameter type-id='type-id-12'/>
+      <parameter type-id='type-id-15'/>
       <parameter type-id='type-id-126'/>
-      <parameter type-id='type-id-12'/>
-      <parameter type-id='type-id-15'/>
-      <parameter type-id='type-id-12'/>
-      <parameter type-id='type-id-15'/>
-      <parameter type-id='type-id-127'/>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-51'/>
     </function-decl>
     <function-decl name='zxc_create_cctx' filepath='/src/src/lib/../../include/zxc_buffer.h' line='478' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-127'/>
-      <return type-id='type-id-126'/>
+      <parameter type-id='type-id-126'/>
+      <return type-id='type-id-125'/>
     </function-decl>
     <function-decl name='zxc_free_cctx' filepath='/src/src/lib/../../include/zxc_buffer.h' line='487' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-126'/>
+      <parameter type-id='type-id-125'/>
       <return type-id='type-id-13'/>
     </function-decl>
   </abi-instr>
-  <abi-instr address-size='64' path='/src/src/lib/zxc_seekable.c' comp-dir-path='/src/build' language='LANG_C11'>
-    <qualified-type-def type-id='type-id-12' restrict='yes' id='type-id-128'/>
+  <abi-instr address-size='64' path='/src/src/lib/zxc_seekable.c' comp-dir-path='/tmp/babi' language='LANG_C11'>
+    <qualified-type-def type-id='type-id-12' restrict='yes' id='type-id-127'/>
   </abi-instr>
-  <abi-instr address-size='64' path='&lt;artificial&gt;-c' comp-dir-path='/src/build' language='LANG_C11'>
-    <type-decl name='char' size-in-bits='8' id='type-id-60'/>
-    <array-type-def dimensions='1' type-id='type-id-60' size-in-bits='8' id='type-id-129'>
-      <subrange length='1' lower-bound='0' upper-bound='0' type-id='type-id-62' id='type-id-130'/>
+  <abi-instr address-size='64' path='&lt;artificial&gt;-c' comp-dir-path='/tmp/babi' language='LANG_C11'>
+    <type-decl name='char' size-in-bits='8' id='type-id-59'/>
+    <array-type-def dimensions='1' type-id='type-id-59' size-in-bits='8' id='type-id-128'>
+      <subrange length='1' lower-bound='0' upper-bound='0' type-id='type-id-61' id='type-id-129'/>
     </array-type-def>
-    <array-type-def dimensions='1' type-id='type-id-60' size-in-bits='160' id='type-id-131'>
-      <subrange length='20' lower-bound='0' upper-bound='19' type-id='type-id-62' id='type-id-132'/>
+    <array-type-def dimensions='1' type-id='type-id-59' size-in-bits='160' id='type-id-130'>
+      <subrange length='20' lower-bound='0' upper-bound='19' type-id='type-id-61' id='type-id-131'/>
     </array-type-def>
-    <array-type-def dimensions='2' type-id='type-id-133' size-in-bits='16384' id='type-id-134'>
-      <subrange length='256' lower-bound='0' upper-bound='255' type-id='type-id-62' id='type-id-135'/>
-      <subrange length='8' lower-bound='0' upper-bound='7' type-id='type-id-62' id='type-id-136'/>
+    <array-type-def dimensions='2' type-id='type-id-132' size-in-bits='16384' id='type-id-133'>
+      <subrange length='256' lower-bound='0' upper-bound='255' type-id='type-id-61' id='type-id-134'/>
+      <subrange length='8' lower-bound='0' upper-bound='7' type-id='type-id-61' id='type-id-135'/>
     </array-type-def>
-    <array-type-def dimensions='3' type-id='type-id-133' size-in-bits='147456' id='type-id-137'>
-      <subrange length='9' lower-bound='0' upper-bound='8' type-id='type-id-62' id='type-id-138'/>
-      <subrange length='256' lower-bound='0' upper-bound='255' type-id='type-id-62' id='type-id-135'/>
-      <subrange length='8' lower-bound='0' upper-bound='7' type-id='type-id-62' id='type-id-136'/>
+    <array-type-def dimensions='3' type-id='type-id-132' size-in-bits='147456' id='type-id-136'>
+      <subrange length='9' lower-bound='0' upper-bound='8' type-id='type-id-61' id='type-id-137'/>
+      <subrange length='256' lower-bound='0' upper-bound='255' type-id='type-id-61' id='type-id-134'/>
+      <subrange length='8' lower-bound='0' upper-bound='7' type-id='type-id-61' id='type-id-135'/>
     </array-type-def>
-    <enum-decl name='cstream_state_t' naming-typedef-id='type-id-139' filepath='/src/src/lib/zxc_pstream.c' line='69' column='1' id='type-id-140'>
-      <underlying-type type-id='type-id-141'/>
+    <enum-decl name='cstream_state_t' naming-typedef-id='type-id-138' filepath='/src/src/lib/zxc_pstream.c' line='69' column='1' id='type-id-139'>
+      <underlying-type type-id='type-id-140'/>
       <enumerator name='CS_INIT' value='0'/>
       <enumerator name='CS_DRAIN_HEADER' value='1'/>
       <enumerator name='CS_ACCUMULATE' value='2'/>
@@ -1036,8 +938,8 @@
       <enumerator name='CS_DONE' value='7'/>
       <enumerator name='CS_ERRORED' value='8'/>
     </enum-decl>
-    <enum-decl name='dstream_state_t' naming-typedef-id='type-id-142' filepath='/src/src/lib/zxc_pstream.c' line='641' column='1' id='type-id-143'>
-      <underlying-type type-id='type-id-141'/>
+    <enum-decl name='dstream_state_t' naming-typedef-id='type-id-141' filepath='/src/src/lib/zxc_pstream.c' line='641' column='1' id='type-id-142'>
+      <underlying-type type-id='type-id-140'/>
       <enumerator name='DS_NEED_FILE_HEADER' value='0'/>
       <enumerator name='DS_NEED_BLOCK_HEADER' value='1'/>
       <enumerator name='DS_NEED_BLOCK_PAYLOAD' value='2'/>
@@ -1052,249 +954,249 @@
       <enumerator name='DS_ERRORED' value='11'/>
     </enum-decl>
     <type-decl name='int' size-in-bits='32' id='type-id-11'/>
-    <array-type-def dimensions='1' type-id='type-id-144' size-in-bits='208' id='type-id-145'>
-      <subrange length='13' lower-bound='0' upper-bound='12' type-id='type-id-62' id='type-id-146'/>
+    <array-type-def dimensions='1' type-id='type-id-143' size-in-bits='208' id='type-id-144'>
+      <subrange length='13' lower-bound='0' upper-bound='12' type-id='type-id-61' id='type-id-145'/>
     </array-type-def>
-    <array-type-def dimensions='1' type-id='type-id-144' size-in-bits='32' id='type-id-147'>
-      <subrange length='2' lower-bound='0' upper-bound='1' type-id='type-id-62' id='type-id-97'/>
+    <array-type-def dimensions='1' type-id='type-id-143' size-in-bits='32' id='type-id-146'>
+      <subrange length='2' lower-bound='0' upper-bound='1' type-id='type-id-61' id='type-id-96'/>
     </array-type-def>
-    <array-type-def dimensions='1' type-id='type-id-144' size-in-bits='8176' id='type-id-148'>
-      <subrange length='511' lower-bound='0' upper-bound='510' type-id='type-id-62' id='type-id-149'/>
+    <array-type-def dimensions='1' type-id='type-id-143' size-in-bits='8176' id='type-id-147'>
+      <subrange length='511' lower-bound='0' upper-bound='510' type-id='type-id-61' id='type-id-148'/>
     </array-type-def>
-    <type-decl name='long int' size-in-bits='64' id='type-id-82'/>
-    <type-decl name='short int' size-in-bits='16' id='type-id-78'/>
-    <type-decl name='signed char' size-in-bits='8' id='type-id-150'/>
-    <class-decl name='_IO_FILE' size-in-bits='1728' is-struct='yes' visibility='default' filepath='/src/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='49' column='1' id='type-id-151'>
+    <type-decl name='long int' size-in-bits='64' id='type-id-81'/>
+    <type-decl name='short int' size-in-bits='16' id='type-id-77'/>
+    <type-decl name='signed char' size-in-bits='8' id='type-id-149'/>
+    <class-decl name='_IO_FILE' size-in-bits='1728' is-struct='yes' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='49' column='1' id='type-id-150'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='_flags' type-id='type-id-11' visibility='default' filepath='/src/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='51' column='1'/>
+        <var-decl name='_flags' type-id='type-id-11' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='51' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='_IO_read_ptr' type-id='type-id-152' visibility='default' filepath='/src/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='54' column='1'/>
+        <var-decl name='_IO_read_ptr' type-id='type-id-151' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='54' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='_IO_read_end' type-id='type-id-152' visibility='default' filepath='/src/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='55' column='1'/>
+        <var-decl name='_IO_read_end' type-id='type-id-151' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='55' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='_IO_read_base' type-id='type-id-152' visibility='default' filepath='/src/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='56' column='1'/>
+        <var-decl name='_IO_read_base' type-id='type-id-151' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='56' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='_IO_write_base' type-id='type-id-152' visibility='default' filepath='/src/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='57' column='1'/>
+        <var-decl name='_IO_write_base' type-id='type-id-151' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='57' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='_IO_write_ptr' type-id='type-id-152' visibility='default' filepath='/src/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='58' column='1'/>
+        <var-decl name='_IO_write_ptr' type-id='type-id-151' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='58' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='_IO_write_end' type-id='type-id-152' visibility='default' filepath='/src/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='59' column='1'/>
+        <var-decl name='_IO_write_end' type-id='type-id-151' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='59' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='448'>
-        <var-decl name='_IO_buf_base' type-id='type-id-152' visibility='default' filepath='/src/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='60' column='1'/>
+        <var-decl name='_IO_buf_base' type-id='type-id-151' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='60' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='512'>
-        <var-decl name='_IO_buf_end' type-id='type-id-152' visibility='default' filepath='/src/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='61' column='1'/>
+        <var-decl name='_IO_buf_end' type-id='type-id-151' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='61' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='576'>
-        <var-decl name='_IO_save_base' type-id='type-id-152' visibility='default' filepath='/src/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='64' column='1'/>
+        <var-decl name='_IO_save_base' type-id='type-id-151' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='64' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='640'>
-        <var-decl name='_IO_backup_base' type-id='type-id-152' visibility='default' filepath='/src/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='65' column='1'/>
+        <var-decl name='_IO_backup_base' type-id='type-id-151' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='65' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='704'>
-        <var-decl name='_IO_save_end' type-id='type-id-152' visibility='default' filepath='/src/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='66' column='1'/>
+        <var-decl name='_IO_save_end' type-id='type-id-151' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='66' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='768'>
-        <var-decl name='_markers' type-id='type-id-153' visibility='default' filepath='/src/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='68' column='1'/>
+        <var-decl name='_markers' type-id='type-id-152' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='68' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='832'>
-        <var-decl name='_chain' type-id='type-id-154' visibility='default' filepath='/src/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='70' column='1'/>
+        <var-decl name='_chain' type-id='type-id-153' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='70' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='896'>
-        <var-decl name='_fileno' type-id='type-id-11' visibility='default' filepath='/src/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='72' column='1'/>
+        <var-decl name='_fileno' type-id='type-id-11' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='72' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='928'>
-        <var-decl name='_flags2' type-id='type-id-11' visibility='default' filepath='/src/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='73' column='1'/>
+        <var-decl name='_flags2' type-id='type-id-11' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='73' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='960'>
-        <var-decl name='_old_offset' type-id='type-id-155' visibility='default' filepath='/src/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='74' column='1'/>
+        <var-decl name='_old_offset' type-id='type-id-154' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='74' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1024'>
-        <var-decl name='_cur_column' type-id='type-id-156' visibility='default' filepath='/src/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='77' column='1'/>
+        <var-decl name='_cur_column' type-id='type-id-155' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='77' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1040'>
-        <var-decl name='_vtable_offset' type-id='type-id-150' visibility='default' filepath='/src/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='78' column='1'/>
+        <var-decl name='_vtable_offset' type-id='type-id-149' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='78' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1048'>
-        <var-decl name='_shortbuf' type-id='type-id-129' visibility='default' filepath='/src/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='79' column='1'/>
+        <var-decl name='_shortbuf' type-id='type-id-128' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='79' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1088'>
-        <var-decl name='_lock' type-id='type-id-157' visibility='default' filepath='/src/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='81' column='1'/>
+        <var-decl name='_lock' type-id='type-id-156' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='81' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1152'>
-        <var-decl name='_offset' type-id='type-id-124' visibility='default' filepath='/src/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='89' column='1'/>
+        <var-decl name='_offset' type-id='type-id-123' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='89' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1216'>
-        <var-decl name='_codecvt' type-id='type-id-158' visibility='default' filepath='/src/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='91' column='1'/>
+        <var-decl name='_codecvt' type-id='type-id-157' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='91' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1280'>
-        <var-decl name='_wide_data' type-id='type-id-159' visibility='default' filepath='/src/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='92' column='1'/>
+        <var-decl name='_wide_data' type-id='type-id-158' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='92' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1344'>
-        <var-decl name='_freeres_list' type-id='type-id-154' visibility='default' filepath='/src/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='93' column='1'/>
+        <var-decl name='_freeres_list' type-id='type-id-153' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='93' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1408'>
-        <var-decl name='_freeres_buf' type-id='type-id-12' visibility='default' filepath='/src/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='94' column='1'/>
+        <var-decl name='_freeres_buf' type-id='type-id-12' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='94' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1472'>
-        <var-decl name='__pad5' type-id='type-id-15' visibility='default' filepath='/src/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='95' column='1'/>
+        <var-decl name='__pad5' type-id='type-id-15' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='95' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1536'>
-        <var-decl name='_mode' type-id='type-id-11' visibility='default' filepath='/src/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='96' column='1'/>
+        <var-decl name='_mode' type-id='type-id-11' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='96' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1568'>
-        <var-decl name='_unused2' type-id='type-id-131' visibility='default' filepath='/src/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='98' column='1'/>
+        <var-decl name='_unused2' type-id='type-id-130' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='98' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='zxc_block_header_t' size-in-bits='64' is-struct='yes' naming-typedef-id='type-id-108' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='1805' column='1' id='type-id-160'>
+    <class-decl name='zxc_block_header_t' size-in-bits='64' is-struct='yes' naming-typedef-id='type-id-107' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='1806' column='1' id='type-id-159'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='block_type' type-id='type-id-19' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='1806' column='1'/>
+        <var-decl name='block_type' type-id='type-id-19' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='1807' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='8'>
-        <var-decl name='block_flags' type-id='type-id-19' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='1807' column='1'/>
+        <var-decl name='block_flags' type-id='type-id-19' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='1808' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='16'>
-        <var-decl name='reserved' type-id='type-id-19' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='1808' column='1'/>
+        <var-decl name='reserved' type-id='type-id-19' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='1809' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='24'>
-        <var-decl name='header_crc' type-id='type-id-19' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='1809' column='1'/>
+        <var-decl name='header_crc' type-id='type-id-19' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='1810' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='comp_size' type-id='type-id-18' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='1810' column='1'/>
+        <var-decl name='comp_size' type-id='type-id-18' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='1811' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='zxc_cctx_s' size-in-bits='2240' is-struct='yes' visibility='default' filepath='/src/src/lib/zxc_dispatch.c' line='1200' column='1' id='type-id-161'>
+    <class-decl name='zxc_cctx_s' size-in-bits='2240' is-struct='yes' visibility='default' filepath='/src/src/lib/zxc_dispatch.c' line='1211' column='1' id='type-id-160'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='inner' type-id='type-id-42' visibility='default' filepath='/src/src/lib/zxc_dispatch.c' line='1201' column='1'/>
+        <var-decl name='inner' type-id='type-id-41' visibility='default' filepath='/src/src/lib/zxc_dispatch.c' line='1212' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1984'>
-        <var-decl name='initialized' type-id='type-id-11' visibility='default' filepath='/src/src/lib/zxc_dispatch.c' line='1202' column='1'/>
+        <var-decl name='initialized' type-id='type-id-11' visibility='default' filepath='/src/src/lib/zxc_dispatch.c' line='1213' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='2016'>
-        <var-decl name='owns_workspace' type-id='type-id-11' visibility='default' filepath='/src/src/lib/zxc_dispatch.c' line='1203' column='1'/>
+        <var-decl name='owns_workspace' type-id='type-id-11' visibility='default' filepath='/src/src/lib/zxc_dispatch.c' line='1214' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='2048'>
-        <var-decl name='last_block_size' type-id='type-id-15' visibility='default' filepath='/src/src/lib/zxc_dispatch.c' line='1206' column='1'/>
+        <var-decl name='last_block_size' type-id='type-id-15' visibility='default' filepath='/src/src/lib/zxc_dispatch.c' line='1217' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='2112'>
-        <var-decl name='stored_level' type-id='type-id-11' visibility='default' filepath='/src/src/lib/zxc_dispatch.c' line='1208' column='1'/>
+        <var-decl name='stored_level' type-id='type-id-11' visibility='default' filepath='/src/src/lib/zxc_dispatch.c' line='1219' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='2144'>
-        <var-decl name='stored_checksum' type-id='type-id-11' visibility='default' filepath='/src/src/lib/zxc_dispatch.c' line='1209' column='1'/>
+        <var-decl name='stored_checksum' type-id='type-id-11' visibility='default' filepath='/src/src/lib/zxc_dispatch.c' line='1220' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='2176'>
-        <var-decl name='stored_block_size' type-id='type-id-15' visibility='default' filepath='/src/src/lib/zxc_dispatch.c' line='1210' column='1'/>
+        <var-decl name='stored_block_size' type-id='type-id-15' visibility='default' filepath='/src/src/lib/zxc_dispatch.c' line='1221' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='zxc_cctx_t' size-in-bits='1984' is-struct='yes' naming-typedef-id='type-id-42' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='1570' column='1' id='type-id-162'>
+    <class-decl name='zxc_cctx_t' size-in-bits='1984' is-struct='yes' naming-typedef-id='type-id-41' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='1571' column='1' id='type-id-161'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='hash_table' type-id='type-id-57' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='1573' column='1'/>
+        <var-decl name='hash_table' type-id='type-id-56' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='1574' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='hash_tags' type-id='type-id-50' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='1574' column='1'/>
+        <var-decl name='hash_tags' type-id='type-id-49' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='1575' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='chain_table' type-id='type-id-163' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='1575' column='1'/>
+        <var-decl name='chain_table' type-id='type-id-162' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='1576' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='memory_block' type-id='type-id-12' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='1576' column='1'/>
+        <var-decl name='memory_block' type-id='type-id-12' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='1577' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='epoch' type-id='type-id-18' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='1577' column='1'/>
+        <var-decl name='epoch' type-id='type-id-18' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='1578' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='buf_sequences' type-id='type-id-57' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='1580' column='1'/>
+        <var-decl name='buf_sequences' type-id='type-id-56' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='1581' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='buf_tokens' type-id='type-id-50' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='1581' column='1'/>
+        <var-decl name='buf_tokens' type-id='type-id-49' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='1582' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='448'>
-        <var-decl name='buf_offsets' type-id='type-id-163' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='1582' column='1'/>
+        <var-decl name='buf_offsets' type-id='type-id-162' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='1583' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='512'>
-        <var-decl name='buf_extras' type-id='type-id-50' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='1583' column='1'/>
+        <var-decl name='buf_extras' type-id='type-id-49' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='1584' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='576'>
-        <var-decl name='literals' type-id='type-id-50' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='1584' column='1'/>
+        <var-decl name='literals' type-id='type-id-49' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='1585' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='640'>
-        <var-decl name='lit_buffer' type-id='type-id-50' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='1587' column='1'/>
+        <var-decl name='lit_buffer' type-id='type-id-49' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='1588' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='704'>
-        <var-decl name='lit_buffer_cap' type-id='type-id-15' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='1588' column='1'/>
+        <var-decl name='lit_buffer_cap' type-id='type-id-15' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='1589' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='768'>
-        <var-decl name='work_buf' type-id='type-id-50' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='1589' column='1'/>
+        <var-decl name='work_buf' type-id='type-id-49' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='1590' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='832'>
-        <var-decl name='work_buf_cap' type-id='type-id-15' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='1590' column='1'/>
+        <var-decl name='work_buf_cap' type-id='type-id-15' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='1591' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='896'>
-        <var-decl name='tok_buffer' type-id='type-id-50' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='1591' column='1'/>
+        <var-decl name='tok_buffer' type-id='type-id-49' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='1592' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='960'>
-        <var-decl name='tok_buffer_cap' type-id='type-id-15' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='1595' column='1'/>
+        <var-decl name='tok_buffer_cap' type-id='type-id-15' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='1596' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1024'>
-        <var-decl name='pivco_scratch' type-id='type-id-50' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='1596' column='1'/>
+        <var-decl name='pivco_scratch' type-id='type-id-49' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='1597' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1088'>
-        <var-decl name='pivco_scratch_cap' type-id='type-id-15' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='1597' column='1'/>
+        <var-decl name='pivco_scratch_cap' type-id='type-id-15' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='1598' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1152'>
-        <var-decl name='entropy_block' type-id='type-id-12' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='1598' column='1'/>
+        <var-decl name='entropy_block' type-id='type-id-12' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='1599' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1216'>
-        <var-decl name='opt_scratch' type-id='type-id-50' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='1602' column='1'/>
+        <var-decl name='opt_scratch' type-id='type-id-49' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='1603' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1280'>
-        <var-decl name='opt_scratch_cap' type-id='type-id-15' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='1606' column='1'/>
+        <var-decl name='opt_scratch_cap' type-id='type-id-15' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='1607' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1344'>
-        <var-decl name='checksum_enabled' type-id='type-id-11' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='1607' column='1'/>
+        <var-decl name='checksum_enabled' type-id='type-id-11' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='1608' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1376'>
-        <var-decl name='compression_level' type-id='type-id-11' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='1608' column='1'/>
+        <var-decl name='compression_level' type-id='type-id-11' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='1609' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1408'>
-        <var-decl name='dict_size' type-id='type-id-15' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='1609' column='1'/>
+        <var-decl name='dict_size' type-id='type-id-15' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='1610' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1472'>
-        <var-decl name='dict_buffer' type-id='type-id-50' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='1610' column='1'/>
+        <var-decl name='dict_buffer' type-id='type-id-49' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='1611' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1536'>
-        <var-decl name='dict_buffer_cap' type-id='type-id-15' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='1612' column='1'/>
+        <var-decl name='dict_buffer_cap' type-id='type-id-15' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='1613' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1600'>
-        <var-decl name='dict_huf' type-id='type-id-164' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='1613' column='1'/>
+        <var-decl name='dict_huf' type-id='type-id-163' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='1614' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1664'>
-        <var-decl name='dict_huf_tree_ok' type-id='type-id-11' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='1617' column='1'/>
+        <var-decl name='dict_huf_tree_ok' type-id='type-id-11' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='1618' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1728'>
-        <var-decl name='lit_freq_acc' type-id='type-id-57' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='1618' column='1'/>
+        <var-decl name='lit_freq_acc' type-id='type-id-56' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='1619' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1792'>
-        <var-decl name='chunk_size' type-id='type-id-15' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='1623' column='1'/>
+        <var-decl name='chunk_size' type-id='type-id-15' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='1624' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1856'>
-        <var-decl name='offset_bits' type-id='type-id-18' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='1624' column='1'/>
+        <var-decl name='offset_bits' type-id='type-id-18' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='1625' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1888'>
-        <var-decl name='offset_mask' type-id='type-id-18' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='1625' column='1'/>
+        <var-decl name='offset_mask' type-id='type-id-18' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='1626' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1920'>
-        <var-decl name='max_epoch' type-id='type-id-18' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='1626' column='1'/>
+        <var-decl name='max_epoch' type-id='type-id-18' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='1627' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='zxc_compress_opts_t' size-in-bits='512' is-struct='yes' naming-typedef-id='type-id-165' visibility='default' filepath='/src/src/lib/../../include/zxc_opts.h' line='61' column='1' id='type-id-166'>
+    <class-decl name='zxc_compress_opts_t' size-in-bits='512' is-struct='yes' naming-typedef-id='type-id-164' visibility='default' filepath='/src/src/lib/../../include/zxc_opts.h' line='61' column='1' id='type-id-165'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='n_threads' type-id='type-id-11' visibility='default' filepath='/src/src/lib/../../include/zxc_opts.h' line='62' column='1'/>
       </data-member>
@@ -1320,30 +1222,30 @@
         <var-decl name='dict_huf' type-id='type-id-12' visibility='default' filepath='/src/src/lib/../../include/zxc_opts.h' line='70' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='progress_cb' type-id='type-id-167' visibility='default' filepath='/src/src/lib/../../include/zxc_opts.h' line='74' column='1'/>
+        <var-decl name='progress_cb' type-id='type-id-166' visibility='default' filepath='/src/src/lib/../../include/zxc_opts.h' line='74' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='448'>
         <var-decl name='user_data' type-id='type-id-12' visibility='default' filepath='/src/src/lib/../../include/zxc_opts.h' line='75' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='zxc_cstream_s' size-in-bits='1216' is-struct='yes' visibility='default' filepath='/src/src/lib/zxc_pstream.c' line='123' column='1' id='type-id-168'>
+    <class-decl name='zxc_cstream_s' size-in-bits='1216' is-struct='yes' visibility='default' filepath='/src/src/lib/zxc_pstream.c' line='123' column='1' id='type-id-167'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='opts' type-id='type-id-165' visibility='default' filepath='/src/src/lib/zxc_pstream.c' line='124' column='1'/>
+        <var-decl name='opts' type-id='type-id-164' visibility='default' filepath='/src/src/lib/zxc_pstream.c' line='124' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='512'>
-        <var-decl name='cctx' type-id='type-id-126' visibility='default' filepath='/src/src/lib/zxc_pstream.c' line='125' column='1'/>
+        <var-decl name='cctx' type-id='type-id-125' visibility='default' filepath='/src/src/lib/zxc_pstream.c' line='125' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='576'>
         <var-decl name='block_size' type-id='type-id-15' visibility='default' filepath='/src/src/lib/zxc_pstream.c' line='126' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='640'>
-        <var-decl name='in_block' type-id='type-id-50' visibility='default' filepath='/src/src/lib/zxc_pstream.c' line='128' column='1'/>
+        <var-decl name='in_block' type-id='type-id-49' visibility='default' filepath='/src/src/lib/zxc_pstream.c' line='128' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='704'>
         <var-decl name='in_used' type-id='type-id-15' visibility='default' filepath='/src/src/lib/zxc_pstream.c' line='129' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='768'>
-        <var-decl name='pending' type-id='type-id-50' visibility='default' filepath='/src/src/lib/zxc_pstream.c' line='131' column='1'/>
+        <var-decl name='pending' type-id='type-id-49' visibility='default' filepath='/src/src/lib/zxc_pstream.c' line='131' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='832'>
         <var-decl name='pending_cap' type-id='type-id-15' visibility='default' filepath='/src/src/lib/zxc_pstream.c' line='132' column='1'/>
@@ -1361,30 +1263,30 @@
         <var-decl name='global_hash' type-id='type-id-18' visibility='default' filepath='/src/src/lib/zxc_pstream.c' line='137' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1120'>
-        <var-decl name='state' type-id='type-id-139' visibility='default' filepath='/src/src/lib/zxc_pstream.c' line='139' column='1'/>
+        <var-decl name='state' type-id='type-id-138' visibility='default' filepath='/src/src/lib/zxc_pstream.c' line='139' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1152'>
         <var-decl name='error_code' type-id='type-id-11' visibility='default' filepath='/src/src/lib/zxc_pstream.c' line='140' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='zxc_dctx_s' size-in-bits='2176' is-struct='yes' visibility='default' filepath='/src/src/lib/zxc_dispatch.c' line='1398' column='1' id='type-id-169'>
+    <class-decl name='zxc_dctx_s' size-in-bits='2176' is-struct='yes' visibility='default' filepath='/src/src/lib/zxc_dispatch.c' line='1409' column='1' id='type-id-168'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='inner' type-id='type-id-42' visibility='default' filepath='/src/src/lib/zxc_dispatch.c' line='1399' column='1'/>
+        <var-decl name='inner' type-id='type-id-41' visibility='default' filepath='/src/src/lib/zxc_dispatch.c' line='1410' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1984'>
-        <var-decl name='last_block_size' type-id='type-id-15' visibility='default' filepath='/src/src/lib/zxc_dispatch.c' line='1400' column='1'/>
+        <var-decl name='last_block_size' type-id='type-id-15' visibility='default' filepath='/src/src/lib/zxc_dispatch.c' line='1411' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='2048'>
-        <var-decl name='last_dict_size' type-id='type-id-15' visibility='default' filepath='/src/src/lib/zxc_dispatch.c' line='1401' column='1'/>
+        <var-decl name='last_dict_size' type-id='type-id-15' visibility='default' filepath='/src/src/lib/zxc_dispatch.c' line='1412' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='2112'>
-        <var-decl name='initialized' type-id='type-id-11' visibility='default' filepath='/src/src/lib/zxc_dispatch.c' line='1402' column='1'/>
+        <var-decl name='initialized' type-id='type-id-11' visibility='default' filepath='/src/src/lib/zxc_dispatch.c' line='1413' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='2144'>
-        <var-decl name='owns_workspace' type-id='type-id-11' visibility='default' filepath='/src/src/lib/zxc_dispatch.c' line='1403' column='1'/>
+        <var-decl name='owns_workspace' type-id='type-id-11' visibility='default' filepath='/src/src/lib/zxc_dispatch.c' line='1414' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='zxc_decompress_opts_t' size-in-bits='384' is-struct='yes' naming-typedef-id='type-id-170' visibility='default' filepath='/src/src/lib/../../include/zxc_opts.h' line='88' column='1' id='type-id-171'>
+    <class-decl name='zxc_decompress_opts_t' size-in-bits='384' is-struct='yes' naming-typedef-id='type-id-169' visibility='default' filepath='/src/src/lib/../../include/zxc_opts.h' line='88' column='1' id='type-id-170'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='n_threads' type-id='type-id-11' visibility='default' filepath='/src/src/lib/../../include/zxc_opts.h' line='89' column='1'/>
       </data-member>
@@ -1401,32 +1303,32 @@
         <var-decl name='dict_huf' type-id='type-id-12' visibility='default' filepath='/src/src/lib/../../include/zxc_opts.h' line='93' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='progress_cb' type-id='type-id-167' visibility='default' filepath='/src/src/lib/../../include/zxc_opts.h' line='96' column='1'/>
+        <var-decl name='progress_cb' type-id='type-id-166' visibility='default' filepath='/src/src/lib/../../include/zxc_opts.h' line='96' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='320'>
         <var-decl name='user_data' type-id='type-id-12' visibility='default' filepath='/src/src/lib/../../include/zxc_opts.h' line='97' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='zxc_dict_huf_state_t' size-in-bits='65888' is-struct='yes' naming-typedef-id='type-id-172' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='652' column='1' id='type-id-173'>
+    <class-decl name='zxc_dict_huf_state_t' size-in-bits='65888' is-struct='yes' naming-typedef-id='type-id-171' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='653' column='1' id='type-id-172'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='tree' type-id='type-id-6' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='653' column='1'/>
+        <var-decl name='tree' type-id='type-id-6' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='654' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='41184'>
-        <var-decl name='codes' type-id='type-id-174' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='654' column='1'/>
+        <var-decl name='codes' type-id='type-id-173' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='655' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='49376'>
-        <var-decl name='code_len' type-id='type-id-175' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='655' column='1'/>
+        <var-decl name='code_len' type-id='type-id-174' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='656' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='51424'>
-        <var-decl name='dec' type-id='type-id-3' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='656' column='1'/>
+        <var-decl name='dec' type-id='type-id-3' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='657' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='zxc_dstream_s' size-in-bits='3776' is-struct='yes' visibility='default' filepath='/src/src/lib/zxc_pstream.c' line='719' column='1' id='type-id-176'>
+    <class-decl name='zxc_dstream_s' size-in-bits='3776' is-struct='yes' visibility='default' filepath='/src/src/lib/zxc_pstream.c' line='719' column='1' id='type-id-175'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='opts' type-id='type-id-170' visibility='default' filepath='/src/src/lib/zxc_pstream.c' line='720' column='1'/>
+        <var-decl name='opts' type-id='type-id-169' visibility='default' filepath='/src/src/lib/zxc_pstream.c' line='720' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='inner' type-id='type-id-42' visibility='default' filepath='/src/src/lib/zxc_pstream.c' line='721' column='1'/>
+        <var-decl name='inner' type-id='type-id-41' visibility='default' filepath='/src/src/lib/zxc_pstream.c' line='721' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='2368'>
         <var-decl name='inner_initialized' type-id='type-id-11' visibility='default' filepath='/src/src/lib/zxc_pstream.c' line='722' column='1'/>
@@ -1438,7 +1340,7 @@
         <var-decl name='file_has_checksum' type-id='type-id-11' visibility='default' filepath='/src/src/lib/zxc_pstream.c' line='724' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='2528'>
-        <var-decl name='scratch' type-id='type-id-177' visibility='default' filepath='/src/src/lib/zxc_pstream.c' line='726' column='1'/>
+        <var-decl name='scratch' type-id='type-id-176' visibility='default' filepath='/src/src/lib/zxc_pstream.c' line='726' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='2816'>
         <var-decl name='scratch_used' type-id='type-id-15' visibility='default' filepath='/src/src/lib/zxc_pstream.c' line='727' column='1'/>
@@ -1447,7 +1349,7 @@
         <var-decl name='scratch_need' type-id='type-id-15' visibility='default' filepath='/src/src/lib/zxc_pstream.c' line='728' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='2944'>
-        <var-decl name='payload' type-id='type-id-50' visibility='default' filepath='/src/src/lib/zxc_pstream.c' line='730' column='1'/>
+        <var-decl name='payload' type-id='type-id-49' visibility='default' filepath='/src/src/lib/zxc_pstream.c' line='730' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='3008'>
         <var-decl name='payload_cap' type-id='type-id-15' visibility='default' filepath='/src/src/lib/zxc_pstream.c' line='731' column='1'/>
@@ -1459,7 +1361,7 @@
         <var-decl name='payload_need' type-id='type-id-15' visibility='default' filepath='/src/src/lib/zxc_pstream.c' line='733' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='3200'>
-        <var-decl name='decoded' type-id='type-id-50' visibility='default' filepath='/src/src/lib/zxc_pstream.c' line='735' column='1'/>
+        <var-decl name='decoded' type-id='type-id-49' visibility='default' filepath='/src/src/lib/zxc_pstream.c' line='735' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='3264'>
         <var-decl name='decoded_cap' type-id='type-id-15' visibility='default' filepath='/src/src/lib/zxc_pstream.c' line='736' column='1'/>
@@ -1471,7 +1373,7 @@
         <var-decl name='decoded_pos' type-id='type-id-15' visibility='default' filepath='/src/src/lib/zxc_pstream.c' line='738' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='3456'>
-        <var-decl name='cur_bh' type-id='type-id-108' visibility='default' filepath='/src/src/lib/zxc_pstream.c' line='740' column='1'/>
+        <var-decl name='cur_bh' type-id='type-id-107' visibility='default' filepath='/src/src/lib/zxc_pstream.c' line='740' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='3520'>
         <var-decl name='sek_remaining' type-id='type-id-15' visibility='default' filepath='/src/src/lib/zxc_pstream.c' line='741' column='1'/>
@@ -1483,13 +1385,13 @@
         <var-decl name='global_hash' type-id='type-id-18' visibility='default' filepath='/src/src/lib/zxc_pstream.c' line='744' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='3680'>
-        <var-decl name='state' type-id='type-id-142' visibility='default' filepath='/src/src/lib/zxc_pstream.c' line='746' column='1'/>
+        <var-decl name='state' type-id='type-id-141' visibility='default' filepath='/src/src/lib/zxc_pstream.c' line='746' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='3712'>
         <var-decl name='error_code' type-id='type-id-11' visibility='default' filepath='/src/src/lib/zxc_pstream.c' line='747' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='zxc_inbuf_t' size-in-bits='192' is-struct='yes' naming-typedef-id='type-id-178' visibility='default' filepath='/src/src/lib/../../include/zxc_pstream.h' line='88' column='1' id='type-id-179'>
+    <class-decl name='zxc_inbuf_t' size-in-bits='192' is-struct='yes' naming-typedef-id='type-id-177' visibility='default' filepath='/src/src/lib/../../include/zxc_pstream.h' line='88' column='1' id='type-id-178'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='src' type-id='type-id-12' visibility='default' filepath='/src/src/lib/../../include/zxc_pstream.h' line='89' column='1'/>
       </data-member>
@@ -1500,7 +1402,7 @@
         <var-decl name='pos' type-id='type-id-15' visibility='default' filepath='/src/src/lib/../../include/zxc_pstream.h' line='91' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='zxc_outbuf_t' size-in-bits='192' is-struct='yes' naming-typedef-id='type-id-180' visibility='default' filepath='/src/src/lib/../../include/zxc_pstream.h' line='108' column='1' id='type-id-181'>
+    <class-decl name='zxc_outbuf_t' size-in-bits='192' is-struct='yes' naming-typedef-id='type-id-179' visibility='default' filepath='/src/src/lib/../../include/zxc_pstream.h' line='108' column='1' id='type-id-180'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='dst' type-id='type-id-12' visibility='default' filepath='/src/src/lib/../../include/zxc_pstream.h' line='109' column='1'/>
       </data-member>
@@ -1511,51 +1413,51 @@
         <var-decl name='pos' type-id='type-id-15' visibility='default' filepath='/src/src/lib/../../include/zxc_pstream.h' line='111' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='zxc_pivco_decode_aux_t' size-in-bits='14448' is-struct='yes' naming-typedef-id='type-id-3' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='637' column='1' id='type-id-182'>
+    <class-decl name='zxc_pivco_decode_aux_t' size-in-bits='14448' is-struct='yes' naming-typedef-id='type-id-3' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='638' column='1' id='type-id-181'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='skip' type-id='type-id-183' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='638' column='1'/>
+        <var-decl name='skip' type-id='type-id-182' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='639' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='4096'>
-        <var-decl name='c2s_off' type-id='type-id-184' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='639' column='1'/>
+        <var-decl name='c2s_off' type-id='type-id-183' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='640' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='12272'>
-        <var-decl name='c2s_pool' type-id='type-id-185' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='640' column='1'/>
+        <var-decl name='c2s_pool' type-id='type-id-184' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='641' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='zxc_pivco_node_t' size-in-bits='48' is-struct='yes' naming-typedef-id='type-id-186' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='594' column='1' id='type-id-187'>
+    <class-decl name='zxc_pivco_node_t' size-in-bits='48' is-struct='yes' naming-typedef-id='type-id-185' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='595' column='1' id='type-id-186'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='child' type-id='type-id-147' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='595' column='1'/>
+        <var-decl name='child' type-id='type-id-146' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='596' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='sym' type-id='type-id-144' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='596' column='1'/>
+        <var-decl name='sym' type-id='type-id-143' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='597' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='zxc_pivco_tree_t' size-in-bits='41184' is-struct='yes' naming-typedef-id='type-id-6' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='607' column='1' id='type-id-188'>
+    <class-decl name='zxc_pivco_tree_t' size-in-bits='41184' is-struct='yes' naming-typedef-id='type-id-6' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='608' column='1' id='type-id-187'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='nd' type-id='type-id-189' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='608' column='1'/>
+        <var-decl name='nd' type-id='type-id-188' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='609' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='24528'>
-        <var-decl name='bfs' type-id='type-id-148' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='609' column='1'/>
+        <var-decl name='bfs' type-id='type-id-147' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='610' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32704'>
-        <var-decl name='lvl_start' type-id='type-id-145' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='610' column='1'/>
+        <var-decl name='lvl_start' type-id='type-id-144' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='611' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32928'>
-        <var-decl name='n_nodes' type-id='type-id-11' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='611' column='1'/>
+        <var-decl name='n_nodes' type-id='type-id-11' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='612' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32960'>
-        <var-decl name='max_depth' type-id='type-id-11' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='612' column='1'/>
+        <var-decl name='max_depth' type-id='type-id-11' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='613' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32992'>
-        <var-decl name='flat_d' type-id='type-id-183' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='620' column='1'/>
+        <var-decl name='flat_d' type-id='type-id-182' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='621' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='37080'>
-        <var-decl name='covered' type-id='type-id-183' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='621' column='1'/>
+        <var-decl name='covered' type-id='type-id-182' visibility='default' filepath='/src/src/lib/zxc_internal.h' line='622' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='zxc_reader_t' size-in-bits='192' is-struct='yes' naming-typedef-id='type-id-190' visibility='default' filepath='/src/src/lib/../../include/zxc_seekable.h' line='108' column='1' id='type-id-191'>
+    <class-decl name='zxc_reader_t' size-in-bits='192' is-struct='yes' naming-typedef-id='type-id-189' visibility='default' filepath='/src/src/lib/../../include/zxc_seekable.h' line='108' column='1' id='type-id-190'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='read_at' type-id='type-id-192' visibility='default' filepath='/src/src/lib/../../include/zxc_seekable.h' line='120' column='1'/>
+        <var-decl name='read_at' type-id='type-id-191' visibility='default' filepath='/src/src/lib/../../include/zxc_seekable.h' line='120' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
         <var-decl name='ctx' type-id='type-id-12' visibility='default' filepath='/src/src/lib/../../include/zxc_seekable.h' line='123' column='1'/>
@@ -1564,7 +1466,7 @@
         <var-decl name='size' type-id='type-id-22' visibility='default' filepath='/src/src/lib/../../include/zxc_seekable.h' line='126' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='zxc_seekable_s' size-in-bits='4032' is-struct='yes' visibility='default' filepath='/src/src/lib/zxc_seekable.c' line='220' column='1' id='type-id-193'>
+    <class-decl name='zxc_seekable_s' size-in-bits='4032' is-struct='yes' visibility='default' filepath='/src/src/lib/zxc_seekable.c' line='220' column='1' id='type-id-192'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='src' type-id='type-id-1' visibility='default' filepath='/src/src/lib/zxc_seekable.c' line='225' column='1'/>
       </data-member>
@@ -1572,7 +1474,7 @@
         <var-decl name='src_size' type-id='type-id-22' visibility='default' filepath='/src/src/lib/zxc_seekable.c' line='226' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='reader' type-id='type-id-190' visibility='default' filepath='/src/src/lib/zxc_seekable.c' line='227' column='1'/>
+        <var-decl name='reader' type-id='type-id-189' visibility='default' filepath='/src/src/lib/zxc_seekable.c' line='227' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='320'>
         <var-decl name='owned_reader_ctx' type-id='type-id-12' visibility='default' filepath='/src/src/lib/zxc_seekable.c' line='233' column='1'/>
@@ -1581,10 +1483,10 @@
         <var-decl name='num_blocks' type-id='type-id-18' visibility='default' filepath='/src/src/lib/zxc_seekable.c' line='236' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='448'>
-        <var-decl name='comp_sizes' type-id='type-id-57' visibility='default' filepath='/src/src/lib/zxc_seekable.c' line='237' column='1'/>
+        <var-decl name='comp_sizes' type-id='type-id-56' visibility='default' filepath='/src/src/lib/zxc_seekable.c' line='237' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='512'>
-        <var-decl name='comp_offsets' type-id='type-id-194' visibility='default' filepath='/src/src/lib/zxc_seekable.c' line='238' column='1'/>
+        <var-decl name='comp_offsets' type-id='type-id-193' visibility='default' filepath='/src/src/lib/zxc_seekable.c' line='238' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='576'>
         <var-decl name='total_decomp' type-id='type-id-22' visibility='default' filepath='/src/src/lib/zxc_seekable.c' line='239' column='1'/>
@@ -1599,149 +1501,149 @@
         <var-decl name='expected_dict_id' type-id='type-id-18' visibility='default' filepath='/src/src/lib/zxc_seekable.c' line='245' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='768'>
-        <var-decl name='dctx' type-id='type-id-42' visibility='default' filepath='/src/src/lib/zxc_seekable.c' line='248' column='1'/>
+        <var-decl name='dctx' type-id='type-id-41' visibility='default' filepath='/src/src/lib/zxc_seekable.c' line='248' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='2752'>
         <var-decl name='dctx_initialized' type-id='type-id-11' visibility='default' filepath='/src/src/lib/zxc_seekable.c' line='249' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='2816'>
-        <var-decl name='dict' type-id='type-id-50' visibility='default' filepath='/src/src/lib/zxc_seekable.c' line='252' column='1'/>
+        <var-decl name='dict' type-id='type-id-49' visibility='default' filepath='/src/src/lib/zxc_seekable.c' line='252' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='2880'>
         <var-decl name='dict_size' type-id='type-id-15' visibility='default' filepath='/src/src/lib/zxc_seekable.c' line='253' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='2944'>
-        <var-decl name='dict_huf' type-id='type-id-195' visibility='default' filepath='/src/src/lib/zxc_seekable.c' line='255' column='1'/>
+        <var-decl name='dict_huf' type-id='type-id-194' visibility='default' filepath='/src/src/lib/zxc_seekable.c' line='255' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='3968'>
         <var-decl name='has_dict_huf' type-id='type-id-11' visibility='default' filepath='/src/src/lib/zxc_seekable.c' line='256' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='FILE' type-id='type-id-151' filepath='/src/usr/include/x86_64-linux-gnu/bits/types/FILE.h' line='7' column='1' id='type-id-196'/>
-    <typedef-decl name='_IO_lock_t' type-id='type-id-13' filepath='/src/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='43' column='1' id='type-id-197'/>
-    <typedef-decl name='__int16_t' type-id='type-id-78' filepath='/src/usr/include/x86_64-linux-gnu/bits/types.h' line='39' column='1' id='type-id-198'/>
-    <typedef-decl name='__int64_t' type-id='type-id-82' filepath='/src/usr/include/x86_64-linux-gnu/bits/types.h' line='44' column='1' id='type-id-199'/>
-    <typedef-decl name='__off64_t' type-id='type-id-82' filepath='/src/usr/include/x86_64-linux-gnu/bits/types.h' line='153' column='1' id='type-id-124'/>
-    <typedef-decl name='__off_t' type-id='type-id-82' filepath='/src/usr/include/x86_64-linux-gnu/bits/types.h' line='152' column='1' id='type-id-155'/>
-    <typedef-decl name='__uint16_t' type-id='type-id-156' filepath='/src/usr/include/x86_64-linux-gnu/bits/types.h' line='40' column='1' id='type-id-200'/>
-    <typedef-decl name='__uint32_t' type-id='type-id-74' filepath='/src/usr/include/x86_64-linux-gnu/bits/types.h' line='42' column='1' id='type-id-201'/>
-    <typedef-decl name='__uint64_t' type-id='type-id-62' filepath='/src/usr/include/x86_64-linux-gnu/bits/types.h' line='45' column='1' id='type-id-202'/>
-    <typedef-decl name='__uint8_t' type-id='type-id-203' filepath='/src/usr/include/x86_64-linux-gnu/bits/types.h' line='38' column='1' id='type-id-204'/>
-    <typedef-decl name='cstream_state_t' type-id='type-id-140' filepath='/src/src/lib/zxc_pstream.c' line='79' column='1' id='type-id-139'/>
-    <typedef-decl name='dstream_state_t' type-id='type-id-143' filepath='/src/src/lib/zxc_pstream.c' line='654' column='1' id='type-id-142'/>
-    <typedef-decl name='int16_t' type-id='type-id-198' filepath='/src/usr/include/x86_64-linux-gnu/bits/stdint-intn.h' line='25' column='1' id='type-id-144'/>
-    <typedef-decl name='int64_t' type-id='type-id-199' filepath='/src/usr/include/x86_64-linux-gnu/bits/stdint-intn.h' line='27' column='1' id='type-id-52'/>
-    <typedef-decl name='size_t' type-id='type-id-62' filepath='/src/usr/lib/gcc/x86_64-linux-gnu/13/include/stddef.h' line='214' column='1' id='type-id-15'/>
-    <typedef-decl name='uint16_t' type-id='type-id-200' filepath='/src/usr/include/x86_64-linux-gnu/bits/stdint-uintn.h' line='25' column='1' id='type-id-205'/>
-    <typedef-decl name='uint32_t' type-id='type-id-201' filepath='/src/usr/include/x86_64-linux-gnu/bits/stdint-uintn.h' line='26' column='1' id='type-id-18'/>
-    <typedef-decl name='uint64_t' type-id='type-id-202' filepath='/src/usr/include/x86_64-linux-gnu/bits/stdint-uintn.h' line='27' column='1' id='type-id-22'/>
-    <typedef-decl name='uint8_t' type-id='type-id-204' filepath='/src/usr/include/x86_64-linux-gnu/bits/stdint-uintn.h' line='24' column='1' id='type-id-19'/>
-    <typedef-decl name='zxc_block_header_t' type-id='type-id-160' filepath='/src/src/lib/zxc_internal.h' line='1811' column='1' id='type-id-108'/>
-    <typedef-decl name='zxc_cctx' type-id='type-id-161' filepath='/src/src/lib/../../include/zxc_buffer.h' line='271' column='1' id='type-id-206'/>
-    <typedef-decl name='zxc_cctx_t' type-id='type-id-162' filepath='/src/src/lib/zxc_internal.h' line='1627' column='1' id='type-id-42'/>
-    <typedef-decl name='zxc_compress_opts_t' type-id='type-id-166' filepath='/src/src/lib/../../include/zxc_opts.h' line='76' column='1' id='type-id-165'/>
-    <typedef-decl name='zxc_cstream' type-id='type-id-168' filepath='/src/src/lib/../../include/zxc_pstream.h' line='116' column='1' id='type-id-207'/>
-    <typedef-decl name='zxc_dctx' type-id='type-id-169' filepath='/src/src/lib/../../include/zxc_buffer.h' line='273' column='1' id='type-id-208'/>
-    <typedef-decl name='zxc_decompress_opts_t' type-id='type-id-171' filepath='/src/src/lib/../../include/zxc_opts.h' line='98' column='1' id='type-id-170'/>
-    <typedef-decl name='zxc_dict_huf_state_t' type-id='type-id-173' filepath='/src/src/lib/zxc_internal.h' line='657' column='1' id='type-id-172'/>
-    <typedef-decl name='zxc_dstream' type-id='type-id-176' filepath='/src/src/lib/../../include/zxc_pstream.h' line='118' column='1' id='type-id-209'/>
-    <typedef-decl name='zxc_inbuf_t' type-id='type-id-179' filepath='/src/src/lib/../../include/zxc_pstream.h' line='92' column='1' id='type-id-178'/>
-    <typedef-decl name='zxc_outbuf_t' type-id='type-id-181' filepath='/src/src/lib/../../include/zxc_pstream.h' line='112' column='1' id='type-id-180'/>
-    <typedef-decl name='zxc_pivco_decode_aux_t' type-id='type-id-182' filepath='/src/src/lib/zxc_internal.h' line='641' column='1' id='type-id-3'/>
-    <typedef-decl name='zxc_pivco_node_t' type-id='type-id-187' filepath='/src/src/lib/zxc_internal.h' line='597' column='1' id='type-id-186'/>
-    <typedef-decl name='zxc_pivco_tree_t' type-id='type-id-188' filepath='/src/src/lib/zxc_internal.h' line='622' column='1' id='type-id-6'/>
-    <typedef-decl name='zxc_progress_callback_t' type-id='type-id-210' filepath='/src/src/lib/../../include/zxc_opts.h' line='46' column='1' id='type-id-167'/>
-    <typedef-decl name='zxc_reader_t' type-id='type-id-191' filepath='/src/src/lib/../../include/zxc_seekable.h' line='127' column='1' id='type-id-190'/>
-    <typedef-decl name='zxc_seekable' type-id='type-id-193' filepath='/src/src/lib/../../include/zxc_seekable.h' line='77' column='1' id='type-id-211'/>
-    <array-type-def dimensions='1' type-id='type-id-205' size-in-bits='8176' id='type-id-184'>
-      <subrange length='511' lower-bound='0' upper-bound='510' type-id='type-id-62' id='type-id-149'/>
+    <typedef-decl name='FILE' type-id='type-id-150' filepath='/usr/include/x86_64-linux-gnu/bits/types/FILE.h' line='7' column='1' id='type-id-195'/>
+    <typedef-decl name='_IO_lock_t' type-id='type-id-13' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='43' column='1' id='type-id-196'/>
+    <typedef-decl name='__int16_t' type-id='type-id-77' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='39' column='1' id='type-id-197'/>
+    <typedef-decl name='__int64_t' type-id='type-id-81' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='44' column='1' id='type-id-198'/>
+    <typedef-decl name='__off64_t' type-id='type-id-81' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='153' column='1' id='type-id-123'/>
+    <typedef-decl name='__off_t' type-id='type-id-81' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='152' column='1' id='type-id-154'/>
+    <typedef-decl name='__uint16_t' type-id='type-id-155' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='40' column='1' id='type-id-199'/>
+    <typedef-decl name='__uint32_t' type-id='type-id-73' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='42' column='1' id='type-id-200'/>
+    <typedef-decl name='__uint64_t' type-id='type-id-61' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='45' column='1' id='type-id-201'/>
+    <typedef-decl name='__uint8_t' type-id='type-id-202' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='38' column='1' id='type-id-203'/>
+    <typedef-decl name='cstream_state_t' type-id='type-id-139' filepath='/src/src/lib/zxc_pstream.c' line='79' column='1' id='type-id-138'/>
+    <typedef-decl name='dstream_state_t' type-id='type-id-142' filepath='/src/src/lib/zxc_pstream.c' line='654' column='1' id='type-id-141'/>
+    <typedef-decl name='int16_t' type-id='type-id-197' filepath='/usr/include/x86_64-linux-gnu/bits/stdint-intn.h' line='25' column='1' id='type-id-143'/>
+    <typedef-decl name='int64_t' type-id='type-id-198' filepath='/usr/include/x86_64-linux-gnu/bits/stdint-intn.h' line='27' column='1' id='type-id-51'/>
+    <typedef-decl name='size_t' type-id='type-id-61' filepath='/usr/lib/gcc/x86_64-linux-gnu/13/include/stddef.h' line='214' column='1' id='type-id-15'/>
+    <typedef-decl name='uint16_t' type-id='type-id-199' filepath='/usr/include/x86_64-linux-gnu/bits/stdint-uintn.h' line='25' column='1' id='type-id-204'/>
+    <typedef-decl name='uint32_t' type-id='type-id-200' filepath='/usr/include/x86_64-linux-gnu/bits/stdint-uintn.h' line='26' column='1' id='type-id-18'/>
+    <typedef-decl name='uint64_t' type-id='type-id-201' filepath='/usr/include/x86_64-linux-gnu/bits/stdint-uintn.h' line='27' column='1' id='type-id-22'/>
+    <typedef-decl name='uint8_t' type-id='type-id-203' filepath='/usr/include/x86_64-linux-gnu/bits/stdint-uintn.h' line='24' column='1' id='type-id-19'/>
+    <typedef-decl name='zxc_block_header_t' type-id='type-id-159' filepath='/src/src/lib/zxc_internal.h' line='1812' column='1' id='type-id-107'/>
+    <typedef-decl name='zxc_cctx' type-id='type-id-160' filepath='/src/src/lib/../../include/zxc_buffer.h' line='271' column='1' id='type-id-205'/>
+    <typedef-decl name='zxc_cctx_t' type-id='type-id-161' filepath='/src/src/lib/zxc_internal.h' line='1628' column='1' id='type-id-41'/>
+    <typedef-decl name='zxc_compress_opts_t' type-id='type-id-165' filepath='/src/src/lib/../../include/zxc_opts.h' line='76' column='1' id='type-id-164'/>
+    <typedef-decl name='zxc_cstream' type-id='type-id-167' filepath='/src/src/lib/../../include/zxc_pstream.h' line='116' column='1' id='type-id-206'/>
+    <typedef-decl name='zxc_dctx' type-id='type-id-168' filepath='/src/src/lib/../../include/zxc_buffer.h' line='273' column='1' id='type-id-207'/>
+    <typedef-decl name='zxc_decompress_opts_t' type-id='type-id-170' filepath='/src/src/lib/../../include/zxc_opts.h' line='98' column='1' id='type-id-169'/>
+    <typedef-decl name='zxc_dict_huf_state_t' type-id='type-id-172' filepath='/src/src/lib/zxc_internal.h' line='658' column='1' id='type-id-171'/>
+    <typedef-decl name='zxc_dstream' type-id='type-id-175' filepath='/src/src/lib/../../include/zxc_pstream.h' line='118' column='1' id='type-id-208'/>
+    <typedef-decl name='zxc_inbuf_t' type-id='type-id-178' filepath='/src/src/lib/../../include/zxc_pstream.h' line='92' column='1' id='type-id-177'/>
+    <typedef-decl name='zxc_outbuf_t' type-id='type-id-180' filepath='/src/src/lib/../../include/zxc_pstream.h' line='112' column='1' id='type-id-179'/>
+    <typedef-decl name='zxc_pivco_decode_aux_t' type-id='type-id-181' filepath='/src/src/lib/zxc_internal.h' line='642' column='1' id='type-id-3'/>
+    <typedef-decl name='zxc_pivco_node_t' type-id='type-id-186' filepath='/src/src/lib/zxc_internal.h' line='598' column='1' id='type-id-185'/>
+    <typedef-decl name='zxc_pivco_tree_t' type-id='type-id-187' filepath='/src/src/lib/zxc_internal.h' line='623' column='1' id='type-id-6'/>
+    <typedef-decl name='zxc_progress_callback_t' type-id='type-id-209' filepath='/src/src/lib/../../include/zxc_opts.h' line='46' column='1' id='type-id-166'/>
+    <typedef-decl name='zxc_reader_t' type-id='type-id-190' filepath='/src/src/lib/../../include/zxc_seekable.h' line='127' column='1' id='type-id-189'/>
+    <typedef-decl name='zxc_seekable' type-id='type-id-192' filepath='/src/src/lib/../../include/zxc_seekable.h' line='77' column='1' id='type-id-210'/>
+    <array-type-def dimensions='1' type-id='type-id-204' size-in-bits='8176' id='type-id-183'>
+      <subrange length='511' lower-bound='0' upper-bound='510' type-id='type-id-61' id='type-id-148'/>
     </array-type-def>
-    <array-type-def dimensions='1' type-id='type-id-18' size-in-bits='8192' id='type-id-174'>
-      <subrange length='256' lower-bound='0' upper-bound='255' type-id='type-id-62' id='type-id-135'/>
+    <array-type-def dimensions='1' type-id='type-id-18' size-in-bits='8192' id='type-id-173'>
+      <subrange length='256' lower-bound='0' upper-bound='255' type-id='type-id-61' id='type-id-134'/>
     </array-type-def>
-    <array-type-def dimensions='1' type-id='type-id-19' size-in-bits='1024' id='type-id-195'>
-      <subrange length='128' lower-bound='0' upper-bound='127' type-id='type-id-62' id='type-id-212'/>
+    <array-type-def dimensions='1' type-id='type-id-19' size-in-bits='1024' id='type-id-194'>
+      <subrange length='128' lower-bound='0' upper-bound='127' type-id='type-id-61' id='type-id-211'/>
     </array-type-def>
-    <array-type-def dimensions='1' type-id='type-id-19' size-in-bits='2048' id='type-id-175'>
-      <subrange length='256' lower-bound='0' upper-bound='255' type-id='type-id-62' id='type-id-135'/>
+    <array-type-def dimensions='1' type-id='type-id-19' size-in-bits='2048' id='type-id-174'>
+      <subrange length='256' lower-bound='0' upper-bound='255' type-id='type-id-61' id='type-id-134'/>
     </array-type-def>
-    <array-type-def dimensions='1' type-id='type-id-19' size-in-bits='2176' id='type-id-185'>
-      <subrange length='272' lower-bound='0' upper-bound='271' type-id='type-id-62' id='type-id-213'/>
+    <array-type-def dimensions='1' type-id='type-id-19' size-in-bits='2176' id='type-id-184'>
+      <subrange length='272' lower-bound='0' upper-bound='271' type-id='type-id-61' id='type-id-212'/>
     </array-type-def>
-    <array-type-def dimensions='1' type-id='type-id-19' size-in-bits='256' id='type-id-177'>
-      <subrange length='32' lower-bound='0' upper-bound='31' type-id='type-id-62' id='type-id-214'/>
+    <array-type-def dimensions='1' type-id='type-id-19' size-in-bits='256' id='type-id-176'>
+      <subrange length='32' lower-bound='0' upper-bound='31' type-id='type-id-61' id='type-id-213'/>
     </array-type-def>
-    <array-type-def dimensions='1' type-id='type-id-19' size-in-bits='4088' id='type-id-183'>
-      <subrange length='511' lower-bound='0' upper-bound='510' type-id='type-id-62' id='type-id-149'/>
+    <array-type-def dimensions='1' type-id='type-id-19' size-in-bits='4088' id='type-id-182'>
+      <subrange length='511' lower-bound='0' upper-bound='510' type-id='type-id-61' id='type-id-148'/>
     </array-type-def>
-    <type-decl name='unnamed-enum-underlying-type-32' is-anonymous='yes' size-in-bits='32' alignment-in-bits='32' id='type-id-141'/>
-    <type-decl name='unsigned char' size-in-bits='8' id='type-id-203'/>
-    <type-decl name='unsigned int' size-in-bits='32' id='type-id-74'/>
-    <type-decl name='unsigned long int' size-in-bits='64' id='type-id-62'/>
-    <type-decl name='unsigned short int' size-in-bits='16' id='type-id-156'/>
-    <array-type-def dimensions='1' type-id='type-id-186' size-in-bits='24528' id='type-id-189'>
-      <subrange length='511' lower-bound='0' upper-bound='510' type-id='type-id-62' id='type-id-149'/>
+    <type-decl name='unnamed-enum-underlying-type-32' is-anonymous='yes' size-in-bits='32' alignment-in-bits='32' id='type-id-140'/>
+    <type-decl name='unsigned char' size-in-bits='8' id='type-id-202'/>
+    <type-decl name='unsigned int' size-in-bits='32' id='type-id-73'/>
+    <type-decl name='unsigned long int' size-in-bits='64' id='type-id-61'/>
+    <type-decl name='unsigned short int' size-in-bits='16' id='type-id-155'/>
+    <array-type-def dimensions='1' type-id='type-id-185' size-in-bits='24528' id='type-id-188'>
+      <subrange length='511' lower-bound='0' upper-bound='510' type-id='type-id-61' id='type-id-148'/>
     </array-type-def>
-    <pointer-type-def type-id='type-id-196' size-in-bits='64' id='type-id-98'/>
-    <pointer-type-def type-id='type-id-151' size-in-bits='64' id='type-id-154'/>
-    <pointer-type-def type-id='type-id-60' size-in-bits='64' id='type-id-152'/>
-    <qualified-type-def type-id='type-id-60' const='yes' id='type-id-215'/>
-    <pointer-type-def type-id='type-id-215' size-in-bits='64' id='type-id-216'/>
-    <qualified-type-def type-id='type-id-11' const='yes' id='type-id-45'/>
-    <qualified-type-def type-id='type-id-15' const='yes' id='type-id-32'/>
-    <pointer-type-def type-id='type-id-32' size-in-bits='64' id='type-id-217'/>
-    <qualified-type-def type-id='type-id-217' restrict='yes' id='type-id-218'/>
-    <qualified-type-def type-id='type-id-18' const='yes' id='type-id-51'/>
-    <pointer-type-def type-id='type-id-51' size-in-bits='64' id='type-id-41'/>
-    <qualified-type-def type-id='type-id-22' const='yes' id='type-id-59'/>
-    <qualified-type-def type-id='type-id-19' const='yes' id='type-id-133'/>
-    <pointer-type-def type-id='type-id-133' size-in-bits='64' id='type-id-1'/>
-    <qualified-type-def type-id='type-id-165' const='yes' id='type-id-219'/>
-    <pointer-type-def type-id='type-id-219' size-in-bits='64' id='type-id-127'/>
-    <qualified-type-def type-id='type-id-127' restrict='yes' id='type-id-220'/>
-    <qualified-type-def type-id='type-id-207' const='yes' id='type-id-221'/>
-    <pointer-type-def type-id='type-id-221' size-in-bits='64' id='type-id-222'/>
-    <qualified-type-def type-id='type-id-170' const='yes' id='type-id-223'/>
-    <pointer-type-def type-id='type-id-223' size-in-bits='64' id='type-id-224'/>
-    <qualified-type-def type-id='type-id-209' const='yes' id='type-id-225'/>
-    <pointer-type-def type-id='type-id-225' size-in-bits='64' id='type-id-226'/>
-    <qualified-type-def type-id='type-id-190' const='yes' id='type-id-227'/>
-    <pointer-type-def type-id='type-id-227' size-in-bits='64' id='type-id-122'/>
-    <qualified-type-def type-id='type-id-211' const='yes' id='type-id-228'/>
-    <pointer-type-def type-id='type-id-228' size-in-bits='64' id='type-id-229'/>
-    <pointer-type-def type-id='type-id-15' size-in-bits='64' id='type-id-55'/>
-    <qualified-type-def type-id='type-id-55' restrict='yes' id='type-id-230'/>
-    <pointer-type-def type-id='type-id-125' size-in-bits='64' id='type-id-192'/>
-    <pointer-type-def type-id='type-id-205' size-in-bits='64' id='type-id-163'/>
-    <pointer-type-def type-id='type-id-18' size-in-bits='64' id='type-id-57'/>
-    <qualified-type-def type-id='type-id-57' restrict='yes' id='type-id-9'/>
-    <pointer-type-def type-id='type-id-22' size-in-bits='64' id='type-id-194'/>
-    <pointer-type-def type-id='type-id-19' size-in-bits='64' id='type-id-50'/>
-    <qualified-type-def type-id='type-id-50' restrict='yes' id='type-id-10'/>
-    <pointer-type-def type-id='type-id-231' size-in-bits='64' id='type-id-210'/>
-    <pointer-type-def type-id='type-id-232' size-in-bits='64' id='type-id-233'/>
-    <qualified-type-def type-id='type-id-233' restrict='yes' id='type-id-234'/>
+    <pointer-type-def type-id='type-id-195' size-in-bits='64' id='type-id-97'/>
+    <pointer-type-def type-id='type-id-150' size-in-bits='64' id='type-id-153'/>
+    <pointer-type-def type-id='type-id-59' size-in-bits='64' id='type-id-151'/>
+    <qualified-type-def type-id='type-id-59' const='yes' id='type-id-214'/>
+    <pointer-type-def type-id='type-id-214' size-in-bits='64' id='type-id-215'/>
+    <qualified-type-def type-id='type-id-11' const='yes' id='type-id-44'/>
+    <qualified-type-def type-id='type-id-15' const='yes' id='type-id-31'/>
+    <pointer-type-def type-id='type-id-31' size-in-bits='64' id='type-id-216'/>
+    <qualified-type-def type-id='type-id-216' restrict='yes' id='type-id-217'/>
+    <qualified-type-def type-id='type-id-18' const='yes' id='type-id-50'/>
+    <pointer-type-def type-id='type-id-50' size-in-bits='64' id='type-id-40'/>
+    <qualified-type-def type-id='type-id-22' const='yes' id='type-id-58'/>
+    <qualified-type-def type-id='type-id-19' const='yes' id='type-id-132'/>
+    <pointer-type-def type-id='type-id-132' size-in-bits='64' id='type-id-1'/>
+    <qualified-type-def type-id='type-id-164' const='yes' id='type-id-218'/>
+    <pointer-type-def type-id='type-id-218' size-in-bits='64' id='type-id-126'/>
+    <qualified-type-def type-id='type-id-126' restrict='yes' id='type-id-219'/>
+    <qualified-type-def type-id='type-id-206' const='yes' id='type-id-220'/>
+    <pointer-type-def type-id='type-id-220' size-in-bits='64' id='type-id-221'/>
+    <qualified-type-def type-id='type-id-169' const='yes' id='type-id-222'/>
+    <pointer-type-def type-id='type-id-222' size-in-bits='64' id='type-id-223'/>
+    <qualified-type-def type-id='type-id-208' const='yes' id='type-id-224'/>
+    <pointer-type-def type-id='type-id-224' size-in-bits='64' id='type-id-225'/>
+    <qualified-type-def type-id='type-id-189' const='yes' id='type-id-226'/>
+    <pointer-type-def type-id='type-id-226' size-in-bits='64' id='type-id-121'/>
+    <qualified-type-def type-id='type-id-210' const='yes' id='type-id-227'/>
+    <pointer-type-def type-id='type-id-227' size-in-bits='64' id='type-id-228'/>
+    <pointer-type-def type-id='type-id-15' size-in-bits='64' id='type-id-54'/>
+    <qualified-type-def type-id='type-id-54' restrict='yes' id='type-id-229'/>
+    <pointer-type-def type-id='type-id-124' size-in-bits='64' id='type-id-191'/>
+    <pointer-type-def type-id='type-id-204' size-in-bits='64' id='type-id-162'/>
+    <pointer-type-def type-id='type-id-18' size-in-bits='64' id='type-id-56'/>
+    <qualified-type-def type-id='type-id-56' restrict='yes' id='type-id-9'/>
+    <pointer-type-def type-id='type-id-22' size-in-bits='64' id='type-id-193'/>
+    <pointer-type-def type-id='type-id-19' size-in-bits='64' id='type-id-49'/>
+    <qualified-type-def type-id='type-id-49' restrict='yes' id='type-id-10'/>
+    <pointer-type-def type-id='type-id-230' size-in-bits='64' id='type-id-209'/>
+    <pointer-type-def type-id='type-id-231' size-in-bits='64' id='type-id-232'/>
+    <qualified-type-def type-id='type-id-232' restrict='yes' id='type-id-233'/>
     <pointer-type-def type-id='type-id-12' size-in-bits='64' id='type-id-14'/>
-    <qualified-type-def type-id='type-id-14' restrict='yes' id='type-id-235'/>
-    <pointer-type-def type-id='type-id-206' size-in-bits='64' id='type-id-126'/>
+    <qualified-type-def type-id='type-id-14' restrict='yes' id='type-id-234'/>
+    <pointer-type-def type-id='type-id-205' size-in-bits='64' id='type-id-125'/>
+    <pointer-type-def type-id='type-id-206' size-in-bits='64' id='type-id-235'/>
     <pointer-type-def type-id='type-id-207' size-in-bits='64' id='type-id-236'/>
+    <pointer-type-def type-id='type-id-171' size-in-bits='64' id='type-id-163'/>
     <pointer-type-def type-id='type-id-208' size-in-bits='64' id='type-id-237'/>
-    <pointer-type-def type-id='type-id-172' size-in-bits='64' id='type-id-164'/>
-    <pointer-type-def type-id='type-id-209' size-in-bits='64' id='type-id-238'/>
-    <pointer-type-def type-id='type-id-178' size-in-bits='64' id='type-id-239'/>
-    <pointer-type-def type-id='type-id-180' size-in-bits='64' id='type-id-240'/>
-    <pointer-type-def type-id='type-id-211' size-in-bits='64' id='type-id-123'/>
-    <pointer-type-def type-id='type-id-241' size-in-bits='64' id='type-id-158'/>
-    <pointer-type-def type-id='type-id-197' size-in-bits='64' id='type-id-157'/>
-    <pointer-type-def type-id='type-id-242' size-in-bits='64' id='type-id-153'/>
-    <pointer-type-def type-id='type-id-243' size-in-bits='64' id='type-id-159'/>
-    <class-decl name='_IO_codecvt' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-241'/>
-    <class-decl name='_IO_marker' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-242'/>
-    <class-decl name='_IO_wide_data' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-243'/>
-    <qualified-type-def type-id='type-id-12' const='yes' id='type-id-232'/>
-    <qualified-type-def type-id='type-id-12' restrict='yes' id='type-id-44'/>
-    <qualified-type-def type-id='type-id-12' restrict='yes' id='type-id-244'/>
-    <qualified-type-def type-id='type-id-12' restrict='yes' id='type-id-54'/>
+    <pointer-type-def type-id='type-id-177' size-in-bits='64' id='type-id-238'/>
+    <pointer-type-def type-id='type-id-179' size-in-bits='64' id='type-id-239'/>
+    <pointer-type-def type-id='type-id-210' size-in-bits='64' id='type-id-122'/>
+    <pointer-type-def type-id='type-id-240' size-in-bits='64' id='type-id-157'/>
+    <pointer-type-def type-id='type-id-196' size-in-bits='64' id='type-id-156'/>
+    <pointer-type-def type-id='type-id-241' size-in-bits='64' id='type-id-152'/>
+    <pointer-type-def type-id='type-id-242' size-in-bits='64' id='type-id-158'/>
+    <class-decl name='_IO_codecvt' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-240'/>
+    <class-decl name='_IO_marker' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-241'/>
+    <class-decl name='_IO_wide_data' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-242'/>
+    <qualified-type-def type-id='type-id-12' const='yes' id='type-id-231'/>
+    <qualified-type-def type-id='type-id-12' restrict='yes' id='type-id-43'/>
+    <qualified-type-def type-id='type-id-12' restrict='yes' id='type-id-243'/>
+    <qualified-type-def type-id='type-id-12' restrict='yes' id='type-id-53'/>
     <function-decl name='zxc_compress_opts_size' mangled-name='zxc_compress_opts_size' filepath='/src/src/lib/zxc_common.c' line='67' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zxc_compress_opts_size'>
       <return type-id='type-id-15'/>
     </function-decl>
@@ -1749,21 +1651,21 @@
       <return type-id='type-id-15'/>
     </function-decl>
     <function-decl name='zxc_compress_block_bound' mangled-name='zxc_compress_block_bound' filepath='/src/src/lib/zxc_common.c' line='875' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zxc_compress_block_bound'>
-      <parameter type-id='type-id-32' name='input_size' filepath='/src/src/lib/zxc_common.c' line='875' column='1'/>
+      <parameter type-id='type-id-31' name='input_size' filepath='/src/src/lib/zxc_common.c' line='875' column='1'/>
       <return type-id='type-id-22'/>
     </function-decl>
     <function-decl name='zxc_decompress_block_bound' mangled-name='zxc_decompress_block_bound' filepath='/src/src/lib/zxc_common.c' line='903' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zxc_decompress_block_bound'>
-      <parameter type-id='type-id-32' name='uncompressed_size' filepath='/src/src/lib/zxc_common.c' line='903' column='1'/>
+      <parameter type-id='type-id-31' name='uncompressed_size' filepath='/src/src/lib/zxc_common.c' line='903' column='1'/>
       <return type-id='type-id-22'/>
     </function-decl>
     <function-decl name='zxc_estimate_cctx_size' mangled-name='zxc_estimate_cctx_size' filepath='/src/src/lib/zxc_common.c' line='926' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zxc_estimate_cctx_size'>
-      <parameter type-id='type-id-32' name='src_size' filepath='/src/src/lib/zxc_common.c' line='926' column='1'/>
-      <parameter type-id='type-id-45' name='level' filepath='/src/src/lib/zxc_common.c' line='926' column='1'/>
+      <parameter type-id='type-id-31' name='src_size' filepath='/src/src/lib/zxc_common.c' line='926' column='1'/>
+      <parameter type-id='type-id-44' name='level' filepath='/src/src/lib/zxc_common.c' line='926' column='1'/>
       <return type-id='type-id-22'/>
     </function-decl>
     <function-decl name='zxc_error_name' mangled-name='zxc_error_name' filepath='/src/src/lib/zxc_common.c' line='945' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zxc_error_name'>
-      <parameter type-id='type-id-45' name='code' filepath='/src/src/lib/zxc_common.c' line='945' column='1'/>
-      <return type-id='type-id-216'/>
+      <parameter type-id='type-id-44' name='code' filepath='/src/src/lib/zxc_common.c' line='945' column='1'/>
+      <return type-id='type-id-215'/>
     </function-decl>
     <function-decl name='zxc_min_level' mangled-name='zxc_min_level' filepath='/src/src/lib/zxc_common.c' line='1003' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zxc_min_level'>
       <return type-id='type-id-11'/>
@@ -1775,311 +1677,311 @@
       <return type-id='type-id-11'/>
     </function-decl>
     <function-decl name='zxc_version_string' mangled-name='zxc_version_string' filepath='/src/src/lib/zxc_common.c' line='1025' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zxc_version_string'>
-      <return type-id='type-id-216'/>
+      <return type-id='type-id-215'/>
     </function-decl>
     <function-decl name='zxc_dict_id' mangled-name='zxc_dict_id' filepath='/src/src/lib/zxc_dict.c' line='35' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zxc_dict_id'>
-      <parameter type-id='type-id-245' name='dict' filepath='/src/src/lib/zxc_dict.c' line='35' column='1'/>
-      <parameter type-id='type-id-32' name='dict_size' filepath='/src/src/lib/zxc_dict.c' line='35' column='1'/>
-      <parameter type-id='type-id-245' name='huf_lengths' filepath='/src/src/lib/zxc_dict.c' line='36' column='1'/>
+      <parameter type-id='type-id-244' name='dict' filepath='/src/src/lib/zxc_dict.c' line='35' column='1'/>
+      <parameter type-id='type-id-31' name='dict_size' filepath='/src/src/lib/zxc_dict.c' line='35' column='1'/>
+      <parameter type-id='type-id-244' name='huf_lengths' filepath='/src/src/lib/zxc_dict.c' line='36' column='1'/>
       <return type-id='type-id-18'/>
     </function-decl>
     <function-decl name='zxc_dict_get_id' mangled-name='zxc_dict_get_id' filepath='/src/src/lib/zxc_dict.c' line='72' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zxc_dict_get_id'>
       <parameter type-id='type-id-12' name='buf' filepath='/src/src/lib/zxc_dict.c' line='72' column='1'/>
-      <parameter type-id='type-id-32' name='buf_size' filepath='/src/src/lib/zxc_dict.c' line='72' column='1'/>
+      <parameter type-id='type-id-31' name='buf_size' filepath='/src/src/lib/zxc_dict.c' line='72' column='1'/>
       <return type-id='type-id-18'/>
     </function-decl>
     <function-decl name='zxc_dict_save_bound' mangled-name='zxc_dict_save_bound' filepath='/src/src/lib/zxc_dict.c' line='88' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zxc_dict_save_bound'>
-      <parameter type-id='type-id-32' name='content_size' filepath='/src/src/lib/zxc_dict.c' line='88' column='1'/>
+      <parameter type-id='type-id-31' name='content_size' filepath='/src/src/lib/zxc_dict.c' line='88' column='1'/>
       <return type-id='type-id-15'/>
     </function-decl>
     <function-decl name='zxc_dict_save' mangled-name='zxc_dict_save' filepath='/src/src/lib/zxc_dict.c' line='108' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zxc_dict_save'>
-      <parameter type-id='type-id-245' name='content' filepath='/src/src/lib/zxc_dict.c' line='108' column='1'/>
-      <parameter type-id='type-id-32' name='content_size' filepath='/src/src/lib/zxc_dict.c' line='108' column='1'/>
-      <parameter type-id='type-id-245' name='huf_lengths' filepath='/src/src/lib/zxc_dict.c' line='109' column='1'/>
-      <parameter type-id='type-id-44' name='buf' filepath='/src/src/lib/zxc_dict.c' line='109' column='1'/>
-      <parameter type-id='type-id-32' name='buf_capacity' filepath='/src/src/lib/zxc_dict.c' line='110' column='1'/>
-      <return type-id='type-id-52'/>
+      <parameter type-id='type-id-244' name='content' filepath='/src/src/lib/zxc_dict.c' line='108' column='1'/>
+      <parameter type-id='type-id-31' name='content_size' filepath='/src/src/lib/zxc_dict.c' line='108' column='1'/>
+      <parameter type-id='type-id-244' name='huf_lengths' filepath='/src/src/lib/zxc_dict.c' line='109' column='1'/>
+      <parameter type-id='type-id-43' name='buf' filepath='/src/src/lib/zxc_dict.c' line='109' column='1'/>
+      <parameter type-id='type-id-31' name='buf_capacity' filepath='/src/src/lib/zxc_dict.c' line='110' column='1'/>
+      <return type-id='type-id-51'/>
     </function-decl>
     <function-decl name='zxc_dict_load' mangled-name='zxc_dict_load' filepath='/src/src/lib/zxc_dict.c' line='151' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zxc_dict_load'>
-      <parameter type-id='type-id-245' name='buf' filepath='/src/src/lib/zxc_dict.c' line='151' column='1'/>
-      <parameter type-id='type-id-32' name='buf_size' filepath='/src/src/lib/zxc_dict.c' line='151' column='1'/>
-      <parameter type-id='type-id-235' name='content_out' filepath='/src/src/lib/zxc_dict.c' line='152' column='1'/>
-      <parameter type-id='type-id-230' name='content_size_out' filepath='/src/src/lib/zxc_dict.c' line='152' column='1'/>
-      <parameter type-id='type-id-235' name='huf_out' filepath='/src/src/lib/zxc_dict.c' line='153' column='1'/>
+      <parameter type-id='type-id-244' name='buf' filepath='/src/src/lib/zxc_dict.c' line='151' column='1'/>
+      <parameter type-id='type-id-31' name='buf_size' filepath='/src/src/lib/zxc_dict.c' line='151' column='1'/>
+      <parameter type-id='type-id-234' name='content_out' filepath='/src/src/lib/zxc_dict.c' line='152' column='1'/>
+      <parameter type-id='type-id-229' name='content_size_out' filepath='/src/src/lib/zxc_dict.c' line='152' column='1'/>
+      <parameter type-id='type-id-234' name='huf_out' filepath='/src/src/lib/zxc_dict.c' line='153' column='1'/>
       <parameter type-id='type-id-9' name='dict_id_out' filepath='/src/src/lib/zxc_dict.c' line='153' column='1'/>
       <return type-id='type-id-11'/>
     </function-decl>
     <function-decl name='zxc_dict_huf' mangled-name='zxc_dict_huf' filepath='/src/src/lib/zxc_dict.c' line='201' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zxc_dict_huf'>
       <parameter type-id='type-id-12' name='buf' filepath='/src/src/lib/zxc_dict.c' line='201' column='1'/>
-      <parameter type-id='type-id-32' name='buf_size' filepath='/src/src/lib/zxc_dict.c' line='201' column='1'/>
+      <parameter type-id='type-id-31' name='buf_size' filepath='/src/src/lib/zxc_dict.c' line='201' column='1'/>
       <return type-id='type-id-12'/>
     </function-decl>
     <function-decl name='zxc_train_dict' mangled-name='zxc_train_dict' filepath='/src/src/lib/zxc_dict.c' line='337' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zxc_train_dict'>
-      <parameter type-id='type-id-234' name='samples' filepath='/src/src/lib/zxc_dict.c' line='337' column='1'/>
-      <parameter type-id='type-id-218' name='sample_sizes' filepath='/src/src/lib/zxc_dict.c' line='337' column='1'/>
-      <parameter type-id='type-id-32' name='n_samples' filepath='/src/src/lib/zxc_dict.c' line='338' column='1'/>
-      <parameter type-id='type-id-44' name='dict_buf' filepath='/src/src/lib/zxc_dict.c' line='338' column='1'/>
-      <parameter type-id='type-id-32' name='dict_capacity' filepath='/src/src/lib/zxc_dict.c' line='339' column='1'/>
-      <return type-id='type-id-52'/>
+      <parameter type-id='type-id-233' name='samples' filepath='/src/src/lib/zxc_dict.c' line='337' column='1'/>
+      <parameter type-id='type-id-217' name='sample_sizes' filepath='/src/src/lib/zxc_dict.c' line='337' column='1'/>
+      <parameter type-id='type-id-31' name='n_samples' filepath='/src/src/lib/zxc_dict.c' line='338' column='1'/>
+      <parameter type-id='type-id-43' name='dict_buf' filepath='/src/src/lib/zxc_dict.c' line='338' column='1'/>
+      <parameter type-id='type-id-31' name='dict_capacity' filepath='/src/src/lib/zxc_dict.c' line='339' column='1'/>
+      <return type-id='type-id-51'/>
     </function-decl>
     <function-decl name='zxc_train_dict_huf' mangled-name='zxc_train_dict_huf' filepath='/src/src/lib/zxc_dict.c' line='529' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zxc_train_dict_huf'>
-      <parameter type-id='type-id-234' name='samples' filepath='/src/src/lib/zxc_dict.c' line='529' column='1'/>
-      <parameter type-id='type-id-218' name='sample_sizes' filepath='/src/src/lib/zxc_dict.c' line='529' column='1'/>
-      <parameter type-id='type-id-32' name='n_samples' filepath='/src/src/lib/zxc_dict.c' line='530' column='1'/>
-      <parameter type-id='type-id-245' name='dict' filepath='/src/src/lib/zxc_dict.c' line='530' column='1'/>
-      <parameter type-id='type-id-32' name='dict_size' filepath='/src/src/lib/zxc_dict.c' line='530' column='1'/>
+      <parameter type-id='type-id-233' name='samples' filepath='/src/src/lib/zxc_dict.c' line='529' column='1'/>
+      <parameter type-id='type-id-217' name='sample_sizes' filepath='/src/src/lib/zxc_dict.c' line='529' column='1'/>
+      <parameter type-id='type-id-31' name='n_samples' filepath='/src/src/lib/zxc_dict.c' line='530' column='1'/>
+      <parameter type-id='type-id-244' name='dict' filepath='/src/src/lib/zxc_dict.c' line='530' column='1'/>
+      <parameter type-id='type-id-31' name='dict_size' filepath='/src/src/lib/zxc_dict.c' line='530' column='1'/>
       <parameter type-id='type-id-10' name='huf_lengths_out' filepath='/src/src/lib/zxc_dict.c' line='531' column='1'/>
       <return type-id='type-id-11'/>
     </function-decl>
     <function-decl name='zxc_dict_train' mangled-name='zxc_dict_train' filepath='/src/src/lib/zxc_dict.c' line='636' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zxc_dict_train'>
-      <parameter type-id='type-id-234' name='samples' filepath='/src/src/lib/zxc_dict.c' line='636' column='1'/>
-      <parameter type-id='type-id-218' name='sample_sizes' filepath='/src/src/lib/zxc_dict.c' line='636' column='1'/>
-      <parameter type-id='type-id-32' name='n_samples' filepath='/src/src/lib/zxc_dict.c' line='637' column='1'/>
-      <parameter type-id='type-id-44' name='zxd_buf' filepath='/src/src/lib/zxc_dict.c' line='637' column='1'/>
-      <parameter type-id='type-id-32' name='zxd_capacity' filepath='/src/src/lib/zxc_dict.c' line='637' column='1'/>
-      <return type-id='type-id-52'/>
+      <parameter type-id='type-id-233' name='samples' filepath='/src/src/lib/zxc_dict.c' line='636' column='1'/>
+      <parameter type-id='type-id-217' name='sample_sizes' filepath='/src/src/lib/zxc_dict.c' line='636' column='1'/>
+      <parameter type-id='type-id-31' name='n_samples' filepath='/src/src/lib/zxc_dict.c' line='637' column='1'/>
+      <parameter type-id='type-id-43' name='zxd_buf' filepath='/src/src/lib/zxc_dict.c' line='637' column='1'/>
+      <parameter type-id='type-id-31' name='zxd_capacity' filepath='/src/src/lib/zxc_dict.c' line='637' column='1'/>
+      <return type-id='type-id-51'/>
     </function-decl>
-    <function-decl name='zxc_decompress' mangled-name='zxc_decompress' filepath='/src/src/lib/zxc_dispatch.c' line='848' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zxc_decompress'>
-      <parameter type-id='type-id-244' name='src' filepath='/src/src/lib/zxc_dispatch.c' line='848' column='1'/>
-      <parameter type-id='type-id-32' name='src_size' filepath='/src/src/lib/zxc_dispatch.c' line='848' column='1'/>
-      <parameter type-id='type-id-54' name='dst' filepath='/src/src/lib/zxc_dispatch.c' line='848' column='1'/>
-      <parameter type-id='type-id-32' name='dst_capacity' filepath='/src/src/lib/zxc_dispatch.c' line='849' column='1'/>
-      <parameter type-id='type-id-224' name='opts' filepath='/src/src/lib/zxc_dispatch.c' line='849' column='1'/>
-      <return type-id='type-id-52'/>
+    <function-decl name='zxc_decompress' mangled-name='zxc_decompress' filepath='/src/src/lib/zxc_dispatch.c' line='859' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zxc_decompress'>
+      <parameter type-id='type-id-243' name='src' filepath='/src/src/lib/zxc_dispatch.c' line='859' column='1'/>
+      <parameter type-id='type-id-31' name='src_size' filepath='/src/src/lib/zxc_dispatch.c' line='859' column='1'/>
+      <parameter type-id='type-id-53' name='dst' filepath='/src/src/lib/zxc_dispatch.c' line='859' column='1'/>
+      <parameter type-id='type-id-31' name='dst_capacity' filepath='/src/src/lib/zxc_dispatch.c' line='860' column='1'/>
+      <parameter type-id='type-id-223' name='opts' filepath='/src/src/lib/zxc_dispatch.c' line='860' column='1'/>
+      <return type-id='type-id-51'/>
     </function-decl>
-    <function-decl name='zxc_decompress_inplace_bound' mangled-name='zxc_decompress_inplace_bound' filepath='/src/src/lib/zxc_dispatch.c' line='1073' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zxc_decompress_inplace_bound'>
-      <parameter type-id='type-id-12' name='src' filepath='/src/src/lib/zxc_dispatch.c' line='1073' column='1'/>
-      <parameter type-id='type-id-32' name='src_size' filepath='/src/src/lib/zxc_dispatch.c' line='1073' column='1'/>
+    <function-decl name='zxc_decompress_inplace_bound' mangled-name='zxc_decompress_inplace_bound' filepath='/src/src/lib/zxc_dispatch.c' line='1084' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zxc_decompress_inplace_bound'>
+      <parameter type-id='type-id-12' name='src' filepath='/src/src/lib/zxc_dispatch.c' line='1084' column='1'/>
+      <parameter type-id='type-id-31' name='src_size' filepath='/src/src/lib/zxc_dispatch.c' line='1084' column='1'/>
       <return type-id='type-id-15'/>
     </function-decl>
-    <function-decl name='zxc_decompress_inplace' mangled-name='zxc_decompress_inplace' filepath='/src/src/lib/zxc_dispatch.c' line='1103' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zxc_decompress_inplace'>
-      <parameter type-id='type-id-12' name='buffer' filepath='/src/src/lib/zxc_dispatch.c' line='1103' column='1'/>
-      <parameter type-id='type-id-32' name='buffer_capacity' filepath='/src/src/lib/zxc_dispatch.c' line='1103' column='1'/>
-      <parameter type-id='type-id-32' name='comp_size' filepath='/src/src/lib/zxc_dispatch.c' line='1103' column='1'/>
-      <parameter type-id='type-id-224' name='opts' filepath='/src/src/lib/zxc_dispatch.c' line='1104' column='1'/>
-      <return type-id='type-id-52'/>
+    <function-decl name='zxc_decompress_inplace' mangled-name='zxc_decompress_inplace' filepath='/src/src/lib/zxc_dispatch.c' line='1114' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zxc_decompress_inplace'>
+      <parameter type-id='type-id-12' name='buffer' filepath='/src/src/lib/zxc_dispatch.c' line='1114' column='1'/>
+      <parameter type-id='type-id-31' name='buffer_capacity' filepath='/src/src/lib/zxc_dispatch.c' line='1114' column='1'/>
+      <parameter type-id='type-id-31' name='comp_size' filepath='/src/src/lib/zxc_dispatch.c' line='1114' column='1'/>
+      <parameter type-id='type-id-223' name='opts' filepath='/src/src/lib/zxc_dispatch.c' line='1115' column='1'/>
+      <return type-id='type-id-51'/>
     </function-decl>
-    <function-decl name='zxc_get_decompressed_size' mangled-name='zxc_get_decompressed_size' filepath='/src/src/lib/zxc_dispatch.c' line='1134' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zxc_get_decompressed_size'>
-      <parameter type-id='type-id-12' name='src' filepath='/src/src/lib/zxc_dispatch.c' line='1134' column='1'/>
-      <parameter type-id='type-id-32' name='src_size' filepath='/src/src/lib/zxc_dispatch.c' line='1134' column='1'/>
+    <function-decl name='zxc_get_decompressed_size' mangled-name='zxc_get_decompressed_size' filepath='/src/src/lib/zxc_dispatch.c' line='1145' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zxc_get_decompressed_size'>
+      <parameter type-id='type-id-12' name='src' filepath='/src/src/lib/zxc_dispatch.c' line='1145' column='1'/>
+      <parameter type-id='type-id-31' name='src_size' filepath='/src/src/lib/zxc_dispatch.c' line='1145' column='1'/>
       <return type-id='type-id-22'/>
     </function-decl>
-    <function-decl name='zxc_get_dict_id' mangled-name='zxc_get_dict_id' filepath='/src/src/lib/zxc_dispatch.c' line='1172' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zxc_get_dict_id'>
-      <parameter type-id='type-id-12' name='src' filepath='/src/src/lib/zxc_dispatch.c' line='1172' column='1'/>
-      <parameter type-id='type-id-32' name='src_size' filepath='/src/src/lib/zxc_dispatch.c' line='1172' column='1'/>
+    <function-decl name='zxc_get_dict_id' mangled-name='zxc_get_dict_id' filepath='/src/src/lib/zxc_dispatch.c' line='1183' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zxc_get_dict_id'>
+      <parameter type-id='type-id-12' name='src' filepath='/src/src/lib/zxc_dispatch.c' line='1183' column='1'/>
+      <parameter type-id='type-id-31' name='src_size' filepath='/src/src/lib/zxc_dispatch.c' line='1183' column='1'/>
       <return type-id='type-id-18'/>
     </function-decl>
-    <function-decl name='zxc_compress_cctx' mangled-name='zxc_compress_cctx' filepath='/src/src/lib/zxc_dispatch.c' line='1287' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zxc_compress_cctx'>
-      <parameter type-id='type-id-126' name='cctx' filepath='/src/src/lib/zxc_dispatch.c' line='1287' column='1'/>
-      <parameter type-id='type-id-244' name='src' filepath='/src/src/lib/zxc_dispatch.c' line='1287' column='1'/>
-      <parameter type-id='type-id-32' name='src_size' filepath='/src/src/lib/zxc_dispatch.c' line='1287' column='1'/>
-      <parameter type-id='type-id-54' name='dst' filepath='/src/src/lib/zxc_dispatch.c' line='1288' column='1'/>
-      <parameter type-id='type-id-32' name='dst_capacity' filepath='/src/src/lib/zxc_dispatch.c' line='1288' column='1'/>
-      <parameter type-id='type-id-127' name='opts' filepath='/src/src/lib/zxc_dispatch.c' line='1289' column='1'/>
-      <return type-id='type-id-52'/>
+    <function-decl name='zxc_compress_cctx' mangled-name='zxc_compress_cctx' filepath='/src/src/lib/zxc_dispatch.c' line='1298' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zxc_compress_cctx'>
+      <parameter type-id='type-id-125' name='cctx' filepath='/src/src/lib/zxc_dispatch.c' line='1298' column='1'/>
+      <parameter type-id='type-id-243' name='src' filepath='/src/src/lib/zxc_dispatch.c' line='1298' column='1'/>
+      <parameter type-id='type-id-31' name='src_size' filepath='/src/src/lib/zxc_dispatch.c' line='1298' column='1'/>
+      <parameter type-id='type-id-53' name='dst' filepath='/src/src/lib/zxc_dispatch.c' line='1299' column='1'/>
+      <parameter type-id='type-id-31' name='dst_capacity' filepath='/src/src/lib/zxc_dispatch.c' line='1299' column='1'/>
+      <parameter type-id='type-id-126' name='opts' filepath='/src/src/lib/zxc_dispatch.c' line='1300' column='1'/>
+      <return type-id='type-id-51'/>
     </function-decl>
-    <function-decl name='zxc_create_dctx' mangled-name='zxc_create_dctx' filepath='/src/src/lib/zxc_dispatch.c' line='1418' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zxc_create_dctx'>
-      <return type-id='type-id-237'/>
+    <function-decl name='zxc_create_dctx' mangled-name='zxc_create_dctx' filepath='/src/src/lib/zxc_dispatch.c' line='1429' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zxc_create_dctx'>
+      <return type-id='type-id-236'/>
     </function-decl>
-    <function-decl name='zxc_free_dctx' mangled-name='zxc_free_dctx' filepath='/src/src/lib/zxc_dispatch.c' line='1431' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zxc_free_dctx'>
-      <parameter type-id='type-id-237' name='dctx' filepath='/src/src/lib/zxc_dispatch.c' line='1431' column='1'/>
+    <function-decl name='zxc_free_dctx' mangled-name='zxc_free_dctx' filepath='/src/src/lib/zxc_dispatch.c' line='1442' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zxc_free_dctx'>
+      <parameter type-id='type-id-236' name='dctx' filepath='/src/src/lib/zxc_dispatch.c' line='1442' column='1'/>
       <return type-id='type-id-13'/>
     </function-decl>
-    <function-decl name='zxc_decompress_dctx' mangled-name='zxc_decompress_dctx' filepath='/src/src/lib/zxc_dispatch.c' line='1457' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zxc_decompress_dctx'>
-      <parameter type-id='type-id-237' name='dctx' filepath='/src/src/lib/zxc_dispatch.c' line='1457' column='1'/>
-      <parameter type-id='type-id-244' name='src' filepath='/src/src/lib/zxc_dispatch.c' line='1457' column='1'/>
-      <parameter type-id='type-id-32' name='src_size' filepath='/src/src/lib/zxc_dispatch.c' line='1457' column='1'/>
-      <parameter type-id='type-id-54' name='dst' filepath='/src/src/lib/zxc_dispatch.c' line='1458' column='1'/>
-      <parameter type-id='type-id-32' name='dst_capacity' filepath='/src/src/lib/zxc_dispatch.c' line='1458' column='1'/>
-      <parameter type-id='type-id-224' name='opts' filepath='/src/src/lib/zxc_dispatch.c' line='1459' column='1'/>
-      <return type-id='type-id-52'/>
+    <function-decl name='zxc_decompress_dctx' mangled-name='zxc_decompress_dctx' filepath='/src/src/lib/zxc_dispatch.c' line='1468' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zxc_decompress_dctx'>
+      <parameter type-id='type-id-236' name='dctx' filepath='/src/src/lib/zxc_dispatch.c' line='1468' column='1'/>
+      <parameter type-id='type-id-243' name='src' filepath='/src/src/lib/zxc_dispatch.c' line='1468' column='1'/>
+      <parameter type-id='type-id-31' name='src_size' filepath='/src/src/lib/zxc_dispatch.c' line='1468' column='1'/>
+      <parameter type-id='type-id-53' name='dst' filepath='/src/src/lib/zxc_dispatch.c' line='1469' column='1'/>
+      <parameter type-id='type-id-31' name='dst_capacity' filepath='/src/src/lib/zxc_dispatch.c' line='1469' column='1'/>
+      <parameter type-id='type-id-223' name='opts' filepath='/src/src/lib/zxc_dispatch.c' line='1470' column='1'/>
+      <return type-id='type-id-51'/>
     </function-decl>
-    <function-decl name='zxc_compress_block' mangled-name='zxc_compress_block' filepath='/src/src/lib/zxc_dispatch.c' line='1588' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zxc_compress_block'>
-      <parameter type-id='type-id-126' name='cctx' filepath='/src/src/lib/zxc_dispatch.c' line='1588' column='1'/>
-      <parameter type-id='type-id-244' name='src' filepath='/src/src/lib/zxc_dispatch.c' line='1588' column='1'/>
-      <parameter type-id='type-id-32' name='src_size' filepath='/src/src/lib/zxc_dispatch.c' line='1588' column='1'/>
-      <parameter type-id='type-id-54' name='dst' filepath='/src/src/lib/zxc_dispatch.c' line='1589' column='1'/>
-      <parameter type-id='type-id-32' name='dst_capacity' filepath='/src/src/lib/zxc_dispatch.c' line='1589' column='1'/>
-      <parameter type-id='type-id-127' name='opts' filepath='/src/src/lib/zxc_dispatch.c' line='1590' column='1'/>
-      <return type-id='type-id-52'/>
+    <function-decl name='zxc_compress_block' mangled-name='zxc_compress_block' filepath='/src/src/lib/zxc_dispatch.c' line='1599' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zxc_compress_block'>
+      <parameter type-id='type-id-125' name='cctx' filepath='/src/src/lib/zxc_dispatch.c' line='1599' column='1'/>
+      <parameter type-id='type-id-243' name='src' filepath='/src/src/lib/zxc_dispatch.c' line='1599' column='1'/>
+      <parameter type-id='type-id-31' name='src_size' filepath='/src/src/lib/zxc_dispatch.c' line='1599' column='1'/>
+      <parameter type-id='type-id-53' name='dst' filepath='/src/src/lib/zxc_dispatch.c' line='1600' column='1'/>
+      <parameter type-id='type-id-31' name='dst_capacity' filepath='/src/src/lib/zxc_dispatch.c' line='1600' column='1'/>
+      <parameter type-id='type-id-126' name='opts' filepath='/src/src/lib/zxc_dispatch.c' line='1601' column='1'/>
+      <return type-id='type-id-51'/>
     </function-decl>
-    <function-decl name='zxc_decompress_block' mangled-name='zxc_decompress_block' filepath='/src/src/lib/zxc_dispatch.c' line='1688' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zxc_decompress_block'>
-      <parameter type-id='type-id-237' name='dctx' filepath='/src/src/lib/zxc_dispatch.c' line='1688' column='1'/>
-      <parameter type-id='type-id-244' name='src' filepath='/src/src/lib/zxc_dispatch.c' line='1688' column='1'/>
-      <parameter type-id='type-id-32' name='src_size' filepath='/src/src/lib/zxc_dispatch.c' line='1688' column='1'/>
-      <parameter type-id='type-id-54' name='dst' filepath='/src/src/lib/zxc_dispatch.c' line='1689' column='1'/>
-      <parameter type-id='type-id-32' name='dst_capacity' filepath='/src/src/lib/zxc_dispatch.c' line='1689' column='1'/>
-      <parameter type-id='type-id-224' name='opts' filepath='/src/src/lib/zxc_dispatch.c' line='1690' column='1'/>
-      <return type-id='type-id-52'/>
+    <function-decl name='zxc_decompress_block' mangled-name='zxc_decompress_block' filepath='/src/src/lib/zxc_dispatch.c' line='1699' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zxc_decompress_block'>
+      <parameter type-id='type-id-236' name='dctx' filepath='/src/src/lib/zxc_dispatch.c' line='1699' column='1'/>
+      <parameter type-id='type-id-243' name='src' filepath='/src/src/lib/zxc_dispatch.c' line='1699' column='1'/>
+      <parameter type-id='type-id-31' name='src_size' filepath='/src/src/lib/zxc_dispatch.c' line='1699' column='1'/>
+      <parameter type-id='type-id-53' name='dst' filepath='/src/src/lib/zxc_dispatch.c' line='1700' column='1'/>
+      <parameter type-id='type-id-31' name='dst_capacity' filepath='/src/src/lib/zxc_dispatch.c' line='1700' column='1'/>
+      <parameter type-id='type-id-223' name='opts' filepath='/src/src/lib/zxc_dispatch.c' line='1701' column='1'/>
+      <return type-id='type-id-51'/>
     </function-decl>
-    <function-decl name='zxc_decompress_block_safe' mangled-name='zxc_decompress_block_safe' filepath='/src/src/lib/zxc_dispatch.c' line='1776' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zxc_decompress_block_safe'>
-      <parameter type-id='type-id-237' name='dctx' filepath='/src/src/lib/zxc_dispatch.c' line='1776' column='1'/>
-      <parameter type-id='type-id-244' name='src' filepath='/src/src/lib/zxc_dispatch.c' line='1776' column='1'/>
-      <parameter type-id='type-id-32' name='src_size' filepath='/src/src/lib/zxc_dispatch.c' line='1776' column='1'/>
-      <parameter type-id='type-id-54' name='dst' filepath='/src/src/lib/zxc_dispatch.c' line='1777' column='1'/>
-      <parameter type-id='type-id-32' name='dst_capacity' filepath='/src/src/lib/zxc_dispatch.c' line='1777' column='1'/>
-      <parameter type-id='type-id-224' name='opts' filepath='/src/src/lib/zxc_dispatch.c' line='1778' column='1'/>
-      <return type-id='type-id-52'/>
+    <function-decl name='zxc_decompress_block_safe' mangled-name='zxc_decompress_block_safe' filepath='/src/src/lib/zxc_dispatch.c' line='1787' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zxc_decompress_block_safe'>
+      <parameter type-id='type-id-236' name='dctx' filepath='/src/src/lib/zxc_dispatch.c' line='1787' column='1'/>
+      <parameter type-id='type-id-243' name='src' filepath='/src/src/lib/zxc_dispatch.c' line='1787' column='1'/>
+      <parameter type-id='type-id-31' name='src_size' filepath='/src/src/lib/zxc_dispatch.c' line='1787' column='1'/>
+      <parameter type-id='type-id-53' name='dst' filepath='/src/src/lib/zxc_dispatch.c' line='1788' column='1'/>
+      <parameter type-id='type-id-31' name='dst_capacity' filepath='/src/src/lib/zxc_dispatch.c' line='1788' column='1'/>
+      <parameter type-id='type-id-223' name='opts' filepath='/src/src/lib/zxc_dispatch.c' line='1789' column='1'/>
+      <return type-id='type-id-51'/>
     </function-decl>
-    <function-decl name='zxc_static_cctx_workspace_size' mangled-name='zxc_static_cctx_workspace_size' filepath='/src/src/lib/zxc_dispatch.c' line='1850' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zxc_static_cctx_workspace_size'>
-      <parameter type-id='type-id-32' name='block_size' filepath='/src/src/lib/zxc_dispatch.c' line='1850' column='1'/>
-      <parameter type-id='type-id-45' name='level' filepath='/src/src/lib/zxc_dispatch.c' line='1850' column='1'/>
+    <function-decl name='zxc_static_cctx_workspace_size' mangled-name='zxc_static_cctx_workspace_size' filepath='/src/src/lib/zxc_dispatch.c' line='1861' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zxc_static_cctx_workspace_size'>
+      <parameter type-id='type-id-31' name='block_size' filepath='/src/src/lib/zxc_dispatch.c' line='1861' column='1'/>
+      <parameter type-id='type-id-44' name='level' filepath='/src/src/lib/zxc_dispatch.c' line='1861' column='1'/>
       <return type-id='type-id-15'/>
     </function-decl>
-    <function-decl name='zxc_init_static_cctx' mangled-name='zxc_init_static_cctx' filepath='/src/src/lib/zxc_dispatch.c' line='1873' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zxc_init_static_cctx'>
-      <parameter type-id='type-id-54' name='workspace' filepath='/src/src/lib/zxc_dispatch.c' line='1873' column='1'/>
-      <parameter type-id='type-id-32' name='workspace_size' filepath='/src/src/lib/zxc_dispatch.c' line='1873' column='1'/>
-      <parameter type-id='type-id-220' name='opts' filepath='/src/src/lib/zxc_dispatch.c' line='1874' column='1'/>
-      <return type-id='type-id-126'/>
+    <function-decl name='zxc_init_static_cctx' mangled-name='zxc_init_static_cctx' filepath='/src/src/lib/zxc_dispatch.c' line='1884' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zxc_init_static_cctx'>
+      <parameter type-id='type-id-53' name='workspace' filepath='/src/src/lib/zxc_dispatch.c' line='1884' column='1'/>
+      <parameter type-id='type-id-31' name='workspace_size' filepath='/src/src/lib/zxc_dispatch.c' line='1884' column='1'/>
+      <parameter type-id='type-id-219' name='opts' filepath='/src/src/lib/zxc_dispatch.c' line='1885' column='1'/>
+      <return type-id='type-id-125'/>
     </function-decl>
-    <function-decl name='zxc_static_dctx_workspace_size' mangled-name='zxc_static_dctx_workspace_size' filepath='/src/src/lib/zxc_dispatch.c' line='1915' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zxc_static_dctx_workspace_size'>
-      <parameter type-id='type-id-32' name='block_size' filepath='/src/src/lib/zxc_dispatch.c' line='1915' column='1'/>
+    <function-decl name='zxc_static_dctx_workspace_size' mangled-name='zxc_static_dctx_workspace_size' filepath='/src/src/lib/zxc_dispatch.c' line='1926' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zxc_static_dctx_workspace_size'>
+      <parameter type-id='type-id-31' name='block_size' filepath='/src/src/lib/zxc_dispatch.c' line='1926' column='1'/>
       <return type-id='type-id-15'/>
     </function-decl>
-    <function-decl name='zxc_init_static_dctx' mangled-name='zxc_init_static_dctx' filepath='/src/src/lib/zxc_dispatch.c' line='1936' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zxc_init_static_dctx'>
-      <parameter type-id='type-id-54' name='workspace' filepath='/src/src/lib/zxc_dispatch.c' line='1936' column='1'/>
-      <parameter type-id='type-id-32' name='workspace_size' filepath='/src/src/lib/zxc_dispatch.c' line='1936' column='1'/>
-      <parameter type-id='type-id-32' name='block_size' filepath='/src/src/lib/zxc_dispatch.c' line='1937' column='1'/>
-      <return type-id='type-id-237'/>
+    <function-decl name='zxc_init_static_dctx' mangled-name='zxc_init_static_dctx' filepath='/src/src/lib/zxc_dispatch.c' line='1947' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zxc_init_static_dctx'>
+      <parameter type-id='type-id-53' name='workspace' filepath='/src/src/lib/zxc_dispatch.c' line='1947' column='1'/>
+      <parameter type-id='type-id-31' name='workspace_size' filepath='/src/src/lib/zxc_dispatch.c' line='1947' column='1'/>
+      <parameter type-id='type-id-31' name='block_size' filepath='/src/src/lib/zxc_dispatch.c' line='1948' column='1'/>
+      <return type-id='type-id-236'/>
     </function-decl>
     <function-decl name='zxc_stream_get_decompressed_size' mangled-name='zxc_stream_get_decompressed_size' filepath='/src/src/lib/zxc_driver.c' line='1101' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zxc_stream_get_decompressed_size'>
-      <parameter type-id='type-id-98' name='f_in' filepath='/src/src/lib/zxc_driver.c' line='1101' column='1'/>
-      <return type-id='type-id-52'/>
+      <parameter type-id='type-id-97' name='f_in' filepath='/src/src/lib/zxc_driver.c' line='1101' column='1'/>
+      <return type-id='type-id-51'/>
     </function-decl>
     <type-decl name='void' id='type-id-13'/>
     <pointer-type-def type-id='type-id-13' id='type-id-12'/>
-    <qualified-type-def type-id='type-id-12' restrict='yes' id='type-id-245'/>
-    <function-decl name='zxc_compress' mangled-name='zxc_compress' filepath='/src/src/lib/zxc_dispatch.c' line='663' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zxc_compress'>
-      <parameter type-id='type-id-244' name='src' filepath='/src/src/lib/zxc_dispatch.c' line='663' column='1'/>
-      <parameter type-id='type-id-32' name='src_size' filepath='/src/src/lib/zxc_dispatch.c' line='663' column='1'/>
-      <parameter type-id='type-id-54' name='dst' filepath='/src/src/lib/zxc_dispatch.c' line='663' column='1'/>
-      <parameter type-id='type-id-32' name='dst_capacity' filepath='/src/src/lib/zxc_dispatch.c' line='664' column='1'/>
-      <parameter type-id='type-id-127' name='opts' filepath='/src/src/lib/zxc_dispatch.c' line='664' column='1'/>
-      <return type-id='type-id-52'/>
+    <qualified-type-def type-id='type-id-12' restrict='yes' id='type-id-244'/>
+    <function-decl name='zxc_compress' mangled-name='zxc_compress' filepath='/src/src/lib/zxc_dispatch.c' line='674' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zxc_compress'>
+      <parameter type-id='type-id-243' name='src' filepath='/src/src/lib/zxc_dispatch.c' line='674' column='1'/>
+      <parameter type-id='type-id-31' name='src_size' filepath='/src/src/lib/zxc_dispatch.c' line='674' column='1'/>
+      <parameter type-id='type-id-53' name='dst' filepath='/src/src/lib/zxc_dispatch.c' line='674' column='1'/>
+      <parameter type-id='type-id-31' name='dst_capacity' filepath='/src/src/lib/zxc_dispatch.c' line='675' column='1'/>
+      <parameter type-id='type-id-126' name='opts' filepath='/src/src/lib/zxc_dispatch.c' line='675' column='1'/>
+      <return type-id='type-id-51'/>
     </function-decl>
     <function-decl name='zxc_stream_compress' mangled-name='zxc_stream_compress' filepath='/src/src/lib/zxc_driver.c' line='1037' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zxc_stream_compress'>
-      <parameter type-id='type-id-98' name='f_in' filepath='/src/src/lib/zxc_driver.c' line='1037' column='1'/>
-      <parameter type-id='type-id-98' name='f_out' filepath='/src/src/lib/zxc_driver.c' line='1037' column='1'/>
-      <parameter type-id='type-id-127' name='opts' filepath='/src/src/lib/zxc_driver.c' line='1037' column='1'/>
-      <return type-id='type-id-52'/>
+      <parameter type-id='type-id-97' name='f_in' filepath='/src/src/lib/zxc_driver.c' line='1037' column='1'/>
+      <parameter type-id='type-id-97' name='f_out' filepath='/src/src/lib/zxc_driver.c' line='1037' column='1'/>
+      <parameter type-id='type-id-126' name='opts' filepath='/src/src/lib/zxc_driver.c' line='1037' column='1'/>
+      <return type-id='type-id-51'/>
     </function-decl>
     <function-decl name='zxc_stream_decompress' mangled-name='zxc_stream_decompress' filepath='/src/src/lib/zxc_driver.c' line='1073' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zxc_stream_decompress'>
-      <parameter type-id='type-id-98' name='f_in' filepath='/src/src/lib/zxc_driver.c' line='1073' column='1'/>
-      <parameter type-id='type-id-98' name='f_out' filepath='/src/src/lib/zxc_driver.c' line='1073' column='1'/>
-      <parameter type-id='type-id-224' name='opts' filepath='/src/src/lib/zxc_driver.c' line='1073' column='1'/>
-      <return type-id='type-id-52'/>
+      <parameter type-id='type-id-97' name='f_in' filepath='/src/src/lib/zxc_driver.c' line='1073' column='1'/>
+      <parameter type-id='type-id-97' name='f_out' filepath='/src/src/lib/zxc_driver.c' line='1073' column='1'/>
+      <parameter type-id='type-id-223' name='opts' filepath='/src/src/lib/zxc_driver.c' line='1073' column='1'/>
+      <return type-id='type-id-51'/>
     </function-decl>
     <function-decl name='zxc_seekable_open_file' mangled-name='zxc_seekable_open_file' filepath='/src/src/lib/zxc_driver.c' line='1221' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zxc_seekable_open_file'>
-      <parameter type-id='type-id-98' name='f' filepath='/src/src/lib/zxc_driver.c' line='1221' column='1'/>
-      <return type-id='type-id-123'/>
+      <parameter type-id='type-id-97' name='f' filepath='/src/src/lib/zxc_driver.c' line='1221' column='1'/>
+      <return type-id='type-id-122'/>
     </function-decl>
-    <var-decl name='zxc_pivco_idxa_u8' type-id='type-id-134' visibility='default' filepath='/src/src/lib/zxc_pivco_tables.h' line='43' column='1'/>
-    <var-decl name='zxc_pivco_idxb_pre' type-id='type-id-137' visibility='default' filepath='/src/src/lib/zxc_pivco_tables.h' line='44' column='1'/>
+    <var-decl name='zxc_pivco_idxa_u8' type-id='type-id-133' visibility='default' filepath='/src/src/lib/zxc_pivco_tables.h' line='46' column='1'/>
+    <var-decl name='zxc_pivco_idxb_pre' type-id='type-id-136' visibility='default' filepath='/src/src/lib/zxc_pivco_tables.h' line='47' column='1'/>
     <function-decl name='zxc_cstream_create' mangled-name='zxc_cstream_create' filepath='/src/src/lib/zxc_pstream.c' line='269' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zxc_cstream_create'>
-      <parameter type-id='type-id-127' name='opts' filepath='/src/src/lib/zxc_pstream.c' line='269' column='1'/>
-      <return type-id='type-id-236'/>
+      <parameter type-id='type-id-126' name='opts' filepath='/src/src/lib/zxc_pstream.c' line='269' column='1'/>
+      <return type-id='type-id-235'/>
     </function-decl>
     <function-decl name='zxc_cstream_free' mangled-name='zxc_cstream_free' filepath='/src/src/lib/zxc_pstream.c' line='401' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zxc_cstream_free'>
-      <parameter type-id='type-id-236' name='cs' filepath='/src/src/lib/zxc_pstream.c' line='401' column='1'/>
+      <parameter type-id='type-id-235' name='cs' filepath='/src/src/lib/zxc_pstream.c' line='401' column='1'/>
       <return type-id='type-id-13'/>
     </function-decl>
     <function-decl name='zxc_cstream_in_size' mangled-name='zxc_cstream_in_size' filepath='/src/src/lib/zxc_pstream.c' line='415' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zxc_cstream_in_size'>
-      <parameter type-id='type-id-222' name='cs' filepath='/src/src/lib/zxc_pstream.c' line='415' column='1'/>
+      <parameter type-id='type-id-221' name='cs' filepath='/src/src/lib/zxc_pstream.c' line='415' column='1'/>
       <return type-id='type-id-15'/>
     </function-decl>
     <function-decl name='zxc_cstream_out_size' mangled-name='zxc_cstream_out_size' filepath='/src/src/lib/zxc_pstream.c' line='427' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zxc_cstream_out_size'>
-      <parameter type-id='type-id-222' name='cs' filepath='/src/src/lib/zxc_pstream.c' line='427' column='1'/>
+      <parameter type-id='type-id-221' name='cs' filepath='/src/src/lib/zxc_pstream.c' line='427' column='1'/>
       <return type-id='type-id-15'/>
     </function-decl>
     <function-decl name='zxc_cstream_compress' mangled-name='zxc_cstream_compress' filepath='/src/src/lib/zxc_pstream.c' line='453' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zxc_cstream_compress'>
-      <parameter type-id='type-id-236' name='cs' filepath='/src/src/lib/zxc_pstream.c' line='453' column='1'/>
-      <parameter type-id='type-id-240' name='out' filepath='/src/src/lib/zxc_pstream.c' line='453' column='1'/>
-      <parameter type-id='type-id-239' name='in' filepath='/src/src/lib/zxc_pstream.c' line='453' column='1'/>
-      <return type-id='type-id-52'/>
+      <parameter type-id='type-id-235' name='cs' filepath='/src/src/lib/zxc_pstream.c' line='453' column='1'/>
+      <parameter type-id='type-id-239' name='out' filepath='/src/src/lib/zxc_pstream.c' line='453' column='1'/>
+      <parameter type-id='type-id-238' name='in' filepath='/src/src/lib/zxc_pstream.c' line='453' column='1'/>
+      <return type-id='type-id-51'/>
     </function-decl>
     <function-decl name='zxc_cstream_end' mangled-name='zxc_cstream_end' filepath='/src/src/lib/zxc_pstream.c' line='532' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zxc_cstream_end'>
-      <parameter type-id='type-id-236' name='cs' filepath='/src/src/lib/zxc_pstream.c' line='532' column='1'/>
-      <parameter type-id='type-id-240' name='out' filepath='/src/src/lib/zxc_pstream.c' line='532' column='1'/>
-      <return type-id='type-id-52'/>
+      <parameter type-id='type-id-235' name='cs' filepath='/src/src/lib/zxc_pstream.c' line='532' column='1'/>
+      <parameter type-id='type-id-239' name='out' filepath='/src/src/lib/zxc_pstream.c' line='532' column='1'/>
+      <return type-id='type-id-51'/>
     </function-decl>
     <function-decl name='zxc_dstream_create' mangled-name='zxc_dstream_create' filepath='/src/src/lib/zxc_pstream.c' line='826' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zxc_dstream_create'>
-      <parameter type-id='type-id-224' name='opts' filepath='/src/src/lib/zxc_pstream.c' line='826' column='1'/>
-      <return type-id='type-id-238'/>
+      <parameter type-id='type-id-223' name='opts' filepath='/src/src/lib/zxc_pstream.c' line='826' column='1'/>
+      <return type-id='type-id-237'/>
     </function-decl>
     <function-decl name='zxc_dstream_free' mangled-name='zxc_dstream_free' filepath='/src/src/lib/zxc_pstream.c' line='849' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zxc_dstream_free'>
-      <parameter type-id='type-id-238' name='ds' filepath='/src/src/lib/zxc_pstream.c' line='849' column='1'/>
+      <parameter type-id='type-id-237' name='ds' filepath='/src/src/lib/zxc_pstream.c' line='849' column='1'/>
       <return type-id='type-id-13'/>
     </function-decl>
     <function-decl name='zxc_dstream_finished' mangled-name='zxc_dstream_finished' filepath='/src/src/lib/zxc_pstream.c' line='863' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zxc_dstream_finished'>
-      <parameter type-id='type-id-226' name='ds' filepath='/src/src/lib/zxc_pstream.c' line='863' column='1'/>
+      <parameter type-id='type-id-225' name='ds' filepath='/src/src/lib/zxc_pstream.c' line='863' column='1'/>
       <return type-id='type-id-11'/>
     </function-decl>
     <function-decl name='zxc_dstream_in_size' mangled-name='zxc_dstream_in_size' filepath='/src/src/lib/zxc_pstream.c' line='875' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zxc_dstream_in_size'>
-      <parameter type-id='type-id-226' name='ds' filepath='/src/src/lib/zxc_pstream.c' line='875' column='1'/>
+      <parameter type-id='type-id-225' name='ds' filepath='/src/src/lib/zxc_pstream.c' line='875' column='1'/>
       <return type-id='type-id-15'/>
     </function-decl>
     <function-decl name='zxc_dstream_out_size' mangled-name='zxc_dstream_out_size' filepath='/src/src/lib/zxc_pstream.c' line='891' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zxc_dstream_out_size'>
-      <parameter type-id='type-id-226' name='ds' filepath='/src/src/lib/zxc_pstream.c' line='891' column='1'/>
+      <parameter type-id='type-id-225' name='ds' filepath='/src/src/lib/zxc_pstream.c' line='891' column='1'/>
       <return type-id='type-id-15'/>
     </function-decl>
     <function-decl name='zxc_dstream_decompress' mangled-name='zxc_dstream_decompress' filepath='/src/src/lib/zxc_pstream.c' line='1053' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zxc_dstream_decompress'>
-      <parameter type-id='type-id-238' name='ds' filepath='/src/src/lib/zxc_pstream.c' line='1053' column='1'/>
-      <parameter type-id='type-id-240' name='out' filepath='/src/src/lib/zxc_pstream.c' line='1053' column='1'/>
-      <parameter type-id='type-id-239' name='in' filepath='/src/src/lib/zxc_pstream.c' line='1053' column='1'/>
-      <return type-id='type-id-52'/>
+      <parameter type-id='type-id-237' name='ds' filepath='/src/src/lib/zxc_pstream.c' line='1053' column='1'/>
+      <parameter type-id='type-id-239' name='out' filepath='/src/src/lib/zxc_pstream.c' line='1053' column='1'/>
+      <parameter type-id='type-id-238' name='in' filepath='/src/src/lib/zxc_pstream.c' line='1053' column='1'/>
+      <return type-id='type-id-51'/>
     </function-decl>
     <function-decl name='zxc_seekable_open' mangled-name='zxc_seekable_open' filepath='/src/src/lib/zxc_seekable.c' line='413' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zxc_seekable_open'>
       <parameter type-id='type-id-12' name='src' filepath='/src/src/lib/zxc_seekable.c' line='413' column='1'/>
-      <parameter type-id='type-id-32' name='src_size' filepath='/src/src/lib/zxc_seekable.c' line='413' column='1'/>
-      <return type-id='type-id-123'/>
+      <parameter type-id='type-id-31' name='src_size' filepath='/src/src/lib/zxc_seekable.c' line='413' column='1'/>
+      <return type-id='type-id-122'/>
     </function-decl>
     <function-decl name='zxc_seekable_get_num_blocks' mangled-name='zxc_seekable_get_num_blocks' filepath='/src/src/lib/zxc_seekable.c' line='567' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zxc_seekable_get_num_blocks'>
-      <parameter type-id='type-id-229' name='s' filepath='/src/src/lib/zxc_seekable.c' line='567' column='1'/>
+      <parameter type-id='type-id-228' name='s' filepath='/src/src/lib/zxc_seekable.c' line='567' column='1'/>
       <return type-id='type-id-18'/>
     </function-decl>
     <function-decl name='zxc_seekable_get_decompressed_size' mangled-name='zxc_seekable_get_decompressed_size' filepath='/src/src/lib/zxc_seekable.c' line='574' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zxc_seekable_get_decompressed_size'>
-      <parameter type-id='type-id-229' name='s' filepath='/src/src/lib/zxc_seekable.c' line='574' column='1'/>
+      <parameter type-id='type-id-228' name='s' filepath='/src/src/lib/zxc_seekable.c' line='574' column='1'/>
       <return type-id='type-id-22'/>
     </function-decl>
     <function-decl name='zxc_seekable_get_block_comp_size' mangled-name='zxc_seekable_get_block_comp_size' filepath='/src/src/lib/zxc_seekable.c' line='585' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zxc_seekable_get_block_comp_size'>
-      <parameter type-id='type-id-229' name='s' filepath='/src/src/lib/zxc_seekable.c' line='585' column='1'/>
-      <parameter type-id='type-id-51' name='block_idx' filepath='/src/src/lib/zxc_seekable.c' line='585' column='1'/>
+      <parameter type-id='type-id-228' name='s' filepath='/src/src/lib/zxc_seekable.c' line='585' column='1'/>
+      <parameter type-id='type-id-50' name='block_idx' filepath='/src/src/lib/zxc_seekable.c' line='585' column='1'/>
       <return type-id='type-id-18'/>
     </function-decl>
     <function-decl name='zxc_seekable_get_block_decomp_size' mangled-name='zxc_seekable_get_block_decomp_size' filepath='/src/src/lib/zxc_seekable.c' line='601' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zxc_seekable_get_block_decomp_size'>
-      <parameter type-id='type-id-229' name='s' filepath='/src/src/lib/zxc_seekable.c' line='601' column='1'/>
-      <parameter type-id='type-id-51' name='block_idx' filepath='/src/src/lib/zxc_seekable.c' line='601' column='1'/>
+      <parameter type-id='type-id-228' name='s' filepath='/src/src/lib/zxc_seekable.c' line='601' column='1'/>
+      <parameter type-id='type-id-50' name='block_idx' filepath='/src/src/lib/zxc_seekable.c' line='601' column='1'/>
       <return type-id='type-id-18'/>
     </function-decl>
     <function-decl name='zxc_seekable_decompress_range' mangled-name='zxc_seekable_decompress_range' filepath='/src/src/lib/zxc_seekable.c' line='701' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zxc_seekable_decompress_range'>
-      <parameter type-id='type-id-123' name='s' filepath='/src/src/lib/zxc_seekable.c' line='701' column='1'/>
+      <parameter type-id='type-id-122' name='s' filepath='/src/src/lib/zxc_seekable.c' line='701' column='1'/>
       <parameter type-id='type-id-12' name='dst' filepath='/src/src/lib/zxc_seekable.c' line='701' column='1'/>
-      <parameter type-id='type-id-32' name='dst_capacity' filepath='/src/src/lib/zxc_seekable.c' line='701' column='1'/>
-      <parameter type-id='type-id-59' name='offset' filepath='/src/src/lib/zxc_seekable.c' line='702' column='1'/>
-      <parameter type-id='type-id-32' name='len' filepath='/src/src/lib/zxc_seekable.c' line='702' column='1'/>
-      <return type-id='type-id-52'/>
+      <parameter type-id='type-id-31' name='dst_capacity' filepath='/src/src/lib/zxc_seekable.c' line='701' column='1'/>
+      <parameter type-id='type-id-58' name='offset' filepath='/src/src/lib/zxc_seekable.c' line='702' column='1'/>
+      <parameter type-id='type-id-31' name='len' filepath='/src/src/lib/zxc_seekable.c' line='702' column='1'/>
+      <return type-id='type-id-51'/>
     </function-decl>
     <function-decl name='zxc_seekable_decompress_range_mt' mangled-name='zxc_seekable_decompress_range_mt' filepath='/src/src/lib/zxc_seekable.c' line='1005' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zxc_seekable_decompress_range_mt'>
-      <parameter type-id='type-id-123' name='s' filepath='/src/src/lib/zxc_seekable.c' line='1005' column='1'/>
+      <parameter type-id='type-id-122' name='s' filepath='/src/src/lib/zxc_seekable.c' line='1005' column='1'/>
       <parameter type-id='type-id-12' name='dst' filepath='/src/src/lib/zxc_seekable.c' line='1005' column='1'/>
-      <parameter type-id='type-id-32' name='dst_capacity' filepath='/src/src/lib/zxc_seekable.c' line='1005' column='1'/>
-      <parameter type-id='type-id-59' name='offset' filepath='/src/src/lib/zxc_seekable.c' line='1006' column='1'/>
-      <parameter type-id='type-id-32' name='len' filepath='/src/src/lib/zxc_seekable.c' line='1006' column='1'/>
+      <parameter type-id='type-id-31' name='dst_capacity' filepath='/src/src/lib/zxc_seekable.c' line='1005' column='1'/>
+      <parameter type-id='type-id-58' name='offset' filepath='/src/src/lib/zxc_seekable.c' line='1006' column='1'/>
+      <parameter type-id='type-id-31' name='len' filepath='/src/src/lib/zxc_seekable.c' line='1006' column='1'/>
       <parameter type-id='type-id-11' name='n_threads' filepath='/src/src/lib/zxc_seekable.c' line='1006' column='1'/>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-51'/>
     </function-decl>
     <function-decl name='zxc_seekable_free' mangled-name='zxc_seekable_free' filepath='/src/src/lib/zxc_seekable.c' line='1125' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zxc_seekable_free'>
-      <parameter type-id='type-id-123' name='s' filepath='/src/src/lib/zxc_seekable.c' line='1125' column='1'/>
+      <parameter type-id='type-id-122' name='s' filepath='/src/src/lib/zxc_seekable.c' line='1125' column='1'/>
       <return type-id='type-id-13'/>
     </function-decl>
     <function-decl name='zxc_seekable_set_dict' mangled-name='zxc_seekable_set_dict' filepath='/src/src/lib/zxc_seekable.c' line='1150' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zxc_seekable_set_dict'>
-      <parameter type-id='type-id-123' name='s' filepath='/src/src/lib/zxc_seekable.c' line='1150' column='1'/>
+      <parameter type-id='type-id-122' name='s' filepath='/src/src/lib/zxc_seekable.c' line='1150' column='1'/>
       <parameter type-id='type-id-12' name='dict' filepath='/src/src/lib/zxc_seekable.c' line='1150' column='1'/>
-      <parameter type-id='type-id-32' name='dict_size' filepath='/src/src/lib/zxc_seekable.c' line='1150' column='1'/>
+      <parameter type-id='type-id-31' name='dict_size' filepath='/src/src/lib/zxc_seekable.c' line='1150' column='1'/>
       <parameter type-id='type-id-12' name='dict_huf' filepath='/src/src/lib/zxc_seekable.c' line='1151' column='1'/>
       <return type-id='type-id-11'/>
     </function-decl>
-    <function-type size-in-bits='64' id='type-id-231'>
+    <function-type size-in-bits='64' id='type-id-230'>
       <parameter type-id='type-id-22'/>
       <parameter type-id='type-id-22'/>
       <parameter type-id='type-id-12'/>

--- a/docs/abi/libzxc.suppr
+++ b/docs/abi/libzxc.suppr
@@ -27,6 +27,14 @@
 # baseline — is a removed/renamed exported symbol, a changed public function
 # signature, or a layout change to a by-value/visible type (e.g. an *_opts_t
 # struct). Those are intentionally NOT suppressed here.
+#
+# Internal FMV variant symbols (zxc_*_default / _neon / _avx2 / _avx512) are
+# NOT public API: they are declared only in the non-installed zxc_internal.h /
+# zxc_dispatch.c, compiled with -fvisibility=hidden for shared builds, and
+# never appear in the exported ELF symbol table. They can surface in the
+# baseline XML only as declaration-only DWARF records (no elf-symbol-id).
+# Adding or removing a variant is therefore NOT an ABI event and must not
+# force a SOVERSION bump — regenerate the baseline and move on.
 
 [suppress_type]
   type_kind = struct

--- a/meson.build
+++ b/meson.build
@@ -64,21 +64,17 @@ variant_sources = ['src/lib/zxc_compress.c',
 variant_sets = [['_default', []]]
 
 if host_cpu == 'x86_64'
+  # No _sse2 variant (SSE2 = x86-64 baseline, already active in _default).
   if is_cl
-    # SSE2 is the x86-64 baseline; /arch:AVX2|AVX512 gate the wider paths. MSVC does
-    # not predefine __BMI__/__BMI2__/__LZCNT__ under /arch, so define them here.
-    variant_sets += [['_sse2',   ['/D__SSE2__']]]
     variant_sets += [['_avx2',   ['/arch:AVX2', '/D__BMI__', '/D__BMI2__', '/D__LZCNT__']]]
     variant_sets += [['_avx512', ['/arch:AVX512', '/D__BMI__', '/D__BMI2__', '/D__LZCNT__']]]
   else
-    variant_sets += [['_sse2',   ['-msse2']]]
-    variant_sets += [['_avx2',   ['-mavx2', '-mfma', '-mbmi', '-mbmi2', '-mlzcnt']]]
+    variant_sets += [['_avx2',   ['-mavx2', '-mbmi', '-mbmi2', '-mlzcnt']]]
     variant_sets += [['_avx512', ['-mavx512f', '-mavx512bw', '-mavx512vbmi', '-mavx512vbmi2', '-mbmi', '-mbmi2', '-mlzcnt']]]
   endif
-elif host_cpu == 'aarch64'
-  # MSVC ARM64 implies NEON; passing -march=armv8-a+simd only warns D9002.
-  variant_sets += is_cl ? [['_neon', []]] : [['_neon', ['-march=armv8-a+simd']]]
 elif host_cpu == 'arm'
+  # 32-bit ARM only: NEON is optional there (runtime getauxval dispatch).
+  # AArch64 needs no extra variant: NEON is baseline and lives in _default.
   variant_sets += [['_neon', ['-march=armv7-a', '-mfpu=neon']]]
 endif
 

--- a/meson.build
+++ b/meson.build
@@ -75,7 +75,7 @@ if host_cpu == 'x86_64'
 elif host_cpu == 'arm'
   # 32-bit ARM only: NEON is optional there (runtime getauxval dispatch).
   # AArch64 needs no extra variant: NEON is baseline and lives in _default.
-  variant_sets += [['_neon', ['-march=armv7-a', '-mfpu=neon']]]
+  variant_sets += [['_neon32', ['-march=armv7-a', '-mfpu=neon']]]
 endif
 
 variant_objects = []

--- a/src/lib/zxc_compress.c
+++ b/src/lib/zxc_compress.c
@@ -17,7 +17,7 @@
 
 /*
  * Function Multi-Versioning Support
- * If ZXC_FUNCTION_SUFFIX is defined (e.g. _avx2, _neon), rename the public
+ * If ZXC_FUNCTION_SUFFIX is defined (e.g. _avx2, _neon32), rename the public
  * entry point AND the Huffman entry points consumed by this TU. The defines
  * sit before zxc_internal.h so that the prototypes the header declares are
  * also rewritten with the suffix, keeping callers and callees consistent.

--- a/src/lib/zxc_decompress.c
+++ b/src/lib/zxc_decompress.c
@@ -16,7 +16,7 @@
 
 /*
  * Function Multi-Versioning Support
- * If ZXC_FUNCTION_SUFFIX is defined (e.g. _avx2, _neon), rename the public
+ * If ZXC_FUNCTION_SUFFIX is defined (e.g. _avx2, _neon32), rename the public
  * entry point AND the Huffman decoder consumed by this TU. The defines sit
  * before zxc_internal.h so that the prototypes the header declares are also
  * rewritten with the suffix, keeping callers and callees consistent.

--- a/src/lib/zxc_dispatch.c
+++ b/src/lib/zxc_dispatch.c
@@ -85,15 +85,15 @@ int zxc_decompress_chunk_wrapper_safe_avx512(const zxc_cctx_t* RESTRICT ctx,
                                              const uint8_t* RESTRICT src, const size_t src_sz,
                                              uint8_t* RESTRICT dst, const size_t dst_cap);
 #elif defined(__arm__) || defined(_M_ARM)
-int zxc_decompress_chunk_wrapper_neon(const zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRICT src,
-                                      const size_t src_sz, uint8_t* RESTRICT dst,
-                                      const size_t dst_cap);
-int zxc_decompress_chunk_wrapper_dict_neon(const zxc_cctx_t* RESTRICT ctx,
-                                           const uint8_t* RESTRICT src, const size_t src_sz,
-                                           uint8_t* RESTRICT dst, const size_t dst_cap);
-int zxc_decompress_chunk_wrapper_safe_neon(const zxc_cctx_t* RESTRICT ctx,
-                                           const uint8_t* RESTRICT src, const size_t src_sz,
-                                           uint8_t* RESTRICT dst, const size_t dst_cap);
+int zxc_decompress_chunk_wrapper_neon32(const zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRICT src,
+                                        const size_t src_sz, uint8_t* RESTRICT dst,
+                                        const size_t dst_cap);
+int zxc_decompress_chunk_wrapper_dict_neon32(const zxc_cctx_t* RESTRICT ctx,
+                                             const uint8_t* RESTRICT src, const size_t src_sz,
+                                             uint8_t* RESTRICT dst, const size_t dst_cap);
+int zxc_decompress_chunk_wrapper_safe_neon32(const zxc_cctx_t* RESTRICT ctx,
+                                             const uint8_t* RESTRICT src, const size_t src_sz,
+                                             uint8_t* RESTRICT dst, const size_t dst_cap);
 #endif
 #endif
 
@@ -140,9 +140,9 @@ int zxc_compress_chunk_wrapper_avx512(zxc_cctx_t* RESTRICT ctx, const uint8_t* R
                                       const size_t src_sz, uint8_t* RESTRICT dst,
                                       const size_t dst_cap);
 #elif defined(__arm__) || defined(_M_ARM)
-int zxc_compress_chunk_wrapper_neon(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRICT src,
-                                    const size_t src_sz, uint8_t* RESTRICT dst,
-                                    const size_t dst_cap);
+int zxc_compress_chunk_wrapper_neon32(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRICT src,
+                                      const size_t src_sz, uint8_t* RESTRICT dst,
+                                      const size_t dst_cap);
 #endif
 
 /*
@@ -325,8 +325,8 @@ static int zxc_decompress_dispatch_init(const zxc_cctx_t* RESTRICT ctx, const ui
     // 32-bit ARM: the only arch with a real runtime NEON probe (getauxval).
     // cppcheck-suppress knownConditionTrueFalse
     if (cpu == ZXC_CPU_NEON) {
-        zxc_decompress_ptr_local = zxc_decompress_chunk_wrapper_neon;
-        zxc_decompress_dict_ptr_local = zxc_decompress_chunk_wrapper_dict_neon;
+        zxc_decompress_ptr_local = zxc_decompress_chunk_wrapper_neon32;
+        zxc_decompress_dict_ptr_local = zxc_decompress_chunk_wrapper_dict_neon32;
     } else {
         zxc_decompress_ptr_local = zxc_decompress_chunk_wrapper_default;
         zxc_decompress_dict_ptr_local = zxc_decompress_chunk_wrapper_dict_default;
@@ -387,7 +387,7 @@ static int zxc_decompress_safe_dispatch_init(const zxc_cctx_t* RESTRICT ctx,
 #elif defined(__arm__) || defined(_M_ARM)
     // cppcheck-suppress knownConditionTrueFalse
     if (cpu == ZXC_CPU_NEON)
-        zxc_decompress_safe_ptr_local = zxc_decompress_chunk_wrapper_safe_neon;
+        zxc_decompress_safe_ptr_local = zxc_decompress_chunk_wrapper_safe_neon32;
     else
         zxc_decompress_safe_ptr_local = zxc_decompress_chunk_wrapper_safe_default;
 #else
@@ -441,7 +441,7 @@ static int zxc_compress_dispatch_init(zxc_cctx_t* RESTRICT ctx, const uint8_t* R
 #elif defined(__arm__) || defined(_M_ARM)
     // cppcheck-suppress knownConditionTrueFalse
     if (cpu == ZXC_CPU_NEON)
-        zxc_compress_ptr_local = zxc_compress_chunk_wrapper_neon;
+        zxc_compress_ptr_local = zxc_compress_chunk_wrapper_neon32;
     else
         zxc_compress_ptr_local = zxc_compress_chunk_wrapper_default;
 #else
@@ -539,7 +539,7 @@ int zxc_compress_chunk_wrapper(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRICT
  * ============================================================================
  * HUFFMAN TRAMPOLINES
  * ============================================================================
- * The Huffman codec is built per-variant (default / avx2 / avx512, plus neon
+ * The Huffman codec is built per-variant (default / avx2 / avx512, plus neon32
  * on 32-bit ARM)
  * alongside zxc_compress.c and zxc_decompress.c, so the LZ77 stages and the
  * Huffman stage in a given variant share the same ISA flags (e.g. -mbmi2 on

--- a/src/lib/zxc_dispatch.c
+++ b/src/lib/zxc_dispatch.c
@@ -9,8 +9,10 @@
  * @file zxc_dispatch.c
  * @brief Runtime CPU feature detection and SIMD dispatch layer.
  *
- * Detects AVX2/AVX512/NEON at runtime and routes compress/decompress calls
- * to the best available implementation via lazy-initialised function pointers.
+ * Detects AVX2/AVX512 (x86-64) and NEON (32-bit ARM) at runtime and routes
+ * compress/decompress calls to the best available implementation via
+ * lazy-initialised function pointers. SSE2 on x86-64 and NEON on AArch64 are
+ * baseline ISA guarantees, so the _default variant already covers those tiers.
  * Also contains the public one-shot buffer API (@ref zxc_compress,
  * @ref zxc_decompress, @ref zxc_get_decompressed_size).
  */
@@ -33,6 +35,10 @@
 #if defined(_M_X64)
 #include <immintrin.h>  // _xgetbv (x86-specific header; x64 AVX state check)
 #endif
+#endif
+
+#if (defined(__x86_64__) || defined(_M_X64)) && !defined(_MSC_VER) && !defined(ZXC_ONLY_DEFAULT)
+#include <cpuid.h>  // __get_cpuid: LZCNT probe in zxc_detect_cpu_features
 #endif
 
 #if defined(__linux__) && (defined(__arm__) || defined(_M_ARM))
@@ -78,16 +84,7 @@ int zxc_decompress_chunk_wrapper_safe_avx2(const zxc_cctx_t* RESTRICT ctx,
 int zxc_decompress_chunk_wrapper_safe_avx512(const zxc_cctx_t* RESTRICT ctx,
                                              const uint8_t* RESTRICT src, const size_t src_sz,
                                              uint8_t* RESTRICT dst, const size_t dst_cap);
-int zxc_decompress_chunk_wrapper_sse2(const zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRICT src,
-                                      const size_t src_sz, uint8_t* RESTRICT dst,
-                                      const size_t dst_cap);
-int zxc_decompress_chunk_wrapper_dict_sse2(const zxc_cctx_t* RESTRICT ctx,
-                                           const uint8_t* RESTRICT src, const size_t src_sz,
-                                           uint8_t* RESTRICT dst, const size_t dst_cap);
-int zxc_decompress_chunk_wrapper_safe_sse2(const zxc_cctx_t* RESTRICT ctx,
-                                           const uint8_t* RESTRICT src, const size_t src_sz,
-                                           uint8_t* RESTRICT dst, const size_t dst_cap);
-#elif defined(__aarch64__) || defined(_M_ARM64) || defined(__arm__) || defined(_M_ARM)
+#elif defined(__arm__) || defined(_M_ARM)
 int zxc_decompress_chunk_wrapper_neon(const zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRICT src,
                                       const size_t src_sz, uint8_t* RESTRICT dst,
                                       const size_t dst_cap);
@@ -142,10 +139,7 @@ int zxc_compress_chunk_wrapper_avx2(zxc_cctx_t* RESTRICT ctx, const uint8_t* RES
 int zxc_compress_chunk_wrapper_avx512(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRICT src,
                                       const size_t src_sz, uint8_t* RESTRICT dst,
                                       const size_t dst_cap);
-int zxc_compress_chunk_wrapper_sse2(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRICT src,
-                                    const size_t src_sz, uint8_t* RESTRICT dst,
-                                    const size_t dst_cap);
-#elif defined(__aarch64__) || defined(_M_ARM64) || defined(__arm__) || defined(_M_ARM)
+#elif defined(__arm__) || defined(_M_ARM)
 int zxc_compress_chunk_wrapper_neon(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRICT src,
                                     const size_t src_sz, uint8_t* RESTRICT dst,
                                     const size_t dst_cap);
@@ -165,8 +159,10 @@ typedef enum {
     ZXC_CPU_GENERIC = 0, /**< @brief Scalar-only fallback.   */
     ZXC_CPU_AVX2 = 1,    /**< @brief x86-64 AVX2 available.  */
     ZXC_CPU_AVX512 = 2,  /**< @brief x86-64 AVX-512F+BW available. */
-    ZXC_CPU_NEON = 3,    /**< @brief ARM NEON available.      */
-    ZXC_CPU_SSE2 = 4     /**< @brief x86 SSE2 available (no AVX2); x86-64 baseline. */
+    ZXC_CPU_NEON = 3,    /**< @brief ARM NEON available (dedicated variant on 32-bit ARM only;
+                          *          AArch64 baseline, served by _default there). */
+    ZXC_CPU_SSE2 = 4     /**< @brief x86 SSE2 available (no AVX2); x86-64 baseline,
+                          *          served by _default (no dedicated variant). */
 } zxc_cpu_feature_t;
 
 /**
@@ -192,6 +188,7 @@ static zxc_cpu_feature_t zxc_detect_cpu_features(void) {
     int sse2 = 0;
     int avx2 = 0;
     int avx512 = 0;
+    int bmi_lzcnt = 0;
 
     __cpuid(regs, 1);
     if (regs[3] & (1 << 26)) sse2 = 1;  // SSE2
@@ -199,17 +196,24 @@ static zxc_cpu_feature_t zxc_detect_cpu_features(void) {
         const unsigned long long xcr0 = _xgetbv(0);
         if ((xcr0 & 0x6) == 0x6) {  // SSE+YMM enabled
             __cpuidex(regs, 7, 0);
+            const int bmi1 = (regs[1] >> 3) & 1;  // CPUID.7.0:EBX[3]
+            const int bmi2 = (regs[1] >> 8) & 1;  // CPUID.7.0:EBX[8]
             if (regs[1] & (1 << 5)) avx2 = 1;
             // AVX512 also needs XCR0[5..7] (opmask/ZMM)
             if ((regs[1] & (1 << 16)) && (regs[1] & (1 << 30)) && (regs[2] & (1 << 6)) &&
                 (xcr0 & 0xE0) == 0xE0)
                 avx512 = 1; /* AVX512 tier = F+BW+VBMI2 (variant built with -mavx512vbmi2) */
+            // The AVX2/AVX512 variants are compiled with BMI1/BMI2/LZCNT enabled,
+            // so both gates must prove those bits too. LZCNT (ABM) lives in
+            // CPUID.80000001H:ECX[5]; that leaf is architectural on x86-64.
+            __cpuid(regs, (int)0x80000001);
+            bmi_lzcnt = bmi1 && bmi2 && ((regs[2] >> 5) & 1);
         }
     }
 
-    if (avx512) {
+    if (avx512 && bmi_lzcnt) {
         features = ZXC_CPU_AVX512;
-    } else if (avx2) {
+    } else if (avx2 && bmi_lzcnt) {
         features = ZXC_CPU_AVX2;
     } else if (sse2) {
         features = ZXC_CPU_SSE2;
@@ -218,10 +222,16 @@ static zxc_cpu_feature_t zxc_detect_cpu_features(void) {
     // GCC/Clang built-in detection
     __builtin_cpu_init();
 
-    if (__builtin_cpu_supports("avx512f") && __builtin_cpu_supports("avx512bw") &&
+    // The AVX2/AVX512 variants are compiled with -mbmi -mbmi2 -mlzcnt, so both
+    // gates must prove BMI1/BMI2/LZCNT too (mirrors the F+BW+VBMI2 rule below).
+    unsigned int eax = 0, ebx = 0, ecx = 0, edx = 0;
+    const int lzcnt = __get_cpuid(0x80000001U, &eax, &ebx, &ecx, &edx) && ((ecx >> 5) & 1U);
+    const int bmi_lzcnt = lzcnt && __builtin_cpu_supports("bmi") && __builtin_cpu_supports("bmi2");
+
+    if (bmi_lzcnt && __builtin_cpu_supports("avx512f") && __builtin_cpu_supports("avx512bw") &&
         __builtin_cpu_supports("avx512vbmi2")) {
         features = ZXC_CPU_AVX512;
-    } else if (__builtin_cpu_supports("avx2")) {
+    } else if (bmi_lzcnt && __builtin_cpu_supports("avx2")) {
         features = ZXC_CPU_AVX2;
     } else if (__builtin_cpu_supports("sse2")) {
         features = ZXC_CPU_SSE2;
@@ -307,14 +317,12 @@ static int zxc_decompress_dispatch_init(const zxc_cctx_t* RESTRICT ctx, const ui
     } else if (cpu == ZXC_CPU_AVX2) {
         zxc_decompress_ptr_local = zxc_decompress_chunk_wrapper_avx2;
         zxc_decompress_dict_ptr_local = zxc_decompress_chunk_wrapper_dict_avx2;
-    } else if (cpu == ZXC_CPU_SSE2) {
-        zxc_decompress_ptr_local = zxc_decompress_chunk_wrapper_sse2;
-        zxc_decompress_dict_ptr_local = zxc_decompress_chunk_wrapper_dict_sse2;
     } else {
         zxc_decompress_ptr_local = zxc_decompress_chunk_wrapper_default;
         zxc_decompress_dict_ptr_local = zxc_decompress_chunk_wrapper_dict_default;
     }
-#elif defined(__aarch64__) || defined(_M_ARM64) || defined(__arm__) || defined(_M_ARM)
+#elif defined(__arm__) || defined(_M_ARM)
+    // 32-bit ARM: the only arch with a real runtime NEON probe (getauxval).
     // cppcheck-suppress knownConditionTrueFalse
     if (cpu == ZXC_CPU_NEON) {
         zxc_decompress_ptr_local = zxc_decompress_chunk_wrapper_neon;
@@ -374,11 +382,9 @@ static int zxc_decompress_safe_dispatch_init(const zxc_cctx_t* RESTRICT ctx,
         zxc_decompress_safe_ptr_local = zxc_decompress_chunk_wrapper_safe_avx512;
     else if (cpu == ZXC_CPU_AVX2)
         zxc_decompress_safe_ptr_local = zxc_decompress_chunk_wrapper_safe_avx2;
-    else if (cpu == ZXC_CPU_SSE2)
-        zxc_decompress_safe_ptr_local = zxc_decompress_chunk_wrapper_safe_sse2;
     else
         zxc_decompress_safe_ptr_local = zxc_decompress_chunk_wrapper_safe_default;
-#elif defined(__aarch64__) || defined(_M_ARM64) || defined(__arm__) || defined(_M_ARM)
+#elif defined(__arm__) || defined(_M_ARM)
     // cppcheck-suppress knownConditionTrueFalse
     if (cpu == ZXC_CPU_NEON)
         zxc_decompress_safe_ptr_local = zxc_decompress_chunk_wrapper_safe_neon;
@@ -430,11 +436,9 @@ static int zxc_compress_dispatch_init(zxc_cctx_t* RESTRICT ctx, const uint8_t* R
         zxc_compress_ptr_local = zxc_compress_chunk_wrapper_avx512;
     else if (cpu == ZXC_CPU_AVX2)
         zxc_compress_ptr_local = zxc_compress_chunk_wrapper_avx2;
-    else if (cpu == ZXC_CPU_SSE2)
-        zxc_compress_ptr_local = zxc_compress_chunk_wrapper_sse2;
     else
         zxc_compress_ptr_local = zxc_compress_chunk_wrapper_default;
-#elif defined(__aarch64__) || defined(_M_ARM64) || defined(__arm__) || defined(_M_ARM)
+#elif defined(__arm__) || defined(_M_ARM)
     // cppcheck-suppress knownConditionTrueFalse
     if (cpu == ZXC_CPU_NEON)
         zxc_compress_ptr_local = zxc_compress_chunk_wrapper_neon;
@@ -535,7 +539,8 @@ int zxc_compress_chunk_wrapper(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRICT
  * ============================================================================
  * HUFFMAN TRAMPOLINES
  * ============================================================================
- * The Huffman codec is built per-variant (default / avx2 / avx512 / neon)
+ * The Huffman codec is built per-variant (default / avx2 / avx512, plus neon
+ * on 32-bit ARM)
  * alongside zxc_compress.c and zxc_decompress.c, so the LZ77 stages and the
  * Huffman stage in a given variant share the same ISA flags (e.g. -mbmi2 on
  * the AVX2/AVX512 variants). The compress/decompress variant TUs resolve

--- a/src/lib/zxc_huffman.c
+++ b/src/lib/zxc_huffman.c
@@ -33,7 +33,7 @@
 
 /*
  * Function Multi-Versioning Support
- * If ZXC_FUNCTION_SUFFIX is defined (e.g. _avx2, _neon), rename the public
+ * If ZXC_FUNCTION_SUFFIX is defined (e.g. _avx2, _neon32), rename the public
  * entry points so each variant TU produces its own copy under a unique symbol
  * (e.g. zxc_huf_decode_section_avx2). The runtime dispatcher in
  * zxc_compress.c / zxc_decompress.c routes to the matching variant.

--- a/src/lib/zxc_internal.h
+++ b/src/lib/zxc_internal.h
@@ -80,9 +80,10 @@ extern "C" {
  * Note: @c -mavx2 / @c -mavx512f imply @c __SSE2__, so @c ZXC_USE_SSE2 is
  * also defined in the AVX variants. The hand-written SIMD code paths therefore
  * order their preprocessor branches AVX512 -> AVX2 -> SSE2 so the widest
- * available path wins; the SSE2 branch is the active one only in the dedicated
- * @c _sse2 variant (no AVX2/AVX512 flags). SSE2 is the x86-64 baseline, so this
- * tier covers every 64-bit x86 CPU (and i686 with @c -msse2). The handful of
+ * available path wins; the SSE2 branch is the active one in the @c _default
+ * variant on x86-64 (no AVX2/AVX512 flags). SSE2 is the x86-64 baseline, so no
+ * dedicated @c _sse2 variant exists: @c _default covers every 64-bit x86 CPU
+ * (and i686 with @c -msse2). The handful of
  * operations that would otherwise require SSE4.1 (@c _mm_max_epu32,
  * @c _mm_blendv_epi8, @c _mm_packus_epi32) or SSSE3 (@c _mm_shuffle_epi8) are
  * emulated with pure SSE2 instruction sequences or fall back to scalar code.

--- a/wrappers/rust/zxc-sys/build.rs
+++ b/wrappers/rust/zxc-sys/build.rs
@@ -12,7 +12,7 @@
 //!
 //! On x86_64: Compiles `_default`, `_avx2`, and `_avx512` variants (SSE2 is
 //! the x86-64 baseline, already active in `_default`).
-//! On 32-bit ARM: `_default` and `_neon` (NEON is optional there; the
+//! On 32-bit ARM: `_default` and `_neon32` (NEON is optional there; the
 //! dispatcher probes it at runtime).
 //! Everywhere else (incl. AArch64, where NEON is baseline, and i686):
 //! `_default` only.
@@ -266,7 +266,7 @@ fn main() {
         compile_variant(
             &include_dir,
             &src_lib,
-            "_neon",
+            "_neon32",
             &["-march=armv7-a", "-mfpu=neon"],
         );
     }

--- a/wrappers/rust/zxc-sys/build.rs
+++ b/wrappers/rust/zxc-sys/build.rs
@@ -10,8 +10,12 @@
 //! This script compiles the ZXC C library with Function Multi-Versioning (FMV)
 //! to support runtime CPU feature detection and optimized code paths.
 //!
-//! On ARM64: Compiles `_default` and `_neon` variants
-//! On x86_64: Compiles `_default`, `_sse2`, `_avx2`, and `_avx512` variants
+//! On x86_64: Compiles `_default`, `_avx2`, and `_avx512` variants (SSE2 is
+//! the x86-64 baseline, already active in `_default`).
+//! On 32-bit ARM: `_default` and `_neon` (NEON is optional there; the
+//! dispatcher probes it at runtime).
+//! Everywhere else (incl. AArch64, where NEON is baseline, and i686):
+//! `_default` only.
 
 use std::env;
 use std::fs;
@@ -186,8 +190,9 @@ fn main() {
     );
 
     let target = env::var("TARGET").unwrap_or_default();
-    let is_arm64 = target.contains("aarch64") || target.contains("arm64");
-    let is_x86_64 = target.contains("x86_64") || target.contains("i686");
+    let is_x86_64 = target.contains("x86_64");
+    let is_arm32 = (target.starts_with("arm") && !target.starts_with("arm64"))
+        || target.starts_with("thumbv7");
 
     // =========================================================================
     // Core library files (common to all architectures)
@@ -208,19 +213,11 @@ fn main() {
         .warnings(false)
         .flag_if_supported("-pthread");
 
+    core_build.compile("zxc_core");
+
     // =========================================================================
     // Function Multi-Versioning: Compile variants with different suffixes
     // =========================================================================
-
-    // Add architecture-specific flags to core build BEFORE compiling
-    if is_arm64 {
-        core_build.flag_if_supported("-march=armv8-a+crc");
-    } else if is_x86_64 {
-        core_build.flag_if_supported("-msse2");
-        core_build.flag_if_supported("-mpclmul");
-    }
-
-    core_build.compile("zxc_core");
 
     // --- Default variant (baseline, always compiled) ---
     compile_variant(&include_dir, &src_lib, "_default", &[]);
@@ -231,10 +228,7 @@ fn main() {
     // needs its own /arch spellings plus the __BMI*__/__LZCNT__ macros the
     // sources test (cl.exe never defines them itself).
     let is_msvc = target.contains("msvc");
-    if is_arm64 {
-        compile_variant(&include_dir, &src_lib, "_neon", &["-march=armv8-a+simd"]);
-    } else if is_x86_64 && is_msvc {
-        compile_variant(&include_dir, &src_lib, "_sse2", &["/D__SSE2__"]);
+    if is_x86_64 && is_msvc {
         compile_variant(
             &include_dir,
             &src_lib,
@@ -248,14 +242,11 @@ fn main() {
             &["/arch:AVX512", "/D__BMI__", "/D__BMI2__", "/D__LZCNT__"],
         );
     } else if is_x86_64 {
-        // SSE2 variant: the x86-64 baseline (also covers any i686 built with
-        // SSE2).
-        compile_variant(&include_dir, &src_lib, "_sse2", &["-msse2"]);
         compile_variant(
             &include_dir,
             &src_lib,
             "_avx2",
-            &["-mavx2", "-mfma", "-mbmi", "-mbmi2", "-mlzcnt"],
+            &["-mavx2", "-mbmi", "-mbmi2", "-mlzcnt"],
         );
         compile_variant(
             &include_dir,
@@ -270,6 +261,13 @@ fn main() {
                 "-mbmi2",
                 "-mlzcnt",
             ],
+        );
+    } else if is_arm32 {
+        compile_variant(
+            &include_dir,
+            &src_lib,
+            "_neon",
+            &["-march=armv7-a", "-mfpu=neon"],
         );
     }
 


### PR DESCRIPTION
libzxc.a shrinks by 38 % on arm64 (385 832 -> 237 808 B) and 26 % on amd64 (1 039 332 -> 767 156 B) with zero behavior change: the removed variants were byte-identical duplicates of _default.
No ABI impact, SOVERSION stays 4.

Two FMV variants were compiled that the baseline ISA already provides:

- x86-64: SSE2 is an architectural guarantee, so the _default TUs already compile with ZXC_USE_SSE2 active: the dedicated _sse2 variant was a duplicate, and _default was runtime-dead.
- arm64: NEON is baseline (__ARM_NEON always defined), so _default already carries the NEON paths: ditto for the _neon variant there.

Only 32-bit ARM keeps a dedicated NEON variant (NEON is optional on armv7; runtime getauxval(AT_HWCAP) dispatch). It is renamed _neon to _neon32, since that is now the only thing the suffix can mean.