### PR TITLE
build(cmake): Make project embeddable as a subproject

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,9 +47,32 @@ option(ZXC_DISABLE_SIMD "Disable explicit SIMD intrinsics (no AVX/NEON code path
 option(ZXC_USE_SYSTEM_RAPIDHASH "Use a system-installed rapidhash.h instead of the vendored copy"
        OFF)
 
-if(ZXC_NATIVE_ARCH AND CMAKE_CROSSCOMPILING)
-    message(STATUS "zxc: cross-compiling - ignoring ZXC_NATIVE_ARCH (-march=native would "
-                   "encode the build host's ISA).")
+# =============================================================================
+# Target architecture
+# =============================================================================
+set(ZXC_TARGET_ARCHS "${CMAKE_SYSTEM_PROCESSOR}")
+if(APPLE AND CMAKE_OSX_ARCHITECTURES)
+    set(ZXC_TARGET_ARCHS "${CMAKE_OSX_ARCHITECTURES}")
+endif()
+
+set(ZXC_TARGET_X86 OFF)
+set(ZXC_TARGET_AARCH64 OFF)
+set(ZXC_TARGET_ARM32 OFF)
+foreach(_arch IN LISTS ZXC_TARGET_ARCHS)
+    if(_arch MATCHES "amd64|x86_64|AMD64")
+        set(ZXC_TARGET_X86 ON)
+    elseif(_arch MATCHES "aarch64|arm64|ARM64")
+        # Must be tested before "^arm", which "arm64" matches too.
+        set(ZXC_TARGET_AARCH64 ON)
+    elseif(_arch MATCHES "^arm")
+        set(ZXC_TARGET_ARM32 ON)
+    endif()
+endforeach()
+
+if(ZXC_NATIVE_ARCH AND (CMAKE_CROSSCOMPILING OR
+                        NOT "${ZXC_TARGET_ARCHS}" STREQUAL "${CMAKE_SYSTEM_PROCESSOR}"))
+    message(STATUS "zxc: target (${ZXC_TARGET_ARCHS}) is not the build host "
+                   "(${CMAKE_SYSTEM_PROCESSOR}) - ignoring ZXC_NATIVE_ARCH.")
     set(ZXC_NATIVE_ARCH OFF)
 endif()
 
@@ -157,6 +180,22 @@ macro(zxc_apply_pgo target)
     endif()
 endmacro()
 
+# Warnings and PGO, for every zxc target. Defined once because each target used
+# to repeat its own list, and the variant objects ended up with no warnings at
+# all. Warning level is top-level only: an embedder sets its own.
+macro(zxc_apply_common_flags target)
+    if(MSVC)
+        # /wd4244: block-bounded uint64->size_t narrowing, lossless.
+        target_compile_options(${target} PRIVATE /wd4244)
+        if(PROJECT_IS_TOP_LEVEL)
+            target_compile_options(${target} PRIVATE /W3)
+        endif()
+    elseif(PROJECT_IS_TOP_LEVEL)
+        target_compile_options(${target} PRIVATE -Wall -Wextra)
+    endif()
+    zxc_apply_pgo(${target})
+endmacro()
+
 # Function Multi-Versioning Helper
 # Compiles compress/decompress/huffman with specific flags and suffix so the
 # runtime dispatcher can route to a BMI2/AVX2/AVX512/NEON-aware Huffman codec
@@ -164,9 +203,10 @@ endmacro()
 macro(zxc_add_variant suffix flags)
     foreach(_src compress decompress huffman)
         add_library(zxc_${_src}${suffix} OBJECT src/lib/zxc_${_src}.c)
+        # Common flags first: the ISA flags below must have the last word, since
+        # a later -march= would reset the feature set they select.
+        zxc_apply_common_flags(zxc_${_src}${suffix})
         target_compile_options(zxc_${_src}${suffix} PRIVATE ${flags})
-        # MSVC C4244: block-bounded uint64->size_t narrowing, lossless (clean on GCC/Clang).
-        target_compile_options(zxc_${_src}${suffix} PRIVATE $<$<C_COMPILER_ID:MSVC>:/wd4244>)
         target_compile_definitions(zxc_${_src}${suffix} PRIVATE ZXC_FUNCTION_SUFFIX=${suffix})
         # For static builds, define ZXC_STATIC_DEFINE
         if(NOT BUILD_SHARED_LIBS)
@@ -182,8 +222,6 @@ macro(zxc_add_variant suffix flags)
         endif()
         # Inherit include directories
         target_include_directories(zxc_${_src}${suffix} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src/lib ${RAPIDHASH_INCLUDE_DIR} PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>)
-        # Propagate PGO flags to variant objects
-        zxc_apply_pgo(zxc_${_src}${suffix})
 
         list(APPEND ZXC_VARIANT_OBJECTS $<TARGET_OBJECTS:zxc_${_src}${suffix}>)
     endforeach()
@@ -198,7 +236,9 @@ zxc_add_variant(_default "")
 if(ZXC_DISABLE_SIMD)
     message(STATUS "ZXC_DISABLE_SIMD: Skipping SIMD variants (no explicit AVX/NEON code paths).")
 else()
-if(CMAKE_SYSTEM_PROCESSOR MATCHES "amd64|x86_64|AMD64")
+# Driven by the target architectures, not the host: a universal build enables
+# several of these branches at once, so they are independent ifs.
+if(ZXC_TARGET_X86)
     message(STATUS "Building x86_64 AVX2 and AVX512 variants...")
     # No _sse2 variant: SSE2 is the x86-64 baseline, so _default already
     # compiles the SSE2 code paths (ZXC_USE_SSE2 in zxc_internal.h).
@@ -208,17 +248,25 @@ if(CMAKE_SYSTEM_PROCESSOR MATCHES "amd64|x86_64|AMD64")
         # AVX512 for MSVC (VS2019 16.10+ supports /arch:AVX512)
         zxc_add_variant(_avx512 "/arch:AVX512;/D__BMI__;/D__BMI2__;/D__LZCNT__")
     else()
-        # AVX2 for GCC/Clang
-        zxc_add_variant(_avx2 "-mavx2;-mbmi;-mbmi2;-mlzcnt")
-        # AVX512 for GCC/Clang
-        zxc_add_variant(_avx512
-                        "-mavx512f;-mavx512bw;-mavx512vbmi;-mavx512vbmi2;-mbmi;-mbmi2;-mlzcnt")
+        set(ZXC_AVX2_FLAGS   -mavx2 -mbmi -mbmi2 -mlzcnt)
+        set(ZXC_AVX512_FLAGS -mavx512f -mavx512bw -mavx512vbmi -mavx512vbmi2 -mbmi -mbmi2 -mlzcnt)
+        if(APPLE AND ZXC_TARGET_AARCH64)
+            # Universal build: every variant is compiled for every slice, so the
+            # x86 flags must be confined to the x86 one. -Xarch_<arch> covers the
+            # single argument that follows it, hence one prefix per flag.
+            list(TRANSFORM ZXC_AVX2_FLAGS   PREPEND "-Xarch_x86_64;")
+            list(TRANSFORM ZXC_AVX512_FLAGS PREPEND "-Xarch_x86_64;")
+        endif()
+        zxc_add_variant(_avx2   "${ZXC_AVX2_FLAGS}")
+        zxc_add_variant(_avx512 "${ZXC_AVX512_FLAGS}")
     endif()
+endif()
 
-elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|arm64|ARM64")
+if(ZXC_TARGET_AARCH64)
     message(STATUS "AArch64: NEON is baseline; no dedicated SIMD variant needed.")
+endif()
 
-elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "^arm")
+if(ZXC_TARGET_ARM32)
     message(STATUS "Building ARMv7 NEON32 variant...")
     zxc_add_variant(_neon32 "-march=armv7-a;-mfpu=neon")
 endif()
