### PR TITLE
perf(huffman): Extend code length nudging to level 6

### DIFF
--- a/docs/FORMAT.md
+++ b/docs/FORMAT.md
@@ -260,7 +260,12 @@ Selection is an encoder policy, not a format rule: the reference encoder
 requires level ≥ 6 and at least 1024 literals, prices every candidate
 (RAW / RLE / Huffman / shared-table Huffman) as
 `J = size + premium(level) * n_decoded_bytes`, and picks the minimum — a
-space-speed Lagrangian with a per-level decode-time premium.
+space-speed Lagrangian with a per-level decode-time premium. Before that
+pricing, the reference encoder also applies a joint flat/length *nudge* to
+the fitted code lengths at levels 6-7 (literals; level 7 also nudges the
+token table): it trades a few bytes of code-length optimality for a
+flatter tree whose PivCo runs decode faster. The nudged lengths remain an
+ordinary canonical, Kraft-exact code — decoders see nothing special.
 
 Decoder validation requirements:
 - Every code length must satisfy `code_len[i] ≤ 11`.

--- a/docs/WHITEPAPER.md
+++ b/docs/WHITEPAPER.md
@@ -97,6 +97,12 @@ the historical conservative margin (~3 %); at level 7 it is lowered (~1.6 %
 for entropy, ~0.4 % for RLE) so the encoder buys more ratio with decode
 cycles, which is exactly the level-7 contract.
 
+**Joint flat/length nudge (levels 6-7).** Before pricing, the fitted code
+lengths are themselves optimized for the *pair* (size, decode time): a DP
+pass relaxes the canonical lengths toward flatter trees whenever the
+modeled PivCo decode saving outweighs the size cost, using the same
+per-level premium. The result is still a canonical, Kraft-exact code.
+
 #### Prefix Varint Format
 
 ZXC uses a **Prefix Varint** encoding for overflow values. Unlike standard VByte (which uses a continuation bit in every byte), Prefix Varint encodes the total length of the integer in the **unary prefix of the first byte**. This allows the decoder to determine the sequence length immediately, enabling branchless or highly predictable decoding without serial dependencies.
@@ -444,7 +450,7 @@ This format is used for standard data. It employs a **multi-stage encoding pipel
     *   *Extras Buffer*: Overflow values for lengths >= 15 (Prefix Varint encoded).
     *   *Offset Mode Selection*: The encoder tracks the maximum offset across all sequences. If all offsets are ≤ 255, the 8-bit mode (`enc_off=1`) is selected, saving 1 byte per sequence compared to 16-bit mode.
 4.  **RLE Pass**: The literals buffer is scanned for run-length encoding opportunities (runs of identical bytes). If beneficial (>10% gain), it is compressed in place.
-5.  **Entropy Pass** (level ≥ 6, ≥ 1024 literals): A length-limited canonical Huffman code (`L = 8` at level 6, `L = 11` at level 7) is fitted to the literal byte distribution and emitted in the PivCo level-ordered layout (§4.3, FORMAT.md §5.2.1). At level 7 the same treatment is applied to the sequence-token stream (`enc_litlen = 2`). Candidates are selected by the space-speed Lagrangian `J = size + premium(level) × decoded_bytes`.
+5.  **Entropy Pass** (level ≥ 6, ≥ 1024 literals): A length-limited canonical Huffman code (`L = 8` at level 6, `L = 11` at level 7) is fitted to the literal byte distribution, joint-nudged toward a flatter (faster-decoding) tree, and emitted in the PivCo level-ordered layout (§4.3, FORMAT.md §5.2.1). At level 7 the same treatment is applied to the sequence-token stream (`enc_litlen = 2`). Candidates are selected by the space-speed Lagrangian `J = size + premium(level) × decoded_bytes`.
     *   **Shared-Table Candidate** (dictionary archives only): when the dictionary carries a shared literal table (§5.10), a second entropy candidate is sized with the dictionary's code lengths and **no inline 128-byte lengths header**. The Lagrangian picks the minimum-J of {RAW, RLE, per-block Huffman, shared-table Huffman} (`enc_lit = 3` for the latter), so the choice is never a regression. Because the shared table only covers symbols seen in training, a block containing an uncovered literal byte automatically falls back to its per-block table. The 128-byte header amortization makes `enc_lit = 3` viable on literal sections far below the 1024-literal threshold of the per-block table — precisely the small-block regime dictionaries target.
 6.  **Final Serialization**: All buffers are concatenated into the payload, preceded by section descriptors.
 

--- a/src/lib/zxc_compress.c
+++ b/src/lib/zxc_compress.c
@@ -1620,9 +1620,8 @@ parse_done:;
 
         if (zxc_huf_build_code_lengths(freq, huf_code_len, ctx->opt_scratch,
                                        zxc_huf_enc_max_code_len(level)) == ZXC_OK) {
-            if (level >= ZXC_LEVEL_ULTRA)
-                (void)zxc_huf_nudge_code_lengths(freq, huf_code_len, ctx->opt_scratch,
-                                                 zxc_huf_enc_max_code_len(level));
+            (void)zxc_huf_nudge_code_lengths(freq, huf_code_len, ctx->opt_scratch,
+                                             zxc_huf_enc_max_code_len(level));
             huf_total_size = zxc_huf_calc_size(freq, huf_code_len, 1);
             /* Space-speed: the entropy candidate must beat the current winner's
              * J, paying its own decode tax over the copy path. */


### PR DESCRIPTION
Previously exclusive to level 7, the joint flat/length nudge is now applied to Huffman code lengths at level 6. This optimization prioritizes faster PivCo decoding by trading a minimal increase in compressed size for flatter trees. Documentation is updated to reflect this expanded applicability.

**Benchmark Impact (Level -6)**
- Decompression speed: +2 to + 3%
- Compression ratio: -0.05%
