### PR TITLE
perf: Slot-ledger DP tier for the Huffman flat/length nudge (level 7 only)

### DIFF
--- a/src/lib/zxc_compress.c
+++ b/src/lib/zxc_compress.c
@@ -739,6 +739,10 @@ static uint32_t zxc_opt_estimate_lit_bits(const uint8_t* RESTRICT src, const siz
     }
 
     uint8_t code_len[ZXC_HUF_NUM_SYMBOLS];
+    /* No flat/length nudge here on purpose: these lengths only feed a
+     * bits/byte estimate into the parse DP and never reach the wire; nudging
+     * them would bias the parse toward worse ratio for zero decode benefit
+     * (the sections the parse produces get their own nudged tables). */
     if (UNLIKELY(zxc_huf_build_code_lengths(hist, code_len, scratch,
                                             ZXC_HUF_MAX_CODE_LEN_DENSITY) != ZXC_OK))
         return CHAR_BIT;
@@ -1616,6 +1620,13 @@ parse_done:;
 
         if (zxc_huf_build_code_lengths(freq, huf_code_len, ctx->opt_scratch,
                                        zxc_huf_enc_max_code_len(level)) == ZXC_OK) {
+#if ZXC_HUF_NUDGE
+            /* Reshape toward flat-friendly class counts when the modeled
+             * decode win clears the adoption guard (encoder policy only; a
+             * rejected nudge leaves the lengths byte-for-byte untouched). */
+            (void)zxc_huf_nudge_code_lengths(freq, huf_code_len, ctx->opt_scratch,
+                                             zxc_huf_enc_max_code_len(level));
+#endif
             huf_total_size = zxc_huf_calc_size(freq, huf_code_len, 1);
             /* Space-speed: the entropy candidate must beat the current winner's
              * J, paying its own decode tax over the copy path. */
@@ -1670,6 +1681,11 @@ parse_done:;
         for (uint32_t i = 0; i < seq_c; i++) tfreq[buf_tokens[i]]++;
         if (zxc_huf_build_code_lengths(tfreq, tok_code_len, ctx->opt_scratch,
                                        zxc_huf_enc_max_code_len(level)) == ZXC_OK) {
+#if ZXC_HUF_NUDGE
+            /* Same flat/length nudge as the literal section above. */
+            (void)zxc_huf_nudge_code_lengths(tfreq, tok_code_len, ctx->opt_scratch,
+                                             zxc_huf_enc_max_code_len(level));
+#endif
             tok_huf_size = zxc_huf_calc_size(tfreq, tok_code_len, 1);
             /* Space-speed J comparison (this path is ULTRA-only): the PivCo
              * token section pays the same decode tax as PivCo literals. */

--- a/src/lib/zxc_compress.c
+++ b/src/lib/zxc_compress.c
@@ -739,10 +739,6 @@ static uint32_t zxc_opt_estimate_lit_bits(const uint8_t* RESTRICT src, const siz
     }
 
     uint8_t code_len[ZXC_HUF_NUM_SYMBOLS];
-    /* No flat/length nudge here on purpose: these lengths only feed a
-     * bits/byte estimate into the parse DP and never reach the wire; nudging
-     * them would bias the parse toward worse ratio for zero decode benefit
-     * (the sections the parse produces get their own nudged tables). */
     if (UNLIKELY(zxc_huf_build_code_lengths(hist, code_len, scratch,
                                             ZXC_HUF_MAX_CODE_LEN_DENSITY) != ZXC_OK))
         return CHAR_BIT;
@@ -1620,10 +1616,6 @@ parse_done:;
 
         if (zxc_huf_build_code_lengths(freq, huf_code_len, ctx->opt_scratch,
                                        zxc_huf_enc_max_code_len(level)) == ZXC_OK) {
-            /* ULTRA only: reshape toward flat-friendly class counts when the
-             * modeled decode win clears the adoption guard (encoder policy; a
-             * rejected nudge leaves the lengths byte-for-byte untouched, and
-             * level 6 output stays byte-identical to the unadjusted encoder). */
             if (level >= ZXC_LEVEL_ULTRA)
                 (void)zxc_huf_nudge_code_lengths(freq, huf_code_len, ctx->opt_scratch,
                                                  zxc_huf_enc_max_code_len(level));
@@ -1681,8 +1673,6 @@ parse_done:;
         for (uint32_t i = 0; i < seq_c; i++) tfreq[buf_tokens[i]]++;
         if (zxc_huf_build_code_lengths(tfreq, tok_code_len, ctx->opt_scratch,
                                        zxc_huf_enc_max_code_len(level)) == ZXC_OK) {
-            /* Same flat/length nudge as the literal section above (this whole
-             * path is already ULTRA-only). */
             (void)zxc_huf_nudge_code_lengths(tfreq, tok_code_len, ctx->opt_scratch,
                                              zxc_huf_enc_max_code_len(level));
             tok_huf_size = zxc_huf_calc_size(tfreq, tok_code_len, 1);

--- a/src/lib/zxc_compress.c
+++ b/src/lib/zxc_compress.c
@@ -1620,13 +1620,13 @@ parse_done:;
 
         if (zxc_huf_build_code_lengths(freq, huf_code_len, ctx->opt_scratch,
                                        zxc_huf_enc_max_code_len(level)) == ZXC_OK) {
-#if ZXC_HUF_NUDGE
-            /* Reshape toward flat-friendly class counts when the modeled
-             * decode win clears the adoption guard (encoder policy only; a
-             * rejected nudge leaves the lengths byte-for-byte untouched). */
-            (void)zxc_huf_nudge_code_lengths(freq, huf_code_len, ctx->opt_scratch,
-                                             zxc_huf_enc_max_code_len(level));
-#endif
+            /* ULTRA only: reshape toward flat-friendly class counts when the
+             * modeled decode win clears the adoption guard (encoder policy; a
+             * rejected nudge leaves the lengths byte-for-byte untouched, and
+             * level 6 output stays byte-identical to the unadjusted encoder). */
+            if (level >= ZXC_LEVEL_ULTRA)
+                (void)zxc_huf_nudge_code_lengths(freq, huf_code_len, ctx->opt_scratch,
+                                                 zxc_huf_enc_max_code_len(level));
             huf_total_size = zxc_huf_calc_size(freq, huf_code_len, 1);
             /* Space-speed: the entropy candidate must beat the current winner's
              * J, paying its own decode tax over the copy path. */
@@ -1681,11 +1681,10 @@ parse_done:;
         for (uint32_t i = 0; i < seq_c; i++) tfreq[buf_tokens[i]]++;
         if (zxc_huf_build_code_lengths(tfreq, tok_code_len, ctx->opt_scratch,
                                        zxc_huf_enc_max_code_len(level)) == ZXC_OK) {
-#if ZXC_HUF_NUDGE
-            /* Same flat/length nudge as the literal section above. */
+            /* Same flat/length nudge as the literal section above (this whole
+             * path is already ULTRA-only). */
             (void)zxc_huf_nudge_code_lengths(tfreq, tok_code_len, ctx->opt_scratch,
                                              zxc_huf_enc_max_code_len(level));
-#endif
             tok_huf_size = zxc_huf_calc_size(tfreq, tok_code_len, 1);
             /* Space-speed J comparison (this path is ULTRA-only): the PivCo
              * token section pays the same decode tax as PivCo literals. */

--- a/src/lib/zxc_dict.c
+++ b/src/lib/zxc_dict.c
@@ -605,14 +605,12 @@ int zxc_train_dict_huf(const void* const* RESTRICT samples, const size_t* RESTRI
              * table at compression time (the encoder's validity check). */
             uint8_t code_len[ZXC_HUF_NUM_SYMBOLS];
             rc = zxc_huf_build_code_lengths(freq, code_len, NULL, ZXC_HUF_MAX_CODE_LEN_DENSITY);
-#if ZXC_HUF_NUDGE
             /* Dict tables serve the most literal-bound decode path (small
              * blocks, tree built once at attach), so the flat/length nudge
-             * pays off most here; training is offline, its cost is free. */
+             * pays off most here. */
             if (rc == ZXC_OK)
                 (void)zxc_huf_nudge_code_lengths(freq, code_len, NULL,
                                                  ZXC_HUF_MAX_CODE_LEN_DENSITY);
-#endif
             if (rc == ZXC_OK) zxc_huf_pack_lengths(code_len, huf_lengths_out);
         }
     }

--- a/src/lib/zxc_dict.c
+++ b/src/lib/zxc_dict.c
@@ -605,6 +605,14 @@ int zxc_train_dict_huf(const void* const* RESTRICT samples, const size_t* RESTRI
              * table at compression time (the encoder's validity check). */
             uint8_t code_len[ZXC_HUF_NUM_SYMBOLS];
             rc = zxc_huf_build_code_lengths(freq, code_len, NULL, ZXC_HUF_MAX_CODE_LEN_DENSITY);
+#if ZXC_HUF_NUDGE
+            /* Dict tables serve the most literal-bound decode path (small
+             * blocks, tree built once at attach), so the flat/length nudge
+             * pays off most here; training is offline, its cost is free. */
+            if (rc == ZXC_OK)
+                (void)zxc_huf_nudge_code_lengths(freq, code_len, NULL,
+                                                 ZXC_HUF_MAX_CODE_LEN_DENSITY);
+#endif
             if (rc == ZXC_OK) zxc_huf_pack_lengths(code_len, huf_lengths_out);
         }
     }

--- a/src/lib/zxc_huffman.c
+++ b/src/lib/zxc_huffman.c
@@ -337,9 +337,9 @@ int zxc_huf_build_code_lengths(const uint32_t* RESTRICT freq, uint8_t* RESTRICT 
  * candidate histogram is priced without building a tree.
  *
  * Compiled once in the primary variant: this is ISA-independent cold encoder
- * policy, and a single copy guarantees cross-ISA identical archives. The
- * ZXC_HUF_NUDGE master switch gates the call sites only, so a switched-off
- * build still links the symbols (tests, A/B tooling).
+ * policy, and a single copy guarantees cross-ISA identical archives. For an
+ * A/B build without the nudge, override the guard from CFLAGS
+ * (-DZXC_HUF_NUDGE_MERGE_Q8=0 rejects every candidate).
  */
 #if defined(ZXC_VARIANT_PRIMARY)
 
@@ -563,6 +563,145 @@ static void zxc_huf_nudge_walk(const uint32_t* RESTRICT blc0, const uint64_t* RE
     }
 }
 
+/**
+ * @brief Exact rank-weighted J of one leaf run placed at coarse level @p lc.
+ *
+ * The DP prices in REAL units through a coarse lens: one coarse slot stands
+ * for a complete depth-@p g_log2 subtree of 2^g_log2 frequency-adjacent
+ * leaves, so a coarse buddy block of 2^d slots is a real block of depth
+ * d + g_log2 whose leaves have real length lc + g_log2. Because canonical
+ * codes fill the code space left to right, a ledger state with @p s open
+ * slots pins the run start at 2^lu - s * 2^(lu - lc): the cost of taking
+ * @p c slots here depends only on (lc, s, c, rank interval) -- which is what
+ * makes the level costs additive and the DP exact for this model.
+ */
+static uint64_t zxc_huf_nudge_dp_run_j(const int lu, const int lc, const int g_log2,
+                                       const uint32_t s, const uint32_t c,
+                                       const uint64_t* RESTRICT pfg, const uint32_t k) {
+    if (!c) return 0;
+    const int lr = lc + g_log2; /* real code length of these leaves */
+    const uint32_t w = 1U << (lu - lc);
+    const uint32_t S = (1U << lu) - s * w;
+    const uint32_t end = S + c * w;
+    const uint64_t bits = (uint64_t)lr * (pfg[k + c] - pfg[k]);
+    uint64_t touches = 0;
+    uint32_t x = S;
+    while (x < end) {
+        const uint32_t wx = x ? (x & (0U - x)) : (1U << lu);
+        const uint32_t wr = 1U << zxc_log2_u32(end - x);
+        const uint32_t W = wx < wr ? wx : wr;
+        const int d = (int)zxc_log2_u32(W >> (lu - lc)) + g_log2;
+        const uint32_t i0 = k + ((x - S) >> (lu - lc));
+        const uint64_t mass = pfg[i0 + (W >> (lu - lc))] - pfg[i0];
+        int t;
+        if (d == 0) {
+            t = lr + 1;
+        } else if (d == 1) {
+            t = lr;
+        } else {
+            t = (lr - d) + 1;
+            if (d > ZXC_HUF_NUDGE_FLAT_SIMD_MAX) t += ZXC_HUF_NUDGE_DEEP_FLAT_PENALTY;
+        }
+        touches += mass * (uint64_t)t;
+        x += W;
+    }
+    return 256U * bits + (uint64_t)ZXC_HUF_NUDGE_LAMBDA_Q8 * touches;
+}
+
+/**
+ * @brief Slot-ledger dynamic program: optimal class counts for the model.
+ *
+ * States are (symbols placed, open slots) per level -- the (k, s) plane of
+ * pivco-huffman #20 -- relaxed level by level with the exact per-run cost
+ * above; a state with s == remaining symbols is a forced finishing level
+ * (continuing needs both c >= s and c <= s - 1). The finishing transition
+ * adds the pass-loop overhead for the resulting max depth. Backtracking the
+ * per-level arrival choices reconstructs the coarse class counts.
+ *
+ * Iteration order and strict-improvement relaxation are fixed, so the result
+ * is deterministic. Returns 0 on allocation failure or no feasible finish
+ * (callers then simply keep their other candidates).
+ */
+static int zxc_huf_nudge_dp_solve(const uint64_t* RESTRICT pfg, const int m, const int cap_c,
+                                  const int lu, const int g_log2, uint32_t* RESTRICT out_cblc) {
+    const size_t plane = (size_t)(m + 1) * (size_t)(m + 1);
+    uint64_t* jcur = (uint64_t*)ZXC_MALLOC(plane * sizeof(uint64_t));
+    uint64_t* jnxt = (uint64_t*)ZXC_MALLOC(plane * sizeof(uint64_t));
+    uint16_t* arrive = (uint16_t*)ZXC_MALLOC((size_t)(cap_c + 1) * plane * sizeof(uint16_t));
+    int ok = 0;
+    if (!jcur || !jnxt || !arrive) goto done;
+#define ZXC_NUDGE_DP_IDX(k, s) ((size_t)(k) * (size_t)(m + 1) + (size_t)(s))
+    for (size_t i = 0; i < plane; i++) jcur[i] = UINT64_MAX;
+    jcur[ZXC_NUDGE_DP_IDX(0, 2)] = 0;
+    uint64_t best_j = UINT64_MAX;
+    int best_l = 0;
+    int best_k = 0;
+    int best_s = 0;
+    for (int lc = 1; lc <= cap_c; lc++) {
+        for (size_t i = 0; i < plane; i++) jnxt[i] = UINT64_MAX;
+        for (int k = 0; k < m; k++) {
+            const uint32_t n_rem = (uint32_t)(m - k);
+            for (uint32_t s = 1; s <= n_rem; s++) {
+                const uint64_t j0 = jcur[ZXC_NUDGE_DP_IDX(k, s)];
+                if (j0 == UINT64_MAX) continue;
+                if (s == n_rem) {
+                    /* Forced finish: fill every slot, close the tree here. */
+                    const uint64_t j =
+                        j0 + zxc_huf_nudge_dp_run_j(lu, lc, g_log2, s, s, pfg, (uint32_t)k) +
+                        (uint64_t)ZXC_HUF_NUDGE_LAMBDA_Q8 * (uint64_t)ZXC_HUF_NUDGE_LEVEL_COST *
+                            (uint64_t)(lc + g_log2 + 1);
+                    if (j < best_j) {
+                        best_j = j;
+                        best_l = lc;
+                        best_k = k;
+                        best_s = (int)s;
+                    }
+                    continue;
+                }
+                if (lc == cap_c) continue; /* must finish at the cap */
+                const uint64_t mm = (uint64_t)1 << (cap_c - lc);
+                const uint32_t lo = (2 * s > n_rem) ? 2 * s - n_rem : 0;
+                uint32_t hi = s - 1;
+                const uint64_t cap_hi = ((uint64_t)s * mm - n_rem) / (mm - 1);
+                if (cap_hi < hi) hi = (uint32_t)cap_hi;
+                for (uint32_t c = lo; c <= hi; c++) {
+                    const uint64_t j =
+                        j0 + zxc_huf_nudge_dp_run_j(lu, lc, g_log2, s, c, pfg, (uint32_t)k);
+                    const size_t to = ZXC_NUDGE_DP_IDX(k + (int)c, 2 * (s - c));
+                    if (j < jnxt[to]) {
+                        jnxt[to] = j;
+                        arrive[(size_t)(lc + 1) * plane + to] = (uint16_t)c;
+                    }
+                }
+            }
+        }
+        uint64_t* tmp = jcur;
+        jcur = jnxt;
+        jnxt = tmp;
+    }
+    if (best_j == UINT64_MAX) goto done;
+    ZXC_MEMSET(out_cblc, 0, (ZXC_HUF_MAX_CODE_LEN_ULTRA + 1) * sizeof(uint32_t));
+    out_cblc[best_l] = (uint32_t)best_s;
+    {
+        int k = best_k;
+        int s = best_s;
+        for (int lc = best_l; lc > 1; lc--) {
+            const uint32_t c = arrive[(size_t)lc * plane + ZXC_NUDGE_DP_IDX(k, s)];
+            out_cblc[lc - 1] = c;
+            s = s / 2 + (int)c;
+            k -= (int)c;
+        }
+        if (k != 0 || s != 2) goto done; /* backtrack corruption: drop the candidate */
+    }
+    ok = 1;
+done:
+#undef ZXC_NUDGE_DP_IDX
+    ZXC_FREE(jcur);
+    ZXC_FREE(jnxt);
+    ZXC_FREE(arrive);
+    return ok;
+}
+
 /** @brief Assign a class-count multiset to symbols: frequency rank r takes the
  *         r-th shortest slot (rearrangement-optimal, deterministic). */
 static void zxc_huf_nudge_assign(const uint32_t* RESTRICT blc, const int16_t* RESTRICT sym_order,
@@ -622,8 +761,9 @@ int zxc_huf_nudge_code_lengths(const uint32_t* RESTRICT freq, uint8_t* RESTRICT 
     /* Candidates: the greedy ledger walk, then package-merge rebuilt at
      * reduced caps (optimal bits for a forced-shallower tree; the pass loop
      * runs max_depth + 1 times, so depth cuts attack the decoder's biggest
-     * fixed cost). Every candidate is a complete, Kraft-exact vector. */
-    uint8_t cand[3][ZXC_HUF_NUM_SYMBOLS];
+     * fixed cost), plus -- at DP efforts -- the slot-ledger dynamic program.
+     * Every candidate is a complete, Kraft-exact vector. */
+    uint8_t cand[4][ZXC_HUF_NUM_SYMBOLS];
     int n_cand = 0;
     {
         uint32_t blc_w[LU + 1];
@@ -645,6 +785,56 @@ int zxc_huf_nudge_code_lengths(const uint32_t* RESTRICT freq, uint8_t* RESTRICT 
         n_cand++;
     }
 
+    /* Slot-ledger DP candidate: optimal class counts under the rank-weighted
+     * model, solved on groups of 2^G frequency-adjacent symbols (G = 0 is
+     * exact for small alphabets; coarse tiers keep the plane cache-resident
+     * for larger ones, bounding the whole call to a few hundred us). When G
+     * does not divide n, the lightest group is padded with zero-freq "ghost"
+     * leaves carried by unused byte values -- wire-legal, their runs
+     * are empty, and the ratio cost of the burnt code space is priced by the
+     * evaluator like everything else. */
+    {
+        const int g_log2 = n <= 64 ? 0 : (n <= 128 ? 1 : 2);
+        const int g = 1 << g_log2;
+        const int m = (n + g - 1) / g;
+        const int cap_c = max_code_len - g_log2;
+        if (m >= 2 && cap_c >= 1 && cap_c <= LU && m <= (1 << cap_c)) {
+            uint64_t pfg[ZXC_HUF_NUM_SYMBOLS + 1];
+            for (int j2 = 0; j2 <= m; j2++) {
+                int r = j2 * g;
+                if (r > n) r = n;
+                pfg[j2] = pf_rank[r];
+            }
+            uint32_t cblc[LU + 1];
+            if (zxc_huf_nudge_dp_solve(pfg, m, cap_c, LU - g_log2, g_log2, cblc)) {
+                uint8_t* const cl = cand[n_cand];
+                ZXC_MEMSET(cl, 0, ZXC_HUF_NUM_SYMBOLS);
+                int r = 0;
+                int ghosts = 0;
+                uint8_t ghost_len = 0;
+                for (int lc = 1; lc <= cap_c; lc++) {
+                    for (uint32_t q = 0; q < cblc[lc]; q++) {
+                        for (int e = 0; e < g; e++, r++) {
+                            if (r < n) {
+                                cl[sym_order[r]] = (uint8_t)(lc + g_log2);
+                            } else {
+                                ghost_len = (uint8_t)(lc + g_log2);
+                                ghosts++;
+                            }
+                        }
+                    }
+                }
+                for (int s = 0; s < ZXC_HUF_NUM_SYMBOLS && ghosts; s++) {
+                    if (freq[s] == 0 && cl[s] == 0) {
+                        cl[s] = ghost_len;
+                        ghosts--;
+                    }
+                }
+                n_cand++;
+            }
+        }
+    }
+
     /* Guard + selection on exact costs: adopt the cheapest candidate clearing
      * both guard rails and strictly beating the baseline's J; otherwise leave
      * code_len byte-for-byte untouched (identical archive to the unadjusted
@@ -653,8 +843,18 @@ int zxc_huf_nudge_code_lengths(const uint32_t* RESTRICT freq, uint8_t* RESTRICT 
     uint64_t best_j = j0;
     int best = -1;
     for (int ci = 0; ci < n_cand; ci++) {
+        /* Every live symbol must keep a code; ghost-padded candidates carry
+         * MORE nonzero lengths than n, which is fine. */
+        int valid = 1;
+        for (int s = 0; s < ZXC_HUF_NUM_SYMBOLS; s++) {
+            if (freq[s] != 0 && cand[ci][s] == 0) {
+                valid = 0;
+                break;
+            }
+        }
+        if (!valid) continue;
         uint32_t blc[LU + 1];
-        if (zxc_huf_nudge_classes(cand[ci], blc) != n) continue;
+        (void)zxc_huf_nudge_classes(cand[ci], blc);
         zxc_huf_nudge_pf_canonical(cand[ci], freq, blc, pf);
         zxc_huf_nudge_cost_t c1;
         zxc_huf_nudge_eval(blc, pf, &c1);

--- a/src/lib/zxc_huffman.c
+++ b/src/lib/zxc_huffman.c
@@ -317,6 +317,362 @@ int zxc_huf_build_code_lengths(const uint32_t* RESTRICT freq, uint8_t* RESTRICT 
 }
 
 /* ===========================================================================
+ * Encoder-side joint flat/length nudge (idea: pivco-huffman issue #20)
+ * ===========================================================================
+ *
+ * Package-merge minimizes bits alone; the PivCo decoder's cost also depends on
+ * the SHAPE of the length histogram (pass count = max_depth + 1, and maximal
+ * complete subtrees collapse into single unpacks -- see the decode section).
+ * The functions below reshape the class counts toward power-of-two boundaries
+ * and shallower caps under an adoption guard, trading a bounded ratio loss for
+ * fewer modeled decode level-touches.
+ *
+ * Everything is exact integer arithmetic on the canonical code space. With
+ * leaves assigned in (length, symbol) ascending order -- the canonical rule of
+ * zxc_pivco_tree_build -- the depth-l leaves occupy one contiguous ALIGNED run
+ * [S_{l-1}, S_l) of the code space at 2^-11 slot granularity, where
+ * S_l = sum_{j<=l} bl_count[j] << (11-j) (each prior term is divisible by
+ * 2^(12-l), so runs start on even slot boundaries). The maximal dyadic (buddy)
+ * blocks of each run are EXACTLY the decoder's maximal flat subtrees, so any
+ * candidate histogram is priced without building a tree.
+ *
+ * Compiled once in the primary variant: this is ISA-independent cold encoder
+ * policy, and a single copy guarantees cross-ISA identical archives. The
+ * ZXC_HUF_NUDGE master switch gates the call sites only, so a switched-off
+ * build still links the symbols (tests, A/B tooling).
+ */
+#if defined(ZXC_VARIANT_PRIMARY)
+
+typedef struct {
+    uint64_t bits;    /* payload bits: sum(len * freq); per-node padding excluded */
+    uint64_t touches; /* modeled decode cost: occurrence-weighted level-touches */
+} zxc_huf_nudge_cost_t;
+
+/** @brief Class counts of a length vector; returns the number of present symbols. */
+static int zxc_huf_nudge_classes(const uint8_t* RESTRICT code_len, uint32_t* RESTRICT blc) {
+    ZXC_MEMSET(blc, 0, (ZXC_HUF_MAX_CODE_LEN_ULTRA + 1) * sizeof(uint32_t));
+    int n = 0;
+    for (int s = 0; s < ZXC_HUF_NUM_SYMBOLS; s++) {
+        const int l = code_len[s];
+        if (!l) continue;
+        blc[l]++;
+        n++;
+    }
+    return n;
+}
+
+/** @brief Frequency prefix sums over the leaves in canonical (length, symbol)
+ *         order: pf[i] = mass of the first i leaves of the code space. */
+static void zxc_huf_nudge_pf_canonical(const uint8_t* RESTRICT code_len,
+                                       const uint32_t* RESTRICT freq, const uint32_t* RESTRICT blc,
+                                       uint64_t* RESTRICT pf) {
+    uint32_t pos[ZXC_HUF_MAX_CODE_LEN_ULTRA + 1];
+    uint32_t acc = 0;
+    for (int l = 1; l <= ZXC_HUF_MAX_CODE_LEN_ULTRA; l++) {
+        pos[l] = acc;
+        acc += blc[l];
+    }
+    uint32_t val[ZXC_HUF_NUM_SYMBOLS];
+    for (int s = 0; s < ZXC_HUF_NUM_SYMBOLS; s++) {
+        const int l = code_len[s];
+        if (l) val[pos[l]++] = freq[s];
+    }
+    pf[0] = 0;
+    for (uint32_t i = 0; i < acc; i++) pf[i + 1] = pf[i] + val[i];
+}
+
+/**
+ * @brief Modeled (bits, level-touches) of one class-count histogram.
+ *
+ * @p pf must hold frequency prefix sums of the leaves in code order (pf[0]=0):
+ * canonical (length, symbol)-order sums give exact costs; frequency-rank sums
+ * give the cheap scores used inside the walk (bits are identical either way,
+ * only the within-run mass split differs). The buddy decomposition of each
+ * same-depth leaf run mirrors zxc_pivco_decode_core row by row: a lone leaf at
+ * depth l is memset once and merged l times (l+1 touches); a leaf pair is
+ * emitted by its parent's XOR-blend (l touches); a flat root at depth t = l-D
+ * is unpacked once and merged t times (t+1 touches, plus a penalty past the
+ * SIMD unpackers); each pass adds a fixed overhead term.
+ */
+static void zxc_huf_nudge_eval(const uint32_t* RESTRICT blc, const uint64_t* RESTRICT pf,
+                               zxc_huf_nudge_cost_t* RESTRICT out) {
+    enum { LU = ZXC_HUF_MAX_CODE_LEN_ULTRA };
+    uint64_t bits = 0;
+    uint64_t touches = 0;
+    int max_len = 0;
+    uint32_t S = 0;    /* code-space cursor, in 2^-LU slots */
+    uint32_t base = 0; /* leaf index where the current run starts */
+    for (int l = 1; l <= LU; l++) {
+        if (!blc[l]) continue;
+        max_len = l;
+        bits += (uint64_t)l * (pf[base + blc[l]] - pf[base]);
+        const uint32_t w = 1U << (LU - l);
+        const uint32_t end = S + blc[l] * w;
+        uint32_t x = S;
+        while (x < end) {
+            const uint32_t wx = x ? (x & (0U - x)) : (1U << LU);
+            const uint32_t wr = 1U << zxc_log2_u32(end - x);
+            const uint32_t W = wx < wr ? wx : wr;
+            const int D = (int)zxc_log2_u32(W) - (LU - l);
+            const uint32_t i0 = base + ((x - S) >> (LU - l));
+            const uint64_t mass = pf[i0 + (W >> (LU - l))] - pf[i0];
+            int t;
+            if (D == 0) {
+                t = l + 1; /* lone leaf: one memset + merges above */
+            } else if (D == 1) {
+                t = l; /* leaf pair: parent XOR-blend at depth l-1 */
+            } else {
+                t = (l - D) + 1; /* flat root: one unpack + merges above */
+                if (D > ZXC_HUF_NUDGE_FLAT_SIMD_MAX) t += ZXC_HUF_NUDGE_DEEP_FLAT_PENALTY;
+            }
+            touches += mass * (uint64_t)t;
+            x += W;
+        }
+        S = end;
+        base += blc[l];
+    }
+    touches += (uint64_t)ZXC_HUF_NUDGE_LEVEL_COST * (uint64_t)(max_len + 1);
+    out->bits = bits;
+    out->touches = touches;
+}
+
+/** @brief Candidate cost J: bits (scaled to Q8) plus lambda per level-touch. */
+static ZXC_ALWAYS_INLINE uint64_t zxc_huf_nudge_j(const zxc_huf_nudge_cost_t* c) {
+    return 256U * c->bits + (uint64_t)ZXC_HUF_NUDGE_LAMBDA_Q8 * c->touches;
+}
+
+/**
+ * @brief Clamp a desired class count into the feasible set at one walk level.
+ *
+ * State: @p s open slots at level @p l, @p n_rem symbols left. A count c is
+ * feasible iff a Kraft-exact completion within @p cap still exists: either
+ * c == n_rem == s (a finishing level fills every slot), or, continuing with
+ * i = s - c internal nodes, i >= 1 and 2*i <= n_rem - c <= i << (cap - l).
+ * Under the walk invariant (s <= n_rem <= s << (cap - l)) the continuing
+ * window [max(0, 2s - n_rem), min(s-1, n_rem-1, (s*M - n_rem)/(M-1))] is
+ * nonempty whenever n_rem > s, and n_rem == s forces the finishing count
+ * (continuing would need both c >= s and c <= s-1).
+ */
+static uint32_t zxc_huf_nudge_clamp(const uint32_t want, const uint32_t s, const uint32_t n_rem,
+                                    const int l, const int cap) {
+    if (n_rem <= s || l >= cap) return n_rem; /* forced finish */
+    const uint64_t m = (uint64_t)1 << (cap - l);
+    const uint32_t lo = (2 * s > n_rem) ? 2 * s - n_rem : 0;
+    uint32_t hi = s - 1; /* s < n_rem here, so min(s-1, n_rem-1) == s-1 */
+    const uint64_t cap_hi = ((uint64_t)s * m - n_rem) / (m - 1);
+    if (cap_hi < hi) hi = (uint32_t)cap_hi;
+    const uint32_t c = want < lo ? lo : want;
+    return c > hi ? hi : c;
+}
+
+/** @brief Baseline-following completion: fill levels l+1..cap with the
+ *         baseline class counts clamped into feasibility. */
+static void zxc_huf_nudge_complete(uint32_t* RESTRICT blc, const int l, uint32_t s, uint32_t n_rem,
+                                   const uint32_t* RESTRICT blc0, const int cap) {
+    for (int j = l + 1; j <= cap && n_rem; j++) {
+        const uint32_t c = zxc_huf_nudge_clamp(blc0[j], s, n_rem, j, cap);
+        blc[j] = c;
+        n_rem -= c;
+        s = 2 * (s - c);
+    }
+}
+
+/**
+ * @brief Greedy shallow-to-deep walk over the slot ledger.
+ *
+ * At each level, up to six feasible class counts are tried: follow the
+ * baseline; make the internal-node count the nearest power of two (down/up)
+ * or a two-bit value (power-of-two internal-node counts keep the run
+ * boundaries aligned, which is what lets deeper runs decompose into large
+ * flat blocks); or finish the whole remainder as uniform-depth subtrees.
+ * Each count is expanded into a full candidate histogram and scored with the
+ * rank-order evaluator; the cheapest count is fixed and the walk descends.
+ * Fixed candidate order + strict improvement keeps the result deterministic.
+ * A chosen uniform-depth finish needs no lock: at the next level it reappears
+ * as the (c = 0, D-1) finish candidate, so the greedy can hold or drop it.
+ */
+static void zxc_huf_nudge_walk(const uint32_t* RESTRICT blc0, const uint64_t* RESTRICT pf_rank,
+                               const int n, const int cap, uint32_t* RESTRICT out_blc) {
+    enum { LU = ZXC_HUF_MAX_CODE_LEN_ULTRA };
+    ZXC_MEMSET(out_blc, 0, (LU + 1) * sizeof(uint32_t));
+    uint32_t s = 2; /* the root's two slots at level 1 (n >= 4 => root is internal) */
+    uint32_t n_rem = (uint32_t)n;
+    for (int l = 1; l <= cap && n_rem; l++) {
+        struct {
+            uint32_t c;
+            int flat_d; /* > 0: complete as one uniform run at depth l + flat_d */
+        } cand[6];
+        int n_cand = 0;
+        const uint32_t c_base = zxc_huf_nudge_clamp(blc0[l], s, n_rem, l, cap);
+        cand[n_cand].c = c_base;
+        cand[n_cand++].flat_d = 0;
+        if (c_base < n_rem) {
+            /* Shape the internal-node count i = s - c toward few set bits. */
+            const uint32_t i_base = s - c_base;
+            const uint32_t i_dn = 1U << zxc_log2_u32(i_base);
+            const uint32_t rest = i_base - i_dn;
+            const uint32_t shapes[3] = {i_dn, i_dn << 1,
+                                        i_dn | (rest ? 1U << zxc_log2_u32(rest) : 0U)};
+            for (int k = 0; k < 3; k++) {
+                const uint32_t want = s > shapes[k] ? s - shapes[k] : 0;
+                const uint32_t c = zxc_huf_nudge_clamp(want, s, n_rem, l, cap);
+                int dup = 0;
+                for (int p = 0; p < n_cand; p++) dup |= (cand[p].c == c && !cand[p].flat_d);
+                if (!dup) {
+                    cand[n_cand].c = c;
+                    cand[n_cand++].flat_d = 0;
+                }
+            }
+            /* Uniform finish: c leaves here, the rest as i complete depth-D
+             * subtrees (c*(2^D - 1) == s*2^D - n_rem must divide exactly). */
+            for (int d = 1; d <= cap - l && n_cand < 6; d++) {
+                const uint64_t den = ((uint64_t)1 << d) - 1;
+                const int64_t num = (int64_t)((uint64_t)s << d) - (int64_t)n_rem;
+                if (num < 0 || (uint64_t)num % den) continue;
+                const uint64_t c64 = (uint64_t)num / den;
+                if (c64 >= s || c64 >= n_rem) continue; /* need i >= 1 and a remainder */
+                cand[n_cand].c = (uint32_t)c64;
+                cand[n_cand++].flat_d = d;
+                break; /* the shallowest exact finish is the aggressive one */
+            }
+        }
+        uint64_t best_j = UINT64_MAX;
+        uint32_t best_c = c_base;
+        for (int k = 0; k < n_cand; k++) {
+            uint32_t tmp[LU + 1];
+            ZXC_MEMCPY(tmp, out_blc, sizeof(tmp));
+            tmp[l] = cand[k].c;
+            const uint32_t rem = n_rem - cand[k].c;
+            if (rem) {
+                if (cand[k].flat_d)
+                    tmp[l + cand[k].flat_d] = rem;
+                else
+                    zxc_huf_nudge_complete(tmp, l, 2 * (s - cand[k].c), rem, blc0, cap);
+            }
+            zxc_huf_nudge_cost_t cc;
+            zxc_huf_nudge_eval(tmp, pf_rank, &cc);
+            const uint64_t j = zxc_huf_nudge_j(&cc);
+            if (j < best_j) {
+                best_j = j;
+                best_c = cand[k].c;
+            }
+        }
+        out_blc[l] = best_c;
+        n_rem -= best_c;
+        s = 2 * (s - best_c);
+    }
+}
+
+/** @brief Assign a class-count multiset to symbols: frequency rank r takes the
+ *         r-th shortest slot (rearrangement-optimal, deterministic). */
+static void zxc_huf_nudge_assign(const uint32_t* RESTRICT blc, const int16_t* RESTRICT sym_order,
+                                 uint8_t* RESTRICT cand_len) {
+    ZXC_MEMSET(cand_len, 0, ZXC_HUF_NUM_SYMBOLS);
+    int r = 0;
+    for (int l = 1; l <= ZXC_HUF_MAX_CODE_LEN_ULTRA; l++)
+        for (uint32_t k = 0; k < blc[l]; k++) cand_len[sym_order[r++]] = (uint8_t)l;
+}
+
+void zxc_huf_nudge_cost(const uint8_t* RESTRICT code_len, const uint32_t* RESTRICT freq,
+                        uint64_t* RESTRICT bits, uint64_t* RESTRICT touches) {
+    uint32_t blc[ZXC_HUF_MAX_CODE_LEN_ULTRA + 1];
+    (void)zxc_huf_nudge_classes(code_len, blc);
+    uint64_t pf[ZXC_HUF_NUM_SYMBOLS + 1];
+    zxc_huf_nudge_pf_canonical(code_len, freq, blc, pf);
+    zxc_huf_nudge_cost_t c;
+    zxc_huf_nudge_eval(blc, pf, &c);
+    *bits = c.bits;
+    *touches = c.touches;
+}
+
+int zxc_huf_nudge_code_lengths(const uint32_t* RESTRICT freq, uint8_t* RESTRICT code_len,
+                               void* RESTRICT scratch, const int max_code_len) {
+    enum { LU = ZXC_HUF_MAX_CODE_LEN_ULTRA };
+    uint32_t blc0[LU + 1];
+    const int n = zxc_huf_nudge_classes(code_len, blc0);
+    /* Degenerate alphabets have no shape freedom (and n == 1 is format-pinned
+     * to code length exactly 1): leave them untouched. */
+    if (n < 4) return 0;
+
+    /* Baseline cost, exact (canonical-order frequency weighting). */
+    uint64_t pf[ZXC_HUF_NUM_SYMBOLS + 1];
+    zxc_huf_nudge_pf_canonical(code_len, freq, blc0, pf);
+    zxc_huf_nudge_cost_t c0;
+    zxc_huf_nudge_eval(blc0, pf, &c0);
+
+    /* Frequency-rank order shared by every candidate (rank 0 = most frequent;
+     * pm_leaves_sort is ascending, ties on symbol, so read it backwards). */
+    pm_leaf_t leaves[ZXC_HUF_NUM_SYMBOLS];
+    int k = 0;
+    for (int s = 0; s < ZXC_HUF_NUM_SYMBOLS; s++) {
+        if (!freq[s]) continue;
+        leaves[k].w = freq[s];
+        leaves[k].sym = (int16_t)s;
+        k++;
+    }
+    pm_leaves_sort(leaves, n);
+    int16_t sym_order[ZXC_HUF_NUM_SYMBOLS];
+    uint64_t pf_rank[ZXC_HUF_NUM_SYMBOLS + 1];
+    pf_rank[0] = 0;
+    for (int r = 0; r < n; r++) {
+        sym_order[r] = leaves[n - 1 - r].sym;
+        pf_rank[r + 1] = pf_rank[r] + leaves[n - 1 - r].w;
+    }
+
+    /* Candidates: the greedy ledger walk, then package-merge rebuilt at
+     * reduced caps (optimal bits for a forced-shallower tree; the pass loop
+     * runs max_depth + 1 times, so depth cuts attack the decoder's biggest
+     * fixed cost). Every candidate is a complete, Kraft-exact vector. */
+    uint8_t cand[3][ZXC_HUF_NUM_SYMBOLS];
+    int n_cand = 0;
+    {
+        uint32_t blc_w[LU + 1];
+        zxc_huf_nudge_walk(blc0, pf_rank, n, max_code_len, blc_w);
+        zxc_huf_nudge_assign(blc_w, sym_order, cand[n_cand]);
+        n_cand++;
+    }
+    int max_len0 = 0;
+    for (int l = LU; l >= 1; l--) {
+        if (blc0[l]) {
+            max_len0 = l;
+            break;
+        }
+    }
+    for (int cut = 1; cut <= 2; cut++) {
+        const int cap2 = max_len0 - cut;
+        if (cap2 < 2 || ((uint32_t)1 << cap2) < (uint32_t)n) break;
+        if (zxc_huf_build_code_lengths(freq, cand[n_cand], scratch, cap2) != ZXC_OK) break;
+        n_cand++;
+    }
+
+    /* Guard + selection on exact costs: adopt the cheapest candidate clearing
+     * both guard rails and strictly beating the baseline's J; otherwise leave
+     * code_len byte-for-byte untouched (identical archive to the unadjusted
+     * encoder -- rejection must not depend on package-merge tie assignment). */
+    const uint64_t j0 = zxc_huf_nudge_j(&c0);
+    uint64_t best_j = j0;
+    int best = -1;
+    for (int ci = 0; ci < n_cand; ci++) {
+        uint32_t blc[LU + 1];
+        if (zxc_huf_nudge_classes(cand[ci], blc) != n) continue;
+        zxc_huf_nudge_pf_canonical(cand[ci], freq, blc, pf);
+        zxc_huf_nudge_cost_t c1;
+        zxc_huf_nudge_eval(blc, pf, &c1);
+        if (c1.bits * 1000 > c0.bits * ZXC_HUF_NUDGE_BITS_PERMIL) continue;
+        if (c1.touches * 256 > c0.touches * ZXC_HUF_NUDGE_MERGE_Q8) continue;
+        const uint64_t j = zxc_huf_nudge_j(&c1);
+        if (j < best_j) {
+            best_j = j;
+            best = ci;
+        }
+    }
+    if (best < 0) return 0;
+    ZXC_MEMCPY(code_len, cand[best], ZXC_HUF_NUM_SYMBOLS);
+    return 1;
+}
+#endif /* ZXC_VARIANT_PRIMARY */
+
+/* ===========================================================================
  * 128-byte length header: 256 x 4-bit lengths, low nibble first.
  * =========================================================================*/
 

--- a/src/lib/zxc_huffman.c
+++ b/src/lib/zxc_huffman.c
@@ -343,12 +343,20 @@ int zxc_huf_build_code_lengths(const uint32_t* RESTRICT freq, uint8_t* RESTRICT 
  */
 #if defined(ZXC_VARIANT_PRIMARY)
 
+/** @brief Modeled cost of one code-length candidate (see zxc_huf_nudge_eval). */
 typedef struct {
-    uint64_t bits;    /* payload bits: sum(len * freq); per-node padding excluded */
-    uint64_t touches; /* modeled decode cost: occurrence-weighted level-touches */
+    uint64_t bits;    /**< Payload bits: sum(len * freq); per-node padding excluded. */
+    uint64_t touches; /**< Modeled decode cost: occurrence-weighted level-touches. */
 } zxc_huf_nudge_cost_t;
 
-/** @brief Class counts of a length vector; returns the number of present symbols. */
+/**
+ * @brief Per-length class counts of a code-length vector.
+ *
+ * @param[in]  code_len Per-symbol code lengths (0 = absent symbol).
+ * @param[out] blc      Class counts indexed by length, entries
+ *                      `0..ZXC_HUF_MAX_CODE_LEN_ULTRA` (entry 0 stays 0).
+ * @return Number of present symbols (nonzero lengths).
+ */
 static int zxc_huf_nudge_classes(const uint8_t* RESTRICT code_len, uint32_t* RESTRICT blc) {
     ZXC_MEMSET(blc, 0, (ZXC_HUF_MAX_CODE_LEN_ULTRA + 1) * sizeof(uint32_t));
     int n = 0;
@@ -361,8 +369,15 @@ static int zxc_huf_nudge_classes(const uint8_t* RESTRICT code_len, uint32_t* RES
     return n;
 }
 
-/** @brief Frequency prefix sums over the leaves in canonical (length, symbol)
- *         order: pf[i] = mass of the first i leaves of the code space. */
+/**
+ * @brief Frequency prefix sums over the leaves in canonical (length, symbol)
+ *        order: `pf[i]` = mass of the first `i` leaves of the code space.
+ *
+ * @param[in]  code_len Per-symbol code lengths.
+ * @param[in]  freq     Frequency table indexed by symbol.
+ * @param[in]  blc      Class counts of @p code_len (from ::zxc_huf_nudge_classes).
+ * @param[out] pf       Prefix sums, `n_present + 1` entries with `pf[0] = 0`.
+ */
 static void zxc_huf_nudge_pf_canonical(const uint8_t* RESTRICT code_len,
                                        const uint32_t* RESTRICT freq, const uint32_t* RESTRICT blc,
                                        uint64_t* RESTRICT pf) {
@@ -384,15 +399,20 @@ static void zxc_huf_nudge_pf_canonical(const uint8_t* RESTRICT code_len,
 /**
  * @brief Modeled (bits, level-touches) of one class-count histogram.
  *
- * @p pf must hold frequency prefix sums of the leaves in code order (pf[0]=0):
- * canonical (length, symbol)-order sums give exact costs; frequency-rank sums
- * give the cheap scores used inside the walk (bits are identical either way,
- * only the within-run mass split differs). The buddy decomposition of each
- * same-depth leaf run mirrors zxc_pivco_decode_core row by row: a lone leaf at
- * depth l is memset once and merged l times (l+1 touches); a leaf pair is
- * emitted by its parent's XOR-blend (l touches); a flat root at depth t = l-D
- * is unpacked once and merged t times (t+1 touches, plus a penalty past the
- * SIMD unpackers); each pass adds a fixed overhead term.
+ * The buddy decomposition of each same-depth leaf run mirrors
+ * zxc_pivco_decode_core row by row: a lone leaf at depth l is memset once and
+ * merged l times (l+1 touches); a leaf pair is emitted by its parent's
+ * XOR-blend (l touches); a flat root at depth t = l-D is unpacked once and
+ * merged t times (t+1 touches, plus a penalty past the SIMD unpackers); each
+ * pass adds a fixed overhead term.
+ *
+ * @param[in]  blc Class counts of the candidate (Kraft-exact by construction).
+ * @param[in]  pf  Frequency prefix sums of the leaves in code order
+ *                 (`pf[0] = 0`): canonical (length, symbol)-order sums give
+ *                 exact costs; frequency-rank sums give the cheap scores used
+ *                 inside the walk (bits are identical either way, only the
+ *                 within-run mass split differs).
+ * @param[out] out Modeled bits and level-touches.
  */
 static void zxc_huf_nudge_eval(const uint32_t* RESTRICT blc, const uint64_t* RESTRICT pf,
                                zxc_huf_nudge_cost_t* RESTRICT out) {
@@ -436,7 +456,12 @@ static void zxc_huf_nudge_eval(const uint32_t* RESTRICT blc, const uint64_t* RES
     out->touches = touches;
 }
 
-/** @brief Candidate cost J: bits (scaled to Q8) plus lambda per level-touch. */
+/**
+ * @brief Candidate cost `J = 256*bits + lambda*touches` (Q8 bit units).
+ *
+ * @param[in] c Modeled cost from ::zxc_huf_nudge_eval.
+ * @return Scalar cost; lower is better.
+ */
 static ZXC_ALWAYS_INLINE uint64_t zxc_huf_nudge_j(const zxc_huf_nudge_cost_t* c) {
     return 256U * c->bits + (uint64_t)ZXC_HUF_NUDGE_LAMBDA_Q8 * c->touches;
 }
@@ -444,14 +469,21 @@ static ZXC_ALWAYS_INLINE uint64_t zxc_huf_nudge_j(const zxc_huf_nudge_cost_t* c)
 /**
  * @brief Clamp a desired class count into the feasible set at one walk level.
  *
- * State: @p s open slots at level @p l, @p n_rem symbols left. A count c is
- * feasible iff a Kraft-exact completion within @p cap still exists: either
- * c == n_rem == s (a finishing level fills every slot), or, continuing with
- * i = s - c internal nodes, i >= 1 and 2*i <= n_rem - c <= i << (cap - l).
- * Under the walk invariant (s <= n_rem <= s << (cap - l)) the continuing
- * window [max(0, 2s - n_rem), min(s-1, n_rem-1, (s*M - n_rem)/(M-1))] is
- * nonempty whenever n_rem > s, and n_rem == s forces the finishing count
- * (continuing would need both c >= s and c <= s-1).
+ * A count c is feasible iff a Kraft-exact completion within @p cap still
+ * exists: either c == n_rem == s (a finishing level fills every slot), or,
+ * continuing with i = s - c internal nodes, i >= 1 and
+ * 2*i <= n_rem - c <= i << (cap - l). Under the walk invariant
+ * (s <= n_rem <= s << (cap - l)) the continuing window
+ * [max(0, 2s - n_rem), min(s-1, n_rem-1, (s*M - n_rem)/(M-1))] is nonempty
+ * whenever n_rem > s, and n_rem == s forces the finishing count (continuing
+ * would need both c >= s and c <= s-1).
+ *
+ * @param[in] want  Desired class count at this level.
+ * @param[in] s     Open slots at level @p l.
+ * @param[in] n_rem Symbols left to place (including this level's).
+ * @param[in] l     Current level.
+ * @param[in] cap   Code-length cap of the walk.
+ * @return The nearest feasible count to @p want.
  */
 static uint32_t zxc_huf_nudge_clamp(const uint32_t want, const uint32_t s, const uint32_t n_rem,
                                     const int l, const int cap) {
@@ -465,8 +497,17 @@ static uint32_t zxc_huf_nudge_clamp(const uint32_t want, const uint32_t s, const
     return c > hi ? hi : c;
 }
 
-/** @brief Baseline-following completion: fill levels l+1..cap with the
- *         baseline class counts clamped into feasibility. */
+/**
+ * @brief Baseline-following completion: fill levels `l+1..cap` with the
+ *        baseline class counts clamped into feasibility.
+ *
+ * @param[in,out] blc   Candidate histogram; levels above @p l are written.
+ * @param[in]     l     Last level already fixed by the caller.
+ * @param[in]     s     Open slots at level `l+1`.
+ * @param[in]     n_rem Symbols still to place.
+ * @param[in]     blc0  Baseline class counts to follow.
+ * @param[in]     cap   Code-length cap of the walk.
+ */
 static void zxc_huf_nudge_complete(uint32_t* RESTRICT blc, const int l, uint32_t s, uint32_t n_rem,
                                    const uint32_t* RESTRICT blc0, const int cap) {
     for (int j = l + 1; j <= cap && n_rem; j++) {
@@ -490,6 +531,12 @@ static void zxc_huf_nudge_complete(uint32_t* RESTRICT blc, const int l, uint32_t
  * Fixed candidate order + strict improvement keeps the result deterministic.
  * A chosen uniform-depth finish needs no lock: at the next level it reappears
  * as the (c = 0, D-1) finish candidate, so the greedy can hold or drop it.
+ *
+ * @param[in]  blc0    Baseline class counts (package-merge output).
+ * @param[in]  pf_rank Frequency-rank prefix sums (rank 0 = most frequent).
+ * @param[in]  n       Number of present symbols (>= 4).
+ * @param[in]  cap     Code-length cap.
+ * @param[out] out_blc Chosen class counts (Kraft-exact by construction).
  */
 static void zxc_huf_nudge_walk(const uint32_t* RESTRICT blc0, const uint64_t* RESTRICT pf_rank,
                                const int n, const int cap, uint32_t* RESTRICT out_blc) {
@@ -574,6 +621,15 @@ static void zxc_huf_nudge_walk(const uint32_t* RESTRICT blc0, const uint64_t* RE
  * slots pins the run start at 2^lu - s * 2^(lu - lc): the cost of taking
  * @p c slots here depends only on (lc, s, c, rank interval) -- which is what
  * makes the level costs additive and the DP exact for this model.
+ *
+ * @param[in] lu     Coarse code-space scale (`ZXC_HUF_MAX_CODE_LEN_ULTRA - g_log2`).
+ * @param[in] lc     Coarse level the run is placed at.
+ * @param[in] g_log2 Granularity: one coarse slot = 2^g_log2 real leaves.
+ * @param[in] s      Open coarse slots at level @p lc.
+ * @param[in] c      Coarse slots taken as leaves at this level.
+ * @param[in] pfg    Group-mass prefix sums in frequency-rank order.
+ * @param[in] k      Groups already placed (rank of the run's first group).
+ * @return J contribution of the run (Q8 bits + lambda * touches).
  */
 static uint64_t zxc_huf_nudge_dp_run_j(const int lu, const int lc, const int g_log2,
                                        const uint32_t s, const uint32_t c,
@@ -619,8 +675,16 @@ static uint64_t zxc_huf_nudge_dp_run_j(const int lu, const int lc, const int g_l
  * per-level arrival choices reconstructs the coarse class counts.
  *
  * Iteration order and strict-improvement relaxation are fixed, so the result
- * is deterministic. Returns 0 on allocation failure or no feasible finish
- * (callers then simply keep their other candidates).
+ * is deterministic.
+ *
+ * @param[in]  pfg      Group-mass prefix sums in frequency-rank order.
+ * @param[in]  m        Number of coarse symbols (groups), >= 2.
+ * @param[in]  cap_c    Coarse code-length cap (`real cap - g_log2`).
+ * @param[in]  lu       Coarse code-space scale (see ::zxc_huf_nudge_dp_run_j).
+ * @param[in]  g_log2   Granularity exponent.
+ * @param[out] out_cblc Optimal coarse class counts (indexed by coarse level).
+ * @return 1 on success; 0 on allocation failure or no feasible finish
+ *         (callers then simply keep their other candidates).
  */
 static int zxc_huf_nudge_dp_solve(const uint64_t* RESTRICT pfg, const int m, const int cap_c,
                                   const int lu, const int g_log2, uint32_t* RESTRICT out_cblc) {
@@ -702,8 +766,14 @@ done:
     return ok;
 }
 
-/** @brief Assign a class-count multiset to symbols: frequency rank r takes the
- *         r-th shortest slot (rearrangement-optimal, deterministic). */
+/**
+ * @brief Assign a class-count multiset to symbols: frequency rank r takes the
+ *        r-th shortest slot (rearrangement-optimal, deterministic).
+ *
+ * @param[in]  blc       Class counts to realize (sum = number of ranks).
+ * @param[in]  sym_order Symbols by descending frequency (rank 0 first).
+ * @param[out] cand_len  Resulting per-symbol code lengths, written in full.
+ */
 static void zxc_huf_nudge_assign(const uint32_t* RESTRICT blc, const int16_t* RESTRICT sym_order,
                                  uint8_t* RESTRICT cand_len) {
     ZXC_MEMSET(cand_len, 0, ZXC_HUF_NUM_SYMBOLS);
@@ -712,6 +782,13 @@ static void zxc_huf_nudge_assign(const uint32_t* RESTRICT blc, const int16_t* RE
         for (uint32_t k = 0; k < blc[l]; k++) cand_len[sym_order[r++]] = (uint8_t)l;
 }
 
+/**
+ * @brief Modeled (bits, level-touches) decode cost of one code-length vector.
+ *
+ * Introspection hook over the exact evaluator (canonical-order weighting);
+ * full contract in zxc_internal.h. The unit tests cross-check it against the
+ * real tree built by the decoder.
+ */
 void zxc_huf_nudge_cost(const uint8_t* RESTRICT code_len, const uint32_t* RESTRICT freq,
                         uint64_t* RESTRICT bits, uint64_t* RESTRICT touches) {
     uint32_t blc[ZXC_HUF_MAX_CODE_LEN_ULTRA + 1];
@@ -724,6 +801,13 @@ void zxc_huf_nudge_cost(const uint8_t* RESTRICT code_len, const uint32_t* RESTRI
     *touches = c.touches;
 }
 
+/**
+ * @brief Optionally reshape freshly built code lengths for faster PivCo decode.
+ *
+ * Candidate generation (walk, reduced-cap rebuilds, slot-ledger DP), exact
+ * pricing and the adoption guard; full contract in zxc_internal.h. On
+ * rejection @p code_len is left byte-for-byte untouched.
+ */
 int zxc_huf_nudge_code_lengths(const uint32_t* RESTRICT freq, uint8_t* RESTRICT code_len,
                                void* RESTRICT scratch, const int max_code_len) {
     enum { LU = ZXC_HUF_MAX_CODE_LEN_ULTRA };
@@ -761,7 +845,7 @@ int zxc_huf_nudge_code_lengths(const uint32_t* RESTRICT freq, uint8_t* RESTRICT 
     /* Candidates: the greedy ledger walk, then package-merge rebuilt at
      * reduced caps (optimal bits for a forced-shallower tree; the pass loop
      * runs max_depth + 1 times, so depth cuts attack the decoder's biggest
-     * fixed cost), plus -- at DP efforts -- the slot-ledger dynamic program.
+     * fixed cost), plus the slot-ledger dynamic program below.
      * Every candidate is a complete, Kraft-exact vector. */
     uint8_t cand[4][ZXC_HUF_NUM_SYMBOLS];
     int n_cand = 0;

--- a/src/lib/zxc_internal.h
+++ b/src/lib/zxc_internal.h
@@ -844,7 +844,6 @@ typedef struct {
      8U + (size_t)ZXC_HUF_MAX_CODE_LEN_ULTRA * sizeof(int) + 8U +          \
      (size_t)ZXC_HUF_MAX_CODE_LEN_ULTRA * (size_t)ZXC_HUF_PM_LEVEL_BOUND * \
          sizeof(zxc_huf_pm_frame_t))
-/** @} */
 
 /** @name Block Size Helpers
  *  @brief Runtime helpers for variable block sizes.

--- a/src/lib/zxc_internal.h
+++ b/src/lib/zxc_internal.h
@@ -665,6 +665,64 @@ typedef struct {
  *         also historically derived from it). */
 #define ZXC_HUF_MARGIN_SHIFT 5
 
+/** @name Encoder-side joint flat/length nudge (PivCo decode-speed shaping)
+ *
+ *  Package-merge minimizes section bits alone, but the PivCo decoder's cost
+ *  also depends on the SHAPE of the code-length histogram: the reconstruction
+ *  pass loop runs `max_depth + 1` times, and every maximal complete subtree
+ *  (all leaves exactly D levels below its root) collapses D merge levels into
+ *  a single unpack. ::zxc_huf_nudge_code_lengths reshapes freshly built
+ *  lengths toward power-of-two class counts and shallower caps, adopting a
+ *  candidate only when its modeled decode win clears the guard below at a
+ *  bounded ratio cost. Wire-compatible by construction: adjusted lengths stay
+ *  canonical, Kraft-exact and within the level cap, so any v7 decoder reads
+ *  the section unchanged (selection is encoder policy, FORMAT.md 5.2.1).
+ *  Idea from pivco-huffman issue #20 (dougallj). All knobs are
+ *  `#ifndef`-guarded so an A/B build can override them from CFLAGS.
+ *  @{ */
+/** @brief Master switch for the call sites; 0 restores archives byte-identical
+ *         to the unadjusted encoder (the functions still compile). */
+#ifndef ZXC_HUF_NUDGE
+#define ZXC_HUF_NUDGE 1
+#endif
+/** @brief Exchange rate (Q8 bits per modeled level-touch) in the candidate
+ *         cost `J = 256*bits + lambda*touches`; 26 ~= 0.10 bit per touch. */
+#ifndef ZXC_HUF_NUDGE_LAMBDA_Q8
+#define ZXC_HUF_NUDGE_LAMBDA_Q8 26
+#endif
+/** @brief Adoption guard, ratio side (permil): adopt only while
+ *         `bits' * 1000 <= bits0 * ZXC_HUF_NUDGE_BITS_PERMIL` (<= +1.5%). */
+#ifndef ZXC_HUF_NUDGE_BITS_PERMIL
+#define ZXC_HUF_NUDGE_BITS_PERMIL 1015
+#endif
+/** @brief Adoption guard, speed side (Q8): adopt only while
+ *         `touches' * 256 <= touches0 * ZXC_HUF_NUDGE_MERGE_Q8` (<= ~0.90x). */
+#ifndef ZXC_HUF_NUDGE_MERGE_Q8
+#define ZXC_HUF_NUDGE_MERGE_Q8 230
+#endif
+/** @brief Deepest flat-subtree depth with a SIMD unpacker (see
+ *         zxc_pivco_unpack_flat); deeper flat roots fall back to the scalar
+ *         bit-reader and must NOT be priced as free. */
+#define ZXC_HUF_NUDGE_FLAT_SIMD_MAX 6
+/** @brief Extra level-touches charged per occurrence under a flat root deeper
+ *         than ::ZXC_HUF_NUDGE_FLAT_SIMD_MAX (scalar bit-reader unpack path).
+ *         Measured on M2 silesia sections: the scalar unpack costs ~18 SIMD
+ *         touch-equivalents per occurrence even in its byte-aligned D = 8 best
+ *         case (a mispriced 2 let the walk collapse a 256-symbol section into
+ *         one all-8-bit flat root: modeled -30% touches, real -54% decode).
+ *         24 keeps low-mass deep-flat tails adoptable while making
+ *         all-the-mass deep flats impossible to justify. */
+#ifndef ZXC_HUF_NUDGE_DEEP_FLAT_PENALTY
+#define ZXC_HUF_NUDGE_DEEP_FLAT_PENALTY 24
+#endif
+/** @brief Fixed per-pass overhead (occurrence-equivalents) charged per merge
+ *         level, modeling the pass-loop and node-dispatch cost so shallower
+ *         trees also win on small sections. */
+#ifndef ZXC_HUF_NUDGE_LEVEL_COST
+#define ZXC_HUF_NUDGE_LEVEL_COST 64
+#endif
+/** @} */
+
 /** @name Space-speed section selection
  *
  *  Section encodings are selected at EVERY level by pricing each candidate
@@ -1472,6 +1530,43 @@ int zxc_read_ghi_header_and_desc(const uint8_t* RESTRICT src, const size_t len,
  */
 int zxc_huf_build_code_lengths(const uint32_t* RESTRICT freq, uint8_t* RESTRICT code_len,
                                void* RESTRICT scratch, int max_code_len);
+
+/**
+ * @brief Optionally reshape freshly built code lengths for faster PivCo decode.
+ *
+ * Explores a small set of Kraft-exact alternatives to @p code_len (a greedy
+ * slot-ledger walk toward power-of-two class counts, plus package-merge
+ * rebuilds at reduced depth caps) and prices each against the modeled decode
+ * cost of zxc_pivco_decode_core. The cheapest candidate that clears the
+ * adoption guard (<= +::ZXC_HUF_NUDGE_BITS_PERMIL ratio cost AND
+ * <= ::ZXC_HUF_NUDGE_MERGE_Q8 modeled level-touches) replaces @p code_len;
+ * otherwise the array is left byte-for-byte untouched, so a rejected nudge
+ * emits an archive identical to the unadjusted encoder.
+ *
+ * Encoder policy only: any adopted output is canonical, Kraft-exact and capped
+ * at @p max_code_len, so the wire format and every deployed decoder are
+ * unaffected. Compiled once in the primary variant (ISA-independent decision
+ * code), guaranteeing cross-ISA identical archives.
+ *
+ * @param[in]     freq         Frequency table of length `ZXC_HUF_NUM_SYMBOLS`.
+ * @param[in,out] code_len     Lengths from ::zxc_huf_build_code_lengths.
+ * @param[in]     scratch      Optional ::ZXC_HUF_BUILD_SCRATCH_SIZE scratch for
+ *                             the reduced-cap rebuilds (NULL = allocate).
+ * @param[in]     max_code_len Cap the caller built with (level cap).
+ * @return 1 if @p code_len was adjusted, 0 if kept.
+ */
+int zxc_huf_nudge_code_lengths(const uint32_t* RESTRICT freq, uint8_t* RESTRICT code_len,
+                               void* RESTRICT scratch, int max_code_len);
+
+/**
+ * @brief Modeled (bits, level-touches) decode cost of one code-length vector.
+ *
+ * Introspection hook for the nudge's cost model (exact, canonical-order
+ * frequency weighting); the unit tests cross-check it against the real
+ * tree built by the decoder. @p code_len must be structurally valid.
+ */
+void zxc_huf_nudge_cost(const uint8_t* RESTRICT code_len, const uint32_t* RESTRICT freq,
+                        uint64_t* RESTRICT bits, uint64_t* RESTRICT touches);
 
 /**
  * @brief Pack per-symbol code lengths into the 128-byte (4-bit nibble) header.

--- a/src/lib/zxc_internal.h
+++ b/src/lib/zxc_internal.h
@@ -678,13 +678,10 @@ typedef struct {
  *  canonical, Kraft-exact and within the level cap, so any v7 decoder reads
  *  the section unchanged (selection is encoder policy, FORMAT.md 5.2.1).
  *  Idea from pivco-huffman issue #20 (dougallj). All knobs are
- *  `#ifndef`-guarded so an A/B build can override them from CFLAGS.
+ *  `#ifndef`-guarded so an A/B build can override them from CFLAGS; in
+ *  particular `-DZXC_HUF_NUDGE_MERGE_Q8=0` makes the guard reject every
+ *  candidate, restoring archives byte-identical to the unadjusted encoder.
  *  @{ */
-/** @brief Master switch for the call sites; 0 restores archives byte-identical
- *         to the unadjusted encoder (the functions still compile). */
-#ifndef ZXC_HUF_NUDGE
-#define ZXC_HUF_NUDGE 1
-#endif
 /** @brief Exchange rate (Q8 bits per modeled level-touch) in the candidate
  *         cost `J = 256*bits + lambda*touches`; 26 ~= 0.10 bit per touch. */
 #ifndef ZXC_HUF_NUDGE_LAMBDA_Q8
@@ -1535,18 +1532,23 @@ int zxc_huf_build_code_lengths(const uint32_t* RESTRICT freq, uint8_t* RESTRICT 
  * @brief Optionally reshape freshly built code lengths for faster PivCo decode.
  *
  * Explores a small set of Kraft-exact alternatives to @p code_len (a greedy
- * slot-ledger walk toward power-of-two class counts, plus package-merge
- * rebuilds at reduced depth caps) and prices each against the modeled decode
- * cost of zxc_pivco_decode_core. The cheapest candidate that clears the
- * adoption guard (<= +::ZXC_HUF_NUDGE_BITS_PERMIL ratio cost AND
+ * slot-ledger walk toward power-of-two class counts, package-merge rebuilds
+ * at reduced depth caps, and the slot-ledger dynamic program at a coarse
+ * granularity picked from the alphabet size) and prices each against the
+ * modeled decode cost of zxc_pivco_decode_core. The cheapest candidate that
+ * clears the adoption guard (<= +::ZXC_HUF_NUDGE_BITS_PERMIL ratio cost AND
  * <= ::ZXC_HUF_NUDGE_MERGE_Q8 modeled level-touches) replaces @p code_len;
  * otherwise the array is left byte-for-byte untouched, so a rejected nudge
- * emits an archive identical to the unadjusted encoder.
+ * emits an archive identical to the unadjusted encoder. Coarse-DP candidates
+ * may pad the tree with zero-frequency "ghost" leaves on unused byte values;
+ * the wire carries them as empty runs.
  *
  * Encoder policy only: any adopted output is canonical, Kraft-exact and capped
  * at @p max_code_len, so the wire format and every deployed decoder are
  * unaffected. Compiled once in the primary variant (ISA-independent decision
- * code), guaranteeing cross-ISA identical archives.
+ * code), guaranteeing cross-ISA identical archives. Cost is a few hundred
+ * microseconds per table at most (DP plane sizes are capped by the coarse
+ * granularity), which the ULTRA-only and trainer call sites absorb.
  *
  * @param[in]     freq         Frequency table of length `ZXC_HUF_NUM_SYMBOLS`.
  * @param[in,out] code_len     Lengths from ::zxc_huf_build_code_lengths.

--- a/tests/test_common.h
+++ b/tests/test_common.h
@@ -180,6 +180,7 @@ int test_seekable_mt_full_file(void);
 
 /* Format (on-disk) */
 int test_huffman_codec(void);
+int test_huffman_nudge(void);
 int test_huffman_codec_dict(void);
 int test_huffman_single_symbol_validation(void);
 int test_eof_block_structure(void);

--- a/tests/test_format.c
+++ b/tests/test_format.c
@@ -122,6 +122,289 @@ int test_huffman_codec() {
     return 1;
 }
 
+/* --------------------------------------------------------------------------
+ * Encoder-side flat/length nudge (zxc_huf_nudge_code_lengths)
+ * -------------------------------------------------------------------------- */
+
+/* Cross-check the nudge's buddy-decomposition cost model against the REAL
+ * tree the decoder builds: bits and modeled level-touches must match exactly,
+ * with the same flat/leaf-pair/deep-flat weighting as zxc_pivco_decode_core.
+ * This pins the "flat coverage from bl_count[] alone" math to the shipping
+ * flat detector (zxc_pivco_tree_build) for any valid length vector. */
+static int nudge_cost_matches_tree(const char* label, const uint8_t* code_len,
+                                   const uint32_t* freq) {
+    uint64_t bits = 0;
+    uint64_t touches = 0;
+    zxc_huf_nudge_cost(code_len, freq, &bits, &touches);
+
+    uint8_t packed[ZXC_HUF_TABLE_SIZE];
+    zxc_huf_pack_lengths(code_len, packed);
+    static zxc_pivco_tree_t tree;
+    static zxc_pivco_decode_aux_t aux;
+    static uint32_t codes[ZXC_HUF_NUM_SYMBOLS];
+    uint8_t len2[ZXC_HUF_NUM_SYMBOLS];
+    if (zxc_huf_dict_tree_build(packed, &tree, codes, len2, &aux) != ZXC_OK) {
+        printf("Failed [%s]: reference tree build rejected the lengths\n", label);
+        return 0;
+    }
+
+    uint32_t count[ZXC_PIVCO_MAX_NODES];
+    for (int i = tree.n_nodes - 1; i >= 0; i--) {
+        const int nid = tree.bfs[i];
+        if (tree.nd[nid].sym >= 0) {
+            count[nid] = freq[tree.nd[nid].sym];
+        } else {
+            uint32_t c = 0;
+            if (tree.nd[nid].child[0] >= 0) c += count[tree.nd[nid].child[0]];
+            if (tree.nd[nid].child[1] >= 0) c += count[tree.nd[nid].child[1]];
+            count[nid] = c;
+        }
+    }
+
+    uint64_t rbits = 0;
+    for (int s = 0; s < ZXC_HUF_NUM_SYMBOLS; s++) rbits += (uint64_t)code_len[s] * freq[s];
+    uint64_t rtouches = 0;
+    for (int i = 0; i < tree.n_nodes; i++) {
+        const int nid = tree.bfs[i];
+        if (tree.covered[nid]) continue;
+        if (tree.nd[nid].sym >= 0) {
+            /* Lone leaf memset; leaf-pair children are emitted by the parent. */
+            if (!aux.skip[nid]) rtouches += count[nid];
+        } else if (tree.flat_d[nid]) {
+            uint64_t t = 1;
+            if (tree.flat_d[nid] > ZXC_HUF_NUDGE_FLAT_SIMD_MAX) t += ZXC_HUF_NUDGE_DEEP_FLAT_PENALTY;
+            rtouches += (uint64_t)count[nid] * t;
+        } else {
+            rtouches += count[nid]; /* merge node (leaf-pair parents included) */
+        }
+    }
+    rtouches += (uint64_t)ZXC_HUF_NUDGE_LEVEL_COST * (uint64_t)(tree.max_depth + 1);
+
+    if (bits != rbits || touches != rtouches) {
+        printf("Failed [%s]: model (bits=%llu touches=%llu) != tree (bits=%llu touches=%llu)\n",
+               label, (unsigned long long)bits, (unsigned long long)touches,
+               (unsigned long long)rbits, (unsigned long long)rtouches);
+        return 0;
+    }
+    return 1;
+}
+
+/* Full nudge pipeline on one distribution and cap: build -> nudge -> validate
+ * structure, the calc_size == encode invariant, the decode roundtrip, the
+ * adoption guard arithmetic, determinism, and the cost model on both the
+ * baseline and the (possibly) adopted vector. */
+static int huf_nudge_case(const char* label, const uint8_t* literals, size_t n_lit,
+                          const int max_code_len) {
+    uint32_t freq[ZXC_HUF_NUM_SYMBOLS] = {0};
+    for (size_t i = 0; i < n_lit; i++) freq[literals[i]]++;
+
+    uint8_t base_len[ZXC_HUF_NUM_SYMBOLS];
+    if (zxc_huf_build_code_lengths(freq, base_len, NULL, max_code_len) != ZXC_OK) {
+        printf("Failed [%s]: build_code_lengths\n", label);
+        return 0;
+    }
+    if (!nudge_cost_matches_tree(label, base_len, freq)) return 0;
+
+    uint8_t nudged[ZXC_HUF_NUM_SYMBOLS];
+    memcpy(nudged, base_len, sizeof(nudged));
+    const int adopted = zxc_huf_nudge_code_lengths(freq, nudged, NULL, max_code_len);
+
+    /* Determinism: a second independent run must reproduce the result. */
+    uint8_t nudged2[ZXC_HUF_NUM_SYMBOLS];
+    memcpy(nudged2, base_len, sizeof(nudged2));
+    const int adopted2 = zxc_huf_nudge_code_lengths(freq, nudged2, NULL, max_code_len);
+    if (adopted != adopted2 || memcmp(nudged, nudged2, sizeof(nudged)) != 0) {
+        printf("Failed [%s]: nudge is not deterministic\n", label);
+        return 0;
+    }
+
+    if (!adopted) {
+        if (memcmp(nudged, base_len, sizeof(nudged)) != 0) {
+            printf("Failed [%s]: rejected nudge modified the lengths\n", label);
+            return 0;
+        }
+    } else {
+        /* Structural rails: cap respected, every live symbol keeps a code. */
+        for (int s = 0; s < ZXC_HUF_NUM_SYMBOLS; s++) {
+            if (nudged[s] > max_code_len || (freq[s] != 0) != (nudged[s] != 0)) {
+                printf("Failed [%s]: adopted lengths invalid at sym %d (len=%d)\n", label, s,
+                       nudged[s]);
+                return 0;
+            }
+        }
+        /* The adoption guard must hold on the exact model costs. */
+        uint64_t b0, t0, b1, t1;
+        zxc_huf_nudge_cost(base_len, freq, &b0, &t0);
+        zxc_huf_nudge_cost(nudged, freq, &b1, &t1);
+        if (b1 * 1000 > b0 * ZXC_HUF_NUDGE_BITS_PERMIL || t1 * 256 > t0 * ZXC_HUF_NUDGE_MERGE_Q8) {
+            printf("Failed [%s]: adopted candidate violates the guard "
+                   "(bits %llu->%llu, touches %llu->%llu)\n",
+                   label, (unsigned long long)b0, (unsigned long long)b1, (unsigned long long)t0,
+                   (unsigned long long)t1);
+            return 0;
+        }
+        if (!nudge_cost_matches_tree(label, nudged, freq)) return 0;
+    }
+
+    /* Selector/encoder invariant + decode roundtrip on the final vector. */
+    const size_t cap = ZXC_HUF_TABLE_SIZE + 2 * n_lit + 4096;
+    uint8_t* enc = (uint8_t*)malloc(cap);
+    uint8_t* dec = (uint8_t*)malloc(n_lit + ZXC_PAD_SIZE);
+    uint8_t* scr = (uint8_t*)malloc(n_lit + ZXC_PIVCO_SCRATCH_PAD);
+    int ok = 0;
+    if (!enc || !dec || !scr) {
+        printf("Failed [%s]: alloc\n", label);
+        goto done;
+    }
+    {
+        const int written = zxc_huf_encode_section(literals, n_lit, freq, nudged, enc, cap);
+        if (written < 0) {
+            printf("Failed [%s]: encode_section -> %d\n", label, written);
+            goto done;
+        }
+        const size_t est = zxc_huf_calc_size(freq, nudged, 1);
+        if (est != (size_t)written) {
+            printf("Failed [%s]: calc_size %zu != encoded %d\n", label, est, written);
+            goto done;
+        }
+        if (zxc_huf_decode_section(enc, (size_t)written, dec, n_lit, scr) != ZXC_OK ||
+            memcmp(literals, dec, n_lit) != 0) {
+            printf("Failed [%s]: nudged roundtrip mismatch\n", label);
+            goto done;
+        }
+    }
+    printf("  [PASS] %s (cap=%d, %s)\n", label, max_code_len, adopted ? "adopted" : "kept");
+    ok = 1;
+done:
+    free(enc);
+    free(dec);
+    free(scr);
+    return ok;
+}
+
+int test_huffman_nudge() {
+    printf("=== TEST: Unit - Huffman flat/length nudge (model + guard + roundtrip) ===\n");
+
+    const size_t N = 16384;
+    uint8_t* buf = (uint8_t*)malloc(N);
+    if (!buf) return 0;
+    int ok = 1;
+
+    /* Geometric: deep 11-bit trees at ULTRA cap, the nudge's main target. */
+    for (size_t i = 0; i < N; i++) {
+        uint32_t r = zxc_test_rand();
+        int b = 0;
+        while (b < 17 && (r & 1)) {
+            b++;
+            r >>= 1;
+        }
+        buf[i] = (uint8_t)b;
+    }
+    ok &= huf_nudge_case("Geometric", buf, N, ZXC_HUF_MAX_CODE_LEN_ULTRA);
+    ok &= huf_nudge_case("Geometric cap8", buf, N, ZXC_HUF_MAX_CODE_LEN_DENSITY);
+
+    /* Zipf over the full alphabet: ragged class counts, boundary rounding. */
+    for (size_t i = 0; i < N; i++) {
+        const uint32_t r = zxc_test_rand() % 6000;
+        uint32_t s = 0;
+        uint32_t acc = 0;
+        while (s < 255) {
+            acc += 1000 / (s + 1);
+            if (r < acc) break;
+            s++;
+        }
+        buf[i] = (uint8_t)s;
+    }
+    ok &= huf_nudge_case("Zipf", buf, N, ZXC_HUF_MAX_CODE_LEN_ULTRA);
+    ok &= huf_nudge_case("Zipf cap8", buf, N, ZXC_HUF_MAX_CODE_LEN_DENSITY);
+
+    /* Text-like: few dozen symbols, mild skew (the common literal section). */
+    for (size_t i = 0; i < N; i++) {
+        const uint32_t r = zxc_test_rand();
+        buf[i] = (uint8_t)('a' + (((r & 0xFF) * ((r >> 8) & 0xFF)) >> 11));
+    }
+    ok &= huf_nudge_case("Text-like", buf, N, ZXC_HUF_MAX_CODE_LEN_ULTRA);
+
+    /* Uniform 256: already a single flat root; the nudge must keep baseline. */
+    for (size_t i = 0; i < N; i++) buf[i] = (uint8_t)(i & 0xFF);
+    {
+        uint32_t freq[ZXC_HUF_NUM_SYMBOLS] = {0};
+        for (size_t i = 0; i < N; i++) freq[buf[i]]++;
+        uint8_t len[ZXC_HUF_NUM_SYMBOLS];
+        uint8_t kept[ZXC_HUF_NUM_SYMBOLS];
+        if (zxc_huf_build_code_lengths(freq, len, NULL, ZXC_HUF_MAX_CODE_LEN_DENSITY) != ZXC_OK) {
+            ok = 0;
+        } else {
+            memcpy(kept, len, sizeof(kept));
+            if (zxc_huf_nudge_code_lengths(freq, len, NULL, ZXC_HUF_MAX_CODE_LEN_DENSITY) != 0 ||
+                memcmp(kept, len, sizeof(kept)) != 0) {
+                printf("Failed [Uniform-256]: expected a no-op nudge\n");
+                ok = 0;
+            } else {
+                printf("  [PASS] Uniform-256 no-op\n");
+            }
+        }
+    }
+
+    /* Degenerate alphabets (n = 1, 2, 3): must never be touched. */
+    for (int nsym = 1; nsym <= 3; nsym++) {
+        uint32_t freq[ZXC_HUF_NUM_SYMBOLS] = {0};
+        for (int s = 0; s < nsym; s++) freq[(uint8_t)('A' + s)] = (uint32_t)(100 * (s + 1));
+        uint8_t len[ZXC_HUF_NUM_SYMBOLS];
+        uint8_t kept[ZXC_HUF_NUM_SYMBOLS];
+        if (zxc_huf_build_code_lengths(freq, len, NULL, ZXC_HUF_MAX_CODE_LEN_DENSITY) != ZXC_OK) {
+            ok = 0;
+            continue;
+        }
+        memcpy(kept, len, sizeof(kept));
+        if (zxc_huf_nudge_code_lengths(freq, len, NULL, ZXC_HUF_MAX_CODE_LEN_DENSITY) != 0 ||
+            memcmp(kept, len, sizeof(kept)) != 0) {
+            printf("Failed [Degenerate n=%d]: expected untouched lengths\n", nsym);
+            ok = 0;
+        }
+    }
+    if (ok) printf("  [PASS] Degenerate n=1..3 untouched\n");
+
+    /* Fuzz: random alphabets/frequencies; the cost model must match the real
+     * tree for every baseline AND every adopted vector, at both caps. */
+    {
+        int checked = 0;
+        int adopted_cnt = 0;
+        for (int it = 0; it < 300 && ok; it++) {
+            uint32_t freq[ZXC_HUF_NUM_SYMBOLS] = {0};
+            const int nsym = 4 + (int)(zxc_test_rand() % 253);
+            for (int s = 0; s < nsym; s++)
+                freq[(uint8_t)(zxc_test_rand() & 0xFF)] = 1 + (zxc_test_rand() & 0xFFFFF);
+            const int cap = (it & 1) ? ZXC_HUF_MAX_CODE_LEN_ULTRA : ZXC_HUF_MAX_CODE_LEN_DENSITY;
+            uint8_t len[ZXC_HUF_NUM_SYMBOLS];
+            if (zxc_huf_build_code_lengths(freq, len, NULL, cap) != ZXC_OK) {
+                ok = 0;
+                break;
+            }
+            if (!nudge_cost_matches_tree("Fuzz baseline", len, freq)) {
+                ok = 0;
+                break;
+            }
+            checked++;
+            if (zxc_huf_nudge_code_lengths(freq, len, NULL, cap)) {
+                adopted_cnt++;
+                if (!nudge_cost_matches_tree("Fuzz nudged", len, freq)) {
+                    ok = 0;
+                    break;
+                }
+            }
+        }
+        if (ok)
+            printf("  [PASS] Fuzz: %d histograms cross-checked, %d nudges adopted\n", checked,
+                   adopted_cnt);
+    }
+
+    free(buf);
+    if (!ok) return 0;
+    printf("PASS\n\n");
+    return 1;
+}
+
 /* Round-trip the shared-table (dictionary) Huffman section codec: encode with
  * external code lengths and NO 128-byte header, decode through a prebuilt
  * table -- the enc_lit == 3 wire path (FORMAT.md Sec 5.2.2). */

--- a/tests/test_format.c
+++ b/tests/test_format.c
@@ -224,9 +224,11 @@ static int huf_nudge_case(const char* label, const uint8_t* literals, size_t n_l
             return 0;
         }
     } else {
-        /* Structural rails: cap respected, every live symbol keeps a code. */
+        /* Structural rails: cap respected, every live symbol keeps a code.
+         * (Coarse-DP candidates may add zero-freq ghost leaves, so a length
+         * on a freq == 0 symbol is legal; the reverse is not.) */
         for (int s = 0; s < ZXC_HUF_NUM_SYMBOLS; s++) {
-            if (nudged[s] > max_code_len || (freq[s] != 0) != (nudged[s] != 0)) {
+            if (nudged[s] > max_code_len || (freq[s] != 0 && nudged[s] == 0)) {
                 printf("Failed [%s]: adopted lengths invalid at sym %d (len=%d)\n", label, s,
                        nudged[s]);
                 return 0;
@@ -366,7 +368,8 @@ int test_huffman_nudge() {
     if (ok) printf("  [PASS] Degenerate n=1..3 untouched\n");
 
     /* Fuzz: random alphabets/frequencies; the cost model must match the real
-     * tree for every baseline AND every adopted vector, at both caps. */
+     * tree for every baseline AND every adopted vector, at both caps (large
+     * alphabets exercise the coarse-DP tiers and their ghost padding). */
     {
         int checked = 0;
         int adopted_cnt = 0;

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -105,6 +105,7 @@ static const test_entry_t g_tests[] = {
 
     /* --- Format (on-disk) --- */
     TEST_CASE(test_huffman_codec),
+    TEST_CASE(test_huffman_nudge),
     TEST_CASE(test_huffman_codec_dict),
     TEST_CASE(test_huffman_single_symbol_validation),
     TEST_CASE(test_eof_block_structure),


### PR DESCRIPTION
Add the dynamic program from pivco-huffman #20 as a third candidate next to the greedy walk and the reduced-cap rebuilds: per-level run costs are exact under the rank-weighted model, solved at a coarse granularity picked from the alphabet size (exact <= 64 symbols, groups of 2/4 above, zero-freq ghost leaves when the group size does not divide the alphabet).

Scope and API tightened: the per-block nudge runs at level 7 only (levels 1-6 stay byte-identical to the unadjusted encoder).

silesia.tar level 7: decode +10.9% Apple M2, +9.8% AMD EPYC 7763, 
ratio 33.00 -> 33.09. Dict 4K JSON: decode +42% and -0.77% size.