### PR TITLE
fix(inplace-decode): Reserve the trailing framing in the in-place bound

### DIFF
--- a/README.md
+++ b/README.md
@@ -502,7 +502,7 @@ int64_t n = zxc_decompress_inplace(buf, need, archive_size, NULL);   // decode i
 // buf[0 .. n) now holds the decompressed data
 ```
 
-The required margin is one block plus the accumulated per-block framing overhead and the wild-copy tail (`block_size + nblocks x (8-12 B) + ~2 KB`) — about **1 %** overhead on a large archive; always size the buffer via `zxc_decompress_inplace_bound` rather than the formula. An undersized buffer is rejected with `ZXC_ERROR_DST_TOO_SMALL`, never silent corruption. This is a library/API capability (like LZ4's and Zstd's in-place modes): it targets embedded/firmware integrators, not the file→file CLI, whose streaming decode is already memory-bounded.
+The required margin is one block, the accumulated per-block framing overhead, the trailing framing the encoder writes after the last block (EOF block, seek table, footer), and the wild-copy tail (`block_size + nblocks x (12-16 B) + ~2 KB`) — about **1 %** overhead on a large archive; always size the buffer via `zxc_decompress_inplace_bound` rather than the formula. An undersized buffer is rejected with `ZXC_ERROR_DST_TOO_SMALL`, never silent corruption. This is a library/API capability: it targets embedded/firmware integrators.
 
 ---
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -391,10 +391,14 @@ ZXC_EXPORT size_t zxc_decompress_inplace_bound(
 Reads `src`'s header and footer (no decoding) and returns the single-buffer
 size `zxc_decompress_inplace` needs: `decompressed_size` plus the safety
 margin `block_size + nblocks x (block header + per-block checksum, if any) +
-file footer + ZXC_DECOMPRESS_TAIL_PAD` — one block, the accumulated per-block
-framing overhead (incompressible blocks make the compressed stream run that
-much longer than the output), the footer, and the wild-copy tail. Always size
-the buffer with this function rather than re-deriving the formula.
+EOF block + seek table + file footer + ZXC_DECOMPRESS_TAIL_PAD` — one block, the
+accumulated per-block framing overhead (incompressible blocks make the
+compressed stream run that much longer than the output), everything the encoder
+writes after the last data block, and the wild-copy tail. The trailing bytes
+matter because they sit to the *right* of the read cursor and so push the
+flush-right archive left, into the write cursor's path; no header flag announces
+a seek table, so its worst case (4 bytes per block) is always reserved. Always
+size the buffer with this function rather than re-deriving the formula.
 
 **Returns**: required buffer size, or `0` if `src` is not a valid archive.
 

--- a/src/lib/zxc_dispatch.c
+++ b/src/lib/zxc_dispatch.c
@@ -1006,23 +1006,41 @@ static int64_t zxc_decompress_frame(const uint8_t* src, const size_t src_size, u
 }
 
 /**
- * @brief Single source of truth for the in-place safety margin (bytes over the
- *        decompressed size @p d).
+ * @brief Bytes an in-place decode needs on top of the decompressed size.
  *
- * The write cursor sweeps [0, d) while the read cursor starts flush-right; the
- * no-overtake invariant `sum_{j<=k} o_j + PAD <= F + 16 + sum_{j<k} c_j` must
- * hold for every block k. Worst case is incompressible input (all RAW blocks,
- * `c_j = o_j + H`): the compressed stream then runs `nblocks * H` longer than
- * the output, squeezing the gap most at the first block, so the margin must
- * carry the full accumulated per-block overhead, not just one block. Hence
- * `chunk_size` (largest single block) + `nblocks * H` (H = block header +
- * optional per-block checksum) + footer + wild-copy tail.
+ * Flush-right placement puts block 0 at `capacity - comp_size`, so the read
+ * cursor before block k sits at `capacity - sum_{j>=k} (c_j + H) - trailing`,
+ * and the no-overtake invariant `sum_{j<=k} o_j + PAD <= R_k` requires
+ *
+ *     capacity >= max_k [ sum_{j<=k} o_j + sum_{j>=k} (c_j + H) ] + PAD + trailing
+ *
+ * Incompressible input (all RAW, `c_j = o_j`) maximises the bracket at
+ * `dsize + chunk_size + nblocks * H`: the margin carries the whole accumulated
+ * per-block overhead, not just one block's.
+ *
+ * `trailing` is everything written after the last data block: EOF header, footer
+ * and seek table. The latter is always reserved at its worst case (4 bytes per
+ * block, <= 0.1% of the payload) because no header flag announces one; omitting
+ * it used to push the bound *below* comp_size for a seekable archive of
+ * incompressible data in small blocks.
+ *
+ * @param[in] dsize      Decompressed size, in bytes.
+ * @param[in] chunk_size Block size from the file header (0 = no blocks).
+ * @param[in] has_cs     Non-zero if blocks carry checksums.
+ * @return Bytes to reserve beyond @p dsize.
  */