@@ -297,25 +345,27 @@ endif()
 # =============================================================================
 # Compiler-specific options (using generator expressions)
 # =============================================================================
-if(NOT MSVC)
-    target_compile_options(zxc_lib PRIVATE
-        $<$<NOT:$<BOOL:${ZXC_ENABLE_COVERAGE}>>:-O3>
-        # Native Arch
-        $<$<BOOL:${ZXC_NATIVE_ARCH}>:-march=native>
-    )
+# The optimisation level comes from the build type, here as everywhere else.
+# Forcing -O3 would only have covered zxc_lib: the codec itself lives in the
+# variant objects, which never had it.
+get_property(ZXC_MULTI_CONFIG GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
+if(NOT ZXC_MULTI_CONFIG AND NOT CMAKE_BUILD_TYPE AND NOT CMAKE_C_FLAGS MATCHES "[-/]O")
+    message(WARNING "zxc: no CMAKE_BUILD_TYPE and no optimisation flag - the library will be "
+                    "built unoptimised. Set CMAKE_BUILD_TYPE=Release.")
+endif()
 
+zxc_apply_common_flags(zxc_lib)
+
+if(NOT MSVC)
+    target_compile_options(zxc_lib PRIVATE $<$<BOOL:${ZXC_NATIVE_ARCH}>:-march=native>)
+
+    # Code generation policy: the parent's business when vendored. Kept off the
+    # variant objects, whose emitted code must not move.
     if(PROJECT_IS_TOP_LEVEL)
         target_compile_options(zxc_lib PRIVATE
-            -Wall -Wextra
-            -fomit-frame-pointer
-            -fstrict-aliasing
-            # Dead code elimination
-            -ffunction-sections -fdata-sections
-        )
+            -fomit-frame-pointer -fstrict-aliasing -ffunction-sections -fdata-sections)
     endif()
 
-    # Profile-Guided Optimization
-    zxc_apply_pgo(zxc_lib)
     if(ZXC_PGO_MODE STREQUAL "GENERATE")
         message(STATUS "PGO: Generating profile data to ${ZXC_PGO_DIR}")
     elseif(ZXC_PGO_MODE STREQUAL "USE")
@@ -334,11 +384,6 @@ if(NOT MSVC)
         endif()
     endif()
 else()
-    # /wd4244: same block-bounded uint64->size_t narrowing as the variants.
-    target_compile_options(zxc_lib PRIVATE $<$<CONFIG:Release>:/O2> /wd4244)
-    if(PROJECT_IS_TOP_LEVEL)
-        target_compile_options(zxc_lib PRIVATE /W3)
-    endif()
     target_compile_definitions(zxc_lib PRIVATE _CRT_SECURE_NO_WARNINGS)
 endif()
 
@@ -387,10 +432,9 @@ if(ZXC_BUILD_CLI)
         target_link_options(zxc PRIVATE setargv.obj)
     endif()
 
