### PR TITLE
fix(warnings): Resolve compiler warnings

### DIFF
--- a/src/cli/main.c
+++ b/src/cli/main.c
@@ -627,7 +627,7 @@ static void cli_progress_callback(uint64_t bytes_processed, uint64_t bytes_total
         bar[BAR_WIDTH] = '\0';
 
         // Estimated time to completion, from the cumulative throughput
-        char eta[24] = "";
+        char eta[40] = "";
         if (speed_mbps > 0.0 && total > bytes_processed) {
             const long secs = (long)((double)(total - bytes_processed) / (speed_mbps * 1e6));
             if (secs >= 3600)

--- a/src/lib/zxc_compress.c
+++ b/src/lib/zxc_compress.c
@@ -55,7 +55,13 @@ static ZXC_ALWAYS_INLINE uint32_t zxc_hash_func(const uint64_t val, const int us
     }
 }
 
-#if defined(ZXC_USE_SSE2)
+/* SSE2 selected, not merely available: guards the two helpers below. */
+#if defined(ZXC_USE_SSE2) && !(defined(ZXC_USE_AVX512) && defined(__AVX512VL__)) && \
+    !defined(ZXC_USE_AVX2) && !defined(ZXC_USE_NEON64) && !defined(ZXC_USE_NEON32)
+#define ZXC_OPT_SSE2
+#endif
+
+#if defined(ZXC_OPT_SSE2)
 /**
  * @brief SSE2 emulation of SSE4.1 @c _mm_blendv_epi8.
  *
@@ -68,7 +74,6 @@ static ZXC_ALWAYS_INLINE uint32_t zxc_hash_func(const uint64_t val, const int us
  * @param[in] mask  Per-byte selector (a full-width compare result).
  * @return The blended 128-bit vector.
  */
-// codeql[cpp/unused-static-function] : Used conditionally when ZXC_USE_SSE2 is defined
 static ZXC_ALWAYS_INLINE __m128i zxc_mm_blendv_epi8_sse2(__m128i a, __m128i b, __m128i mask) {
     return _mm_or_si128(_mm_and_si128(mask, b), _mm_andnot_si128(mask, a));
 }
@@ -85,7 +90,6 @@ static ZXC_ALWAYS_INLINE __m128i zxc_mm_blendv_epi8_sse2(__m128i a, __m128i b, _
  * @param[in] b  Four u32 lanes forming the high half of the result.
  * @return The eight u16 lanes packed from @p a then @p b.
  */
-// codeql[cpp/unused-static-function] : Used conditionally when ZXC_USE_SSE2 is defined
 static ZXC_ALWAYS_INLINE __m128i zxc_mm_packus_epi32_sse2(__m128i a, __m128i b) {
     const __m128i bias32 = _mm_set1_epi32(0x8000);
     const __m128i bias16 = _mm_set1_epi16((short)0x8000);
@@ -665,7 +669,7 @@ static ZXC_ALWAYS_INLINE size_t zxc_opt_dp_update_const_cost(
             vst1_u16(&parent_off[p + L], vbsl_u16(v_mask16, v_off, v_po));
         }
     }
-#elif defined(ZXC_USE_SSE2)
+#elif defined(ZXC_OPT_SSE2)
     if (L + 4 <= L_end) {
         const __m128i v_inc = _mm_setr_epi32(0, 1, 2, 3);
         const __m128i v_nxt = _mm_set1_epi32((int)nxt);

--- a/tests/fuzz_dict.c
+++ b/tests/fuzz_dict.c
@@ -136,6 +136,7 @@ int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
         uint32_t lid = 0;
         const int rc = zxc_dict_load(zxd_buf, (size_t)zxd_sz, &lc, &lcs, &lh, &lid);
         assert(rc == ZXC_OK);
+        (void)rc;
         assert(lcs == (size_t)dict_sz);
         assert(memcmp(lc, dict_buf, (size_t)dict_sz) == 0);
         assert(lh != NULL && memcmp(lh, huf, ZXC_HUF_TABLE_SIZE) == 0);
@@ -148,6 +149,7 @@ int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
         const size_t small_cap = corrupt_pos % (size_t)zxd_sz; /* in [0, zxd_sz) */
         const int64_t r = zxc_dict_save(dict_buf, (size_t)dict_sz, huf, zxd_buf, small_cap);
         assert(r < 0);
+        (void)r;
     }
 
     /* Re-save (the DST_TOO_SMALL attempt left zxd_buf untouched, but be safe). */

--- a/tests/fuzz_seekable.c
+++ b/tests/fuzz_seekable.c
@@ -113,6 +113,7 @@ int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
         dec_result = zxc_seekable_decompress_range(s, decomp_buf, size, 0, size);
     }
     assert(dec_result == (int64_t)size);
+    (void)dec_result;
     assert(memcmp(data, decomp_buf, size) == 0);
 
     /* ------------------------------------------------------------------ */

--- a/tests/test_context_api.c
+++ b/tests/test_context_api.c
@@ -12,7 +12,7 @@ int test_opaque_context_api() {
 
     /* 1. NULL context -> ZXC_ERROR_NULL_INPUT */
     {
-        uint8_t d[64];
+        uint8_t d[64] = {0};
         zxc_compress_opts_t co = {.level = 3, .checksum_enabled = 0};
         if (zxc_compress_cctx(NULL, d, sizeof(d), d, sizeof(d), &co) != ZXC_ERROR_NULL_INPUT) {
             printf("  [FAIL] compress_cctx NULL ctx\n");


### PR DESCRIPTION
Resolves compiler warnings across various modules and refines the logic for selecting optimal SIMD instruction sets.

*   **Enhances SIMD Selection Logic:** Conditions SSE2-specific optimizations to be active only when more advanced instruction sets (AVX512, AVX2, NEON) are not available. This prevents potential conflicts and ensures that the most optimal SIMD path is chosen for performance.
*   **Addresses Compiler Warnings:**
    *   Suppresses unused variable warnings in fuzzer harnesses by explicitly casting certain return values to `void`.
    *   Initializes a local buffer in a test case to prevent potential uninitialized variable warnings or undefined behavior.
*   **Improves CLI Robustness:** Increases the buffer size allocated for the estimated time to completion (ETA) display in the command-line interface, preventing potential truncation with longer time estimates.