-static uint64_t zxc_inplace_margin(const uint64_t d, const size_t chunk_size, const int has_cs) {
-    const uint64_t nblocks = chunk_size ? (d + (uint64_t)chunk_size - 1) / (uint64_t)chunk_size : 0;
+static uint64_t zxc_inplace_margin(const uint64_t dsize, const size_t chunk_size,
+                                   const int has_cs) {
+    const uint64_t nblocks =
+        chunk_size ? (dsize + (uint64_t)chunk_size - 1) / (uint64_t)chunk_size : 0;
     const uint64_t per_block =
         (uint64_t)ZXC_BLOCK_HEADER_SIZE + (has_cs ? (uint64_t)ZXC_BLOCK_CHECKSUM_SIZE : 0);
-    return (uint64_t)chunk_size + nblocks * per_block + (uint64_t)ZXC_FILE_FOOTER_SIZE +
+    const uint64_t trailing =
+        (uint64_t)ZXC_BLOCK_HEADER_SIZE +  // EOF block header
+        ((uint64_t)ZXC_BLOCK_HEADER_SIZE +
+         nblocks * (uint64_t)ZXC_SEEK_ENTRY_SIZE) +  // Seek table (worst case)
+        (uint64_t)ZXC_FILE_FOOTER_SIZE;
+    return (uint64_t)chunk_size + nblocks * per_block + trailing +
            (uint64_t)ZXC_DECOMPRESS_TAIL_PAD;
 }
 
@@ -1035,9 +1053,14 @@ static uint64_t zxc_inplace_margin(const uint64_t d, const size_t chunk_size, co
  * and @ref zxc_decompress_inplace always agree on what a buffer of at least
  * the bound must satisfy.
  *
+ * @param[in]  comp      Compressed archive; only the header and footer are read.
+ * @param[in]  comp_size Size of the archive in bytes. The caller guarantees it
+ *                       covers at least the file header and footer.
+ * @param[out] dsize     Decompressed size read from the footer.
+ * @param[out] margin    In-place margin for @p dsize, from @ref zxc_inplace_margin.
  * @return ZXC_OK, or a negative @ref zxc_error_t on an invalid archive.
  */
-static int zxc_inplace_probe(const uint8_t* comp, const size_t comp_size, uint64_t* d,
+static int zxc_inplace_probe(const uint8_t* comp, const size_t comp_size, uint64_t* dsize,
                              uint64_t* margin) {
     if (UNLIKELY(zxc_le32(comp) != ZXC_MAGIC_WORD)) return ZXC_ERROR_BAD_MAGIC;
     size_t chunk_size = 0;
@@ -1045,8 +1068,8 @@ static int zxc_inplace_probe(const uint8_t* comp, const size_t comp_size, uint64
     uint32_t did = 0;
     if (UNLIKELY(zxc_read_file_header(comp, comp_size, &chunk_size, &has_cs, &did) != ZXC_OK))
         return ZXC_ERROR_BAD_HEADER;
-    *d = zxc_le64(comp + comp_size - ZXC_FILE_FOOTER_SIZE);
-    *margin = zxc_inplace_margin(*d, chunk_size, has_cs);
+    *dsize = zxc_le64(comp + comp_size - ZXC_FILE_FOOTER_SIZE);
+    *margin = zxc_inplace_margin(*dsize, chunk_size, has_cs);
     return ZXC_OK;
 }
 
@@ -1067,11 +1090,12 @@ static int zxc_inplace_probe(const uint8_t* comp, const size_t comp_size, uint64
 // cppcheck-suppress unusedFunction
 size_t zxc_decompress_inplace_bound(const void* src, const size_t src_size) {
     if (UNLIKELY(!src || src_size < ZXC_FILE_HEADER_SIZE + ZXC_FILE_FOOTER_SIZE)) return 0;
-    uint64_t d = 0;
+    uint64_t dsize = 0;
     uint64_t margin = 0;
-    if (UNLIKELY(zxc_inplace_probe((const uint8_t*)src, src_size, &d, &margin) != ZXC_OK)) return 0;
-    if (UNLIKELY(margin > (uint64_t)SIZE_MAX || d > (uint64_t)SIZE_MAX - margin)) return 0;
-    return (size_t)(d + margin);
+    if (UNLIKELY(zxc_inplace_probe((const uint8_t*)src, src_size, &dsize, &margin) != ZXC_OK))
+        return 0;
+    if (UNLIKELY(margin > (uint64_t)SIZE_MAX || dsize > (uint64_t)SIZE_MAX - margin)) return 0;
+    return (size_t)(dsize + margin);
 }
 
 /**
@@ -1102,11 +1126,11 @@ int64_t zxc_decompress_inplace(void* buffer, const size_t buffer_capacity, const
         return ZXC_ERROR_NULL_INPUT;
     uint8_t* const buf = (uint8_t*)buffer;
     const uint8_t* const comp = buf + (buffer_capacity - comp_size); /* flush-right */
-    uint64_t d = 0;
+    uint64_t dsize = 0;
     uint64_t margin = 0;
-    if (UNLIKELY(zxc_inplace_probe(comp, comp_size, &d, &margin) != ZXC_OK))
+    if (UNLIKELY(zxc_inplace_probe(comp, comp_size, &dsize, &margin) != ZXC_OK))
         return ZXC_ERROR_BAD_HEADER;
-    if (UNLIKELY(d > (uint64_t)buffer_capacity || (uint64_t)buffer_capacity - d < margin))
+    if (UNLIKELY(dsize > (uint64_t)buffer_capacity || (uint64_t)buffer_capacity - dsize < margin))
         return ZXC_ERROR_DST_TOO_SMALL;
     return zxc_decompress_frame(comp, comp_size, buf, buffer_capacity, opts);
 }
@@ -1138,18 +1162,18 @@ uint64_t zxc_get_decompressed_size(const void* src, const size_t src_size) {
     if (UNLIKELY(zxc_read_file_header(p, src_size, &chunk_size, &has_cs, &did) != ZXC_OK)) return 0;
 
     const uint8_t* const footer = p + src_size - ZXC_FILE_FOOTER_SIZE;
-    const uint64_t d = zxc_le64(footer);
+    const uint64_t dsize = zxc_le64(footer);
 
     /* Plausibility: an archive of src_size bytes cannot carry more blocks
      * than src_size / ZXC_BLOCK_HEADER_SIZE, and each block decodes to at
      * most chunk_size bytes. Division form keeps the compare overflow-free
-     * (the usual `(d + chunk - 1) / chunk` ceil would wrap for a forged d
-     * near UINT64_MAX). */
+     * (the usual `(dsize + chunk - 1) / chunk` ceil would wrap for a forged
+     * dsize near UINT64_MAX). */
     const uint64_t blocks_needed =
-        chunk_size ? d / (uint64_t)chunk_size + (d % (uint64_t)chunk_size != 0) : 0;
+        chunk_size ? dsize / (uint64_t)chunk_size + (dsize % (uint64_t)chunk_size != 0) : 0;
     if (UNLIKELY(blocks_needed > (uint64_t)(src_size / ZXC_BLOCK_HEADER_SIZE))) return 0;
 
-    return d;
+    return dsize;
 }
 
 /**

--- a/tests/test_buffer_api.c
+++ b/tests/test_buffer_api.c
@@ -159,7 +159,7 @@ int test_get_decompressed_size() {
     uint8_t* forged = malloc((size_t)comp_size);
     memcpy(forged, compressed, (size_t)comp_size);
     uint8_t* footer_size = forged + comp_size - ZXC_FILE_FOOTER_SIZE;
-    for (int i = 0; i < 8; i++) footer_size[i] = 0xFF; // size = 2^64 - 1
+    for (int i = 0; i < 8; i++) footer_size[i] = 0xFF;  // size = 2^64 - 1
     if (zxc_get_decompressed_size(forged, (size_t)comp_size) != 0) {
         printf("Failed: Should return 0 for a forged (implausible) footer size\n");
         free(forged);
@@ -508,8 +508,8 @@ int test_decompress_empty_frame_null_dst() {
     /* 4. dst=NULL, dst_capacity=0 on non-empty frame -> ZXC_ERROR_DST_TOO_SMALL */
     uint8_t payload[128] = "hello";
     uint8_t non_empty_frame[256];
-    int64_t ne_sz = zxc_compress(payload, sizeof(payload), non_empty_frame,
-                                 sizeof(non_empty_frame), NULL);
+    int64_t ne_sz =
+        zxc_compress(payload, sizeof(payload), non_empty_frame, sizeof(non_empty_frame), NULL);
     if (ne_sz <= 0) {
         printf("  [FAIL] non-empty compress: got %lld\n", (long long)ne_sz);
         return 0;
@@ -537,8 +537,8 @@ int test_decompress_empty_frame_null_dst() {
     /* 6. Caller bug: dst=NULL with non-zero capacity -> ZXC_ERROR_NULL_INPUT */
     r = zxc_decompress(empty_frame, (size_t)comp_sz, NULL, 100, NULL);
     if (r != ZXC_ERROR_NULL_INPUT) {
-        printf("  [FAIL] NULL dst + cap>0: expected %d, got %lld\n",
-               ZXC_ERROR_NULL_INPUT, (long long)r);
+        printf("  [FAIL] NULL dst + cap>0: expected %d, got %lld\n", ZXC_ERROR_NULL_INPUT,
+               (long long)r);
         return 0;
     }
     printf("  [PASS] NULL dst + cap>0 -> NULL_INPUT\n");
@@ -824,12 +824,15 @@ int test_decompress_fast_vs_safe_path() {
  * left-to-right into the same buffer. Covers a compressible input, a
  * high-entropy input whose flush-right archive OVERLAPS the output region
  * (the core in-place invariant), and the too-small-buffer rejection. */
-static int inplace_case(const char* label, const uint8_t* orig, size_t n, int level,
-                        int checksum) {
+static int inplace_case(const char* label, const uint8_t* orig, size_t n, int level, int checksum,
+                        size_t block_size, int seekable) {
     const size_t cbound = (size_t)zxc_compress_bound(n);
     uint8_t* comp = (uint8_t*)malloc(cbound);
     if (!comp) return 0;
-    zxc_compress_opts_t co = {.level = level, .checksum_enabled = checksum};
+    zxc_compress_opts_t co = {.level = level,
+                              .checksum_enabled = checksum,
+                              .block_size = block_size,
+                              .seekable = seekable};
     const int64_t c = zxc_compress(orig, n, comp, cbound, &co);
     if (c <= 0) {
         printf("Failed [%s]: compress -> %lld\n", label, (long long)c);
@@ -839,8 +842,8 @@ static int inplace_case(const char* label, const uint8_t* orig, size_t n, int le
     const size_t csz = (size_t)c;
 
     const size_t need = zxc_decompress_inplace_bound(comp, csz);
-    if (need == 0 || need < n) {
-        printf("Failed [%s]: bound %zu\n", label, need);
+    if (need == 0 || need < n || need < csz) {
+        printf("Failed [%s]: bound %zu (n=%zu, comp=%zu)\n", label, need, n, csz);
         free(comp);
         return 0;
     }
@@ -895,14 +898,31 @@ int test_decompress_inplace(void) {
     int ok = 1;
 
     gen_lz_data(a, N);
-    ok &= inplace_case("compressible L3", a, N, 3, 1);
-    ok &= inplace_case("compressible L6", a, N, 6, 0);
+    ok &= inplace_case("compressible L3", a, N, 3, 1, 0, 0);
+    ok &= inplace_case("compressible L6", a, N, 6, 0, 0, 0);
 
     /* high-entropy: comp_size ~ N so the flush-right archive sits INSIDE the
      * output region -> the write cursor sweeps through the compressed bytes. */
     gen_random_data(a, N);
-    ok &= inplace_case("random L1 (overlap)", a, N, 1, 0);
-    ok &= inplace_case("random L7 (overlap)", a, N, 7, 1);
+    ok &= inplace_case("random L1 (overlap)", a, N, 1, 0, 0, 0);
+    ok &= inplace_case("random L7 (overlap)", a, N, 7, 1, 0, 0);
+
+    /* Seekable archives carry a seek table between the EOF block and the footer.
+     * Those bytes sit to the RIGHT of the read cursor, so they push the
+     * flush-right archive left, into the write cursor's path -- the margin has
+     * to reserve them. The biting shape is many small blocks (a large table)
+     * over incompressible data (no slack): the bound used to land below
+     * comp_size there, so the documented flush-right memcpy underflowed. */
+    free(a);
+    const size_t M = 8 * 1024 * 1024;
+    a = (uint8_t*)malloc(M);
+    if (!a) return 0;
+    gen_lz_data(a, M);
+    ok &= inplace_case("seekable text, 4K blocks", a, M, 3, 1, ZXC_BLOCK_SIZE_MIN, 1);
+    gen_random_data(a, M);
+    ok &= inplace_case("seekable random, 4K blocks", a, M, 1, 1, ZXC_BLOCK_SIZE_MIN, 1);
+    ok &= inplace_case("seekable random, 64K blocks", a, M, 1, 0, 64 * 1024, 1);
+    ok &= inplace_case("seekable random, default blocks", a, M, 3, 1, 0, 1);
 
     /* bound on garbage must be 0. */
     uint8_t junk[64];


### PR DESCRIPTION
`zxc_inplace_margin()` previously miscalculated the required buffer size by missing metadata written after the last data block: the EOF block header and the seek table (for seekable archives).

Because in-place decompression places the archive flush-right, these extra trailing bytes push the archive left, directly into the path of the write cursor.

**Fix**
Reserved the worst-case seek table overhead unconditionally (4 bytes per block). Since there is no file-header flag to indicate whether a seek table exists, reserving this memory adds at most 0.1% overhead for tiny 4 KB blocks, and a negligible amount for default block sizes. Updated the doc comments with the full derivation.

**Tests**
Updated `inplace_case()` in regression tests.