-    # Propagate compile options and definitions
+    zxc_apply_common_flags(zxc)
     target_compile_options(zxc PRIVATE
-        $<$<AND:$<NOT:$<C_COMPILER_ID:MSVC>>,$<BOOL:${ZXC_NATIVE_ARCH}>>:-march=native>
-    )
+        $<$<AND:$<NOT:$<C_COMPILER_ID:MSVC>>,$<BOOL:${ZXC_NATIVE_ARCH}>>:-march=native>)
     target_compile_definitions(zxc PRIVATE
         $<$<C_COMPILER_ID:MSVC>:_CRT_SECURE_NO_WARNINGS>
         $<$<NOT:$<C_COMPILER_ID:MSVC>>:_GNU_SOURCE>
@@ -413,9 +457,6 @@ if(ZXC_BUILD_CLI)
         endif()
     endif()
     
-    # Profile-Guided Optimization for CLI
-    zxc_apply_pgo(zxc)
-
     # Linker options for Dead Code Stripping
     if(NOT MSVC)
         if(APPLE)
@@ -490,11 +531,17 @@ if(ZXC_BUILD_TESTS)
                 ${RAPIDHASH_INCLUDE_DIR}
         )
         
-        # Apply same compiler settings as main library
-        target_compile_options(zxc_lib_static PRIVATE
-            $<TARGET_PROPERTY:zxc_lib,COMPILE_OPTIONS>
-        )
-        
+        # Same settings as the main library
+        zxc_apply_common_flags(zxc_lib_static)
+        if(NOT MSVC)
+            target_compile_options(zxc_lib_static PRIVATE
+                $<$<BOOL:${ZXC_NATIVE_ARCH}>:-march=native>)
+            if(PROJECT_IS_TOP_LEVEL)
+                target_compile_options(zxc_lib_static PRIVATE
+                    -fomit-frame-pointer -fstrict-aliasing -ffunction-sections -fdata-sections)
+            endif()
+        endif()
+
         target_compile_definitions(zxc_lib_static PUBLIC ZXC_STATIC_DEFINE)
         target_link_libraries(zxc_lib_static PRIVATE Threads::Threads)
         
@@ -505,10 +552,9 @@ if(ZXC_BUILD_TESTS)
         target_link_libraries(zxc_test PRIVATE zxc_lib)
     endif()
     
-    # Propagate compile options
+    zxc_apply_common_flags(zxc_test)
     target_compile_options(zxc_test PRIVATE
-        $<$<AND:$<NOT:$<C_COMPILER_ID:MSVC>>,$<BOOL:${ZXC_NATIVE_ARCH}>>:-march=native>
-    )
+        $<$<AND:$<NOT:$<C_COMPILER_ID:MSVC>>,$<BOOL:${ZXC_NATIVE_ARCH}>>:-march=native>)
     # Propagate definitions
     target_compile_definitions(zxc_test PRIVATE
         $<$<C_COMPILER_ID:MSVC>:_CRT_SECURE_NO_WARNINGS>)
@@ -519,9 +565,6 @@ if(ZXC_BUILD_TESTS)
             target_link_options(zxc_test PRIVATE --coverage)
         endif()
     endif()
-    
-    # Profile-Guided Optimization for tests
-    zxc_apply_pgo(zxc_test)
     
     target_include_directories(zxc_test PRIVATE src/lib ${RAPIDHASH_INCLUDE_DIR})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,8 @@ option(ZXC_INSTALL "Generate install rules (headers, pkg-config, CMake package)"
        ${PROJECT_IS_TOP_LEVEL})
 option(ZXC_ENABLE_COVERAGE "Enable code coverage generation" OFF)
 option(ZXC_DISABLE_SIMD "Disable explicit SIMD intrinsics (no AVX/NEON code paths)" OFF)
+option(ZXC_USE_SYSTEM_RAPIDHASH "Use a system-installed rapidhash.h instead of the vendored copy"
+       OFF)
 
 if(ZXC_NATIVE_ARCH AND CMAKE_CROSSCOMPILING)
     message(STATUS "zxc: cross-compiling - ignoring ZXC_NATIVE_ARCH (-march=native would "
@@ -103,12 +105,15 @@ endif()
 # =============================================================================
 # Rapidhash: system-installed (e.g. vcpkg) or vendored fallback
 # =============================================================================
-find_path(RAPIDHASH_INCLUDE_DIR rapidhash.h)
-if(NOT RAPIDHASH_INCLUDE_DIR)
+if(ZXC_USE_SYSTEM_RAPIDHASH)
+    find_path(RAPIDHASH_INCLUDE_DIR rapidhash.h)
+    if(NOT RAPIDHASH_INCLUDE_DIR)
+        message(FATAL_ERROR "ZXC_USE_SYSTEM_RAPIDHASH is ON but rapidhash.h was not found.")
+    endif()
+    message(STATUS "Using system rapidhash from ${RAPIDHASH_INCLUDE_DIR}")
+else()
     set(RAPIDHASH_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/src/lib/vendors")
     message(STATUS "Using vendored rapidhash from ${RAPIDHASH_INCLUDE_DIR}")
-else()
-    message(STATUS "Found system rapidhash in ${RAPIDHASH_INCLUDE_DIR}")
 endif()
 
 # =============================================================================
@@ -295,14 +300,19 @@ endif()
 if(NOT MSVC)
     target_compile_options(zxc_lib PRIVATE
         $<$<NOT:$<BOOL:${ZXC_ENABLE_COVERAGE}>>:-O3>
-        -Wall -Wextra
-        -fomit-frame-pointer
-        -fstrict-aliasing
         # Native Arch
         $<$<BOOL:${ZXC_NATIVE_ARCH}>:-march=native>
-        # Dead code elimination
-        -ffunction-sections -fdata-sections
     )
+
+    if(PROJECT_IS_TOP_LEVEL)
+        target_compile_options(zxc_lib PRIVATE
+            -Wall -Wextra
+            -fomit-frame-pointer
+            -fstrict-aliasing
+            # Dead code elimination
+            -ffunction-sections -fdata-sections
+        )
+    endif()
 
     # Profile-Guided Optimization
     zxc_apply_pgo(zxc_lib)
@@ -315,15 +325,20 @@ if(NOT MSVC)
         message(STATUS "PGO: Using profile data from ${ZXC_PGO_DIR}")
     endif()
 
-    # Linker options for Dead Code Stripping
-    if(APPLE)
-        target_link_options(zxc_lib PRIVATE -Wl,-dead_strip)
-    else()
-        target_link_options(zxc_lib PRIVATE -Wl,--gc-sections)
+    # Linker options for Dead Code Stripping (pairs with -ffunction-sections)
+    if(PROJECT_IS_TOP_LEVEL)
+        if(APPLE)
+            target_link_options(zxc_lib PRIVATE -Wl,-dead_strip)
+        else()
+            target_link_options(zxc_lib PRIVATE -Wl,--gc-sections)
+        endif()
     endif()
 else()
     # /wd4244: same block-bounded uint64->size_t narrowing as the variants.
-    target_compile_options(zxc_lib PRIVATE $<$<CONFIG:Release>:/O2> /W3 /wd4244)
+    target_compile_options(zxc_lib PRIVATE $<$<CONFIG:Release>:/O2> /wd4244)
+    if(PROJECT_IS_TOP_LEVEL)
+        target_compile_options(zxc_lib PRIVATE /W3)
+    endif()
     target_compile_definitions(zxc_lib PRIVATE _CRT_SECURE_NO_WARNINGS)
 endif()
 
@@ -699,6 +714,11 @@ message(STATUS "  PGO Mode:       ${ZXC_PGO_MODE}")
 message(STATUS "  Build CLI:      ${ZXC_BUILD_CLI}")
 message(STATUS "  Build Tests:    ${ZXC_BUILD_TESTS}")
 message(STATUS "  Install Rules:  ${ZXC_INSTALL}")
+if(ZXC_USE_SYSTEM_RAPIDHASH)
+    message(STATUS "  Rapidhash:      system (${RAPIDHASH_INCLUDE_DIR})")
+else()
+    message(STATUS "  Rapidhash:      vendored")
+endif()
 message(STATUS "")
 
 # =============================================================================

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,15 +25,31 @@ project(zxc
 # =============================================================================
 # Build Options
 # =============================================================================
+if(NOT DEFINED PROJECT_IS_TOP_LEVEL)
+    if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
+        set(PROJECT_IS_TOP_LEVEL ON)
+    else()
+        set(PROJECT_IS_TOP_LEVEL OFF)
+    endif()
+endif()
+
 option(BUILD_SHARED_LIBS "Build shared libraries instead of static" OFF)
-option(ZXC_NATIVE_ARCH "Enable -march=native for maximum performance" ON)
-option(ZXC_ENABLE_LTO "Enable Interprocedural Optimization (LTO)" ON)
+option(ZXC_NATIVE_ARCH "Enable -march=native for maximum performance" ${PROJECT_IS_TOP_LEVEL})
+option(ZXC_ENABLE_LTO "Enable Interprocedural Optimization (LTO)" ${PROJECT_IS_TOP_LEVEL})
 set(ZXC_PGO_MODE "OFF" CACHE STRING "Profile-Guided Optimization mode (OFF/GENERATE/USE)")
 set_property(CACHE ZXC_PGO_MODE PROPERTY STRINGS OFF GENERATE USE)
-option(ZXC_BUILD_CLI "Build the command-line interface" ON)
-option(ZXC_BUILD_TESTS "Build unit tests" ON)
+option(ZXC_BUILD_CLI "Build the command-line interface" ${PROJECT_IS_TOP_LEVEL})
+option(ZXC_BUILD_TESTS "Build unit tests" ${PROJECT_IS_TOP_LEVEL})
+option(ZXC_INSTALL "Generate install rules (headers, pkg-config, CMake package)"
+       ${PROJECT_IS_TOP_LEVEL})
 option(ZXC_ENABLE_COVERAGE "Enable code coverage generation" OFF)
 option(ZXC_DISABLE_SIMD "Disable explicit SIMD intrinsics (no AVX/NEON code paths)" OFF)
+
+if(ZXC_NATIVE_ARCH AND CMAKE_CROSSCOMPILING)
+    message(STATUS "zxc: cross-compiling - ignoring ZXC_NATIVE_ARCH (-march=native would "
+                   "encode the build host's ISA).")
+    set(ZXC_NATIVE_ARCH OFF)
+endif()
 
 # =============================================================================
 # Emscripten / WebAssembly overrides
@@ -231,6 +247,10 @@ add_library(zxc_lib
     ${ZXC_VARIANT_OBJECTS}
 )
 
+# Carries the same name as the target exported by the installed package, so a
+# vendored add_subdirectory() and a find_package(zxc) are interchangeable.
+add_library(zxc::zxc_lib ALIAS zxc_lib)
+
 # =============================================================================
 # ABI Versioning (Debian/Linux shared libraries)
 # =============================================================================
@@ -275,15 +295,15 @@ endif()
 if(NOT MSVC)
     target_compile_options(zxc_lib PRIVATE
         $<$<NOT:$<BOOL:${ZXC_ENABLE_COVERAGE}>>:-O3>
-        -Wall -Wextra 
-        -fomit-frame-pointer 
+        -Wall -Wextra
+        -fomit-frame-pointer
         -fstrict-aliasing
         # Native Arch
         $<$<BOOL:${ZXC_NATIVE_ARCH}>:-march=native>
         # Dead code elimination
         -ffunction-sections -fdata-sections
     )
-    
+
     # Profile-Guided Optimization
     zxc_apply_pgo(zxc_lib)
     if(ZXC_PGO_MODE STREQUAL "GENERATE")
@@ -408,7 +428,9 @@ endif()
 # Tests
 # =============================================================================
 if(ZXC_BUILD_TESTS)
-    enable_testing()
+    if(PROJECT_IS_TOP_LEVEL)
+        enable_testing()
+    endif()
     
     add_executable(zxc_test
         tests/test_main.c
@@ -549,71 +571,73 @@ endif()
 # =============================================================================
 # Installation
 # =============================================================================
-include(GNUInstallDirs)
+if(ZXC_INSTALL)
+    include(GNUInstallDirs)
 
-configure_file(
-    ${CMAKE_CURRENT_SOURCE_DIR}/libzxc.pc.in
-    ${CMAKE_CURRENT_BINARY_DIR}/libzxc.pc
-    @ONLY
-)
-
-install(TARGETS zxc_lib
-    EXPORT zxc-targets
-    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-    INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
-)
-
-install(DIRECTORY include/
-    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
-    FILES_MATCHING PATTERN "*.h"
-)
-
-if(ZXC_BUILD_CLI)
-    install(TARGETS zxc
-        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    configure_file(
+        ${CMAKE_CURRENT_SOURCE_DIR}/libzxc.pc.in
+        ${CMAKE_CURRENT_BINARY_DIR}/libzxc.pc
+        @ONLY
     )
-    # "unzxc" alias: a symlink to zxc that defaults to decompression. 
-    # Symbolic links are POSIX-only; skipped on Windows.
-    if(NOT WIN32)
-        install(CODE "
-            execute_process(COMMAND \"${CMAKE_COMMAND}\" -E create_symlink
-                zxc \"\$ENV{DESTDIR}${CMAKE_INSTALL_FULL_BINDIR}/unzxc\")
-        ")
+
+    install(TARGETS zxc_lib
+        EXPORT zxc-targets
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+        INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+    )
+
+    install(DIRECTORY include/
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+        FILES_MATCHING PATTERN "*.h"
+    )
+
+    if(ZXC_BUILD_CLI)
+        install(TARGETS zxc
+            RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+        )
+        # "unzxc" alias: a symlink to zxc that defaults to decompression. 
+        # Symbolic links are POSIX-only; skipped on Windows.
+        if(NOT WIN32)
+            install(CODE "
+                execute_process(COMMAND \"${CMAKE_COMMAND}\" -E create_symlink
+                    zxc \"\$ENV{DESTDIR}${CMAKE_INSTALL_FULL_BINDIR}/unzxc\")
+            ")
+        endif()
     endif()
+
+    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/libzxc.pc
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
+    )
+
+    # CMake package config files for find_package(zxc)
+    include(CMakePackageConfigHelpers)
+
+    install(EXPORT zxc-targets
+        FILE zxc-targets.cmake
+        NAMESPACE zxc::
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/zxc
+    )
+
+    configure_package_config_file(
+        ${CMAKE_CURRENT_SOURCE_DIR}/zxcConfig.cmake.in
+        ${CMAKE_CURRENT_BINARY_DIR}/zxcConfig.cmake
+        INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/zxc
+    )
+
+    write_basic_package_version_file(
+        ${CMAKE_CURRENT_BINARY_DIR}/zxcConfigVersion.cmake
+        VERSION ${PROJECT_VERSION}
+        COMPATIBILITY SameMajorVersion
+    )
+
+    install(FILES
+        ${CMAKE_CURRENT_BINARY_DIR}/zxcConfig.cmake
+        ${CMAKE_CURRENT_BINARY_DIR}/zxcConfigVersion.cmake
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/zxc
+    )
 endif()
-
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/libzxc.pc
-    DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
-)
-
-# CMake package config files for find_package(zxc)
-include(CMakePackageConfigHelpers)
-
-install(EXPORT zxc-targets
-    FILE zxc-targets.cmake
-    NAMESPACE zxc::
-    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/zxc
-)
-
-configure_package_config_file(
-    ${CMAKE_CURRENT_SOURCE_DIR}/zxcConfig.cmake.in
-    ${CMAKE_CURRENT_BINARY_DIR}/zxcConfig.cmake
-    INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/zxc
-)
-
-write_basic_package_version_file(
-    ${CMAKE_CURRENT_BINARY_DIR}/zxcConfigVersion.cmake
-    VERSION ${PROJECT_VERSION}
-    COMPATIBILITY SameMajorVersion
-)
-
-install(FILES
-    ${CMAKE_CURRENT_BINARY_DIR}/zxcConfig.cmake
-    ${CMAKE_CURRENT_BINARY_DIR}/zxcConfigVersion.cmake
-    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/zxc
-)
 
 # =============================================================================
 # Code Formatting (clang-format)
@@ -624,7 +648,7 @@ if(DEFINED ENV{CLANG_FORMAT})
 else()
     find_program(CLANG_FORMAT clang-format)
 endif()
-if(CLANG_FORMAT)
+if(CLANG_FORMAT AND PROJECT_IS_TOP_LEVEL)
     file(GLOB_RECURSE ZXC_FORMAT_SOURCES CONFIGURE_DEPENDS
         "${CMAKE_CURRENT_SOURCE_DIR}/include/*.h"
         "${CMAKE_CURRENT_SOURCE_DIR}/src/lib/*.c"
@@ -648,7 +672,7 @@ if(CLANG_FORMAT)
         COMMENT "Checking formatting of include/, src/lib/ and src/cli/"
         VERBATIM
     )
-else()
+elseif(PROJECT_IS_TOP_LEVEL)
     message(STATUS "clang-format not found - format/format-check targets disabled")
 endif()
 
@@ -658,6 +682,11 @@ endif()
 message(STATUS "")
 message(STATUS "ZXC Configuration Summary:")
 message(STATUS "  Version:        ${PROJECT_VERSION}")
+if(PROJECT_IS_TOP_LEVEL)
+    message(STATUS "  Build Mode:     Standalone")
+else()
+    message(STATUS "  Build Mode:     Embedded (vendored in ${CMAKE_PROJECT_NAME})")
+endif()
 if(BUILD_SHARED_LIBS)
     message(STATUS "  Library Type:   Shared")
 else()
@@ -669,6 +698,7 @@ message(STATUS "  LTO Enabled:    ${ZXC_ENABLE_LTO}")
 message(STATUS "  PGO Mode:       ${ZXC_PGO_MODE}")
 message(STATUS "  Build CLI:      ${ZXC_BUILD_CLI}")
 message(STATUS "  Build Tests:    ${ZXC_BUILD_TESTS}")
+message(STATUS "  Install Rules:  ${ZXC_INSTALL}")
 message(STATUS "")
 
 # =============================================================================
@@ -768,8 +798,11 @@ endif()
 # =============================================================================
 # Documentation (Doxygen)
 # =============================================================================
-find_package(Doxygen)
-if(DOXYGEN_FOUND)
+# Maintainer tooling: a generic target name an embedding project may own too.
+if(PROJECT_IS_TOP_LEVEL)
+    find_package(Doxygen)
+endif()
+if(DOXYGEN_FOUND AND PROJECT_IS_TOP_LEVEL)
     # Generate the Doxyfile with the current project version
     configure_file(${CMAKE_CURRENT_SOURCE_DIR}/docs/Doxyfile.in ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile @ONLY)
     

--- a/Makefile
+++ b/Makefile
@@ -47,11 +47,11 @@ conformance:
 
 # ── Formatting ───────────────────────────────────────────────
 format:
-	@$(CMAKE) -S . -B $(BUILD)
+	@$(CMAKE) -S . -B $(BUILD) -DCMAKE_BUILD_TYPE=Release $(CMAKE_EXTRA)
 	@$(CMAKE) --build $(BUILD) --target format
 
 format-check:
-	@$(CMAKE) -S . -B $(BUILD)
+	@$(CMAKE) -S . -B $(BUILD) -DCMAKE_BUILD_TYPE=Release $(CMAKE_EXTRA)
 	@$(CMAKE) --build $(BUILD) --target format-check
 
 # ── Lint (mirrors .github/workflows/quality.yml) ─────────────
@@ -70,7 +70,7 @@ lint:
 
 # ── Documentation ────────────────────────────────────────────
 doc:
-	@$(CMAKE) -S . -B $(BUILD)
+	@$(CMAKE) -S . -B $(BUILD) -DCMAKE_BUILD_TYPE=Release $(CMAKE_EXTRA)
 	@$(CMAKE) --build $(BUILD) --target doc
 
 # ── Clean ────────────────────────────────────────────────────

--- a/README.md
+++ b/README.md
@@ -357,7 +357,35 @@ meson compile -C build
 When consumed as a subproject, only the library is built (CLI and tests are
 skipped automatically).
 
-### Option 6: Winget
+### Option 6: CMake Subproject (vendored)
+
+zxc can be vendored directly into a CMake build, either as a git submodule with
+`add_subdirectory()` or through `FetchContent`:
+
+```cmake
+include(FetchContent)
+FetchContent_Declare(zxc
+    GIT_REPOSITORY https://github.com/hellobertrand/zxc.git
+    GIT_TAG        v0.13.1
+)
+FetchContent_MakeAvailable(zxc)
+
+target_link_libraries(myapp PRIVATE zxc::zxc_lib)
+```
+
+`zxc::zxc_lib` is the same target name the installed package exports, so
+switching between a vendored copy and `find_package(zxc)` needs no other
+change.
+
+When zxc is not the top-level project it builds the library only: the CLI, the
+tests, `-march=native`, LTO and the install rules all default to off, so the
+embedding project keeps full control of its own compiler flags, CTest
+registration and install set. Any of them can still be turned back on
+explicitly (`-DZXC_BUILD_CLI=ON`, `-DZXC_NATIVE_ARCH=ON`, `-DZXC_INSTALL=ON`,
+...). `-march=native` is also ignored whenever CMake is cross-compiling, since
+it would encode the build host's ISA.
+
+### Option 7: Winget
 
 **Requirements:** Windows 10 1709 (or later)
 
@@ -367,7 +395,7 @@ Use winget to install the zxc CLI:
 winget install hellobertrand.zxc
 ```
 
-### Option 7: Building from Source (CMake)
+### Option 8: Building from Source (CMake)
 
 **Requirements:** CMake (3.14+), C17 Compiler (Clang/GCC/MSVC).
 

--- a/README.md
+++ b/README.md
@@ -379,11 +379,25 @@ change.
 
 When zxc is not the top-level project it builds the library only: the CLI, the
 tests, `-march=native`, LTO and the install rules all default to off, so the
-embedding project keeps full control of its own compiler flags, CTest
-registration and install set. Any of them can still be turned back on
-explicitly (`-DZXC_BUILD_CLI=ON`, `-DZXC_NATIVE_ARCH=ON`, `-DZXC_INSTALL=ON`,
-...). `-march=native` is also ignored whenever CMake is cross-compiling, since
-it would encode the build host's ISA.
+embedding project keeps full control of its own CTest registration and install
+set. Any of them can still be turned back on explicitly (`-DZXC_BUILD_CLI=ON`,
+`-DZXC_NATIVE_ARCH=ON`, `-DZXC_INSTALL=ON`, ...). `-march=native` is also
+ignored whenever CMake is cross-compiling, since it would encode the build
+host's ISA.
+
+Compiler flags follow the same rule. Vendored, zxc adds only `-O3` (`/O2` on
+MSVC) to the flags it inherits from the parent: the warning level
+(`-Wall -Wextra`, `/W3`) and the code generation policy
+(`-fomit-frame-pointer`, `-fstrict-aliasing`, `-ffunction-sections`,
+`-fdata-sections` and the matching dead-strip link options) are the embedding
+project's to set. An embedder that builds with frame pointers for its profiler,
+its own aliasing rules or a quiet build log keeps them. `-O3` stays because the
+decoder's published throughput assumes it, and a parent whose build type is
+unset would otherwise ship an unoptimized zxc.
+
+Third-party code is vendored, never probed: `rapidhash.h` comes from the copy in
+the tree unless `-DZXC_USE_SYSTEM_RAPIDHASH=ON` asks for a system one, so a
+build cannot silently pick up a header from the host.
 
 ### Option 7: Winget
 
@@ -420,13 +434,19 @@ sudo cmake --install build
 | Option | Default | Description |
 |--------|---------|-------------|
 | `BUILD_SHARED_LIBS` | OFF | Build shared libraries instead of static (`libzxc.so`, `libzxc.dylib`, `zxc.dll`) |
-| `ZXC_NATIVE_ARCH` | ON | Enable `-march=native` for maximum performance |
-| `ZXC_ENABLE_LTO` | ON | Enable Link-Time Optimization (LTO) |
+| `ZXC_NATIVE_ARCH` | ON / OFF | Enable `-march=native` for maximum performance |
+| `ZXC_ENABLE_LTO` | ON / OFF | Enable Link-Time Optimization (LTO) |
 | `ZXC_PGO_MODE` | OFF | Profile-Guided Optimization mode (`OFF`, `GENERATE`, `USE`) |
-| `ZXC_BUILD_CLI` | ON | Build command-line interface |
-| `ZXC_BUILD_TESTS` | ON | Build unit tests |
+| `ZXC_BUILD_CLI` | ON / OFF | Build command-line interface |
+| `ZXC_BUILD_TESTS` | ON / OFF | Build unit tests |
+| `ZXC_INSTALL` | ON / OFF | Generate install rules (headers, pkg-config, CMake package) |
 | `ZXC_ENABLE_COVERAGE` | OFF | Enable code coverage generation (disables LTO/PGO) |
 | `ZXC_DISABLE_SIMD` | OFF | Disable hand-written SIMD paths (AVX2/AVX512/NEON) |
+| `ZXC_USE_SYSTEM_RAPIDHASH` | OFF | Use a system-installed `rapidhash.h` instead of the vendored copy |
+
+Options listed as `ON / OFF` default to ON for a standalone build and to OFF when
+zxc is vendored as a subproject, so an embedding project keeps control of its own
+compiler flags, test registration and install set.
 
 ```bash
 # Build shared library

--- a/README.md
+++ b/README.md
@@ -385,15 +385,15 @@ set. Any of them can still be turned back on explicitly (`-DZXC_BUILD_CLI=ON`,
 ignored whenever CMake is cross-compiling, since it would encode the build
 host's ISA.
 
-Compiler flags follow the same rule. Vendored, zxc adds only `-O3` (`/O2` on
-MSVC) to the flags it inherits from the parent: the warning level
-(`-Wall -Wextra`, `/W3`) and the code generation policy
+Compiler flags follow the same rule. Vendored, zxc adds nothing to what it
+inherits from the parent: the optimisation level comes from the build type, and
+the warning level (`-Wall -Wextra`, `/W3`) and code generation policy
 (`-fomit-frame-pointer`, `-fstrict-aliasing`, `-ffunction-sections`,
 `-fdata-sections` and the matching dead-strip link options) are the embedding
 project's to set. An embedder that builds with frame pointers for its profiler,
-its own aliasing rules or a quiet build log keeps them. `-O3` stays because the
-decoder's published throughput assumes it, and a parent whose build type is
-unset would otherwise ship an unoptimized zxc.
+its own aliasing rules or a quiet build log keeps them. A configure-time warning
+fires if neither a build type nor an optimisation flag is set, since zxc would
+then be built unoptimised.
 
 Third-party code is vendored, never probed: `rapidhash.h` comes from the copy in
 the tree unless `-DZXC_USE_SYSTEM_RAPIDHASH=ON` asks for a system one, so a
@@ -431,22 +431,22 @@ sudo cmake --install build
 
 #### CMake Options
 
-| Option | Default | Description |
-|--------|---------|-------------|
-| `BUILD_SHARED_LIBS` | OFF | Build shared libraries instead of static (`libzxc.so`, `libzxc.dylib`, `zxc.dll`) |
-| `ZXC_NATIVE_ARCH` | ON / OFF | Enable `-march=native` for maximum performance |
-| `ZXC_ENABLE_LTO` | ON / OFF | Enable Link-Time Optimization (LTO) |
-| `ZXC_PGO_MODE` | OFF | Profile-Guided Optimization mode (`OFF`, `GENERATE`, `USE`) |
-| `ZXC_BUILD_CLI` | ON / OFF | Build command-line interface |
-| `ZXC_BUILD_TESTS` | ON / OFF | Build unit tests |
-| `ZXC_INSTALL` | ON / OFF | Generate install rules (headers, pkg-config, CMake package) |
-| `ZXC_ENABLE_COVERAGE` | OFF | Enable code coverage generation (disables LTO/PGO) |
-| `ZXC_DISABLE_SIMD` | OFF | Disable hand-written SIMD paths (AVX2/AVX512/NEON) |
-| `ZXC_USE_SYSTEM_RAPIDHASH` | OFF | Use a system-installed `rapidhash.h` instead of the vendored copy |
+| Option | Default (standalone) | Default (vendored) | Description |
+|--------|----------------------|--------------------|-------------|
+| `BUILD_SHARED_LIBS` | OFF | OFF | Build shared libraries instead of static (`libzxc.so`, `libzxc.dylib`, `zxc.dll`) |
+| `ZXC_NATIVE_ARCH` | ON | OFF | Enable `-march=native` for maximum performance |
+| `ZXC_ENABLE_LTO` | ON | OFF | Enable Link-Time Optimization (LTO) |
+| `ZXC_PGO_MODE` | OFF | OFF | Profile-Guided Optimization mode (`OFF`, `GENERATE`, `USE`) |
+| `ZXC_BUILD_CLI` | ON | OFF | Build command-line interface |
+| `ZXC_BUILD_TESTS` | ON | OFF | Build unit tests |
+| `ZXC_INSTALL` | ON | OFF | Generate install rules (headers, pkg-config, CMake package) |
+| `ZXC_ENABLE_COVERAGE` | OFF | OFF | Enable code coverage generation (disables LTO/PGO) |
+| `ZXC_DISABLE_SIMD` | OFF | OFF | Disable hand-written SIMD paths (AVX2/AVX512/NEON) |
+| `ZXC_USE_SYSTEM_RAPIDHASH` | OFF | OFF | Use a system-installed `rapidhash.h` instead of the vendored copy |
 
-Options listed as `ON / OFF` default to ON for a standalone build and to OFF when
-zxc is vendored as a subproject, so an embedding project keeps control of its own
-compiler flags, test registration and install set.
+"Vendored" is a build where zxc is not the top-level project (`add_subdirectory()`,
+`FetchContent`): the embedding project then keeps control of its own compiler flags,
+test registration and install set.
 
 ```bash
 # Build shared library


### PR DESCRIPTION
Lets zxc be vendored into another CMake build (`add_subdirectory()`, `FetchContent`) without imposing anything on the parent project.

- **Subproject defaults.** When zxc is not top-level, the CLI, tests, install rules, LTO and `-march=native` default to OFF, and the warning level and code generation flags are left to the parent. `enable_testing()` and the `format` / `doc` targets stay top-level only, so they cannot collide with the parent's. Adds the `ZXC_INSTALL` option and a `zxc::zxc_lib` alias, so a vendored copy and `find_package(zxc)` are interchangeable.
- **`ZXC_USE_SYSTEM_RAPIDHASH` (OFF).** `rapidhash.h` now comes from the vendored copy instead of probing the system, which hermetic builds rule out. Package managers that ship it as a dependency (vcpkg, conan) need `-DZXC_USE_SYSTEM_RAPIDHASH=ON` in their recipe.
- **Variant selection follows the target, not the host.** It now reads `CMAKE_OSX_ARCHITECTURES` when set: an x86-64 or universal build from an arm64 Mac used to compile the x86 dispatcher without the AVX2/AVX-512 variants it calls, and failed to link. `-march=native` is ignored whenever the target is not the build host.
- **One flag helper** replaces the per-target flag lists. `-O3` is no longer forced on `zxc_lib`.