### PR TITLE
feat(mmap): Introduce zero-copy memory-mapped file decompression

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
         src/lib/zxc_pivco_tables.c
         src/lib/zxc_dict.c
         src/lib/zxc_dispatch.c
+        src/lib/zxc_mmap.c
         src/lib/zxc_pstream.c
         src/lib/zxc_seekable.c
     )
@@ -43,6 +44,7 @@ else()
         src/lib/zxc_dict.c
         src/lib/zxc_driver.c
         src/lib/zxc_dispatch.c
+        src/lib/zxc_mmap.c
         src/lib/zxc_pstream.c
         src/lib/zxc_seekable.c
     )

--- a/README.md
+++ b/README.md
@@ -551,6 +551,19 @@ int64_t n = zxc_decompress_inplace(buf, need, archive_size, NULL);   // decode i
 
 The required margin is one block, the accumulated per-block framing overhead, the trailing framing the encoder writes after the last block (EOF block, seek table, footer), and the wild-copy tail (`block_size + nblocks x (12-16 B) + ~2 KB`) — about **1 %** overhead on a large archive; always size the buffer via `zxc_decompress_inplace_bound` rather than the formula. An undersized buffer is rejected with `ZXC_ERROR_DST_TOO_SMALL`, never silent corruption. This is a library/API capability: it targets embedded/firmware integrators.
 
+### Zero-copy from a file (`zxc_mmap.h`)
+
+When the archive is a file, the opt-in mapped API does the placement for you and skips the `memcpy` above entirely: the archive is **mapped** flush-right into a single region and decoded left-to-right into the head of that same region. No staging input buffer, no output allocation, and on POSIX not a single copy of the compressed bytes.
+
+```c
+zxc_map_t out;
+int64_t n = zxc_decompress_mmap("payload.zxc", &out, NULL);   // one call, one mapping
+consume(out.data, out.size);                                  // writable, page-aligned
+zxc_mmap_close(&out);
+```
+
+Measured on a 56 MiB payload (Apple M2, warm page cache): decode throughput is on par with `read()` + `zxc_decompress`, while peak RSS drops **24 %** on compressible data and **49 %** on incompressible data (where the archive copy is as large as the payload). `zxc_mmap_open` additionally maps an archive read-only, so the ordinary buffer API can consume an on-disk archive with no input copy. On Windows the archive is copied once into the single region; on targets without mapping every entry point returns `ZXC_ERROR_UNSUPPORTED`.
+
 ---
 
 ## Dictionary Compression

--- a/README.md
+++ b/README.md
@@ -562,7 +562,9 @@ consume(out.data, out.size);                                  // writable, page-
 zxc_mmap_close(&out);
 ```
 
-Measured on a 56 MiB payload (Apple M2, warm page cache): decode throughput is on par with `read()` + `zxc_decompress`, while peak RSS drops **24 %** on compressible data and **49 %** on incompressible data (where the archive copy is as large as the payload). `zxc_mmap_open` additionally maps an archive read-only, so the ordinary buffer API can consume an on-disk archive with no input copy. On Windows the archive is copied once into the single region; on targets without mapping every entry point returns `ZXC_ERROR_UNSUPPORTED`.
+Measured on a 56 MiB payload (Apple M2, warm page cache): decode throughput is on par with `read()` + `zxc_decompress`, while peak RSS drops **24 %** on compressible data and **49 %** on incompressible data (where the archive copy is as large as the payload). `zxc_mmap_open` additionally maps an archive read-only, so the ordinary buffer API can consume an on-disk archive with no input copy.
+
+The placement is zero-copy on POSIX (`MAP_FIXED` over an anonymous reservation) and on Windows 10 1803 / Server 2019+ (placeholder mappings via `VirtualAlloc2` + `MapViewOfFile3`, resolved at run time); older Windows falls back to a single copy of the archive into the same one region, and `zxc_mmap_is_zerocopy()` reports which route ran. On targets without mapping every entry point returns `ZXC_ERROR_UNSUPPORTED`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -551,20 +551,26 @@ int64_t n = zxc_decompress_inplace(buf, need, archive_size, NULL);   // decode i
 
 The required margin is one block, the accumulated per-block framing overhead, the trailing framing the encoder writes after the last block (EOF block, seek table, footer), and the wild-copy tail (`block_size + nblocks x (12-16 B) + ~2 KB`) — about **1 %** overhead on a large archive; always size the buffer via `zxc_decompress_inplace_bound` rather than the formula. An undersized buffer is rejected with `ZXC_ERROR_DST_TOO_SMALL`, never silent corruption. This is a library/API capability: it targets embedded/firmware integrators.
 
-### Zero-copy from a file (`zxc_mmap.h`)
+### Mapping an archive from a file (`zxc_mmap.h`)
 
-When the archive is a file, the opt-in mapped API does the placement for you and skips the `memcpy` above entirely: the archive is **mapped** flush-right into a single region and decoded left-to-right into the head of that same region. No staging input buffer, no output allocation, and on POSIX not a single copy of the compressed bytes.
+The opt-in mapped API hands the buffer API an on-disk archive without reading it
+into a buffer first: the file is mapped read-only and its bytes are faulted in
+on demand.
 
 ```c
-zxc_map_t out;
-int64_t n = zxc_decompress_mmap("payload.zxc", &out, NULL);   // one call, one mapping
-consume(out.data, out.size);                                  // writable, page-aligned
-zxc_mmap_close(&out);
+zxc_map_t archive;
+if (zxc_mmap_open("payload.zxc", &archive) == ZXC_OK) {
+    const uint64_t n = zxc_get_decompressed_size(archive.data, archive.size);
+    // archive.data / archive.size feed zxc_decompress directly - no input copy
+    zxc_mmap_close(&archive);   // the mapping outlives the descriptor
+}
 ```
 
-Measured on a 56 MiB payload (Apple M2, warm page cache): decode throughput is on par with `read()` + `zxc_decompress`, while peak RSS drops **24 %** on compressible data and **49 %** on incompressible data (where the archive copy is as large as the payload). `zxc_mmap_open` additionally maps an archive read-only, so the ordinary buffer API can consume an on-disk archive with no input copy.
-
-The placement is zero-copy on POSIX (`MAP_FIXED` over an anonymous reservation) and on Windows 10 1803 / Server 2019+ (placeholder mappings via `VirtualAlloc2` + `MapViewOfFile3`, resolved at run time); older Windows falls back to a single copy of the archive into the same one region, and `zxc_mmap_is_zerocopy()` reports which route ran. On targets without mapping every entry point returns `ZXC_ERROR_UNSUPPORTED`.
+It also composes with the seekable API: a `zxc_reader_t` whose `read_at` is a
+`memcpy` out of the mapping needs no `read()` syscall per block and is
+reentrant, so it is legal on `zxc_seekable_decompress_range_mt` too (see
+`docs/API.md` section 7b). On targets without mapping every entry point returns
+`ZXC_ERROR_UNSUPPORTED`.
 
 ---
 

--- a/cmake/zxcTests.cmake
+++ b/cmake/zxcTests.cmake
@@ -17,6 +17,7 @@ if(ZXC_BUILD_TESTS)
         tests/test_block_api.c
         tests/test_context_api.c
         tests/test_static_ctx.c
+        tests/test_mmap.c
         tests/test_pstream_api.c
         tests/test_stream_api.c
         tests/test_seekable.c
@@ -38,6 +39,7 @@ if(ZXC_BUILD_TESTS)
             src/lib/zxc_dict.c
             src/lib/zxc_driver.c
             src/lib/zxc_dispatch.c
+            src/lib/zxc_mmap.c
             src/lib/zxc_pstream.c
             src/lib/zxc_seekable.c
             ${ZXC_VARIANT_OBJECTS}

--- a/docs/API.md
+++ b/docs/API.md
@@ -515,6 +515,31 @@ bound while what the caller keeps is just the decompressed data.
 deployment can log whether it gets the mapped or the copying path. The
 decompressed bytes are identical either way.
 
+### Seekable archives
+
+`zxc_decompress_mmap` decodes a seekable archive like any other — the seek table
+sits behind the EOF block and is skipped, and `zxc_decompress_inplace_bound`
+reserves room for it.
+
+For *random access* you want the [Seekable API](#11-seekable-api) instead, and
+`zxc_mmap_open` is a natural backend for it: a `read_at` that `memcpy`s out of
+the mapping needs no `read()` syscall per block and is reentrant, so it is legal
+on `zxc_seekable_decompress_range_mt` too.
+
+```c
+static int64_t map_read_at(void* ctx, void* dst, size_t len, uint64_t offset) {
+    const zxc_map_t* m = (const zxc_map_t*)ctx;
+    if (offset > m->size || len > m->size - offset) return ZXC_ERROR_IO;
+    memcpy(dst, (const unsigned char*)m->data + offset, len);
+    return (int64_t)len;
+}
+
+zxc_map_t m;
+zxc_mmap_open("archive.zxc", &m);
+const zxc_reader_t reader = { .read_at = map_read_at, .ctx = &m, .size = m.size };
+zxc_seekable* s = zxc_seekable_open_reader(&reader);   // free before zxc_mmap_close
+```
+
 ### `zxc_map_t`
 
 ```c

--- a/docs/API.md
+++ b/docs/API.md
@@ -506,9 +506,14 @@ bound while what the caller keeps is just the decompressed data.
 
 | Platform | Behaviour |
 |----------|-----------|
-| Linux, macOS, *BSD, illumos | Zero-copy as described above. |
-| Windows | Single region, but the archive is copied once into it (a file view cannot be placed inside a `VirtualAlloc` reservation without the Win10 placeholder APIs). The decode is still in-place with no output allocation. |
+| Linux, macOS, *BSD, illumos | Zero-copy as described above (`MAP_FIXED` over an anonymous reservation). |
+| Windows 10 1803 / Server 2019+ | Zero-copy: the same geometry via **placeholder mappings** — reserve `[0, region)` with `MEM_RESERVE_PLACEHOLDER`, split it at `off`, then replace the halves with committed private memory and a `PAGE_WRITECOPY` view of the archive. `VirtualAlloc2` / `MapViewOfFile3` are resolved at run time (no `onecore.lib` dependency, no minimum-version bump). |
+| Older Windows | Fallback: one reservation plus a single copy of the archive into the flush-right slot. Still one region, still no output allocation. |
 | Emscripten / freestanding | Every entry point returns `ZXC_ERROR_UNSUPPORTED`; `zxc_mmap_supported()` returns 0. |
+
+`zxc_mmap_is_zerocopy()` reports which route a given result took, so a
+deployment can log whether it gets the mapped or the copying path. The
+decompressed bytes are identical either way.
 
 ### `zxc_map_t`
 
@@ -536,6 +541,17 @@ ZXC_EXPORT int zxc_mmap_supported(void);
 
 **Returns**: `1` when the mapping entry points are functional, `0` when they all
 return `ZXC_ERROR_UNSUPPORTED`.
+
+### `zxc_mmap_is_zerocopy`
+
+```c
+ZXC_EXPORT int zxc_mmap_is_zerocopy(const zxc_map_t* map);
+```
+
+**Returns**: `1` when `map` is a live mapping that involved no copy of the file's
+bytes (always the case on POSIX and Windows 10 1803+), `0` otherwise — including
+for `NULL`, a closed or empty map, and the older-Windows fallback where
+`zxc_decompress_mmap` copies the archive once into its single region.
 
 ### `zxc_decompress_mmap` / `zxc_decompress_mmap_fd`
 
@@ -1672,7 +1688,7 @@ if (result < 0) {
 
 ## 14. Exported Symbols Summary
 
-The shared library exports **73 symbols** (verified with `nm -gU`):
+The shared library exports **74 symbols** (verified with `nm -gU`):
 
 | # | Symbol | API Layer | Header |
 |---|--------|-----------|--------|
@@ -1749,6 +1765,7 @@ The shared library exports **73 symbols** (verified with `nm -gU`):
 | 71 | `zxc_decompress_mmap` | Memory-Mapped | `zxc_mmap.h` |
 | 72 | `zxc_decompress_mmap_fd` | Memory-Mapped | `zxc_mmap.h` |
 | 73 | `zxc_mmap_close` | Memory-Mapped | `zxc_mmap.h` |
+| 74 | `zxc_mmap_is_zerocopy` | Memory-Mapped | `zxc_mmap.h` |
 
 No internal symbols leak into the public ABI. FMV dispatch variants
 (`_default`, `_neon32`, `_avx2`, `_avx512`) are compiled with

--- a/docs/API.md
+++ b/docs/API.md
@@ -22,6 +22,7 @@ For the on-disk binary format see [`FORMAT.md`](FORMAT.md).
 - [5. Constants and Enumerations](#5-constants-and-enumerations)
 - [6. Type Definitions](#6-type-definitions)
 - [7. Buffer API](#7-buffer-api)
+- [7b. Memory-Mapped API](#7b-memory-mapped-api)
 - [8. Block API](#8-block-api)
 - [9. Reusable Context API](#9-reusable-context-api)
 - [9b. Static Context API](#9b-static-context-api)
@@ -55,6 +56,11 @@ opt-in, freestanding-safe (no <stdio.h>):
     zxc_seekable.h     <- Seekable random-access API (storage-agnostic via
                           zxc_reader_t; usable from kernel-space)
         └── zxc_export.h
+
+opt-in, userspace only (need OS file mapping; not freestanding-safe):
+    zxc_mmap.h         <- Memory-mapped zero-copy in-place decode of files
+        └── zxc_export.h
+        └── zxc_opts.h
 
 opt-in, userspace only (pull <stdio.h>; not freestanding-safe):
     zxc_stream.h       <- Multi-threaded FILE*-based streaming + the FILE*
@@ -234,9 +240,11 @@ typedef enum {
     ZXC_ERROR_DICT_REQUIRED  = -15, // file requires a dictionary but none provided
     ZXC_ERROR_DICT_MISMATCH  = -16, // provided dictionary ID does not match header
     ZXC_ERROR_DICT_TOO_LARGE = -17, // dictionary exceeds ZXC_DICT_SIZE_MAX
-    ZXC_ERROR_BAD_LEVEL      = -18  // level unsupported by this context's workspace
+    ZXC_ERROR_BAD_LEVEL      = -18, // level unsupported by this context's workspace
                                     // (static context dense-tier raise; out-of-range
                                     // levels are otherwise silently clamped)
+    ZXC_ERROR_UNSUPPORTED    = -19  // operation unavailable on this platform / build
+                                    // (e.g. the mapped API on a target without mmap)
 } zxc_error_t;
 ```
 
@@ -455,6 +463,10 @@ int64_t n = zxc_decompress_inplace(buf, need, archive_size, NULL);
 **Returns**: decompressed size (> 0), `0` for an empty frame, or negative
 `zxc_error_t`.
 
+For an archive that lives in a file, `zxc_decompress_mmap`
+([7b. Memory-Mapped API](#7b-memory-mapped-api)) does the placement for you and
+skips the `memcpy` above entirely.
+
 ### `zxc_get_decompressed_size`
 
 ```c
@@ -467,6 +479,125 @@ ZXC_EXPORT uint64_t zxc_get_decompressed_size(
 Reads the original size from the file footer without decompressing.
 
 **Returns**: original size, or `0` if the buffer is invalid.
+
+---
+
+## 7b. Memory-Mapped API
+
+`zxc_mmap.h` — opt-in, userspace only. This is `zxc_decompress_inplace` turned
+into a one-call file API: the archive is **mapped** flush-right into a single
+region and decoded left-to-right into the head of that same region. There is no
+staging input buffer, no output allocation, and on POSIX not a single copy of
+the compressed bytes.
+
+```text
+  base                                     base+off              base+region
+    |<---------- decoded output ----------->|<--- archive ------->|
+    [ anonymous, private, zero-filled       | MAP_FIXED file view ]
+```
+
+One anonymous reservation of `zxc_decompress_inplace_bound` bytes is taken, then
+the file is mapped over its tail pages (`MAP_FIXED`, `MAP_PRIVATE`). Compressed
+pages fault in straight from the page cache into the buffer the decoder reads
+from; the decoder's writes over already-consumed compressed bytes are
+copy-on-write, so the archive on disk is never modified. When decoding is done
+the region is trimmed back to the payload, so the peak footprint is the in-place
+bound while what the caller keeps is just the decompressed data.
+
+| Platform | Behaviour |
+|----------|-----------|
+| Linux, macOS, *BSD, illumos | Zero-copy as described above. |
+| Windows | Single region, but the archive is copied once into it (a file view cannot be placed inside a `VirtualAlloc` reservation without the Win10 placeholder APIs). The decode is still in-place with no output allocation. |
+| Emscripten / freestanding | Every entry point returns `ZXC_ERROR_UNSUPPORTED`; `zxc_mmap_supported()` returns 0. |
+
+### `zxc_map_t`
+
+```c
+typedef struct {
+    void*  data;        // first byte of the region (page-aligned), NULL if empty
+    size_t size;        // valid bytes at data
+    /* private: owned by the library */
+    void*  map_base;
+    size_t map_size;
+    void*  map_handle;
+    int    map_kind;
+} zxc_map_t;
+```
+
+Only `data` and `size` are part of the contract. Release every successfully
+filled map with `zxc_mmap_close`, which also clears it (so a second close is a
+no-op, not a double free).
+
+### `zxc_mmap_supported`
+
+```c
+ZXC_EXPORT int zxc_mmap_supported(void);
+```
+
+**Returns**: `1` when the mapping entry points are functional, `0` when they all
+return `ZXC_ERROR_UNSUPPORTED`.
+
+### `zxc_decompress_mmap` / `zxc_decompress_mmap_fd`
+
+```c
+ZXC_EXPORT int64_t zxc_decompress_mmap(
+    const char*                  path,
+    zxc_map_t*                   out,
+    const zxc_decompress_opts_t* opts     // NULL = defaults
+);
+
+ZXC_EXPORT int64_t zxc_decompress_mmap_fd(
+    int                          fd,      // CRT descriptor on Windows
+    zxc_map_t*                   out,
+    const zxc_decompress_opts_t* opts
+);
+```
+
+Decompresses a whole file into one mapped region, in place. `out->data` is
+writable, page-aligned, and independent of the file (the mapping is private).
+Dictionary archives are supported: pass the dictionary in `opts` exactly as for
+`zxc_decompress`. The `_fd` variant only uses the descriptor during the call —
+it may be closed as soon as it returns — and ignores its file position.
+
+`out` is zeroed before anything else happens, so it is safe to `zxc_mmap_close`
+a map whose producing call failed. An empty frame succeeds with
+`out->data == NULL` and `out->size == 0`.
+
+```c
+zxc_map_t out;
+int64_t n = zxc_decompress_mmap("payload.zxc", &out, NULL);
+if (n < 0) { fprintf(stderr, "%s\n", zxc_error_name((int)n)); return 1; }
+consume(out.data, out.size);
+zxc_mmap_close(&out);
+```
+
+**Returns**: decompressed size (>= 0), or negative `zxc_error_t`
+(`ZXC_ERROR_IO` if the file cannot be opened / stat'ed / mapped or is not a
+regular file, `ZXC_ERROR_SRC_TOO_SMALL` if it is shorter than a frame,
+`ZXC_ERROR_BAD_HEADER` if it is not a ZXC archive).
+
+### `zxc_mmap_open` / `zxc_mmap_open_fd`
+
+```c
+ZXC_EXPORT int zxc_mmap_open(const char* path, zxc_map_t* out);
+ZXC_EXPORT int zxc_mmap_open_fd(int fd, zxc_map_t* out);
+```
+
+Maps a file read-only without decoding it: a zero-copy way to hand an on-disk
+archive to `zxc_decompress`, `zxc_get_decompressed_size`, or a `zxc_reader_t`.
+The mapping outlives the descriptor used to create it. The region is read-only
+(writing to it traps), and — as with any file mapping — truncating the file
+underneath it makes the vanished pages fatal to touch (`SIGBUS`).
+
+**Returns**: `ZXC_OK`, or negative `zxc_error_t`.
+
+### `zxc_mmap_close`
+
+```c
+ZXC_EXPORT void zxc_mmap_close(zxc_map_t* map);
+```
+
+Releases the region and zeroes `map`. Safe on `NULL` and on a zeroed map.
 
 ---
 
@@ -1541,7 +1672,7 @@ if (result < 0) {
 
 ## 14. Exported Symbols Summary
 
-The shared library exports **47 symbols** (verified with `nm -gU`):
+The shared library exports **73 symbols** (verified with `nm -gU`):
 
 | # | Symbol | API Layer | Header |
 |---|--------|-----------|--------|
@@ -1606,6 +1737,18 @@ The shared library exports **47 symbols** (verified with `nm -gU`):
 | 59 | `zxc_dict_get_id` | Dictionary | `zxc_dict.h` |
 | 60 | `zxc_dict_save_bound` | Dictionary | `zxc_dict.h` |
 | 61 | `zxc_seekable_set_dict` | Seekable | `zxc_seekable.h` |
+| 62 | `zxc_seekable_open_reader` | Seekable | `zxc_seekable.h` |
+| 63 | `zxc_decompress_inplace_bound` | Buffer | `zxc_buffer.h` |
+| 64 | `zxc_decompress_inplace` | Buffer | `zxc_buffer.h` |
+| 65 | `zxc_get_dict_id` | Buffer | `zxc_buffer.h` |
+| 66 | `zxc_compress_opts_size` | Options | `zxc_opts.h` |
+| 67 | `zxc_decompress_opts_size` | Options | `zxc_opts.h` |
+| 68 | `zxc_mmap_supported` | Memory-Mapped | `zxc_mmap.h` |
+| 69 | `zxc_mmap_open` | Memory-Mapped | `zxc_mmap.h` |
+| 70 | `zxc_mmap_open_fd` | Memory-Mapped | `zxc_mmap.h` |
+| 71 | `zxc_decompress_mmap` | Memory-Mapped | `zxc_mmap.h` |
+| 72 | `zxc_decompress_mmap_fd` | Memory-Mapped | `zxc_mmap.h` |
+| 73 | `zxc_mmap_close` | Memory-Mapped | `zxc_mmap.h` |
 
 No internal symbols leak into the public ABI. FMV dispatch variants
 (`_default`, `_neon32`, `_avx2`, `_avx512`) are compiled with

--- a/docs/API.md
+++ b/docs/API.md
@@ -58,7 +58,7 @@ opt-in, freestanding-safe (no <stdio.h>):
         └── zxc_export.h
 
 opt-in, userspace only (need OS file mapping; not freestanding-safe):
-    zxc_mmap.h         <- Memory-mapped zero-copy in-place decode of files
+    zxc_mmap.h         <- Read-only, zero-copy mappings of archive files
         └── zxc_export.h
         └── zxc_opts.h
 
@@ -470,9 +470,9 @@ int64_t n = zxc_decompress_inplace(buf, need, archive_size, NULL);
 **Returns**: decompressed size (> 0), `0` for an empty frame, or negative
 `zxc_error_t`.
 
-For an archive that lives in a file, `zxc_decompress_mmap`
-([7b. Memory-Mapped API](#7b-memory-mapped-api)) does the placement for you and
-skips the `memcpy` above entirely.
+To get the archive into that buffer without reading it first, map it read-only
+with `zxc_mmap_open` ([7b. Memory-Mapped API](#7b-memory-mapped-api)) and
+`memcpy` from the mapping.
 
 ### `zxc_get_decompressed_size`
 
@@ -491,59 +491,48 @@ Reads the original size from the file footer without decompressing.
 
 ## 7b. Memory-Mapped API
 
-`zxc_mmap.h` — opt-in, userspace only. This is `zxc_decompress_inplace` turned
-into a one-call file API: the archive is **mapped** flush-right into a single
-region and decoded left-to-right into the head of that same region. There is no
-staging input buffer, no output allocation, and on POSIX not a single copy of
-the compressed bytes.
+`zxc_mmap.h` — opt-in, userspace only. Maps an archive file read-only and hands
+back its bytes as they are on disk, faulted in on demand. The point is to feed
+the buffer API (`zxc_decompress`, `zxc_get_decompressed_size`) or a
+`zxc_reader_t` without reading the file into a buffer first.
 
-```text
-  base                                     base+off              base+region
-    |<---------- decoded output ----------->|<--- archive ------->|
-    [ anonymous, private, zero-filled       | MAP_FIXED file view ]
+```c
+zxc_map_t archive;
+if (zxc_mmap_open("payload.zxc", &archive) != ZXC_OK) return 1;
+
+const uint64_t n = zxc_get_decompressed_size(archive.data, archive.size);
+void* dst = n ? malloc((size_t)n) : NULL;
+if (dst) {
+    const int64_t d = zxc_decompress(archive.data, archive.size, dst, (size_t)n, NULL);
+    if (d < 0) fprintf(stderr, "%s\n", zxc_error_name((int)d));
+    free(dst);
+}
+zxc_mmap_close(&archive);   // the mapping outlived the descriptor
 ```
-
-One anonymous reservation of `zxc_decompress_inplace_bound` bytes is taken, then
-the file is mapped over its tail pages (`MAP_FIXED`, `MAP_PRIVATE`). Compressed
-pages fault in straight from the page cache into the buffer the decoder reads
-from; the decoder's writes over already-consumed compressed bytes are
-copy-on-write, so the archive on disk is never modified. When decoding is done
-the region is trimmed back to the payload, so the peak footprint is the in-place
-bound while what the caller keeps is just the decompressed data — except on
-Windows, where a view is released whole or not at all: a payload reaching into
-the archive slot keeps the region at its peak until `zxc_mmap_close()`.
 
 | Platform | Behaviour |
 |----------|-----------|
-| Linux, macOS, *BSD, illumos | Zero-copy as described above (`MAP_FIXED` over an anonymous reservation). |
-| Windows 10 1803 / Server 2019+ | Zero-copy: the same geometry via **placeholder mappings** — reserve `[0, region)` with `MEM_RESERVE_PLACEHOLDER`, split it at `off`, then replace the halves with committed private memory and a `PAGE_WRITECOPY` view of the archive. `VirtualAlloc2` / `MapViewOfFile3` are resolved at run time (no `onecore.lib` dependency, no minimum-version bump). |
-| Older Windows | Fallback: one reservation plus a single copy of the archive into the flush-right slot. Still one region, still no output allocation. |
+| Linux, macOS, *BSD, illumos | `mmap(PROT_READ, MAP_PRIVATE)` over the whole file. |
+| Windows | `CreateFileMapping(PAGE_READONLY)` + `MapViewOfFile`; the section handle is closed straight away, the view keeps it alive. |
 | Emscripten / freestanding | Every entry point returns `ZXC_ERROR_UNSUPPORTED`; `zxc_mmap_supported()` returns 0. |
 
-`zxc_mmap_is_zerocopy()` reports which route a given result took, so a
-deployment can log whether it gets the mapped or the copying path. The
-decompressed bytes are identical either way.
+**Truncation.** The archive is a live file mapping for as long as the map is
+open, so the usual rule applies: if another process truncates or overwrites the
+file, touching a vanished page raises `SIGBUS`. The realistic cases are network
+shares, removable volumes, and files a writer is still appending to; copy the
+file first when that is possible.
 
-**Truncation.** The archive is a live file mapping *for the duration of the
-call*, so the usual rule applies: if another process truncates or overwrites the
-file while `zxc_decompress_mmap` runs, touching a vanished page raises `SIGBUS`
-inside the library. The realistic cases are network shares, removable volumes,
-and files a writer is still appending to; decode from a private copy when that
-is possible. The `size` bytes handed back do **not** carry the hazard — all of
-them were written by the decoder. What lies *past* them can: the rest of the
-last page, and the untrimmed tail in the Windows case above. Nothing there is
-the caller's to touch.
+**Decompressing a file with a minimal footprint** is a separate tool: the
+buffer-level `zxc_decompress_inplace`
+([7. Buffer API](#7-buffer-api)) decodes into a single buffer holding the
+archive flush-right, with no second allocation. It is not built on this header
+and carries no truncation hazard.
 
 ### Seekable archives
 
-`zxc_decompress_mmap` decodes a seekable archive like any other — the seek table
-sits behind the EOF block and is skipped, and `zxc_decompress_inplace_bound`
-reserves room for it.
-
-For *random access* you want the [Seekable API](#11-seekable-api) instead, and
-`zxc_mmap_open` is a natural backend for it: a `read_at` that `memcpy`s out of
-the mapping needs no `read()` syscall per block and is reentrant, so it is legal
-on `zxc_seekable_decompress_range_mt` too.
+`zxc_mmap_open` is a natural backend for the [Seekable API](#11-seekable-api): a
+`read_at` that `memcpy`s out of the mapping needs no `read()` syscall per block
+and is reentrant, so it is legal on `zxc_seekable_decompress_range_mt` too.
 
 ```c
 static int64_t map_read_at(void* ctx, void* dst, size_t len, uint64_t offset) {
@@ -563,13 +552,11 @@ zxc_seekable* s = zxc_seekable_open_reader(&reader);   // free before zxc_mmap_c
 
 ```c
 typedef struct {
-    void*  data;        // first byte of the region (page-aligned), NULL if empty
-    size_t size;        // valid bytes at data
+    const void* data;   // first byte of the mapping (page-aligned), NULL if none
+    size_t      size;   // valid bytes at data
     /* private: owned by the library */
-    void*  map_base;
-    size_t map_size;
-    void*  map_handle;
-    int    map_kind;
+    void*       map_base;
+    size_t      map_size;
 } zxc_map_t;
 ```
 
@@ -586,70 +573,22 @@ ZXC_EXPORT int zxc_mmap_supported(void);
 **Returns**: `1` when the mapping entry points are functional, `0` when they all
 return `ZXC_ERROR_UNSUPPORTED`.
 
-### `zxc_mmap_is_zerocopy`
-
-```c
-ZXC_EXPORT int zxc_mmap_is_zerocopy(const zxc_map_t* map);
-```
-
-**Returns**: `1` when `map` is a live mapping that involved no copy of the file's
-bytes (always the case on POSIX and Windows 10 1803+), `0` otherwise — including
-for `NULL`, a closed or empty map, and the older-Windows fallback where
-`zxc_decompress_mmap` copies the archive once into its single region.
-
-### `zxc_decompress_mmap` / `zxc_decompress_mmap_fd`
-
-```c
-ZXC_EXPORT int64_t zxc_decompress_mmap(
-    const char*                  path,
-    zxc_map_t*                   out,
-    const zxc_decompress_opts_t* opts     // NULL = defaults
-);
-
-ZXC_EXPORT int64_t zxc_decompress_mmap_fd(
-    int                          fd,      // CRT descriptor on Windows
-    zxc_map_t*                   out,
-    const zxc_decompress_opts_t* opts
-);
-```
-
-Decompresses a whole file into one mapped region, in place. `out->data` is
-writable, page-aligned, and independent of the file (the mapping is private).
-Dictionary archives are supported: pass the dictionary in `opts` exactly as for
-`zxc_decompress`. The `_fd` variant only uses the descriptor during the call —
-it may be closed as soon as it returns — and ignores its file position.
-
-`out` is zeroed before anything else happens, so it is safe to `zxc_mmap_close`
-a map whose producing call failed. An empty frame succeeds with
-`out->data == NULL` and `out->size == 0`.
-
-```c
-zxc_map_t out;
-int64_t n = zxc_decompress_mmap("payload.zxc", &out, NULL);
-if (n < 0) { fprintf(stderr, "%s\n", zxc_error_name((int)n)); return 1; }
-consume(out.data, out.size);
-zxc_mmap_close(&out);
-```
-
-**Returns**: decompressed size (>= 0), or negative `zxc_error_t`
-(`ZXC_ERROR_IO` if the file cannot be opened / stat'ed / mapped or is not a
-regular file, `ZXC_ERROR_SRC_TOO_SMALL` if it is shorter than a frame,
-`ZXC_ERROR_BAD_HEADER` if it is not a ZXC archive).
-
 ### `zxc_mmap_open` / `zxc_mmap_open_fd`
 
 ```c
 ZXC_EXPORT int zxc_mmap_open(const char* path, zxc_map_t* out);
-ZXC_EXPORT int zxc_mmap_open_fd(int fd, zxc_map_t* out);
+ZXC_EXPORT int zxc_mmap_open_fd(int fd, zxc_map_t* out);   // CRT descriptor on Windows
 ```
 
-Maps a file read-only without decoding it: a zero-copy way to hand an on-disk
-archive to `zxc_decompress`, `zxc_get_decompressed_size`, or a `zxc_reader_t`.
-The mapping outlives the descriptor used to create it. The region is read-only
-(writing to it traps), and — as with any file mapping — truncating the file
-underneath it makes the vanished pages fatal to touch (`SIGBUS`).
+Maps a regular file read-only. The mapping outlives the descriptor used to
+create it, and the `_fd` variant leaves that descriptor's file position
+untouched. The region is read-only — writing to it traps. `out` is zeroed before
+anything else happens, so it is safe to `zxc_mmap_close` a map whose producing
+call failed.
 
-**Returns**: `ZXC_OK`, or negative `zxc_error_t`.
+**Returns**: `ZXC_OK`, or negative `zxc_error_t` (`ZXC_ERROR_IO` if the file
+cannot be opened / stat'ed / mapped or is not a regular file,
+`ZXC_ERROR_SRC_TOO_SMALL` for an empty file).
 
 ### `zxc_mmap_close`
 
@@ -657,7 +596,7 @@ underneath it makes the vanished pages fatal to touch (`SIGBUS`).
 ZXC_EXPORT void zxc_mmap_close(zxc_map_t* map);
 ```
 
-Releases the region and zeroes `map`. Safe on `NULL` and on a zeroed map.
+Releases the mapping and zeroes `map`. Safe on `NULL` and on a zeroed map.
 
 ---
 
@@ -1732,7 +1671,7 @@ if (result < 0) {
 
 ## 14. Exported Symbols Summary
 
-The shared library exports **74 symbols** (verified with `nm -gU`):
+The shared library exports **71 symbols** (verified with `nm -gU`):
 
 | # | Symbol | API Layer | Header |
 |---|--------|-----------|--------|
@@ -1806,10 +1745,7 @@ The shared library exports **74 symbols** (verified with `nm -gU`):
 | 68 | `zxc_mmap_supported` | Memory-Mapped | `zxc_mmap.h` |
 | 69 | `zxc_mmap_open` | Memory-Mapped | `zxc_mmap.h` |
 | 70 | `zxc_mmap_open_fd` | Memory-Mapped | `zxc_mmap.h` |
-| 71 | `zxc_decompress_mmap` | Memory-Mapped | `zxc_mmap.h` |
-| 72 | `zxc_decompress_mmap_fd` | Memory-Mapped | `zxc_mmap.h` |
-| 73 | `zxc_mmap_close` | Memory-Mapped | `zxc_mmap.h` |
-| 74 | `zxc_mmap_is_zerocopy` | Memory-Mapped | `zxc_mmap.h` |
+| 71 | `zxc_mmap_close` | Memory-Mapped | `zxc_mmap.h` |
 
 No internal symbols leak into the public ABI. FMV dispatch variants
 (`_default`, `_neon32`, `_avx2`, `_avx512`) are compiled with

--- a/docs/API.md
+++ b/docs/API.md
@@ -429,7 +429,14 @@ flush-right archive left, into the write cursor's path; no header flag announces
 a seek table, so its worst case (4 bytes per block) is always reserved. Always
 size the buffer with this function rather than re-deriving the formula.
 
-**Returns**: required buffer size, or `0` if `src` is not a valid archive.
+The footer is untrusted input, so the decompressed size it carries is checked
+for plausibility against the archive itself — an archive of `src_size` bytes
+cannot hold more than `src_size / block header` blocks, and each block decodes
+to at most one block size. A forged footer therefore returns `0` instead of an
+arbitrary allocation size, the same check `zxc_get_decompressed_size` applies.
+
+**Returns**: required buffer size, or `0` if `src` is not a valid archive
+(bad magic, bad header, or an implausible footer).
 
 ### `zxc_decompress_inplace`
 
@@ -514,6 +521,15 @@ bound while what the caller keeps is just the decompressed data.
 `zxc_mmap_is_zerocopy()` reports which route a given result took, so a
 deployment can log whether it gets the mapped or the copying path. The
 decompressed bytes are identical either way.
+
+**Truncation.** The archive is a live file mapping *for the duration of the
+call*, so the usual rule applies: if another process truncates or overwrites the
+file while `zxc_decompress_mmap` runs, touching a vanished page raises `SIGBUS`
+inside the library. The realistic cases are network shares, removable volumes,
+and files a writer is still appending to; decode from a private copy when that
+is possible. The region handed back does **not** carry the hazard — by the time
+the call returns, every byte in it was written by the decoder and none of it is
+still backed by the file.
 
 ### Seekable archives
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -509,7 +509,9 @@ pages fault in straight from the page cache into the buffer the decoder reads
 from; the decoder's writes over already-consumed compressed bytes are
 copy-on-write, so the archive on disk is never modified. When decoding is done
 the region is trimmed back to the payload, so the peak footprint is the in-place
-bound while what the caller keeps is just the decompressed data.
+bound while what the caller keeps is just the decompressed data — except on
+Windows, where a view is released whole or not at all: a payload reaching into
+the archive slot keeps the region at its peak until `zxc_mmap_close()`.
 
 | Platform | Behaviour |
 |----------|-----------|
@@ -527,9 +529,10 @@ call*, so the usual rule applies: if another process truncates or overwrites the
 file while `zxc_decompress_mmap` runs, touching a vanished page raises `SIGBUS`
 inside the library. The realistic cases are network shares, removable volumes,
 and files a writer is still appending to; decode from a private copy when that
-is possible. The region handed back does **not** carry the hazard — by the time
-the call returns, every byte in it was written by the decoder and none of it is
-still backed by the file.
+is possible. The `size` bytes handed back do **not** carry the hazard — all of
+them were written by the decoder. What lies *past* them can: the rest of the
+last page, and the untrimmed tail in the Windows case above. Nothing there is
+the caller's to touch.
 
 ### Seekable archives
 

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -4,6 +4,7 @@ This document provides complete, working examples for using the ZXC compression 
 
 ## Table of Contents
 - [Buffer API (In-Memory)](#buffer-api-in-memory)
+- [Memory-Mapped Zero-Copy Decode](#memory-mapped-zero-copy-decode)
 - [Stream API (Multi-Threaded)](#stream-api-multi-threaded)
 - [Reusable Context API](#reusable-context-api)
 - [Seekable Reader (Custom Storage Backend)](#seekable-reader-custom-storage-backend)
@@ -105,6 +106,76 @@ int main(void) {
 **Compilation:**
 ```bash
 gcc -o buffer_example buffer_example.c -I include -L build -lzxc_lib
+```
+
+---
+
+## Memory-Mapped Zero-Copy Decode
+
+When the archive is a file, `zxc_mmap.h` decodes it with **one mapping and zero
+copies of the compressed bytes**: the archive is mapped flush-right into a
+single region and decoded left-to-right into the head of that same region (the
+in-place decoder guarantees the write cursor never overtakes the read cursor).
+No input staging buffer, no output allocation.
+
+```c
+#include "zxc_mmap.h"   // opt-in: not pulled by <zxc.h>
+#include "zxc_error.h"
+#include <stdio.h>
+
+int main(int argc, char** argv) {
+    if (argc < 2) return 1;
+
+    if (!zxc_mmap_supported()) {
+        fprintf(stderr, "no file mapping on this platform\n");
+        return 1;
+    }
+
+    zxc_map_t out;
+    const zxc_decompress_opts_t opts = { .checksum_enabled = 1 };
+    const int64_t n = zxc_decompress_mmap(argv[1], &out, &opts);
+    if (n < 0) {
+        fprintf(stderr, "decode failed: %s\n", zxc_error_name((int)n));
+        return 1;
+    }
+
+    // out.data holds n writable, page-aligned bytes. The file on disk is
+    // untouched (the mapping is private / copy-on-write).
+    printf("%lld bytes decompressed, first byte 0x%02X\n",
+           (long long)n, n ? ((const unsigned char*)out.data)[0] : 0);
+
+    zxc_mmap_close(&out);   // also clears `out`; a second close is a no-op
+    return 0;
+}
+```
+
+Peak memory is `zxc_decompress_inplace_bound()` (payload + one block + framing
+margin); the region is trimmed back to the payload before the call returns, so
+what you keep resident is just the decompressed data.
+
+To feed an on-disk archive to the ordinary buffer API without copying it —
+useful when you already own the output buffer, or only want the header — map it
+read-only instead:
+
+```c
+zxc_map_t archive;
+if (zxc_mmap_open("payload.zxc", &archive) == ZXC_OK) {
+    const uint64_t orig = zxc_get_decompressed_size(archive.data, archive.size);
+    void* dst = malloc((size_t)orig);
+    zxc_decompress(archive.data, archive.size, dst, (size_t)orig, NULL);
+    zxc_mmap_close(&archive);   // the mapping outlived the descriptor
+    free(dst);
+}
+```
+
+On Windows the archive is copied once into the single region (a file view cannot
+be placed inside a `VirtualAlloc` reservation without the Win10 placeholder
+APIs); the decode itself is still in-place. On targets without mapping at all
+every entry point returns `ZXC_ERROR_UNSUPPORTED`.
+
+**Compilation:**
+```bash
+gcc -o mmap_example mmap_example.c -I include -L build -lzxc_lib
 ```
 
 ---

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -151,7 +151,9 @@ int main(int argc, char** argv) {
 
 Peak memory is `zxc_decompress_inplace_bound()` (payload + one block + framing
 margin); the region is trimmed back to the payload before the call returns, so
-what you keep resident is just the decompressed data.
+what you keep resident is just the decompressed data — except on Windows, where
+a view is released whole or not at all, so a payload reaching into the archive
+slot keeps the region at its peak until `zxc_mmap_close()`.
 
 To feed an on-disk archive to the ordinary buffer API without copying it —
 useful when you already own the output buffer, or only want the header — map it
@@ -160,11 +162,15 @@ read-only instead:
 ```c
 zxc_map_t archive;
 if (zxc_mmap_open("payload.zxc", &archive) == ZXC_OK) {
+    // 0 means corrupt or forged footer: the size is untrusted input.
     const uint64_t orig = zxc_get_decompressed_size(archive.data, archive.size);
-    void* dst = malloc((size_t)orig);
-    zxc_decompress(archive.data, archive.size, dst, (size_t)orig, NULL);
+    void* dst = orig ? malloc((size_t)orig) : NULL;
+    if (dst) {
+        const int64_t n = zxc_decompress(archive.data, archive.size, dst, (size_t)orig, NULL);
+        if (n < 0) fprintf(stderr, "decode failed: %s\n", zxc_error_name((int)n));
+        free(dst);
+    }
     zxc_mmap_close(&archive);   // the mapping outlived the descriptor
-    free(dst);
 }
 ```
 

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -400,6 +400,10 @@ typedef struct {
 to use `zxc_seekable_decompress_range_mt()`. The single-threaded path makes no
 concurrent calls.
 
+`zxc_mmap_open()` ([Memory-Mapped API](#memory-mapped-zero-copy-decode)) gives
+you the same mapping portably (it also covers Windows), if you would rather not
+call `mmap()` yourself.
+
 The example below wires the reader to an `mmap()`'d archive file, then
 decompresses an arbitrary byte range — no `FILE*` is involved.
 

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -168,10 +168,12 @@ if (zxc_mmap_open("payload.zxc", &archive) == ZXC_OK) {
 }
 ```
 
-On Windows the archive is copied once into the single region (a file view cannot
-be placed inside a `VirtualAlloc` reservation without the Win10 placeholder
-APIs); the decode itself is still in-place. On targets without mapping at all
-every entry point returns `ZXC_ERROR_UNSUPPORTED`.
+Windows 10 1803 / Server 2019 and later get the very same zero-copy placement
+through placeholder mappings (`VirtualAlloc2` + `MapViewOfFile3`, resolved at
+run time); older Windows falls back to a single copy of the archive into the
+same one region. `zxc_mmap_is_zerocopy(&out)` tells you which route ran. On
+targets without mapping at all every entry point returns
+`ZXC_ERROR_UNSUPPORTED`.
 
 **Compilation:**
 ```bash

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -4,7 +4,7 @@ This document provides complete, working examples for using the ZXC compression 
 
 ## Table of Contents
 - [Buffer API (In-Memory)](#buffer-api-in-memory)
-- [Memory-Mapped Zero-Copy Decode](#memory-mapped-zero-copy-decode)
+- [Memory-Mapped Archive (zero-copy input)](#memory-mapped-archive-zero-copy-input)
 - [Stream API (Multi-Threaded)](#stream-api-multi-threaded)
 - [Reusable Context API](#reusable-context-api)
 - [Seekable Reader (Custom Storage Backend)](#seekable-reader-custom-storage-backend)
@@ -110,18 +110,18 @@ gcc -o buffer_example buffer_example.c -I include -L build -lzxc_lib
 
 ---
 
-## Memory-Mapped Zero-Copy Decode
+## Memory-Mapped Archive (zero-copy input)
 
-When the archive is a file, `zxc_mmap.h` decodes it with **one mapping and zero
-copies of the compressed bytes**: the archive is mapped flush-right into a
-single region and decoded left-to-right into the head of that same region (the
-in-place decoder guarantees the write cursor never overtakes the read cursor).
-No input staging buffer, no output allocation.
+`zxc_mmap.h` maps an archive file read-only so the buffer API can read it
+without an input copy: the compressed pages are faulted in straight from the
+page cache.
 
 ```c
 #include "zxc_mmap.h"   // opt-in: not pulled by <zxc.h>
+#include "zxc_buffer.h"
 #include "zxc_error.h"
 #include <stdio.h>
+#include <stdlib.h>
 
 int main(int argc, char** argv) {
     if (argc < 2) return 1;
@@ -131,55 +131,39 @@ int main(int argc, char** argv) {
         return 1;
     }
 
-    zxc_map_t out;
-    const zxc_decompress_opts_t opts = { .checksum_enabled = 1 };
-    const int64_t n = zxc_decompress_mmap(argv[1], &out, &opts);
-    if (n < 0) {
-        fprintf(stderr, "decode failed: %s\n", zxc_error_name((int)n));
+    zxc_map_t archive;
+    int rc = zxc_mmap_open(argv[1], &archive);
+    if (rc != ZXC_OK) {
+        fprintf(stderr, "map failed: %s\n", zxc_error_name(rc));
         return 1;
     }
 
-    // out.data holds n writable, page-aligned bytes. The file on disk is
-    // untouched (the mapping is private / copy-on-write).
-    printf("%lld bytes decompressed, first byte 0x%02X\n",
-           (long long)n, n ? ((const unsigned char*)out.data)[0] : 0);
-
-    zxc_mmap_close(&out);   // also clears `out`; a second close is a no-op
-    return 0;
-}
-```
-
-Peak memory is `zxc_decompress_inplace_bound()` (payload + one block + framing
-margin); the region is trimmed back to the payload before the call returns, so
-what you keep resident is just the decompressed data — except on Windows, where
-a view is released whole or not at all, so a payload reaching into the archive
-slot keeps the region at its peak until `zxc_mmap_close()`.
-
-To feed an on-disk archive to the ordinary buffer API without copying it —
-useful when you already own the output buffer, or only want the header — map it
-read-only instead:
-
-```c
-zxc_map_t archive;
-if (zxc_mmap_open("payload.zxc", &archive) == ZXC_OK) {
     // 0 means corrupt or forged footer: the size is untrusted input.
     const uint64_t orig = zxc_get_decompressed_size(archive.data, archive.size);
     void* dst = orig ? malloc((size_t)orig) : NULL;
     if (dst) {
-        const int64_t n = zxc_decompress(archive.data, archive.size, dst, (size_t)orig, NULL);
+        const zxc_decompress_opts_t opts = { .checksum_enabled = 1 };
+        const int64_t n = zxc_decompress(archive.data, archive.size, dst, (size_t)orig, &opts);
         if (n < 0) fprintf(stderr, "decode failed: %s\n", zxc_error_name((int)n));
+        else       printf("%lld bytes decompressed\n", (long long)n);
         free(dst);
     }
-    zxc_mmap_close(&archive);   // the mapping outlived the descriptor
+
+    zxc_mmap_close(&archive);   // also clears it; a second close is a no-op
+    return 0;
 }
 ```
 
-Windows 10 1803 / Server 2019 and later get the very same zero-copy placement
-through placeholder mappings (`VirtualAlloc2` + `MapViewOfFile3`, resolved at
-run time); older Windows falls back to a single copy of the archive into the
-same one region. `zxc_mmap_is_zerocopy(&out)` tells you which route ran. On
-targets without mapping at all every entry point returns
+The mapping outlives the descriptor used to create it, so `zxc_mmap_open_fd`
+lets you hand over a `FILE*`'s descriptor and close it right away. It is
+read-only — writing to the region traps — and, as with any file mapping,
+truncating the file underneath it makes the vanished pages fatal to touch
+(`SIGBUS`). On targets without mapping every entry point returns
 `ZXC_ERROR_UNSUPPORTED`.
+
+To decompress a file with a minimal footprint, use `zxc_decompress_inplace`
+instead: one buffer holds the flush-right archive and receives the output, so
+there is no second allocation. See the in-place section of `docs/API.md`.
 
 **Compilation:**
 ```bash
@@ -406,7 +390,7 @@ typedef struct {
 to use `zxc_seekable_decompress_range_mt()`. The single-threaded path makes no
 concurrent calls.
 
-`zxc_mmap_open()` ([Memory-Mapped API](#memory-mapped-zero-copy-decode)) gives
+`zxc_mmap_open()` ([Memory-Mapped Archive](#memory-mapped-archive-zero-copy-input)) gives
 you the same mapping portably (it also covers Windows), if you would rather not
 call `mmap()` yourself.
 

--- a/include/zxc_error.h
+++ b/include/zxc_error.h
@@ -72,6 +72,9 @@ typedef enum {
     /* Parameter errors */
     ZXC_ERROR_BAD_LEVEL = -18, /**< Compression level not supported by this context's workspace. */
 
+    /* Platform errors */
+    ZXC_ERROR_UNSUPPORTED = -19, /**< Operation unavailable on this platform / build. */
+
 } zxc_error_t;
 
 /**

--- a/include/zxc_mmap.h
+++ b/include/zxc_mmap.h
@@ -33,7 +33,8 @@
  * - No output buffer: the decompressed bytes land in the same region, in front
  *   of the compressed bytes still to be consumed.
  * - Peak footprint is @ref zxc_decompress_inplace_bound, and the region is
- *   trimmed back to the payload before the call returns.
+ *   trimmed back to the payload before the call returns (with one Windows
+ *   exception, see @ref zxc_decompress_mmap).
  *
  * @par Platform support
  * POSIX (Linux, macOS, *BSD, illumos) is zero-copy as described, and so is
@@ -153,7 +154,9 @@ ZXC_EXPORT int zxc_mmap_open_fd(int fd, zxc_map_t* out);
  * @ref zxc_decompress_inplace_bound and decodes left-to-right into its head:
  * the compressed bytes are never copied into a staging buffer, and no separate
  * output buffer is allocated. Once decoding is done the region is trimmed back
- * to the payload, so the caller is left holding exactly the decompressed data.
+ * to the payload, so the caller is left holding exactly the decompressed data
+ * -- except on Windows, where a view is released whole or not at all: a payload
+ * reaching into the archive slot keeps the region until @ref zxc_mmap_close.
  *
  * Dictionary archives are supported: pass the dictionary in @p opts exactly as
  * for @ref zxc_decompress (they decode through the context's own bounce
@@ -161,9 +164,10 @@ ZXC_EXPORT int zxc_mmap_open_fd(int fd, zxc_map_t* out);
  *
  * @note @c out->data is writable and page-aligned, and it is *not* the file's
  *       memory: the mapping is private, so decoding never modifies the archive
- *       on disk. Once the call has returned, nothing in the region is still
- *       backed by the file -- every byte handed back has been written by the
- *       decoder -- so the truncation hazard below does not outlive the call.
+ *       on disk. All @c out->size bytes were written by the decoder, so the
+ *       truncation hazard below does not reach them. It can reach past them --
+ *       the rest of the last page, and the untrimmed tail on Windows -- but
+ *       nothing there is yours to touch.
  * @note *During* the call the archive is mapped, so the usual file-mapping rule
  *       applies: truncating or overwriting the file from another process while
  *       this runs makes the vanished pages fatal to touch (@c SIGBUS), inside
@@ -181,7 +185,8 @@ ZXC_EXPORT int zxc_mmap_open_fd(int fd, zxc_map_t* out);
  * @return Decompressed size in bytes (>= 0), or a negative @ref zxc_error_t
  *         (@ref ZXC_ERROR_IO on open / map failure,
  *         @ref ZXC_ERROR_SRC_TOO_SMALL if the file is shorter than a frame,
- *         @ref ZXC_ERROR_BAD_HEADER if it is not a ZXC archive).
+ *         @ref ZXC_ERROR_BAD_MAGIC or @ref ZXC_ERROR_BAD_HEADER if it is not a
+ *         ZXC archive, @ref ZXC_ERROR_CORRUPT_DATA for a forged footer).
  */
 ZXC_EXPORT int64_t zxc_decompress_mmap(const char* path, zxc_map_t* out,
                                        const zxc_decompress_opts_t* opts);
@@ -191,7 +196,7 @@ ZXC_EXPORT int64_t zxc_decompress_mmap(const char* path, zxc_map_t* out,
  *
  * Same contract as @ref zxc_decompress_mmap, for callers that already hold a
  * descriptor. The whole file is taken to be the archive; the descriptor's file
- * position is irrelevant and left untouched.
+ * position is irrelevant on entry and restored before returning.
  *
  * @param[in]  fd    Readable descriptor on a regular file. On Windows this is a
  *                   CRT file descriptor.

--- a/include/zxc_mmap.h
+++ b/include/zxc_mmap.h
@@ -161,7 +161,15 @@ ZXC_EXPORT int zxc_mmap_open_fd(int fd, zxc_map_t* out);
  *
  * @note @c out->data is writable and page-aligned, and it is *not* the file's
  *       memory: the mapping is private, so decoding never modifies the archive
- *       on disk.
+ *       on disk. Once the call has returned, nothing in the region is still
+ *       backed by the file -- every byte handed back has been written by the
+ *       decoder -- so the truncation hazard below does not outlive the call.
+ * @note *During* the call the archive is mapped, so the usual file-mapping rule
+ *       applies: truncating or overwriting the file from another process while
+ *       this runs makes the vanished pages fatal to touch (@c SIGBUS), inside
+ *       the library. Archives on a network share or a removable volume, and
+ *       files another writer is still appending to, are the realistic cases;
+ *       decode from a private copy if that is a possibility.
  * @note An empty frame (stored size 0) succeeds with @c out->data == NULL and
  *       @c out->size == 0; @ref zxc_mmap_close on it is a no-op.
  *

--- a/include/zxc_mmap.h
+++ b/include/zxc_mmap.h
@@ -1,0 +1,196 @@
+/*
+ * ZXC - High-performance lossless compression
+ *
+ * Copyright (c) 2025-2026 Bertrand Lebonnois and contributors.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/**
+ * @file zxc_mmap.h
+ * @brief Memory-mapped, zero-copy decompression of on-disk archives.
+ *
+ * This header turns the in-place decoder (@ref zxc_decompress_inplace) into a
+ * one-call file API: the archive is *mapped* flush-right into a single region
+ * and decoded left-to-right into the head of that same region. Nothing is
+ * read() into a staging buffer and no second (output) allocation exists, so an
+ * archive decompresses with one mapping and zero copies of the compressed
+ * bytes.
+ *
+ * @par Typical usage
+ * @code
+ * zxc_map_t out;
+ * const int64_t n = zxc_decompress_mmap("payload.zxc", &out, NULL);
+ * if (n < 0) { fprintf(stderr, "%s\n", zxc_error_name((int)n)); return 1; }
+ *
+ * // out.data holds n bytes of decompressed, writable, page-aligned data.
+ * consume(out.data, out.size);
+ * zxc_mmap_close(&out);
+ * @endcode
+ *
+ * @par Why this is cheaper than read() + zxc_decompress()
+ * - No input buffer: compressed pages are faulted in straight from the page
+ *   cache into the buffer the decoder reads from.
+ * - No output buffer: the decompressed bytes land in the same region, in front
+ *   of the compressed bytes still to be consumed.
+ * - Peak footprint is @ref zxc_decompress_inplace_bound, and the region is
+ *   trimmed back to the payload before the call returns.
+ *
+ * @par Platform support
+ * POSIX (Linux, macOS, *BSD, illumos) is zero-copy as described. On Windows
+ * the archive is copied once into the single region (the flush-right file view
+ * requires placeholder mappings); the decode itself is still in-place and no
+ * output allocation is made. Where the platform has no mapping support at all
+ * (freestanding / Emscripten builds), every entry point returns
+ * @ref ZXC_ERROR_UNSUPPORTED and @ref zxc_mmap_supported returns 0.
+ *
+ * @see zxc_buffer.h for @ref zxc_decompress_inplace, the buffer-level primitive
+ *      this API is built on.
+ */
+
+#ifndef ZXC_MMAP_H
+#define ZXC_MMAP_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "zxc_export.h"
+#include "zxc_opts.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @defgroup mmap_api Memory-Mapped API
+ * @brief Zero-copy, single-region decompression of files.
+ * @{
+ */
+
+/**
+ * @brief A library-owned memory region: the result of a mapping call.
+ *
+ * Only @c data and @c size are part of the contract; the remaining fields are
+ * bookkeeping for @ref zxc_mmap_close and must not be modified. Release every
+ * successfully filled @ref zxc_map_t with @ref zxc_mmap_close.
+ */
+typedef struct {
+    void* data;  /**< First byte of the region (page-aligned), or NULL if empty. */
+    size_t size; /**< Number of valid bytes at @c data. */
+
+    /* --- private: owned by the library, do not touch --------------------- */
+    void* map_base;   /**< Private: base address passed to the unmap call. */
+    size_t map_size;  /**< Private: resident length of the mapping in bytes. */
+    void* map_handle; /**< Private: platform mapping handle, or NULL. */
+    int map_kind;     /**< Private: which release path @c map_base needs. */
+} zxc_map_t;
+
+/**
+ * @brief Reports whether this build can map files.
+ *
+ * @return 1 when the mapping entry points are functional, 0 when they all
+ *         return @ref ZXC_ERROR_UNSUPPORTED (freestanding / Emscripten).
+ */
+ZXC_EXPORT int zxc_mmap_supported(void);
+
+/**
+ * @brief Maps a file read-only, without decoding it.
+ *
+ * A zero-copy way to feed an on-disk archive to the buffer API
+ * (@ref zxc_decompress, @ref zxc_get_decompressed_size) or to a
+ * @c zxc_reader_t: the returned bytes are the file's bytes, faulted in on
+ * demand. The mapping outlives the descriptor used to create it.
+ *
+ * @note The region is read-only; writing to it traps.
+ * @note As with any file mapping, truncating the file underneath the mapping
+ *       makes the vanished pages fatal to touch (@c SIGBUS).
+ *
+ * @param[in]  path  Path of the file to map (must be a regular file).
+ * @param[out] out   Receives the mapping; zeroed first, so it is safe to
+ *                   @ref zxc_mmap_close even after a failure.
+ * @return @ref ZXC_OK, or a negative @ref zxc_error_t (@ref ZXC_ERROR_IO if
+ *         the file cannot be opened, stat'ed, or mapped;
+ *         @ref ZXC_ERROR_SRC_TOO_SMALL for an empty file).
+ */
+ZXC_EXPORT int zxc_mmap_open(const char* path, zxc_map_t* out);
+
+/**
+ * @brief Maps an already-open file read-only, without decoding it.
+ *
+ * Same contract as @ref zxc_mmap_open, for callers that already hold a
+ * descriptor (inherited fd, @c fileno of a @c FILE*, a socketpair-passed fd,
+ * ...). The descriptor is only used during the call and may be closed as soon
+ * as it returns; the mapping stays valid.
+ *
+ * @param[in]  fd   Readable descriptor on a regular file. On Windows this is a
+ *                  CRT file descriptor (as returned by @c _open / @c _fileno).
+ * @param[out] out  Receives the mapping (zeroed first).
+ * @return @ref ZXC_OK, or a negative @ref zxc_error_t.
+ */
+ZXC_EXPORT int zxc_mmap_open_fd(int fd, zxc_map_t* out);
+
+/**
+ * @brief Decompresses a file into a single mapped region, in place.
+ *
+ * Maps the archive flush-right into one region sized
+ * @ref zxc_decompress_inplace_bound and decodes left-to-right into its head:
+ * the compressed bytes are never copied into a staging buffer, and no separate
+ * output buffer is allocated. Once decoding is done the region is trimmed back
+ * to the payload, so the caller is left holding exactly the decompressed data.
+ *
+ * Dictionary archives are supported: pass the dictionary in @p opts exactly as
+ * for @ref zxc_decompress (they decode through the context's own bounce
+ * buffer, which does not alias the region).
+ *
+ * @note @c out->data is writable and page-aligned, and it is *not* the file's
+ *       memory: the mapping is private, so decoding never modifies the archive
+ *       on disk.
+ * @note An empty frame (stored size 0) succeeds with @c out->data == NULL and
+ *       @c out->size == 0; @ref zxc_mmap_close on it is a no-op.
+ *
+ * @param[in]  path  Path of the archive to decompress.
+ * @param[out] out   Receives the decompressed region (zeroed first, so it is
+ *                   safe to @ref zxc_mmap_close even after a failure).
+ * @param[in]  opts  Decompression options (checksum verification, dictionary),
+ *                   or NULL for defaults.
+ * @return Decompressed size in bytes (>= 0), or a negative @ref zxc_error_t
+ *         (@ref ZXC_ERROR_IO on open / map failure,
+ *         @ref ZXC_ERROR_SRC_TOO_SMALL if the file is shorter than a frame,
+ *         @ref ZXC_ERROR_BAD_HEADER if it is not a ZXC archive).
+ */
+ZXC_EXPORT int64_t zxc_decompress_mmap(const char* path, zxc_map_t* out,
+                                       const zxc_decompress_opts_t* opts);
+
+/**
+ * @brief Decompresses an already-open file into a single mapped region.
+ *
+ * Same contract as @ref zxc_decompress_mmap, for callers that already hold a
+ * descriptor. The whole file is taken to be the archive; the descriptor's file
+ * position is irrelevant and left untouched.
+ *
+ * @param[in]  fd    Readable descriptor on a regular file. On Windows this is a
+ *                   CRT file descriptor.
+ * @param[out] out   Receives the decompressed region (zeroed first).
+ * @param[in]  opts  Decompression options, or NULL for defaults.
+ * @return Decompressed size in bytes (>= 0), or a negative @ref zxc_error_t.
+ */
+ZXC_EXPORT int64_t zxc_decompress_mmap_fd(int fd, zxc_map_t* out,
+                                          const zxc_decompress_opts_t* opts);
+
+/**
+ * @brief Releases a region obtained from this API and clears @p map.
+ *
+ * Safe to call on a NULL pointer, on a zeroed @ref zxc_map_t, and on a map
+ * whose producing call failed. Never call it twice on the same live mapping
+ * (the clear makes a second call a no-op, not a double free).
+ *
+ * @param[in,out] map  Region to release; zeroed on return.
+ */
+ZXC_EXPORT void zxc_mmap_close(zxc_map_t* map);
+
+/** @} */ /* end of mmap_api */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZXC_MMAP_H */

--- a/include/zxc_mmap.h
+++ b/include/zxc_mmap.h
@@ -36,12 +36,15 @@
  *   trimmed back to the payload before the call returns.
  *
  * @par Platform support
- * POSIX (Linux, macOS, *BSD, illumos) is zero-copy as described. On Windows
- * the archive is copied once into the single region (the flush-right file view
- * requires placeholder mappings); the decode itself is still in-place and no
- * output allocation is made. Where the platform has no mapping support at all
- * (freestanding / Emscripten builds), every entry point returns
- * @ref ZXC_ERROR_UNSUPPORTED and @ref zxc_mmap_supported returns 0.
+ * POSIX (Linux, macOS, *BSD, illumos) is zero-copy as described, and so is
+ * Windows 10 1803 / Server 2019 and later, which reaches the same placement
+ * through placeholder mappings (@c VirtualAlloc2 + @c MapViewOfFile3, resolved
+ * at run time). Older Windows falls back to a single copy of the archive into
+ * the same one region: the decode is still in-place with no output allocation.
+ * @ref zxc_mmap_is_zerocopy reports which route a given result took. Where the
+ * platform has no mapping support at all (freestanding / Emscripten builds),
+ * every entry point returns @ref ZXC_ERROR_UNSUPPORTED and
+ * @ref zxc_mmap_supported returns 0.
  *
  * @see zxc_buffer.h for @ref zxc_decompress_inplace, the buffer-level primitive
  *      this API is built on.
@@ -91,6 +94,21 @@ typedef struct {
  *         return @ref ZXC_ERROR_UNSUPPORTED (freestanding / Emscripten).
  */
 ZXC_EXPORT int zxc_mmap_supported(void);
+
+/**
+ * @brief Reports whether @p map holds its bytes without a copy having been made.
+ *
+ * Always 1 for a successful mapping on POSIX and on Windows 10 1803+; 0 on older
+ * Windows, where @ref zxc_decompress_mmap copies the archive once into its
+ * single region (see @ref zxc_map_t and the platform notes above). Useful to log
+ * which route a deployment actually takes; the result of the call is identical
+ * either way.
+ *
+ * @param[in] map  A map filled by this API, or NULL.
+ * @return 1 when @p map is a live mapping that involved no copy, 0 otherwise
+ *         (including for NULL, a closed, or an empty map).
+ */
+ZXC_EXPORT int zxc_mmap_is_zerocopy(const zxc_map_t* map);
 
 /**
  * @brief Maps a file read-only, without decoding it.

--- a/include/zxc_mmap.h
+++ b/include/zxc_mmap.h
@@ -7,48 +7,39 @@
 
 /**
  * @file zxc_mmap.h
- * @brief Memory-mapped, zero-copy decompression of on-disk archives.
+ * @brief Read-only, zero-copy mappings of on-disk archives.
  *
- * This header turns the in-place decoder (@ref zxc_decompress_inplace) into a
- * one-call file API: the archive is *mapped* flush-right into a single region
- * and decoded left-to-right into the head of that same region. Nothing is
- * read() into a staging buffer and no second (output) allocation exists, so an
- * archive decompresses with one mapping and zero copies of the compressed
- * bytes.
+ * Maps an archive file into memory and hands back the bytes as they are on
+ * disk, faulted in on demand. The point is to feed the buffer API
+ * (@ref zxc_decompress, @ref zxc_get_decompressed_size) or a @c zxc_reader_t
+ * without reading the file into a buffer first.
  *
  * @par Typical usage
  * @code
- * zxc_map_t out;
- * const int64_t n = zxc_decompress_mmap("payload.zxc", &out, NULL);
- * if (n < 0) { fprintf(stderr, "%s\n", zxc_error_name((int)n)); return 1; }
+ * zxc_map_t archive;
+ * if (zxc_mmap_open("payload.zxc", &archive) != ZXC_OK) return 1;
  *
- * // out.data holds n bytes of decompressed, writable, page-aligned data.
- * consume(out.data, out.size);
- * zxc_mmap_close(&out);
+ * const uint64_t n = zxc_get_decompressed_size(archive.data, archive.size);
+ * void* dst = n ? malloc((size_t)n) : NULL;
+ * if (dst) zxc_decompress(archive.data, archive.size, dst, (size_t)n, NULL);
+ *
+ * zxc_mmap_close(&archive);   // the mapping outlived the descriptor
  * @endcode
  *
- * @par Why this is cheaper than read() + zxc_decompress()
- * - No input buffer: compressed pages are faulted in straight from the page
- *   cache into the buffer the decoder reads from.
- * - No output buffer: the decompressed bytes land in the same region, in front
- *   of the compressed bytes still to be consumed.
- * - Peak footprint is @ref zxc_decompress_inplace_bound, and the region is
- *   trimmed back to the payload before the call returns (with one Windows
- *   exception, see @ref zxc_decompress_mmap).
+ * @par Why this composes with the seekable API
+ * A @c read_at that @c memcpy's out of the mapping needs no @c read() syscall
+ * per block and is reentrant, so it is legal on
+ * @c zxc_seekable_decompress_range_mt too. See docs/API.md section 7b.
  *
  * @par Platform support
- * POSIX (Linux, macOS, *BSD, illumos) is zero-copy as described, and so is
- * Windows 10 1803 / Server 2019 and later, which reaches the same placement
- * through placeholder mappings (@c VirtualAlloc2 + @c MapViewOfFile3, resolved
- * at run time). Older Windows falls back to a single copy of the archive into
- * the same one region: the decode is still in-place with no output allocation.
- * @ref zxc_mmap_is_zerocopy reports which route a given result took. Where the
- * platform has no mapping support at all (freestanding / Emscripten builds),
- * every entry point returns @ref ZXC_ERROR_UNSUPPORTED and
- * @ref zxc_mmap_supported returns 0.
+ * POSIX (Linux, macOS, *BSD, illumos) and Windows. Where the platform has no
+ * mapping support at all (freestanding / Emscripten builds), every entry point
+ * returns @ref ZXC_ERROR_UNSUPPORTED and @ref zxc_mmap_supported returns 0.
  *
- * @see zxc_buffer.h for @ref zxc_decompress_inplace, the buffer-level primitive
- *      this API is built on.
+ * @note To decompress a file with a minimal memory footprint, the buffer-level
+ *       @ref zxc_decompress_inplace decodes into a single buffer that holds the
+ *       archive flush-right; see @c zxc_buffer.h. It is not built on this
+ *       header, and it does not carry the truncation hazard a live mapping does.
  */
 
 #ifndef ZXC_MMAP_H
@@ -58,7 +49,6 @@
 #include <stdint.h>
 
 #include "zxc_export.h"
-#include "zxc_opts.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -66,26 +56,24 @@ extern "C" {
 
 /**
  * @defgroup mmap_api Memory-Mapped API
- * @brief Zero-copy, single-region decompression of files.
+ * @brief Zero-copy read-only mappings of archive files.
  * @{
  */
 
 /**
- * @brief A library-owned memory region: the result of a mapping call.
+ * @brief A library-owned mapping: the result of a mapping call.
  *
- * Only @c data and @c size are part of the contract; the remaining fields are
- * bookkeeping for @ref zxc_mmap_close and must not be modified. Release every
- * successfully filled @ref zxc_map_t with @ref zxc_mmap_close.
+ * Only @c data and @c size are part of the contract; the rest is bookkeeping
+ * for @ref zxc_mmap_close and must not be modified. Release every successfully
+ * filled @ref zxc_map_t with @ref zxc_mmap_close.
  */
 typedef struct {
-    void* data;  /**< First byte of the region (page-aligned), or NULL if empty. */
-    size_t size; /**< Number of valid bytes at @c data. */
+    const void* data; /**< First byte of the mapping (page-aligned), or NULL. */
+    size_t size;      /**< Number of valid bytes at @c data. */
 
     /* --- private: owned by the library, do not touch --------------------- */
-    void* map_base;   /**< Private: base address passed to the unmap call. */
-    size_t map_size;  /**< Private: resident length of the mapping in bytes. */
-    void* map_handle; /**< Private: platform mapping handle, or NULL. */
-    int map_kind;     /**< Private: which release path @c map_base needs. */
+    void* map_base;  /**< Private: base address passed to the unmap call. */
+    size_t map_size; /**< Private: length of the mapping in bytes. */
 } zxc_map_t;
 
 /**
@@ -97,31 +85,15 @@ typedef struct {
 ZXC_EXPORT int zxc_mmap_supported(void);
 
 /**
- * @brief Reports whether @p map holds its bytes without a copy having been made.
+ * @brief Maps a file read-only.
  *
- * Always 1 for a successful mapping on POSIX and on Windows 10 1803+; 0 on older
- * Windows, where @ref zxc_decompress_mmap copies the archive once into its
- * single region (see @ref zxc_map_t and the platform notes above). Useful to log
- * which route a deployment actually takes; the result of the call is identical
- * either way.
- *
- * @param[in] map  A map filled by this API, or NULL.
- * @return 1 when @p map is a live mapping that involved no copy, 0 otherwise
- *         (including for NULL, a closed, or an empty map).
- */
-ZXC_EXPORT int zxc_mmap_is_zerocopy(const zxc_map_t* map);
-
-/**
- * @brief Maps a file read-only, without decoding it.
- *
- * A zero-copy way to feed an on-disk archive to the buffer API
- * (@ref zxc_decompress, @ref zxc_get_decompressed_size) or to a
- * @c zxc_reader_t: the returned bytes are the file's bytes, faulted in on
- * demand. The mapping outlives the descriptor used to create it.
+ * The mapping outlives the descriptor used to create it.
  *
  * @note The region is read-only; writing to it traps.
  * @note As with any file mapping, truncating the file underneath the mapping
- *       makes the vanished pages fatal to touch (@c SIGBUS).
+ *       makes the vanished pages fatal to touch (@c SIGBUS). The realistic
+ *       cases are network shares, removable volumes, and files a writer is
+ *       still appending to.
  *
  * @param[in]  path  Path of the file to map (must be a regular file).
  * @param[out] out   Receives the mapping; zeroed first, so it is safe to
@@ -133,12 +105,12 @@ ZXC_EXPORT int zxc_mmap_is_zerocopy(const zxc_map_t* map);
 ZXC_EXPORT int zxc_mmap_open(const char* path, zxc_map_t* out);
 
 /**
- * @brief Maps an already-open file read-only, without decoding it.
+ * @brief Maps an already-open file read-only.
  *
  * Same contract as @ref zxc_mmap_open, for callers that already hold a
  * descriptor (inherited fd, @c fileno of a @c FILE*, a socketpair-passed fd,
  * ...). The descriptor is only used during the call and may be closed as soon
- * as it returns; the mapping stays valid.
+ * as it returns; the mapping stays valid, and its file position is untouched.
  *
  * @param[in]  fd   Readable descriptor on a regular file. On Windows this is a
  *                  CRT file descriptor (as returned by @c _open / @c _fileno).
@@ -148,73 +120,13 @@ ZXC_EXPORT int zxc_mmap_open(const char* path, zxc_map_t* out);
 ZXC_EXPORT int zxc_mmap_open_fd(int fd, zxc_map_t* out);
 
 /**
- * @brief Decompresses a file into a single mapped region, in place.
- *
- * Maps the archive flush-right into one region sized
- * @ref zxc_decompress_inplace_bound and decodes left-to-right into its head:
- * the compressed bytes are never copied into a staging buffer, and no separate
- * output buffer is allocated. Once decoding is done the region is trimmed back
- * to the payload, so the caller is left holding exactly the decompressed data
- * -- except on Windows, where a view is released whole or not at all: a payload
- * reaching into the archive slot keeps the region until @ref zxc_mmap_close.
- *
- * Dictionary archives are supported: pass the dictionary in @p opts exactly as
- * for @ref zxc_decompress (they decode through the context's own bounce
- * buffer, which does not alias the region).
- *
- * @note @c out->data is writable and page-aligned, and it is *not* the file's
- *       memory: the mapping is private, so decoding never modifies the archive
- *       on disk. All @c out->size bytes were written by the decoder, so the
- *       truncation hazard below does not reach them. It can reach past them --
- *       the rest of the last page, and the untrimmed tail on Windows -- but
- *       nothing there is yours to touch.
- * @note *During* the call the archive is mapped, so the usual file-mapping rule
- *       applies: truncating or overwriting the file from another process while
- *       this runs makes the vanished pages fatal to touch (@c SIGBUS), inside
- *       the library. Archives on a network share or a removable volume, and
- *       files another writer is still appending to, are the realistic cases;
- *       decode from a private copy if that is a possibility.
- * @note An empty frame (stored size 0) succeeds with @c out->data == NULL and
- *       @c out->size == 0; @ref zxc_mmap_close on it is a no-op.
- *
- * @param[in]  path  Path of the archive to decompress.
- * @param[out] out   Receives the decompressed region (zeroed first, so it is
- *                   safe to @ref zxc_mmap_close even after a failure).
- * @param[in]  opts  Decompression options (checksum verification, dictionary),
- *                   or NULL for defaults.
- * @return Decompressed size in bytes (>= 0), or a negative @ref zxc_error_t
- *         (@ref ZXC_ERROR_IO on open / map failure,
- *         @ref ZXC_ERROR_SRC_TOO_SMALL if the file is shorter than a frame,
- *         @ref ZXC_ERROR_BAD_MAGIC or @ref ZXC_ERROR_BAD_HEADER if it is not a
- *         ZXC archive, @ref ZXC_ERROR_CORRUPT_DATA for a forged footer).
- */
-ZXC_EXPORT int64_t zxc_decompress_mmap(const char* path, zxc_map_t* out,
-                                       const zxc_decompress_opts_t* opts);
-
-/**
- * @brief Decompresses an already-open file into a single mapped region.
- *
- * Same contract as @ref zxc_decompress_mmap, for callers that already hold a
- * descriptor. The whole file is taken to be the archive; the descriptor's file
- * position is irrelevant on entry and restored before returning.
- *
- * @param[in]  fd    Readable descriptor on a regular file. On Windows this is a
- *                   CRT file descriptor.
- * @param[out] out   Receives the decompressed region (zeroed first).
- * @param[in]  opts  Decompression options, or NULL for defaults.
- * @return Decompressed size in bytes (>= 0), or a negative @ref zxc_error_t.
- */
-ZXC_EXPORT int64_t zxc_decompress_mmap_fd(int fd, zxc_map_t* out,
-                                          const zxc_decompress_opts_t* opts);
-
-/**
- * @brief Releases a region obtained from this API and clears @p map.
+ * @brief Releases a mapping obtained from this API and clears @p map.
  *
  * Safe to call on a NULL pointer, on a zeroed @ref zxc_map_t, and on a map
  * whose producing call failed. Never call it twice on the same live mapping
  * (the clear makes a second call a no-op, not a double free).
  *
- * @param[in,out] map  Region to release; zeroed on return.
+ * @param[in,out] map  Mapping to release; zeroed on return.
  */
 ZXC_EXPORT void zxc_mmap_close(zxc_map_t* map);
 

--- a/meson.build
+++ b/meson.build
@@ -112,6 +112,7 @@ libzxc_sources = files(
   'src/lib/zxc_dict.c',
   'src/lib/zxc_driver.c',
   'src/lib/zxc_dispatch.c',
+  'src/lib/zxc_mmap.c',
   'src/lib/zxc_pstream.c',
   'src/lib/zxc_seekable.c',
 )
@@ -173,6 +174,7 @@ install_headers(
   'include/zxc_dict.h',
   'include/zxc_error.h',
   'include/zxc_export.h',
+  'include/zxc_mmap.h',
   'include/zxc_opts.h',
   'include/zxc_pstream.h',
   'include/zxc_seekable.h',
@@ -220,6 +222,7 @@ if not meson.is_subproject()
       'tests/test_block_api.c',
       'tests/test_context_api.c',
       'tests/test_static_ctx.c',
+      'tests/test_mmap.c',
       'tests/test_pstream_api.c',
       'tests/test_stream_api.c',
       'tests/test_seekable.c',

--- a/src/lib/zxc_common.c
+++ b/src/lib/zxc_common.c
@@ -970,6 +970,8 @@ const char* zxc_error_name(const int code) {
             return "ZXC_ERROR_DICT_TOO_LARGE";
         case ZXC_ERROR_BAD_LEVEL:
             return "ZXC_ERROR_BAD_LEVEL";
+        case ZXC_ERROR_UNSUPPORTED:
+            return "ZXC_ERROR_UNSUPPORTED";
         default:
             return "ZXC_UNKNOWN_ERROR";
     }

--- a/src/lib/zxc_dispatch.c
+++ b/src/lib/zxc_dispatch.c
@@ -1062,26 +1062,69 @@ static uint64_t zxc_inplace_margin(const uint64_t dsize, const size_t chunk_size
  *
  * Keeping this parse in one place guarantees @ref zxc_decompress_inplace_bound
  * and @ref zxc_decompress_inplace always agree on what a buffer of at least
- * the bound must satisfy.
+ * the bound must satisfy. The header and footer are taken separately so a
+ * caller holding neither in one buffer -- the mapped decoder reads the two ends
+ * of the file with two small reads -- shares this exact parse.
  *
- * @param[in]  comp      Compressed archive; only the header and footer are read.
- * @param[in]  comp_size Size of the archive in bytes. The caller guarantees it
- *                       covers at least the file header and footer.
+ * The footer is untrusted input, so its size is checked for plausibility the
+ * same way @ref zxc_get_decompressed_size checks it: an archive of @p comp_size
+ * bytes cannot carry more blocks than `comp_size / ZXC_BLOCK_HEADER_SIZE`, and
+ * each block decodes to at most one block size. Without that check a forged
+ * footer turns straight into an arbitrary allocation (or, for the mapped
+ * decoder, an arbitrary reservation) before decoding ever fails. It also keeps
+ * the block count in @ref zxc_inplace_margin from overflowing.
+ *
+ * @param[in]  head      File header, @ref ZXC_FILE_HEADER_SIZE readable bytes.
+ * @param[in]  foot      File footer, @ref ZXC_FILE_FOOTER_SIZE readable bytes.
+ * @param[in]  comp_size Size of the whole archive in bytes; at least
+ *                       `ZXC_FILE_HEADER_SIZE + ZXC_FILE_FOOTER_SIZE`.
  * @param[out] dsize     Decompressed size read from the footer.
  * @param[out] margin    In-place margin for @p dsize, from @ref zxc_inplace_margin.
  * @return ZXC_OK, or a negative @ref zxc_error_t on an invalid archive.
  */
-static int zxc_inplace_probe(const uint8_t* comp, const size_t comp_size, uint64_t* dsize,
-                             uint64_t* margin) {
-    if (UNLIKELY(zxc_le32(comp) != ZXC_MAGIC_WORD)) return ZXC_ERROR_BAD_MAGIC;
+static int zxc_inplace_parse(const uint8_t* head, const uint8_t* foot, const size_t comp_size,
+                             uint64_t* dsize, uint64_t* margin) {
+    if (UNLIKELY(zxc_le32(head) != ZXC_MAGIC_WORD)) return ZXC_ERROR_BAD_MAGIC;
     size_t chunk_size = 0;
     int has_cs = 0;
     uint32_t did = 0;
-    if (UNLIKELY(zxc_read_file_header(comp, comp_size, &chunk_size, &has_cs, &did) != ZXC_OK))
+    if (UNLIKELY(zxc_read_file_header(head, comp_size, &chunk_size, &has_cs, &did) != ZXC_OK))
         return ZXC_ERROR_BAD_HEADER;
-    *dsize = zxc_le64(comp + comp_size - ZXC_FILE_FOOTER_SIZE);
-    *margin = zxc_inplace_margin(*dsize, chunk_size, has_cs);
+
+    const uint64_t d = zxc_le64(foot);
+    /* Division form keeps the compare overflow-free for a forged size near
+     * UINT64_MAX, where the usual `(d + chunk - 1) / chunk` ceil would wrap. */
+    const uint64_t blocks_needed =
+        chunk_size ? d / (uint64_t)chunk_size + (d % (uint64_t)chunk_size != 0) : 0;
+    if (UNLIKELY(blocks_needed > (uint64_t)(comp_size / ZXC_BLOCK_HEADER_SIZE)))
+        return ZXC_ERROR_CORRUPT_DATA;
+
+    *dsize = d;
+    *margin = zxc_inplace_margin(d, chunk_size, has_cs);
     return ZXC_OK;
+}
+
+/**
+ * @brief @ref zxc_decompress_inplace_bound from the archive's two ends alone.
+ *
+ * Internal entry point for callers that can cheaply read the header and the
+ * footer but would rather not have the whole archive in one buffer -- the
+ * mapped decoder answers the bound with two small reads instead of mapping the
+ * file just to look at 28 bytes of it.
+ *
+ * @param[in] head      File header, @ref ZXC_FILE_HEADER_SIZE readable bytes.
+ * @param[in] foot      File footer, @ref ZXC_FILE_FOOTER_SIZE readable bytes.
+ * @param[in] comp_size Size of the whole archive in bytes.
+ * @return Required buffer size in bytes, or 0 if the archive is not valid.
+ */
+size_t zxc_inplace_bound_parts(const uint8_t* head, const uint8_t* foot, const size_t comp_size) {
+    if (UNLIKELY(!head || !foot || comp_size < ZXC_FILE_HEADER_SIZE + ZXC_FILE_FOOTER_SIZE))
+        return 0;
+    uint64_t dsize = 0;
+    uint64_t margin = 0;
+    if (UNLIKELY(zxc_inplace_parse(head, foot, comp_size, &dsize, &margin) != ZXC_OK)) return 0;
+    if (UNLIKELY(margin > (uint64_t)SIZE_MAX || dsize > (uint64_t)SIZE_MAX - margin)) return 0;
+    return (size_t)(dsize + margin);
 }
 
 /**
@@ -1101,12 +1144,8 @@ static int zxc_inplace_probe(const uint8_t* comp, const size_t comp_size, uint64
 // cppcheck-suppress unusedFunction
 size_t zxc_decompress_inplace_bound(const void* src, const size_t src_size) {
     if (UNLIKELY(!src || src_size < ZXC_FILE_HEADER_SIZE + ZXC_FILE_FOOTER_SIZE)) return 0;
-    uint64_t dsize = 0;
-    uint64_t margin = 0;
-    if (UNLIKELY(zxc_inplace_probe((const uint8_t*)src, src_size, &dsize, &margin) != ZXC_OK))
-        return 0;
-    if (UNLIKELY(margin > (uint64_t)SIZE_MAX || dsize > (uint64_t)SIZE_MAX - margin)) return 0;
-    return (size_t)(dsize + margin);
+    const uint8_t* const p = (const uint8_t*)src;
+    return zxc_inplace_bound_parts(p, p + src_size - ZXC_FILE_FOOTER_SIZE, src_size);
 }
 
 /**
@@ -1139,7 +1178,8 @@ int64_t zxc_decompress_inplace(void* buffer, const size_t buffer_capacity, const
     const uint8_t* const comp = buf + (buffer_capacity - comp_size); /* flush-right */
     uint64_t dsize = 0;
     uint64_t margin = 0;
-    if (UNLIKELY(zxc_inplace_probe(comp, comp_size, &dsize, &margin) != ZXC_OK))
+    if (UNLIKELY(zxc_inplace_parse(comp, comp + comp_size - ZXC_FILE_FOOTER_SIZE, comp_size, &dsize,
+                                   &margin) != ZXC_OK))
         return ZXC_ERROR_BAD_HEADER;
     if (UNLIKELY(dsize > (uint64_t)buffer_capacity || (uint64_t)buffer_capacity - dsize < margin))
         return ZXC_ERROR_DST_TOO_SMALL;

--- a/src/lib/zxc_dispatch.c
+++ b/src/lib/zxc_dispatch.c
@@ -1017,6 +1017,33 @@ static int64_t zxc_decompress_frame(const uint8_t* src, const size_t src_size, u
 }
 
 /**
+ * @brief Whether a footer's decompressed size is reachable for this archive.
+ *
+ * The footer is untrusted, and a forged size becomes an arbitrary allocation --
+ * or, for the mapped decoder, an arbitrary reservation -- before decoding ever
+ * fails. Every block costs at least @ref ZXC_BLOCK_HEADER_SIZE compressed bytes
+ * and decodes to at most one block size, which bounds the ratio an authentic
+ * archive can reach. It also keeps the block count in @ref zxc_inplace_margin
+ * from overflowing. Shared by @ref zxc_inplace_parse and
+ * @ref zxc_get_decompressed_size so the two cannot drift apart.
+ *
+ * The division form keeps the compare overflow-free: the usual ceil wraps on a
+ * forged @p dsize near @c UINT64_MAX.
+ *
+ * @param[in] dsize      Decompressed size read from the footer.
+ * @param[in] chunk_size Block size from the file header; never 0 after a
+ *                       @ref ZXC_OK from @ref zxc_read_file_header.
+ * @param[in] comp_size  Size of the whole archive in bytes.
+ * @return 1 when @p dsize is reachable, 0 for a forged footer.
+ */
+static int zxc_footer_dsize_plausible(const uint64_t dsize, const size_t chunk_size,
+                                      const size_t comp_size) {
+    const uint64_t blocks_needed =
+        dsize / (uint64_t)chunk_size + (dsize % (uint64_t)chunk_size != 0);
+    return blocks_needed <= (uint64_t)(comp_size / ZXC_BLOCK_HEADER_SIZE);
+}
+
+/**
  * @brief Bytes an in-place decode needs on top of the decompressed size.
  *
  * Flush-right placement puts block 0 at `capacity - comp_size`, so the read
@@ -1066,13 +1093,8 @@ static uint64_t zxc_inplace_margin(const uint64_t dsize, const size_t chunk_size
  * caller holding neither in one buffer -- the mapped decoder reads the two ends
  * of the file with two small reads -- shares this exact parse.
  *
- * The footer is untrusted input, so its size is checked for plausibility the
- * same way @ref zxc_get_decompressed_size checks it: an archive of @p comp_size
- * bytes cannot carry more blocks than `comp_size / ZXC_BLOCK_HEADER_SIZE`, and
- * each block decodes to at most one block size. Without that check a forged
- * footer turns straight into an arbitrary allocation (or, for the mapped
- * decoder, an arbitrary reservation) before decoding ever fails. It also keeps
- * the block count in @ref zxc_inplace_margin from overflowing.
+ * The footer is untrusted input, so its size goes through the same
+ * @ref zxc_footer_dsize_plausible check @ref zxc_get_decompressed_size applies.
  *
  * @param[in]  head      File header, @ref ZXC_FILE_HEADER_SIZE readable bytes.
  * @param[in]  foot      File footer, @ref ZXC_FILE_FOOTER_SIZE readable bytes.
@@ -1092,11 +1114,7 @@ static int zxc_inplace_parse(const uint8_t* head, const uint8_t* foot, const siz
         return ZXC_ERROR_BAD_HEADER;
 
     const uint64_t d = zxc_le64(foot);
-    /* Division form keeps the compare overflow-free for a forged size near
-     * UINT64_MAX, where the usual `(d + chunk - 1) / chunk` ceil would wrap. */
-    const uint64_t blocks_needed =
-        chunk_size ? d / (uint64_t)chunk_size + (d % (uint64_t)chunk_size != 0) : 0;
-    if (UNLIKELY(blocks_needed > (uint64_t)(comp_size / ZXC_BLOCK_HEADER_SIZE)))
+    if (UNLIKELY(!zxc_footer_dsize_plausible(d, chunk_size, comp_size)))
         return ZXC_ERROR_CORRUPT_DATA;
 
     *dsize = d;
@@ -1112,19 +1130,29 @@ static int zxc_inplace_parse(const uint8_t* head, const uint8_t* foot, const siz
  * mapped decoder answers the bound with two small reads instead of mapping the
  * file just to look at 28 bytes of it.
  *
- * @param[in] head      File header, @ref ZXC_FILE_HEADER_SIZE readable bytes.
- * @param[in] foot      File footer, @ref ZXC_FILE_FOOTER_SIZE readable bytes.
- * @param[in] comp_size Size of the whole archive in bytes.
- * @return Required buffer size in bytes, or 0 if the archive is not valid.
+ * @param[in]  head      File header, @ref ZXC_FILE_HEADER_SIZE readable bytes.
+ * @param[in]  foot      File footer, @ref ZXC_FILE_FOOTER_SIZE readable bytes.
+ * @param[in]  comp_size Size of the whole archive in bytes.
+ * @param[out] out_bound Receives the required buffer size; written only on
+ *                       @ref ZXC_OK.
+ * @return @ref ZXC_OK, or the @ref zxc_inplace_parse verdict for an invalid
+ *         archive -- @ref ZXC_ERROR_NULL_INPUT / @ref ZXC_ERROR_SRC_TOO_SMALL
+ *         for the arguments themselves, and @ref ZXC_ERROR_MEMORY for a bound
+ *         the address space cannot hold.
  */
-size_t zxc_inplace_bound_parts(const uint8_t* head, const uint8_t* foot, const size_t comp_size) {
-    if (UNLIKELY(!head || !foot || comp_size < ZXC_FILE_HEADER_SIZE + ZXC_FILE_FOOTER_SIZE))
-        return 0;
+int zxc_inplace_bound_parts(const uint8_t* head, const uint8_t* foot, const size_t comp_size,
+                            size_t* const out_bound) {
+    if (UNLIKELY(!head || !foot || !out_bound)) return ZXC_ERROR_NULL_INPUT;
+    if (UNLIKELY(comp_size < ZXC_FILE_HEADER_SIZE + ZXC_FILE_FOOTER_SIZE))
+        return ZXC_ERROR_SRC_TOO_SMALL;
     uint64_t dsize = 0;
     uint64_t margin = 0;
-    if (UNLIKELY(zxc_inplace_parse(head, foot, comp_size, &dsize, &margin) != ZXC_OK)) return 0;
-    if (UNLIKELY(margin > (uint64_t)SIZE_MAX || dsize > (uint64_t)SIZE_MAX - margin)) return 0;
-    return (size_t)(dsize + margin);
+    const int rc = zxc_inplace_parse(head, foot, comp_size, &dsize, &margin);
+    if (UNLIKELY(rc != ZXC_OK)) return rc;
+    if (UNLIKELY(margin > (uint64_t)SIZE_MAX || dsize > (uint64_t)SIZE_MAX - margin))
+        return ZXC_ERROR_MEMORY;
+    *out_bound = (size_t)(dsize + margin);
+    return ZXC_OK;
 }
 
 /**
@@ -1143,9 +1171,15 @@ size_t zxc_inplace_bound_parts(const uint8_t* head, const uint8_t* foot, const s
  */
 // cppcheck-suppress unusedFunction
 size_t zxc_decompress_inplace_bound(const void* src, const size_t src_size) {
+    /* Not the duplicate it looks like: the footer pointer below is undefined for
+     * a NULL src or a src_size under ZXC_FILE_FOOTER_SIZE, so it has to be ruled
+     * out here, before zxc_inplace_bound_parts gets a chance to. */
     if (UNLIKELY(!src || src_size < ZXC_FILE_HEADER_SIZE + ZXC_FILE_FOOTER_SIZE)) return 0;
     const uint8_t* const p = (const uint8_t*)src;
-    return zxc_inplace_bound_parts(p, p + src_size - ZXC_FILE_FOOTER_SIZE, src_size);
+    size_t bound = 0;
+    const int rc =
+        zxc_inplace_bound_parts(p, p + src_size - ZXC_FILE_FOOTER_SIZE, src_size, &bound);
+    return (rc == ZXC_OK) ? bound : 0;
 }
 
 /**
@@ -1165,8 +1199,11 @@ size_t zxc_decompress_inplace_bound(const void* src, const size_t src_size) {
  * @param[in]     buffer_capacity  Total size of @p buffer in bytes.
  * @param[in]     comp_size        Size of the compressed archive in bytes.
  * @param[in]     opts             Decompression options, or NULL for defaults.
- * @return Decompressed size in bytes, or a negative @ref zxc_error_t code
- *         (`ZXC_ERROR_DST_TOO_SMALL` if the buffer lacks the safety margin).
+ * @return Decompressed size in bytes, or a negative @ref zxc_error_t code:
+ *         @ref ZXC_ERROR_DST_TOO_SMALL if the buffer lacks the safety margin,
+ *         otherwise the @ref zxc_inplace_parse verdict -- @ref ZXC_ERROR_BAD_MAGIC,
+ *         @ref ZXC_ERROR_BAD_HEADER, or @ref ZXC_ERROR_CORRUPT_DATA for a
+ *         forged footer.
  */
 // cppcheck-suppress unusedFunction
 int64_t zxc_decompress_inplace(void* buffer, const size_t buffer_capacity, const size_t comp_size,
@@ -1178,9 +1215,9 @@ int64_t zxc_decompress_inplace(void* buffer, const size_t buffer_capacity, const
     const uint8_t* const comp = buf + (buffer_capacity - comp_size); /* flush-right */
     uint64_t dsize = 0;
     uint64_t margin = 0;
-    if (UNLIKELY(zxc_inplace_parse(comp, comp + comp_size - ZXC_FILE_FOOTER_SIZE, comp_size, &dsize,
-                                   &margin) != ZXC_OK))
-        return ZXC_ERROR_BAD_HEADER;
+    const int rc = zxc_inplace_parse(comp, comp + comp_size - ZXC_FILE_FOOTER_SIZE, comp_size,
+                                     &dsize, &margin);
+    if (UNLIKELY(rc != ZXC_OK)) return rc;
     if (UNLIKELY(dsize > (uint64_t)buffer_capacity || (uint64_t)buffer_capacity - dsize < margin))
         return ZXC_ERROR_DST_TOO_SMALL;
     return zxc_decompress_frame(comp, comp_size, buf, buffer_capacity, opts);
@@ -1189,13 +1226,10 @@ int64_t zxc_decompress_inplace(void* buffer, const size_t buffer_capacity, const
 /**
  * @brief Reads the decompressed size from a ZXC-compressed buffer.
  *
- * The size is stored in the file footer (last @ref ZXC_FILE_FOOTER_SIZE bytes).
- * The footer is untrusted input, so the value is checked for plausibility
- * against the archive itself: every decoded block costs at least
- * @ref ZXC_BLOCK_HEADER_SIZE compressed bytes and expands to at most one
- * block size, which bounds the ratio an authentic archive can reach. A size
- * beyond that bound (a forged footer) returns 0, so callers sizing an output
- * allocation from this value inherit the check.
+ * The size is stored in the file footer (last @ref ZXC_FILE_FOOTER_SIZE bytes)
+ * and is untrusted, so it goes through @ref zxc_footer_dsize_plausible: a
+ * forged size returns 0, and callers sizing an output allocation from this
+ * value inherit the check.
  *
  * @param[in] src      Compressed data.
  * @param[in] src_size Size of @p src in bytes.
@@ -1215,12 +1249,7 @@ uint64_t zxc_get_decompressed_size(const void* src, const size_t src_size) {
     const uint8_t* const footer = p + src_size - ZXC_FILE_FOOTER_SIZE;
     const uint64_t dsize = zxc_le64(footer);
 
-    /* Plausibility: at most src_size / ZXC_BLOCK_HEADER_SIZE blocks, each
-     * decoding to at most chunk_size. The division form keeps the compare
-     * overflow-free - a ceil would wrap on a forged dsize near UINT64_MAX. */
-    const uint64_t blocks_needed =
-        chunk_size ? dsize / (uint64_t)chunk_size + (dsize % (uint64_t)chunk_size != 0) : 0;
-    if (UNLIKELY(blocks_needed > (uint64_t)(src_size / ZXC_BLOCK_HEADER_SIZE))) return 0;
+    if (UNLIKELY(!zxc_footer_dsize_plausible(dsize, chunk_size, src_size))) return 0;
 
     return dsize;
 }

--- a/src/lib/zxc_dispatch.c
+++ b/src/lib/zxc_dispatch.c
@@ -1123,39 +1123,6 @@ static int zxc_inplace_parse(const uint8_t* head, const uint8_t* foot, const siz
 }
 
 /**
- * @brief @ref zxc_decompress_inplace_bound from the archive's two ends alone.
- *
- * Internal entry point for callers that can cheaply read the header and the
- * footer but would rather not have the whole archive in one buffer -- the
- * mapped decoder answers the bound with two small reads instead of mapping the
- * file just to look at 28 bytes of it.
- *
- * @param[in]  head      File header, @ref ZXC_FILE_HEADER_SIZE readable bytes.
- * @param[in]  foot      File footer, @ref ZXC_FILE_FOOTER_SIZE readable bytes.
- * @param[in]  comp_size Size of the whole archive in bytes.
- * @param[out] out_bound Receives the required buffer size; written only on
- *                       @ref ZXC_OK.
- * @return @ref ZXC_OK, or the @ref zxc_inplace_parse verdict for an invalid
- *         archive -- @ref ZXC_ERROR_NULL_INPUT / @ref ZXC_ERROR_SRC_TOO_SMALL
- *         for the arguments themselves, and @ref ZXC_ERROR_MEMORY for a bound
- *         the address space cannot hold.
- */
-int zxc_inplace_bound_parts(const uint8_t* head, const uint8_t* foot, const size_t comp_size,
-                            size_t* const out_bound) {
-    if (UNLIKELY(!head || !foot || !out_bound)) return ZXC_ERROR_NULL_INPUT;
-    if (UNLIKELY(comp_size < ZXC_FILE_HEADER_SIZE + ZXC_FILE_FOOTER_SIZE))
-        return ZXC_ERROR_SRC_TOO_SMALL;
-    uint64_t dsize = 0;
-    uint64_t margin = 0;
-    const int rc = zxc_inplace_parse(head, foot, comp_size, &dsize, &margin);
-    if (UNLIKELY(rc != ZXC_OK)) return rc;
-    if (UNLIKELY(margin > (uint64_t)SIZE_MAX || dsize > (uint64_t)SIZE_MAX - margin))
-        return ZXC_ERROR_MEMORY;
-    *out_bound = (size_t)(dsize + margin);
-    return ZXC_OK;
-}
-
-/**
  * @brief Minimum single-buffer size for a safe in-place decode of @p src.
  *
  * Reads the archive header (block size) and footer (decompressed size) without
@@ -1171,15 +1138,15 @@ int zxc_inplace_bound_parts(const uint8_t* head, const uint8_t* foot, const size
  */
 // cppcheck-suppress unusedFunction
 size_t zxc_decompress_inplace_bound(const void* src, const size_t src_size) {
-    /* Not the duplicate it looks like: the footer pointer below is undefined for
-     * a NULL src or a src_size under ZXC_FILE_FOOTER_SIZE, so it has to be ruled
-     * out here, before zxc_inplace_bound_parts gets a chance to. */
     if (UNLIKELY(!src || src_size < ZXC_FILE_HEADER_SIZE + ZXC_FILE_FOOTER_SIZE)) return 0;
     const uint8_t* const p = (const uint8_t*)src;
-    size_t bound = 0;
-    const int rc =
-        zxc_inplace_bound_parts(p, p + src_size - ZXC_FILE_FOOTER_SIZE, src_size, &bound);
-    return (rc == ZXC_OK) ? bound : 0;
+    uint64_t dsize = 0;
+    uint64_t margin = 0;
+    if (UNLIKELY(zxc_inplace_parse(p, p + src_size - ZXC_FILE_FOOTER_SIZE, src_size, &dsize,
+                                   &margin) != ZXC_OK))
+        return 0;
+    if (UNLIKELY(margin > (uint64_t)SIZE_MAX || dsize > (uint64_t)SIZE_MAX - margin)) return 0;
+    return (size_t)(dsize + margin);
 }
 
 /**

--- a/src/lib/zxc_internal.h
+++ b/src/lib/zxc_internal.h
@@ -1946,25 +1946,6 @@ int zxc_read_file_header(const uint8_t* RESTRICT src, const size_t src_size, siz
                          int* out_has_checksum, uint32_t* out_dict_id);
 
 /**
- * @brief @c zxc_decompress_inplace_bound from the archive's two ends alone.
- *
- * Same parse, same validation and same result as the public bound, for callers
- * that hold the file header and the file footer separately instead of having
- * the whole archive in one buffer. The mapped decoder (@c zxc_mmap.c) uses it
- * to size its region from two small reads rather than mapping the file twice.
- *
- * @param[in]  head      File header, @c ZXC_FILE_HEADER_SIZE readable bytes.
- * @param[in]  foot      File footer, @c ZXC_FILE_FOOTER_SIZE readable bytes.
- * @param[in]  comp_size Size of the whole archive in bytes.
- * @param[out] out_bound Receives the required buffer size; written only on
- *                       @c ZXC_OK.
- * @return @c ZXC_OK, or the negative @c zxc_error_t saying why the archive was
- *         refused; the mapped decoder passes it straight to its caller.
- */
-int zxc_inplace_bound_parts(const uint8_t* head, const uint8_t* foot, const size_t comp_size,
-                            size_t* out_bound);
-
-/**
  * @brief Encodes a block header into @p dst.
  *
  * Serialises the contents of a @ref zxc_block_header_t structure into a byte

--- a/src/lib/zxc_internal.h
+++ b/src/lib/zxc_internal.h
@@ -1946,6 +1946,21 @@ int zxc_read_file_header(const uint8_t* RESTRICT src, const size_t src_size, siz
                          int* out_has_checksum, uint32_t* out_dict_id);
 
 /**
+ * @brief @c zxc_decompress_inplace_bound from the archive's two ends alone.
+ *
+ * Same parse, same validation and same result as the public bound, for callers
+ * that hold the file header and the file footer separately instead of having
+ * the whole archive in one buffer. The mapped decoder (@c zxc_mmap.c) uses it
+ * to size its region from two small reads rather than mapping the file twice.
+ *
+ * @param[in] head      File header, @c ZXC_FILE_HEADER_SIZE readable bytes.
+ * @param[in] foot      File footer, @c ZXC_FILE_FOOTER_SIZE readable bytes.
+ * @param[in] comp_size Size of the whole archive in bytes.
+ * @return Required buffer size in bytes, or 0 if the archive is not valid.
+ */
+size_t zxc_inplace_bound_parts(const uint8_t* head, const uint8_t* foot, const size_t comp_size);
+
+/**
  * @brief Encodes a block header into @p dst.
  *
  * Serialises the contents of a @ref zxc_block_header_t structure into a byte

--- a/src/lib/zxc_internal.h
+++ b/src/lib/zxc_internal.h
@@ -1953,12 +1953,16 @@ int zxc_read_file_header(const uint8_t* RESTRICT src, const size_t src_size, siz
  * the whole archive in one buffer. The mapped decoder (@c zxc_mmap.c) uses it
  * to size its region from two small reads rather than mapping the file twice.
  *
- * @param[in] head      File header, @c ZXC_FILE_HEADER_SIZE readable bytes.
- * @param[in] foot      File footer, @c ZXC_FILE_FOOTER_SIZE readable bytes.
- * @param[in] comp_size Size of the whole archive in bytes.
- * @return Required buffer size in bytes, or 0 if the archive is not valid.
+ * @param[in]  head      File header, @c ZXC_FILE_HEADER_SIZE readable bytes.
+ * @param[in]  foot      File footer, @c ZXC_FILE_FOOTER_SIZE readable bytes.
+ * @param[in]  comp_size Size of the whole archive in bytes.
+ * @param[out] out_bound Receives the required buffer size; written only on
+ *                       @c ZXC_OK.
+ * @return @c ZXC_OK, or the negative @c zxc_error_t saying why the archive was
+ *         refused; the mapped decoder passes it straight to its caller.
  */
-size_t zxc_inplace_bound_parts(const uint8_t* head, const uint8_t* foot, const size_t comp_size);
+int zxc_inplace_bound_parts(const uint8_t* head, const uint8_t* foot, const size_t comp_size,
+                            size_t* out_bound);
 
 /**
  * @brief Encodes a block header into @p dst.

--- a/src/lib/zxc_mmap.c
+++ b/src/lib/zxc_mmap.c
@@ -81,6 +81,7 @@
 #include "zxc_internal.h"
 
 #if defined(ZXC_MMAP_POSIX)
+#include <errno.h>
 #include <fcntl.h>
 #include <sys/mman.h>
 #include <sys/stat.h>
@@ -325,7 +326,10 @@ static int zxc_desc_read_at(const zxc_desc_t d, void* const buf, const size_t le
     uint64_t at = offset;
     while (left > 0) {
         const ssize_t n = pread(d, p, left, (off_t)at);
-        if (UNLIKELY(n <= 0)) return ZXC_ERROR_IO;  // LCOV_EXCL_LINE
+        /* A handler without SA_RESTART interrupts pread on slow storage
+         * (NFS, FUSE); that is not a failed archive. */
+        if (UNLIKELY(n < 0 && errno == EINTR)) continue;  // LCOV_EXCL_LINE
+        if (UNLIKELY(n <= 0)) return ZXC_ERROR_IO;        // LCOV_EXCL_LINE
         p += (size_t)n;
         at += (uint64_t)n;
         left -= (size_t)n;
@@ -622,8 +626,10 @@ typedef struct {
  *
  * The answer cannot change while the process lives, so it is cached: a caller
  * decompressing many small archives would otherwise take the loader lock three
- * times per file. The cache is written idempotently -- two threads racing here
- * resolve the same pointers and store the same bytes -- so no lock is needed.
+ * times per file. Publishing it needs ordering, not just idempotency -- with
+ * plain stores a reader can see the flag over a still-empty cache -- hence the
+ * Interlocked pair, a full barrier at any @c _WIN32_WINNT and on every
+ * toolchain. Two threads may both resolve and write identical bytes; harmless.
  *
  * @param[out] fns  Receives both entry points; cleared first, so the struct is
  *                  never left holding one resolved pointer and one stale value.
@@ -632,9 +638,10 @@ typedef struct {
  */
 static int zxc_win_ext_resolve(zxc_win_ext_t* const fns) {
     static zxc_win_ext_t g_cache;
-    static int g_resolved; /* 0 = not tried, 1 = available, -1 = unavailable */
+    static volatile LONG g_state; /* 0 = not tried, 1 = available, -1 = unavailable */
 
-    const int state = g_resolved;
+    /* Acquire: a published state implies g_cache is written. */
+    const LONG state = InterlockedCompareExchange(&g_state, 0, 0);
     if (state != 0) {
         *fns = g_cache;
         return (state > 0) ? ZXC_OK : ZXC_ERROR_UNSUPPORTED;
@@ -646,21 +653,22 @@ static int zxc_win_ext_resolve(zxc_win_ext_t* const fns) {
     HMODULE mod = GetModuleHandleW(L"kernelbase.dll");
     if (!mod) mod = GetModuleHandleW(L"kernel32.dll");
     if (!mod) {
-        g_resolved = -1;
+        (void)InterlockedExchange(&g_state, -1);
         return ZXC_ERROR_UNSUPPORTED;
     }
 
     const FARPROC p_alloc2 = GetProcAddress(mod, "VirtualAlloc2");
     const FARPROC p_map3 = GetProcAddress(mod, "MapViewOfFile3");
     if (!p_alloc2 || !p_map3) {
-        g_resolved = -1;
+        (void)InterlockedExchange(&g_state, -1);
         return ZXC_ERROR_UNSUPPORTED;
     }
 
     ZXC_MEMCPY(&fns->alloc2, &p_alloc2, sizeof(fns->alloc2));
     ZXC_MEMCPY(&fns->map3, &p_map3, sizeof(fns->map3));
     g_cache = *fns;
-    g_resolved = 1;
+    /* Release: publish only once g_cache is whole. */
+    (void)InterlockedExchange(&g_state, 1);
     return ZXC_OK;
 }
 
@@ -795,9 +803,11 @@ static int zxc_map_readonly(const zxc_desc_t d, zxc_map_t* const out) {
 /**
  * @brief Reads exactly @p len bytes at @p offset, short reads included.
  *
- * The offset travels in the @c OVERLAPPED block rather than through a seek, so
- * the caller's CRT descriptor keeps its file position -- the same promise the
- * POSIX backend gets from @c pread.
+ * An @c OVERLAPPED offset is not the Windows @c pread: on a synchronous handle
+ * -- what @ref zxc_desc_open and a CRT descriptor both give -- the file pointer
+ * still moves to the end of every transfer, which would reposition the caller's
+ * descriptor. It is saved and restored instead. @c SetFilePointerEx fails on a
+ * handle that has no position (a pipe), which is the guard.
  *
  * @param[in]  d       Handle to read from.
  * @param[out] buf     Destination for @p len bytes.
@@ -807,21 +817,36 @@ static int zxc_map_readonly(const zxc_desc_t d, zxc_map_t* const out) {
  */
 static int zxc_desc_read_at(const zxc_desc_t d, void* const buf, const size_t len,
                             const uint64_t offset) {
+    LARGE_INTEGER saved;
+    LARGE_INTEGER zero;
+    saved.QuadPart = 0;
+    zero.QuadPart = 0;
+    const BOOL restore = SetFilePointerEx(d, zero, &saved, FILE_CURRENT);
+
     uint8_t* p = (uint8_t*)buf;
     size_t left = len;
     uint64_t at = offset;
+    int rc = ZXC_OK;
     while (left > 0) {
         OVERLAPPED ov;
         ZXC_MEMSET(&ov, 0, sizeof(ov));
         ov.Offset = (DWORD)(at & 0xFFFFFFFFU);
         ov.OffsetHigh = (DWORD)(at >> 32);
+        /* Clamped, not cast: a remaining length that is a multiple of 4 GiB
+         * truncates to a 0-byte request, i.e. a spurious ZXC_ERROR_IO. */
+        const DWORD want = (left > 0x40000000U) ? 0x40000000U : (DWORD)left;
         DWORD got = 0;
-        if (UNLIKELY(!ReadFile(d, p, (DWORD)left, &got, &ov) || got == 0)) return ZXC_ERROR_IO;
+        if (UNLIKELY(!ReadFile(d, p, want, &got, &ov) || got == 0)) {
+            rc = ZXC_ERROR_IO;
+            break;
+        }
         p += got;
         at += got;
         left -= got;
     }
-    return ZXC_OK;
+
+    if (restore) (void)SetFilePointerEx(d, saved, NULL, FILE_BEGIN);
+    return rc;
 }
 
 /**
@@ -896,28 +921,31 @@ static void zxc_map_unplace(uint8_t* const base, const size_t region, void* cons
 /**
  * @brief Gives back everything the decoded payload does not occupy.
  *
- * A view is released as a whole, so the archive slot can only go back when the
- * payload ends before that slot begins; the private part is decommitted either
- * way. Whatever survives is released by @ref zxc_map_release at close.
+ * Windows has no partial @c UnmapViewOfFile, so the archive slot only goes back
+ * when the payload ends before it begins: a payload reaching into the slot keeps
+ * the whole region, since `[keep, region)` cannot go back while `[off, keep)`
+ * holds decoded bytes. The copying route has no view and always decommits its
+ * tail. What survives is released by @ref zxc_map_release.
  *
  * @param[in]     base    Region base from @ref zxc_map_place.
  * @param[in]     off     Flush-right offset: where the archive slot begins.
  * @param[in]     region  Full region size in bytes.
  * @param[in]     keep    Page-rounded payload size to keep.
  * @param[in,out] handle  Archive view; cleared if this call unmapped it.
- * @return Bytes still mapped at @p base, i.e. @p keep.
+ * @return Bytes still mapped at @p base: @p keep once the tail is back,
+ *         @p region when the view could not be given up.
  */
 static size_t zxc_map_trim(uint8_t* const base, const size_t off, const size_t region,
                            const size_t keep, void** const handle) {
-    if (*handle) {
-        if (keep <= off) {
-            (void)UnmapViewOfFile(*handle);
-            *handle = NULL;
-            if (keep < off) (void)VirtualFree(base + keep, off - keep, MEM_DECOMMIT);
-        }
-    } else if (keep < region) {
-        (void)VirtualFree(base + keep, region - keep, MEM_DECOMMIT);
+    if (!*handle) {
+        if (keep < region) (void)VirtualFree(base + keep, region - keep, MEM_DECOMMIT);
+        return keep;
     }
+    if (keep > off) return region;
+
+    (void)UnmapViewOfFile(*handle);
+    *handle = NULL;
+    if (keep < off) (void)VirtualFree(base + keep, off - keep, MEM_DECOMMIT);
     return keep;
 }
 
@@ -959,7 +987,9 @@ static void zxc_map_release(zxc_map_t* const m) {
  *                        it covers a file header and a footer.
  * @param[out] need       Receives the in-place bound in bytes.
  * @return @ref ZXC_OK, @ref ZXC_ERROR_IO if the two ends cannot be read, or
- *         @ref ZXC_ERROR_BAD_HEADER if they do not describe a ZXC archive.
+ *         the verdict @ref zxc_inplace_bound_parts reached on an archive it
+ *         refused (@ref ZXC_ERROR_BAD_MAGIC, @ref ZXC_ERROR_BAD_HEADER,
+ *         @ref ZXC_ERROR_CORRUPT_DATA for a forged footer).
  */
 static int zxc_map_bound(const zxc_desc_t d, const size_t comp_size, size_t* const need) {
     uint8_t head[ZXC_FILE_HEADER_SIZE];
@@ -970,10 +1000,7 @@ static int zxc_map_bound(const zxc_desc_t d, const size_t comp_size, size_t* con
     rc = zxc_desc_read_at(d, foot, sizeof(foot), (uint64_t)comp_size - ZXC_FILE_FOOTER_SIZE);
     if (UNLIKELY(rc != ZXC_OK)) return rc;  // LCOV_EXCL_LINE
 
-    const size_t n = zxc_inplace_bound_parts(head, foot, comp_size);
-    if (UNLIKELY(n == 0)) return ZXC_ERROR_BAD_HEADER;
-    *need = n;
-    return ZXC_OK;
+    return zxc_inplace_bound_parts(head, foot, comp_size, need);
 }
 
 /**

--- a/src/lib/zxc_mmap.c
+++ b/src/lib/zxc_mmap.c
@@ -1,0 +1,589 @@
+/*
+ * ZXC - High-performance lossless compression
+ *
+ * Copyright (c) 2025-2026 Bertrand Lebonnois and contributors.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/**
+ * @file zxc_mmap.c
+ * @brief Memory-mapped, zero-copy in-place decompression of files.
+ *
+ * The whole subsystem is a thin OS layer over @ref zxc_decompress_inplace: the
+ * buffer-level decoder already tolerates a flush-right archive overlapping its
+ * own output, so all that is missing to decode a file without copying it is a
+ * way to *place* the archive at the right end of a single region.
+ *
+ * @par POSIX geometry (true zero-copy)
+ * @code
+ *   base                                     base+off              base+region
+ *     |<---------- decoded output ----------->|<--- archive ------->|
+ *     [ anonymous, private, zero-filled       | MAP_FIXED file view ]
+ * @endcode
+ * One anonymous reservation is taken, then the file is mapped over its tail
+ * pages with @c MAP_FIXED. @c off is page-aligned (mapping requirement) and at
+ * least `bound - comp_size`, so the logical capacity `off + comp_size` always
+ * satisfies @ref zxc_decompress_inplace_bound and the write cursor provably
+ * never overtakes the read cursor. The file view is @c MAP_PRIVATE, so the
+ * decoder writing over already-consumed compressed bytes is copy-on-write and
+ * the archive on disk is never modified.
+ *
+ * @par Windows geometry (single region, one input copy)
+ * @c MapViewOfFile cannot land inside a @c VirtualAlloc reservation without the
+ * Win10 placeholder APIs, so the archive is copied once from a read-only view
+ * into the same flush-right slot. The decode stays in-place and no output
+ * allocation is made.
+ *
+ * Platforms with no mapping at all (Emscripten, freestanding) compile to stubs
+ * returning @ref ZXC_ERROR_UNSUPPORTED, keeping the ABI identical everywhere.
+ */
+
+/* glibc/musl hide the POSIX mapping interfaces behind a feature-test macro when
+ * the compiler runs in strict mode (-std=cNN, which the stock CMake and Meson
+ * builds pair with -D_GNU_SOURCE). Setting the default profile here keeps
+ * ad-hoc consumers (a bare `cc -std=c17` over the sources) building. Must precede every
+ * include; scoped to Linux because on macOS and the BSDs defining a feature
+ * macro *narrows* what the system headers expose. */
+#if defined(__linux__) && !defined(_GNU_SOURCE) && !defined(_DEFAULT_SOURCE) && \
+    !defined(_POSIX_C_SOURCE) && !defined(_XOPEN_SOURCE)
+#define _DEFAULT_SOURCE 1
+#endif
+
+#include "../../include/zxc_mmap.h"
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "../../include/zxc_buffer.h"
+#include "../../include/zxc_constants.h"
+#include "../../include/zxc_error.h"
+#include "zxc_internal.h"
+
+/*
+ * ============================================================================
+ * PLATFORM SELECTION
+ * ============================================================================
+ */
+#if defined(_WIN32)
+#define ZXC_MMAP_WIN32 1
+#elif defined(__EMSCRIPTEN__)
+/* Emscripten has no MAP_FIXED file mappings: fall through to the stubs. */
+#elif defined(__unix__) || defined(__unix) || (defined(__APPLE__) && defined(__MACH__))
+#define ZXC_MMAP_POSIX 1
+#endif
+
+#if defined(ZXC_MMAP_POSIX) || defined(ZXC_MMAP_WIN32)
+#define ZXC_MMAP_ENABLED 1
+#endif
+
+#if defined(ZXC_MMAP_ENABLED)
+
+/** @brief Release path a @ref zxc_map_t base address needs. */
+enum {
+    ZXC_MAP_KIND_NONE = 0,  /**< Nothing mapped. */
+    ZXC_MAP_KIND_VIEW = 1,  /**< Read-only file view (@ref zxc_mmap_open). */
+    ZXC_MAP_KIND_REGION = 2 /**< Decode region (@ref zxc_decompress_mmap). */
+};
+
+/**
+ * @brief Zeroes a caller's @ref zxc_map_t so a failed call still leaves a map
+ *        that is safe to pass to @ref zxc_mmap_close.
+ */
+static void zxc_map_reset(zxc_map_t* const m) {
+    m->data = NULL;
+    m->size = 0;
+    m->map_base = NULL;
+    m->map_size = 0;
+    m->map_handle = NULL;
+    m->map_kind = ZXC_MAP_KIND_NONE;
+}
+
+/** @brief Rounds @p v up to the next multiple of the power-of-two @p pow2. */
+static size_t zxc_round_up_pow2(const size_t v, const size_t pow2) {
+    return (v + (pow2 - 1)) & ~(pow2 - 1);
+}
+
+/**
+ * @brief Computes the single-region geometry for an in-place decode.
+ *
+ * @param[in]  comp_size  Archive size in bytes.
+ * @param[in]  need       @ref zxc_decompress_inplace_bound for that archive.
+ * @param[in]  page       Page size (power of two).
+ * @param[out] off        Flush-right offset of the archive: page-aligned (so a
+ *                        file mapping can start there) and >= @p need -
+ *                        @p comp_size (so the in-place margin holds).
+ * @param[out] capacity   Logical buffer capacity to hand
+ *                        @ref zxc_decompress_inplace (@p off + @p comp_size).
+ * @param[out] region     Total bytes to reserve: @p capacity rounded out to
+ *                        whole pages, since a file mapping of @p comp_size
+ *                        bytes occupies its last page in full.
+ * @return @ref ZXC_OK, or @ref ZXC_ERROR_MEMORY if the geometry overflows
+ *         @c size_t.
+ */
+static int zxc_map_geometry(const size_t comp_size, const size_t need, const size_t page,
+                            size_t* const off, size_t* const capacity, size_t* const region) {
+    const size_t gap = (need > comp_size) ? need - comp_size : 0;
+    if (UNLIKELY(gap > SIZE_MAX - (page - 1))) return ZXC_ERROR_MEMORY;
+    const size_t o = zxc_round_up_pow2(gap, page);
+
+    if (UNLIKELY(comp_size > SIZE_MAX - o)) return ZXC_ERROR_MEMORY;
+    if (UNLIKELY(comp_size > SIZE_MAX - (page - 1))) return ZXC_ERROR_MEMORY;
+    const size_t tail = zxc_round_up_pow2(comp_size, page);
+    if (UNLIKELY(tail > SIZE_MAX - o)) return ZXC_ERROR_MEMORY;
+
+    *off = o;
+    *capacity = o + comp_size;
+    *region = o + tail;
+    return ZXC_OK;
+}
+
+#endif /* ZXC_MMAP_ENABLED */
+
+/*
+ * ============================================================================
+ * POSIX BACKEND
+ * ============================================================================
+ */
+#if defined(ZXC_MMAP_POSIX)
+
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#if !defined(MAP_ANONYMOUS) && defined(MAP_ANON)
+#define MAP_ANONYMOUS MAP_ANON
+#endif
+#if !defined(O_CLOEXEC)
+#define O_CLOEXEC 0
+#endif
+
+/** @brief Descriptor the backend works on (a file descriptor here). */
+typedef int zxc_desc_t;
+
+/** @brief Opens @p path for the duration of a mapping call. */
+static zxc_desc_t zxc_desc_open(const char* const path) { return open(path, O_RDONLY | O_CLOEXEC); }
+
+/** @brief Adopts a caller-owned descriptor (no ownership transfer). */
+static zxc_desc_t zxc_desc_from_fd(const int fd) { return fd; }
+
+/** @brief True when @p d can be mapped. */
+static int zxc_desc_valid(const zxc_desc_t d) { return d >= 0; }
+
+/** @brief Closes a descriptor this TU opened; mappings outlive it. */
+static void zxc_desc_close(const zxc_desc_t d) { (void)close(d); }
+
+/** @brief Returns the platform page size (mapping granularity). */
+static size_t zxc_page_size(void) {
+    const long ps = sysconf(_SC_PAGESIZE);
+    return (ps > 0) ? (size_t)ps : 4096u;
+}
+
+/**
+ * @brief Measures a mappable file.
+ *
+ * @param[in]  d     Descriptor to measure.
+ * @param[out] size  Receives the file size in bytes.
+ * @return @ref ZXC_OK, @ref ZXC_ERROR_IO (stat failure or not a regular file:
+ *         pipes and sockets cannot be mapped), @ref ZXC_ERROR_SRC_TOO_SMALL for
+ *         an empty file, or @ref ZXC_ERROR_MEMORY if it exceeds the address
+ *         space.
+ */
+static int zxc_desc_size(const zxc_desc_t d, size_t* const size) {
+    struct stat st;
+    if (UNLIKELY(fstat(d, &st) != 0)) return ZXC_ERROR_IO;
+    if (UNLIKELY(!S_ISREG(st.st_mode))) return ZXC_ERROR_IO;
+    if (UNLIKELY(st.st_size <= 0)) return ZXC_ERROR_SRC_TOO_SMALL;
+    if (UNLIKELY((uint64_t)st.st_size > (uint64_t)SIZE_MAX)) return ZXC_ERROR_MEMORY;
+    *size = (size_t)st.st_size;
+    return ZXC_OK;
+}
+
+/** @brief Backend of @ref zxc_mmap_open: whole-file read-only private view. */
+static int zxc_map_readonly(const zxc_desc_t d, zxc_map_t* const out) {
+    size_t size = 0;
+    const int rc = zxc_desc_size(d, &size);
+    if (UNLIKELY(rc != ZXC_OK)) return rc;
+
+    void* const view = mmap(NULL, size, PROT_READ, MAP_PRIVATE, d, 0);
+    if (UNLIKELY(view == MAP_FAILED)) return ZXC_ERROR_IO;  // LCOV_EXCL_LINE
+
+    out->data = view;
+    out->size = size;
+    out->map_base = view;
+    out->map_size = size;
+    out->map_kind = ZXC_MAP_KIND_VIEW;
+    return ZXC_OK;
+}
+
+/**
+ * @brief Backend of @ref zxc_decompress_mmap: reserve, map flush-right, decode,
+ *        trim.
+ */
+static int64_t zxc_map_decompress(const zxc_desc_t d, zxc_map_t* const out,
+                                  const zxc_decompress_opts_t* const opts) {
+    size_t comp_size = 0;
+    int rc = zxc_desc_size(d, &comp_size);
+    if (UNLIKELY(rc != ZXC_OK)) return rc;
+    if (UNLIKELY(comp_size < ZXC_FILE_HEADER_SIZE + ZXC_FILE_FOOTER_SIZE))
+        return ZXC_ERROR_SRC_TOO_SMALL;
+
+    /* Probe pass: the bound only reads the file header and footer, so a
+     * throw-away read-only view answers it without copying anything. */
+    void* const probe = mmap(NULL, comp_size, PROT_READ, MAP_PRIVATE, d, 0);
+    if (UNLIKELY(probe == MAP_FAILED)) return ZXC_ERROR_IO;  // LCOV_EXCL_LINE
+    const size_t need = zxc_decompress_inplace_bound(probe, comp_size);
+    (void)munmap(probe, comp_size);
+    if (UNLIKELY(need == 0)) return ZXC_ERROR_BAD_HEADER;
+
+    const size_t page = zxc_page_size();
+    size_t off = 0, capacity = 0, region = 0;
+    rc = zxc_map_geometry(comp_size, need, page, &off, &capacity, &region);
+    if (UNLIKELY(rc != ZXC_OK)) return rc;  // LCOV_EXCL_LINE
+
+    uint8_t* const base =
+        (uint8_t*)mmap(NULL, region, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    if (UNLIKELY(base == MAP_FAILED)) return ZXC_ERROR_MEMORY;  // LCOV_EXCL_LINE
+
+    /* Land the archive flush-right: MAP_FIXED replaces exactly the tail pages
+     * of our own reservation, and MAP_PRIVATE makes the decoder's writes over
+     * consumed compressed bytes copy-on-write. */
+    if (UNLIKELY(mmap(base + off, comp_size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_FIXED, d,
+                      0) == MAP_FAILED)) {
+        // LCOV_EXCL_START
+        (void)munmap(base, region);
+        return ZXC_ERROR_IO;
+        // LCOV_EXCL_STOP
+    }
+#if defined(MADV_SEQUENTIAL)
+    /* The decoder walks the archive front to back exactly once. */
+    (void)madvise(base + off, comp_size, MADV_SEQUENTIAL);
+#endif
+
+    const int64_t decoded = zxc_decompress_inplace(base, capacity, comp_size, opts);
+    if (UNLIKELY(decoded <= 0)) {
+        /* Errors and the empty frame both leave nothing worth handing back. */
+        (void)munmap(base, region);
+        return decoded;
+    }
+
+    /* Trim: give back the margin and the file-backed tail, so what the caller
+     * keeps resident is the payload rather than the in-place bound. */
+    const size_t keep = zxc_round_up_pow2((size_t)decoded, page);
+    if (keep < region) (void)munmap(base + keep, region - keep);
+
+    out->data = base;
+    out->size = (size_t)decoded;
+    out->map_base = base;
+    out->map_size = keep;
+    out->map_kind = ZXC_MAP_KIND_REGION;
+    return decoded;
+}
+
+/** @brief Backend of @ref zxc_mmap_close (one call covers both map kinds). */
+static void zxc_map_release(zxc_map_t* const m) { (void)munmap(m->map_base, m->map_size); }
+
+/*
+ * ============================================================================
+ * WIN32 BACKEND
+ * ============================================================================
+ */
+#elif defined(ZXC_MMAP_WIN32)
+
+#include <io.h> /* _get_osfhandle */
+#include <windows.h>
+
+/** @brief Descriptor the backend works on (an OS file handle here). */
+typedef HANDLE zxc_desc_t;
+
+// LCOV_EXCL_START - Win32 paths, not reachable on POSIX CI
+/** @brief Opens @p path for the duration of a mapping call. */
+static zxc_desc_t zxc_desc_open(const char* const path) {
+    return CreateFileA(path, GENERIC_READ, FILE_SHARE_READ, NULL, OPEN_EXISTING,
+                       FILE_ATTRIBUTE_NORMAL, NULL);
+}
+
+/** @brief Adopts a caller-owned CRT descriptor (no ownership transfer). */
+static zxc_desc_t zxc_desc_from_fd(const int fd) {
+    if (fd < 0) return INVALID_HANDLE_VALUE;
+    return (HANDLE)(intptr_t)_get_osfhandle(fd);
+}
+
+/** @brief True when @p d can be mapped. */
+static int zxc_desc_valid(const zxc_desc_t d) { return d != INVALID_HANDLE_VALUE && d != NULL; }
+
+/** @brief Closes a handle this TU opened; mappings outlive it. */
+static void zxc_desc_close(const zxc_desc_t d) { (void)CloseHandle(d); }
+
+/** @brief Returns the platform page size (VirtualFree decommit granularity). */
+static size_t zxc_page_size(void) {
+    SYSTEM_INFO si;
+    GetSystemInfo(&si);
+    return si.dwPageSize ? (size_t)si.dwPageSize : 4096u;
+}
+
+/**
+ * @brief Measures a mappable file.
+ * @see the POSIX twin above for the return-code contract.
+ */
+static int zxc_desc_size(const zxc_desc_t d, size_t* const size) {
+    LARGE_INTEGER li;
+    if (UNLIKELY(!GetFileSizeEx(d, &li))) return ZXC_ERROR_IO;
+    if (UNLIKELY(li.QuadPart <= 0)) return ZXC_ERROR_SRC_TOO_SMALL;
+    if (UNLIKELY((uint64_t)li.QuadPart > (uint64_t)SIZE_MAX)) return ZXC_ERROR_MEMORY;
+    *size = (size_t)li.QuadPart;
+    return ZXC_OK;
+}
+
+/**
+ * @brief Maps the whole file read-only.
+ *
+ * The section handle is closed immediately: the returned view keeps it (and the
+ * file) alive, which is what lets the descriptor be closed straight after.
+ */
+static int zxc_win_view(const zxc_desc_t d, void** const view) {
+    HANDLE section = CreateFileMappingA(d, NULL, PAGE_READONLY, 0, 0, NULL);
+    if (UNLIKELY(!section)) return ZXC_ERROR_IO;
+    void* const p = MapViewOfFile(section, FILE_MAP_READ, 0, 0, 0);
+    (void)CloseHandle(section);
+    if (UNLIKELY(!p)) return ZXC_ERROR_IO;
+    *view = p;
+    return ZXC_OK;
+}
+
+/** @brief Backend of @ref zxc_mmap_open: whole-file read-only view. */
+static int zxc_map_readonly(const zxc_desc_t d, zxc_map_t* const out) {
+    size_t size = 0;
+    int rc = zxc_desc_size(d, &size);
+    if (UNLIKELY(rc != ZXC_OK)) return rc;
+
+    void* view = NULL;
+    rc = zxc_win_view(d, &view);
+    if (UNLIKELY(rc != ZXC_OK)) return rc;
+
+    out->data = view;
+    out->size = size;
+    out->map_base = view;
+    out->map_size = size;
+    out->map_kind = ZXC_MAP_KIND_VIEW;
+    return ZXC_OK;
+}
+
+/**
+ * @brief Backend of @ref zxc_decompress_mmap.
+ *
+ * Same geometry as POSIX, but the archive is copied once from a read-only view
+ * into the flush-right slot: a view cannot be placed inside a @c VirtualAlloc
+ * reservation without the Win10-only placeholder APIs. Still a single region
+ * and no output allocation.
+ */
+static int64_t zxc_map_decompress(const zxc_desc_t d, zxc_map_t* const out,
+                                  const zxc_decompress_opts_t* const opts) {
+    size_t comp_size = 0;
+    int rc = zxc_desc_size(d, &comp_size);
+    if (UNLIKELY(rc != ZXC_OK)) return rc;
+    if (UNLIKELY(comp_size < ZXC_FILE_HEADER_SIZE + ZXC_FILE_FOOTER_SIZE))
+        return ZXC_ERROR_SRC_TOO_SMALL;
+
+    void* view = NULL;
+    rc = zxc_win_view(d, &view);
+    if (UNLIKELY(rc != ZXC_OK)) return rc;
+
+    const size_t need = zxc_decompress_inplace_bound(view, comp_size);
+    if (UNLIKELY(need == 0)) {
+        (void)UnmapViewOfFile(view);
+        return ZXC_ERROR_BAD_HEADER;
+    }
+
+    const size_t page = zxc_page_size();
+    size_t off = 0, capacity = 0, region = 0;
+    rc = zxc_map_geometry(comp_size, need, page, &off, &capacity, &region);
+    if (UNLIKELY(rc != ZXC_OK)) {
+        (void)UnmapViewOfFile(view);
+        return rc;
+    }
+
+    uint8_t* const base =
+        (uint8_t*)VirtualAlloc(NULL, region, MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE);
+    if (UNLIKELY(!base)) {
+        (void)UnmapViewOfFile(view);
+        return ZXC_ERROR_MEMORY;
+    }
+    ZXC_MEMCPY(base + off, view, comp_size);
+    (void)UnmapViewOfFile(view);
+
+    const int64_t decoded = zxc_decompress_inplace(base, capacity, comp_size, opts);
+    if (UNLIKELY(decoded <= 0)) {
+        (void)VirtualFree(base, 0, MEM_RELEASE);
+        return decoded;
+    }
+
+    /* Trim: decommit the margin (the reservation itself can only be released
+     * whole, which zxc_mmap_close does). */
+    const size_t keep = zxc_round_up_pow2((size_t)decoded, page);
+    if (keep < region) (void)VirtualFree(base + keep, region - keep, MEM_DECOMMIT);
+
+    out->data = base;
+    out->size = (size_t)decoded;
+    out->map_base = base;
+    out->map_size = keep;
+    out->map_kind = ZXC_MAP_KIND_REGION;
+    return decoded;
+}
+
+/** @brief Backend of @ref zxc_mmap_close: views unmap, reservations release. */
+static void zxc_map_release(zxc_map_t* const m) {
+    if (m->map_kind == ZXC_MAP_KIND_VIEW)
+        (void)UnmapViewOfFile(m->map_base);
+    else
+        (void)VirtualFree(m->map_base, 0, MEM_RELEASE);
+}
+// LCOV_EXCL_STOP
+
+#endif /* backend selection */
+
+/*
+ * ============================================================================
+ * PUBLIC API
+ * ============================================================================
+ */
+
+#if defined(ZXC_MMAP_ENABLED)
+
+/**
+ * @brief Reports whether this build can map files.
+ *
+ * Public API; see @c zxc_mmap.h.
+ */
+// cppcheck-suppress unusedFunction
+int zxc_mmap_supported(void) { return 1; }
+
+/**
+ * @brief Maps a file read-only, without decoding it.
+ *
+ * Public API; full contract in @c zxc_mmap.h. Opens @p path, delegates to the
+ * platform backend, then drops the descriptor: the mapping owns what it needs.
+ */
+// cppcheck-suppress unusedFunction
+int zxc_mmap_open(const char* const path, zxc_map_t* const out) {
+    if (UNLIKELY(!out)) return ZXC_ERROR_NULL_INPUT;
+    zxc_map_reset(out);
+    if (UNLIKELY(!path)) return ZXC_ERROR_NULL_INPUT;
+
+    const zxc_desc_t d = zxc_desc_open(path);
+    if (UNLIKELY(!zxc_desc_valid(d))) return ZXC_ERROR_IO;
+    const int rc = zxc_map_readonly(d, out);
+    zxc_desc_close(d);
+    return rc;
+}
+
+/**
+ * @brief Maps an already-open file read-only, without decoding it.
+ *
+ * Public API; full contract in @c zxc_mmap.h. The descriptor stays the
+ * caller's; only the mapping created from it is handed over.
+ */
+// cppcheck-suppress unusedFunction
+int zxc_mmap_open_fd(const int fd, zxc_map_t* const out) {
+    if (UNLIKELY(!out)) return ZXC_ERROR_NULL_INPUT;
+    zxc_map_reset(out);
+
+    const zxc_desc_t d = zxc_desc_from_fd(fd);
+    if (UNLIKELY(!zxc_desc_valid(d))) return ZXC_ERROR_IO;
+    return zxc_map_readonly(d, out);
+}
+
+/**
+ * @brief Decompresses a file into a single mapped region, in place.
+ *
+ * Public API; full contract in @c zxc_mmap.h.
+ */
+// cppcheck-suppress unusedFunction
+int64_t zxc_decompress_mmap(const char* const path, zxc_map_t* const out,
+                            const zxc_decompress_opts_t* const opts) {
+    if (UNLIKELY(!out)) return ZXC_ERROR_NULL_INPUT;
+    zxc_map_reset(out);
+    if (UNLIKELY(!path)) return ZXC_ERROR_NULL_INPUT;
+
+    const zxc_desc_t d = zxc_desc_open(path);
+    if (UNLIKELY(!zxc_desc_valid(d))) return ZXC_ERROR_IO;
+    const int64_t rc = zxc_map_decompress(d, out, opts);
+    zxc_desc_close(d);
+    return rc;
+}
+
+/**
+ * @brief Decompresses an already-open file into a single mapped region.
+ *
+ * Public API; full contract in @c zxc_mmap.h.
+ */
+// cppcheck-suppress unusedFunction
+int64_t zxc_decompress_mmap_fd(const int fd, zxc_map_t* const out,
+                               const zxc_decompress_opts_t* const opts) {
+    if (UNLIKELY(!out)) return ZXC_ERROR_NULL_INPUT;
+    zxc_map_reset(out);
+
+    const zxc_desc_t d = zxc_desc_from_fd(fd);
+    if (UNLIKELY(!zxc_desc_valid(d))) return ZXC_ERROR_IO;
+    return zxc_map_decompress(d, out, opts);
+}
+
+/**
+ * @brief Releases a region obtained from this API and clears @p map.
+ *
+ * Public API; full contract in @c zxc_mmap.h.
+ */
+// cppcheck-suppress unusedFunction
+void zxc_mmap_close(zxc_map_t* const map) {
+    if (!map || !map->map_base) return;
+    zxc_map_release(map);
+    zxc_map_reset(map);
+}
+
+#else /* !ZXC_MMAP_ENABLED: no mapping primitives on this target */
+
+/** @brief Reports whether this build can map files (it cannot). */
+// cppcheck-suppress unusedFunction
+int zxc_mmap_supported(void) { return 0; }
+
+/** @brief Unsupported on this target; see @ref zxc_mmap_supported. */
+// cppcheck-suppress unusedFunction
+int zxc_mmap_open(const char* path, zxc_map_t* out) {
+    (void)path;
+    if (out) ZXC_MEMSET(out, 0, sizeof(*out));
+    return ZXC_ERROR_UNSUPPORTED;
+}
+
+/** @brief Unsupported on this target; see @ref zxc_mmap_supported. */
+// cppcheck-suppress unusedFunction
+int zxc_mmap_open_fd(int fd, zxc_map_t* out) {
+    (void)fd;
+    if (out) ZXC_MEMSET(out, 0, sizeof(*out));
+    return ZXC_ERROR_UNSUPPORTED;
+}
+
+/** @brief Unsupported on this target; see @ref zxc_mmap_supported. */
+// cppcheck-suppress unusedFunction
+int64_t zxc_decompress_mmap(const char* path, zxc_map_t* out, const zxc_decompress_opts_t* opts) {
+    (void)path;
+    (void)opts;
+    if (out) ZXC_MEMSET(out, 0, sizeof(*out));
+    return ZXC_ERROR_UNSUPPORTED;
+}
+
+/** @brief Unsupported on this target; see @ref zxc_mmap_supported. */
+// cppcheck-suppress unusedFunction
+int64_t zxc_decompress_mmap_fd(int fd, zxc_map_t* out, const zxc_decompress_opts_t* opts) {
+    (void)fd;
+    (void)opts;
+    if (out) ZXC_MEMSET(out, 0, sizeof(*out));
+    return ZXC_ERROR_UNSUPPORTED;
+}
+
+/** @brief Nothing can be mapped on this target, so nothing can be released. */
+// cppcheck-suppress unusedFunction
+void zxc_mmap_close(zxc_map_t* map) {
+    if (map) ZXC_MEMSET(map, 0, sizeof(*map));
+}
+
+#endif /* ZXC_MMAP_ENABLED */

--- a/src/lib/zxc_mmap.c
+++ b/src/lib/zxc_mmap.c
@@ -9,7 +9,7 @@
  * @file zxc_mmap.c
  * @brief Memory-mapped, zero-copy in-place decompression of files.
  *
- * The whole subsystem is a thin OS layer over @ref zxc_decompress_inplace: the
+ * The whole subsystem is a thin OS layer over @ref zxc_decompress_inplace. That
  * buffer-level decoder already tolerates a flush-right archive overlapping its
  * own output, so all that is missing to decode a file without copying it is a
  * way to *place* the archive at the right end of a single region.
@@ -53,16 +53,6 @@
 #define _DEFAULT_SOURCE 1
 #endif
 
-#include "../../include/zxc_mmap.h"
-
-#include <stddef.h>
-#include <stdint.h>
-
-#include "../../include/zxc_buffer.h"
-#include "../../include/zxc_constants.h"
-#include "../../include/zxc_error.h"
-#include "zxc_internal.h"
-
 /*
  * ============================================================================
  * PLATFORM SELECTION
@@ -80,6 +70,33 @@
 #define ZXC_MMAP_ENABLED 1
 #endif
 
+#include "../../include/zxc_mmap.h"
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "../../include/zxc_buffer.h"
+#include "../../include/zxc_constants.h"
+#include "../../include/zxc_error.h"
+#include "zxc_internal.h"
+
+#if defined(ZXC_MMAP_POSIX)
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#if !defined(MAP_ANONYMOUS) && defined(MAP_ANON)
+#define MAP_ANONYMOUS MAP_ANON
+#endif
+#if !defined(O_CLOEXEC)
+#define O_CLOEXEC 0
+#endif
+#elif defined(ZXC_MMAP_WIN32)
+#include <io.h> /* _get_osfhandle */
+#include <windows.h>
+#endif
+
 #if defined(ZXC_MMAP_ENABLED)
 
 /** @brief Release path a @ref zxc_map_t base address needs. */
@@ -93,6 +110,12 @@ enum {
 /**
  * @brief Zeroes a caller's @ref zxc_map_t so a failed call still leaves a map
  *        that is safe to pass to @ref zxc_mmap_close.
+ *
+ * Every public entry point calls this before anything can fail, which is what
+ * makes "close it even if the call errored" a valid contract.
+ *
+ * @param[out] m  Map to clear; must be non-NULL, and is left in the same state
+ *                a zero-initialised @ref zxc_map_t would be in.
  */
 static void zxc_map_reset(zxc_map_t* const m) {
     m->data = NULL;
@@ -103,7 +126,15 @@ static void zxc_map_reset(zxc_map_t* const m) {
     m->map_kind = ZXC_MAP_KIND_NONE;
 }
 
-/** @brief Rounds @p v up to the next multiple of the power-of-two @p pow2. */
+/**
+ * @brief Rounds @p v up to the next multiple of the power-of-two @p pow2.
+ *
+ * @param[in] v     Value to round. Callers check beforehand that @p v is at
+ *                  most `SIZE_MAX - (pow2 - 1)`, so the sum cannot wrap.
+ * @param[in] pow2  Alignment; must be a power of two (a page size or an
+ *                  allocation granularity, both of which always are).
+ * @return @p v rounded up to a multiple of @p pow2.
+ */
 static size_t zxc_round_up_pow2(const size_t v, const size_t pow2) {
     return (v + (pow2 - 1)) & ~(pow2 - 1);
 }
@@ -162,31 +193,45 @@ static int zxc_map_geometry(const size_t comp_size, const size_t need, const siz
  */
 #if defined(ZXC_MMAP_POSIX)
 
-#include <fcntl.h>
-#include <sys/mman.h>
-#include <sys/stat.h>
-#include <unistd.h>
-
-#if !defined(MAP_ANONYMOUS) && defined(MAP_ANON)
-#define MAP_ANONYMOUS MAP_ANON
-#endif
-#if !defined(O_CLOEXEC)
-#define O_CLOEXEC 0
-#endif
-
 /** @brief Descriptor the backend works on (a file descriptor here). */
 typedef int zxc_desc_t;
 
-/** @brief Opens @p path for the duration of a mapping call. */
+/**
+ * @brief Opens @p path for the duration of a mapping call.
+ *
+ * @c O_CLOEXEC keeps the descriptor from leaking into a child forked while the
+ * call runs; it degrades to 0 on systems that lack it (see the fallback above).
+ *
+ * @param[in] path  Path to open read-only.
+ * @return An open descriptor, or -1 (see @ref zxc_desc_valid). Every successful
+ *         open is closed by @ref zxc_desc_close before the entry point returns.
+ */
 static zxc_desc_t zxc_desc_open(const char* const path) { return open(path, O_RDONLY | O_CLOEXEC); }
 
-/** @brief Adopts a caller-owned descriptor (no ownership transfer). */
+/**
+ * @brief Adopts a caller-owned descriptor (no ownership transfer).
+ *
+ * @param[in] fd  Descriptor supplied by the caller of an @c _fd entry point.
+ * @return @p fd unchanged: on POSIX the backend descriptor *is* the file
+ *         descriptor, so nothing is opened and nothing must be closed.
+ */
 static zxc_desc_t zxc_desc_from_fd(const int fd) { return fd; }
 
-/** @brief True when @p d can be mapped. */
+/**
+ * @brief Reports whether @p d is a descriptor the backend can map.
+ *
+ * @param[in] d  Descriptor from @ref zxc_desc_open or @ref zxc_desc_from_fd.
+ * @return Non-zero when @p d is usable, 0 when the open failed or the caller
+ *         passed a negative descriptor (nothing to close in that case).
+ */
 static int zxc_desc_valid(const zxc_desc_t d) { return d >= 0; }
 
-/** @brief Closes a descriptor this TU opened; mappings outlive it. */
+/**
+ * @brief Closes a descriptor this TU opened; mappings outlive it.
+ *
+ * @param[in] d  Descriptor from a successful @ref zxc_desc_open. Never called on
+ *               a caller-owned descriptor, which stays the caller's to close.
+ */
 static void zxc_desc_close(const zxc_desc_t d) { (void)close(d); }
 
 /**
@@ -223,7 +268,18 @@ static int zxc_desc_size(const zxc_desc_t d, size_t* const size) {
     return ZXC_OK;
 }
 
-/** @brief Backend of @ref zxc_mmap_open: whole-file read-only private view. */
+/**
+ * @brief Backend of @ref zxc_mmap_open -- whole-file read-only private view.
+ *
+ * The mapping holds its own reference to the file, so the caller's descriptor
+ * can be closed as soon as this returns.
+ *
+ * @param[in]  d    Descriptor to map.
+ * @param[out] out  Receives the view; untouched unless the call succeeds (the
+ *                  entry point has already reset it).
+ * @return @ref ZXC_OK, the @ref zxc_desc_size error codes, or
+ *         @ref ZXC_ERROR_IO if the file cannot be mapped.
+ */
 static int zxc_map_readonly(const zxc_desc_t d, zxc_map_t* const out) {
     size_t size = 0;
     const int rc = zxc_desc_size(d, &size);
@@ -241,8 +297,25 @@ static int zxc_map_readonly(const zxc_desc_t d, zxc_map_t* const out) {
 }
 
 /**
- * @brief Backend of @ref zxc_decompress_mmap: reserve, map flush-right, decode,
- *        trim.
+ * @brief Backend of @ref zxc_decompress_mmap -- reserve, map flush-right,
+ *        decode, trim.
+ *
+ * Four steps: measure the archive and probe its in-place bound through a
+ * throw-away view, reserve one anonymous region and drop the file over its tail
+ * pages with @c MAP_FIXED, decode into the head, then unmap everything the
+ * payload does not occupy. Every failure path unmaps what it had taken, so the
+ * caller never has to release a partial region.
+ *
+ * @param[in]  d     Descriptor of the archive to decode.
+ * @param[out] out   Receives the decoded region; filled only on success.
+ * @param[in]  opts  Decompression options, or NULL for defaults.
+ * @return Decompressed size in bytes (> 0), 0 for an empty frame (nothing is
+ *         mapped, @p out stays cleared), or a negative @c zxc_error_t:
+ *         @ref ZXC_ERROR_SRC_TOO_SMALL if the file is shorter than a frame,
+ *         @ref ZXC_ERROR_BAD_HEADER if it is not a ZXC archive,
+ *         @ref ZXC_ERROR_IO on a mapping failure, @ref ZXC_ERROR_MEMORY if the
+ *         region cannot be reserved, or whatever @ref zxc_decompress_inplace
+ *         reports for a corrupt archive.
  */
 static int64_t zxc_map_decompress(const zxc_desc_t d, zxc_map_t* const out,
                                   const zxc_decompress_opts_t* const opts) {
@@ -305,10 +378,23 @@ static int64_t zxc_map_decompress(const zxc_desc_t d, zxc_map_t* const out,
     return decoded;
 }
 
-/** @brief Backend of @ref zxc_mmap_close (one call covers both map kinds). */
+/**
+ * @brief Backend of @ref zxc_mmap_close (one call covers both map kinds).
+ *
+ * A read-only view and a decode region both release with a single @c munmap;
+ * the kind only matters on Windows.
+ *
+ * @param[in] m  Live map; @c map_base / @c map_size describe exactly what is
+ *               still mapped, the decode path having already trimmed the rest.
+ */
 static void zxc_map_release(zxc_map_t* const m) { (void)munmap(m->map_base, m->map_size); }
 
-/** @brief Backend of @ref zxc_mmap_is_zerocopy: here every region is mapped. */
+/**
+ * @brief Backend of @ref zxc_mmap_is_zerocopy -- here every region is mapped.
+ *
+ * @param[in] m  Live map (unused: POSIX has no copying route).
+ * @return Always 1.
+ */
 static int zxc_map_zerocopy(const zxc_map_t* const m) {
     (void)m;
     return 1;
@@ -321,29 +407,59 @@ static int zxc_map_zerocopy(const zxc_map_t* const m) {
  */
 #elif defined(ZXC_MMAP_WIN32)
 
-#include <io.h> /* _get_osfhandle */
-#include <windows.h>
-
 /** @brief Descriptor the backend works on (an OS file handle here). */
 typedef HANDLE zxc_desc_t;
 
 // LCOV_EXCL_START - Win32 paths, not reachable on POSIX CI
-/** @brief Opens @p path for the duration of a mapping call. */
+/**
+ * @brief Opens @p path for the duration of a mapping call.
+ *
+ * @c FILE_SHARE_READ lets other readers (and other mappings of the same
+ * archive) proceed while this one runs; write sharing is deliberately withheld,
+ * since a file truncated underneath a live view is fatal to touch.
+ *
+ * @param[in] path  Path to open read-only.
+ * @return An open handle, or @c INVALID_HANDLE_VALUE (see @ref zxc_desc_valid).
+ *         Every successful open is closed by @ref zxc_desc_close before the
+ *         entry point returns.
+ */
 static zxc_desc_t zxc_desc_open(const char* const path) {
     return CreateFileA(path, GENERIC_READ, FILE_SHARE_READ, NULL, OPEN_EXISTING,
                        FILE_ATTRIBUTE_NORMAL, NULL);
 }
 
-/** @brief Adopts a caller-owned CRT descriptor (no ownership transfer). */
+/**
+ * @brief Adopts a caller-owned CRT descriptor (no ownership transfer).
+ *
+ * The public API takes a CRT file descriptor on every platform, so the Windows
+ * backend translates it to the OS handle the mapping calls need.
+ * @c _get_osfhandle already returns an @c intptr_t, hence the single cast.
+ *
+ * @param[in] fd  CRT descriptor supplied by the caller of an @c _fd entry point.
+ * @return The underlying OS handle, or @c INVALID_HANDLE_VALUE for a negative
+ *         @p fd or one the CRT does not know. The handle belongs to the CRT
+ *         descriptor and is never closed here.
+ */
 static zxc_desc_t zxc_desc_from_fd(const int fd) {
     if (fd < 0) return INVALID_HANDLE_VALUE;
-    return (HANDLE)(intptr_t)_get_osfhandle(fd);
+    return (HANDLE)_get_osfhandle(fd);
 }
 
-/** @brief True when @p d can be mapped. */
+/**
+ * @brief Reports whether @p d is a handle the backend can map.
+ *
+ * @param[in] d  Handle from @ref zxc_desc_open or @ref zxc_desc_from_fd.
+ * @return Non-zero when @p d is usable, 0 for @c INVALID_HANDLE_VALUE or NULL
+ *         (nothing to close in either case).
+ */
 static int zxc_desc_valid(const zxc_desc_t d) { return d != INVALID_HANDLE_VALUE && d != NULL; }
 
-/** @brief Closes a handle this TU opened; mappings outlive it. */
+/**
+ * @brief Closes a handle this TU opened; mappings outlive it.
+ *
+ * @param[in] d  Handle from a successful @ref zxc_desc_open. Never called on a
+ *               handle borrowed from a caller's CRT descriptor.
+ */
 static void zxc_desc_close(const zxc_desc_t d) { (void)CloseHandle(d); }
 
 /**
@@ -365,7 +481,14 @@ static void zxc_map_grains(size_t* const off_gran, size_t* const page) {
 
 /**
  * @brief Measures a mappable file.
- * @see the POSIX twin above for the return-code contract.
+ *
+ * @param[in]  d     Handle to measure.
+ * @param[out] size  Receives the file size in bytes.
+ * @return @ref ZXC_OK, @ref ZXC_ERROR_IO if the size cannot be queried,
+ *         @ref ZXC_ERROR_SRC_TOO_SMALL for an empty file, or
+ *         @ref ZXC_ERROR_MEMORY if it exceeds the address space. No regular-file
+ *         check is needed here: @c CreateFileMappingA rejects what cannot back a
+ *         section, unlike @c mmap.
  */
 static int zxc_desc_size(const zxc_desc_t d, size_t* const size) {
     LARGE_INTEGER li;
@@ -381,6 +504,12 @@ static int zxc_desc_size(const zxc_desc_t d, size_t* const size) {
  *
  * The section handle is closed immediately: the returned view keeps it (and the
  * file) alive, which is what lets the descriptor be closed straight after.
+ *
+ * @param[in]  d     Handle to map.
+ * @param[out] view  Receives the view address; set only on success, and released
+ *                   with @c UnmapViewOfFile.
+ * @return @ref ZXC_OK, or @ref ZXC_ERROR_IO if the section or the view cannot be
+ *         created.
  */
 static int zxc_win_view(const zxc_desc_t d, void** const view) {
     HANDLE section = CreateFileMappingA(d, NULL, PAGE_READONLY, 0, 0, NULL);
@@ -417,7 +546,10 @@ static int zxc_win_view(const zxc_desc_t d, void** const view) {
 
 /* The MEM_EXTENDED_PARAMETER argument is always NULL here, so it is typed
  * void* rather than pulling the struct in from a newer SDK. */
+
+/** @brief Signature of @c VirtualAlloc2 (process, base, size, type, prot, ext, count). */
 typedef PVOID(WINAPI* zxc_virtual_alloc2_fn)(HANDLE, PVOID, SIZE_T, ULONG, ULONG, void*, ULONG);
+/** @brief Signature of @c MapViewOfFile3 (section, process, base, offset, size, ...). */
 typedef PVOID(WINAPI* zxc_map_view_of_file3_fn)(HANDLE, HANDLE, PVOID, ULONG64, SIZE_T, ULONG,
                                                 ULONG, void*, ULONG);
 
@@ -435,6 +567,8 @@ typedef struct {
  * @c FARPROC values are copied instead of cast so no toolchain objects to the
  * function-pointer conversion.
  *
+ * @param[out] fns  Receives both entry points; cleared first, so the struct is
+ *                  never left holding one resolved pointer and one stale value.
  * @return @ref ZXC_OK, or @ref ZXC_ERROR_UNSUPPORTED when this Windows lacks
  *         the placeholder APIs.
  */
@@ -462,6 +596,13 @@ static int zxc_win_ext_resolve(zxc_win_ext_t* const fns) {
  * decoder's writes over consumed compressed bytes private, so the archive on
  * disk is never modified. The size arguments are 0 on purpose: an explicit size
  * beyond the file, with a write-capable protection, would *grow* the file.
+ *
+ * @param[in]  d        Handle of the archive.
+ * @param[out] section  Receives the section handle; set only on success, and
+ *                      closed by the caller once a view exists (a live view
+ *                      keeps the section alive on its own).
+ * @return @ref ZXC_OK, or @ref ZXC_ERROR_IO when the file cannot back a
+ *         copy-on-write section, which sends the caller to the copying route.
  */
 static int zxc_win_section_cow(const zxc_desc_t d, HANDLE* const section) {
     HANDLE s = CreateFileMappingA(d, NULL, PAGE_WRITECOPY, 0, 0, NULL);
@@ -536,7 +677,14 @@ static int zxc_win_place(const HANDLE section, const size_t comp_size, const siz
     return ZXC_OK;
 }
 
-/** @brief Backend of @ref zxc_mmap_open: whole-file read-only view. */
+/**
+ * @brief Backend of @ref zxc_mmap_open -- whole-file read-only view.
+ *
+ * @param[in]  d    Handle to map.
+ * @param[out] out  Receives the view; untouched unless the call succeeds.
+ * @return @ref ZXC_OK, the @ref zxc_desc_size error codes, or
+ *         @ref ZXC_ERROR_IO if the file cannot be mapped.
+ */
 static int zxc_map_readonly(const zxc_desc_t d, zxc_map_t* const out) {
     size_t size = 0;
     int rc = zxc_desc_size(d, &size);
@@ -555,13 +703,21 @@ static int zxc_map_readonly(const zxc_desc_t d, zxc_map_t* const out) {
 }
 
 /**
- * @brief Backend of @ref zxc_decompress_mmap: place (or copy) the archive
+ * @brief Backend of @ref zxc_decompress_mmap -- place (or copy) the archive
  *        flush-right in a single region, decode, trim.
  *
  * Prefers the placeholder placement (@ref zxc_win_place, zero-copy). Older
  * Windows, or a file that cannot back a copy-on-write section, fall back to one
  * reservation plus a single copy of the archive: still one region, still no
  * output allocation. @ref zxc_mmap_is_zerocopy reports which route ran.
+ *
+ * @param[in]  d     Handle of the archive to decode.
+ * @param[out] out   Receives the decoded region; filled only on success, with
+ *                   @c map_kind recording which of the two routes produced it.
+ * @param[in]  opts  Decompression options, or NULL for defaults.
+ * @return Decompressed size in bytes (> 0), 0 for an empty frame (nothing is
+ *         mapped, @p out stays cleared), or a negative @c zxc_error_t -- see the
+ *         POSIX twin above, whose error contract this shares.
  */
 static int64_t zxc_map_decompress(const zxc_desc_t d, zxc_map_t* const out,
                                   const zxc_decompress_opts_t* const opts) {
@@ -580,9 +736,12 @@ static int64_t zxc_map_decompress(const zxc_desc_t d, zxc_map_t* const out,
     (void)UnmapViewOfFile(probe);
     if (UNLIKELY(need == 0)) return ZXC_ERROR_BAD_HEADER;
 
-    size_t off_gran = 0, page = 0;
+    size_t off_gran = 0;
+    size_t page = 0;
     zxc_map_grains(&off_gran, &page);
-    size_t off = 0, capacity = 0, region = 0;
+    size_t off = 0;
+    size_t capacity = 0;
+    size_t region = 0;
     rc = zxc_map_geometry(comp_size, need, off_gran, page, &off, &capacity, &region);
     if (UNLIKELY(rc != ZXC_OK)) return rc;
 
@@ -647,7 +806,13 @@ static int64_t zxc_map_decompress(const zxc_desc_t d, zxc_map_t* const out,
     return decoded;
 }
 
-/** @brief Backend of @ref zxc_mmap_close: views unmap, reservations release. */
+/**
+ * @brief Backend of @ref zxc_mmap_close -- views unmap, reservations release.
+ *
+ * @param[in] m  Live map. @c map_kind selects the release path and @c map_handle
+ *               carries the archive view still to unmap, if the trim could not
+ *               already give it back.
+ */
 static void zxc_map_release(zxc_map_t* const m) {
     if (m->map_kind == ZXC_MAP_KIND_VIEW) {
         (void)UnmapViewOfFile(m->map_base);
@@ -660,7 +825,13 @@ static void zxc_map_release(zxc_map_t* const m) {
     (void)VirtualFree(m->map_base, 0, MEM_RELEASE);
 }
 
-/** @brief Backend of @ref zxc_mmap_is_zerocopy: only the copy route copies. */
+/**
+ * @brief Backend of @ref zxc_mmap_is_zerocopy -- only the copy route copies.
+ *
+ * @param[in] m  Live map.
+ * @return 1 for a read-only view and for a placeholder-placed decode region,
+ *         0 for @ref ZXC_MAP_KIND_REGION, the route that copied the archive.
+ */
 static int zxc_map_zerocopy(const zxc_map_t* const m) { return m->map_kind != ZXC_MAP_KIND_REGION; }
 // LCOV_EXCL_STOP
 
@@ -690,7 +861,7 @@ int zxc_mmap_supported(void) { return 1; }
  */
 // cppcheck-suppress unusedFunction
 int zxc_mmap_is_zerocopy(const zxc_map_t* const map) {
-    if (!map || !map->data) return 0;
+    if (UNLIKELY(!map || !map->data)) return 0;
     return zxc_map_zerocopy(map);
 }
 

--- a/src/lib/zxc_mmap.c
+++ b/src/lib/zxc_mmap.c
@@ -7,36 +7,17 @@
 
 /**
  * @file zxc_mmap.c
- * @brief Memory-mapped, zero-copy in-place decompression of files.
+ * @brief Read-only whole-file mappings for the buffer and seekable APIs.
  *
- * The whole subsystem is a thin OS layer over @ref zxc_decompress_inplace. That
- * buffer-level decoder already tolerates a flush-right archive overlapping its
- * own output, so all that is missing to decode a file without copying it is a
- * way to *place* the archive at the right end of a single region.
+ * A thin OS layer: @c mmap on POSIX, @c CreateFileMapping + @c MapViewOfFile on
+ * Windows, behind one struct and one release call. The mapping is private and
+ * read-only, and it holds its own reference to the file, so the descriptor used
+ * to create it can be closed straight away.
  *
- * @par POSIX geometry (true zero-copy)
- * @code
- *   base                                     base+off              base+region
- *     |<---------- decoded output ----------->|<--- archive ------->|
- *     [ anonymous, private, zero-filled       | MAP_FIXED file view ]
- * @endcode
- * One anonymous reservation is taken, then the file is mapped over its tail
- * pages with @c MAP_FIXED. @c off is page-aligned (mapping requirement) and at
- * least `bound - comp_size`, so the logical capacity `off + comp_size` always
- * satisfies @ref zxc_decompress_inplace_bound and the write cursor provably
- * never overtakes the read cursor. The file view is @c MAP_PRIVATE, so the
- * decoder writing over already-consumed compressed bytes is copy-on-write and
- * the archive on disk is never modified.
- *
- * @par Windows geometry (same, via placeholder mappings)
- * @c MapViewOfFile cannot land inside a plain @c VirtualAlloc reservation, so
- * the same placement is built from the Windows 10 1803 placeholder APIs: reserve
- * `[0, region)` as a placeholder, split it at @c off, then replace the two
- * halves with committed private memory and a @c PAGE_WRITECOPY view of the
- * archive. @c VirtualAlloc2 / @c MapViewOfFile3 are resolved at run time, and
- * anything older (or any file that cannot back a copy-on-write section) falls
- * back to one reservation plus a single copy of the archive -- still one region,
- * still no output allocation. @ref zxc_mmap_is_zerocopy tells the two apart.
+ * What it buys is an archive the buffer API can read without a copy -- and a
+ * @c zxc_reader_t whose @c read_at is a @c memcpy out of the mapping instead of
+ * a @c read() syscall per block, which is also reentrant, hence legal under
+ * @ref zxc_seekable_decompress_range_mt.
  *
  * Platforms with no mapping at all (Emscripten, freestanding) compile to stubs
  * returning @ref ZXC_ERROR_UNSUPPORTED, keeping the ABI identical everywhere.
@@ -75,21 +56,15 @@
 #include <stddef.h>
 #include <stdint.h>
 
-#include "../../include/zxc_buffer.h"
-#include "../../include/zxc_constants.h"
 #include "../../include/zxc_error.h"
 #include "zxc_internal.h"
 
 #if defined(ZXC_MMAP_POSIX)
-#include <errno.h>
 #include <fcntl.h>
 #include <sys/mman.h>
 #include <sys/stat.h>
 #include <unistd.h>
 
-#if !defined(MAP_ANONYMOUS) && defined(MAP_ANON)
-#define MAP_ANONYMOUS MAP_ANON
-#endif
 #if !defined(O_CLOEXEC)
 #define O_CLOEXEC 0
 #endif
@@ -98,23 +73,6 @@
 #include <stdlib.h> /* _set_thread_local_invalid_parameter_handler */
 #include <windows.h>
 #endif
-
-/**
- * @brief Release path a @ref zxc_map_t base address needs, and whether the
- *        archive got there without a copy.
- *
- * The two decode kinds are what @ref zxc_mmap_is_zerocopy reads: every backend
- * that places the archive by mapping reports @ref ZXC_MAP_KIND_MAPPED, and only
- * the Win32 pre-1803 route, which copies the archive into its region, reports
- * @ref ZXC_MAP_KIND_COPIED. Defined outside @c ZXC_MMAP_ENABLED so the
- * unsupported-platform stubs can share @ref zxc_map_reset.
- */
-enum {
-    ZXC_MAP_KIND_NONE = 0,   /**< Nothing mapped. */
-    ZXC_MAP_KIND_VIEW = 1,   /**< Read-only file view (@ref zxc_mmap_open). */
-    ZXC_MAP_KIND_COPIED = 2, /**< Decode region, archive copied in (Win32 fallback). */
-    ZXC_MAP_KIND_MAPPED = 3  /**< Decode region, archive mapped into it (zero-copy). */
-};
 
 /**
  * @brief Zeroes a caller's @ref zxc_map_t so a failed call still leaves a map
@@ -131,71 +89,7 @@ static void zxc_map_reset(zxc_map_t* const m) {
     m->size = 0;
     m->map_base = NULL;
     m->map_size = 0;
-    m->map_handle = NULL;
-    m->map_kind = ZXC_MAP_KIND_NONE;
 }
-
-#if defined(ZXC_MMAP_ENABLED)
-
-/**
- * @brief Rounds @p v up to the next multiple of the power-of-two @p pow2.
- *
- * @param[in] v     Value to round. Callers check beforehand that @p v is at
- *                  most `SIZE_MAX - (pow2 - 1)`, so the sum cannot wrap.
- * @param[in] pow2  Alignment; must be a power of two (a page size or an
- *                  allocation granularity, both of which always are).
- * @return @p v rounded up to a multiple of @p pow2.
- */
-static size_t zxc_round_up_pow2(const size_t v, const size_t pow2) {
-    return (v + (pow2 - 1)) & ~(pow2 - 1);
-}
-
-/**
- * @brief Computes the single-region geometry for an in-place decode.
- *
- * Two granularities, because the two ends answer to different rules: a file
- * mapping must *start* on an allocation-granularity boundary (64 KiB on Windows,
- * one page on POSIX), while the region it *spans* is page-granular. Sizing the
- * archive slot to exactly `roundup(comp_size, page)` is what lets Windows
- * replace that slot with a view of the archive, which insists the view and the
- * placeholder it replaces cover the same range.
- *
- * @param[in]  comp_size  Archive size in bytes.
- * @param[in]  need       @ref zxc_decompress_inplace_bound for that archive.
- * @param[in]  off_gran   Mapping-start granularity (power of two, multiple of
- *                        @p page).
- * @param[in]  page       Page size (power of two).
- * @param[out] off        Flush-right offset of the archive: aligned to
- *                        @p off_gran (so a file mapping can start there) and
- *                        >= @p need - @p comp_size (so the in-place margin
- *                        holds).
- * @param[out] capacity   Logical buffer capacity to hand
- *                        @ref zxc_decompress_inplace (@p off + @p comp_size).
- * @param[out] region     Total bytes to reserve: @p capacity rounded out to
- *                        whole pages, since a file mapping of @p comp_size
- *                        bytes occupies its last page in full.
- * @return @ref ZXC_OK, or @ref ZXC_ERROR_MEMORY if the geometry overflows
- *         @c size_t.
- */
-static int zxc_map_geometry(const size_t comp_size, const size_t need, const size_t off_gran,
-                            const size_t page, size_t* const off, size_t* const capacity,
-                            size_t* const region) {
-    const size_t gap = (need > comp_size) ? need - comp_size : 0;
-    if (UNLIKELY(gap > SIZE_MAX - (off_gran - 1))) return ZXC_ERROR_MEMORY;
-    const size_t o = zxc_round_up_pow2(gap, off_gran);
-
-    if (UNLIKELY(comp_size > SIZE_MAX - o)) return ZXC_ERROR_MEMORY;
-    if (UNLIKELY(comp_size > SIZE_MAX - (page - 1))) return ZXC_ERROR_MEMORY;
-    const size_t tail = zxc_round_up_pow2(comp_size, page);
-    if (UNLIKELY(tail > SIZE_MAX - o)) return ZXC_ERROR_MEMORY;
-
-    *off = o;
-    *capacity = o + comp_size;
-    *region = o + tail;
-    return ZXC_OK;
-}
-
-#endif /* ZXC_MMAP_ENABLED */
 
 /*
  * ============================================================================
@@ -246,20 +140,6 @@ static int zxc_desc_valid(const zxc_desc_t d) { return d >= 0; }
 static void zxc_desc_close(const zxc_desc_t d) { (void)close(d); }
 
 /**
- * @brief Reports the two granularities the geometry needs.
- *
- * On POSIX both are the page size: @c mmap accepts any page-aligned address.
- *
- * @param[out] off_gran  Granularity a file mapping must start on.
- * @param[out] page      Page size.
- */
-static void zxc_map_grains(size_t* const off_gran, size_t* const page) {
-    const long ps = sysconf(_SC_PAGESIZE);
-    *page = (ps > 0) ? (size_t)ps : 4096U;
-    *off_gran = *page;
-}
-
-/**
  * @brief Measures a mappable file.
  *
  * @param[in]  d     Descriptor to measure.
@@ -303,124 +183,13 @@ static int zxc_map_readonly(const zxc_desc_t d, zxc_map_t* const out) {
     out->size = size;
     out->map_base = view;
     out->map_size = size;
-    out->map_kind = ZXC_MAP_KIND_VIEW;
     return ZXC_OK;
 }
 
 /**
- * @brief Reads exactly @p len bytes at @p offset, short reads included.
+ * @brief Backend of @ref zxc_mmap_close.
  *
- * @c pread leaves the descriptor's file position alone, which is what lets the
- * @c _fd entry points promise they do not disturb it.
- *
- * @param[in]  d       Descriptor to read from.
- * @param[out] buf     Destination for @p len bytes.
- * @param[in]  len     Number of bytes to read.
- * @param[in]  offset  Absolute offset to read at.
- * @return @ref ZXC_OK, or @ref ZXC_ERROR_IO on a read error or end of file.
- */
-static int zxc_desc_read_at(const zxc_desc_t d, void* const buf, const size_t len,
-                            const uint64_t offset) {
-    uint8_t* p = (uint8_t*)buf;
-    size_t left = len;
-    uint64_t at = offset;
-    while (left > 0) {
-        const ssize_t n = pread(d, p, left, (off_t)at);
-        /* A handler without SA_RESTART interrupts pread on slow storage
-         * (NFS, FUSE); that is not a failed archive. */
-        if (UNLIKELY(n < 0 && errno == EINTR)) continue;  // LCOV_EXCL_LINE
-        if (UNLIKELY(n <= 0)) return ZXC_ERROR_IO;        // LCOV_EXCL_LINE
-        p += (size_t)n;
-        at += (uint64_t)n;
-        left -= (size_t)n;
-    }
-    return ZXC_OK;
-}
-
-/**
- * @brief Places the archive flush-right in a fresh single region.
- *
- * One anonymous reservation, then the file dropped over its tail pages with
- * @c MAP_FIXED: that replaces exactly the tail of our own reservation, and
- * @c MAP_PRIVATE makes the decoder's writes over consumed compressed bytes
- * copy-on-write, so the archive on disk is never modified.
- *
- * @param[in]  d          Descriptor of the archive.
- * @param[in]  comp_size  Archive size in bytes.
- * @param[in]  off        Flush-right offset from @ref zxc_map_geometry.
- * @param[in]  region     Total bytes to reserve.
- * @param[out] base       Receives the region base on success.
- * @param[out] handle     Receives the backend release token; always NULL here,
- *                        a POSIX region needing nothing beyond @c munmap.
- * @param[out] zerocopy   Receives 1: POSIX has no copying route.
- * @return @ref ZXC_OK, @ref ZXC_ERROR_MEMORY if the region cannot be reserved,
- *         or @ref ZXC_ERROR_IO if the file cannot be mapped over its tail.
- *         Nothing is left mapped on failure.
- */
-static int zxc_map_place(const zxc_desc_t d, const size_t comp_size, const size_t off,
-                         const size_t region, uint8_t** const base, void** const handle,
-                         int* const zerocopy) {
-    uint8_t* const p =
-        (uint8_t*)mmap(NULL, region, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
-    if (UNLIKELY(p == MAP_FAILED)) return ZXC_ERROR_MEMORY;  // LCOV_EXCL_LINE
-
-    if (UNLIKELY(mmap(p + off, comp_size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_FIXED, d, 0) ==
-                 MAP_FAILED)) {
-        // LCOV_EXCL_START
-        (void)munmap(p, region);
-        return ZXC_ERROR_IO;
-        // LCOV_EXCL_STOP
-    }
-#if defined(MADV_SEQUENTIAL)
-    /* The decoder walks the archive front to back exactly once. */
-    (void)madvise(p + off, comp_size, MADV_SEQUENTIAL);
-#endif
-
-    *base = p;
-    *handle = NULL;
-    *zerocopy = 1;
-    return ZXC_OK;
-}
-
-/**
- * @brief Releases a placement whose decode did not produce a region to keep.
- *
- * @param[in] base    Region base from @ref zxc_map_place.
- * @param[in] region  Its full size in bytes.
- * @param[in] handle  Backend token from @ref zxc_map_place (always NULL here).
- */
-static void zxc_map_unplace(uint8_t* const base, const size_t region, void* const handle) {
-    (void)handle;
-    (void)munmap(base, region);
-}
-
-/**
- * @brief Gives back everything the decoded payload does not occupy.
- *
- * @param[in]     base    Region base from @ref zxc_map_place.
- * @param[in]     off     Flush-right offset (unused here: @c munmap can carve
- *                        the archive's own pages out of the region).
- * @param[in]     region  Full region size in bytes.
- * @param[in]     keep    Page-rounded payload size to keep.
- * @param[in,out] handle  Backend token; untouched here.
- * @return Bytes still mapped at @p base, i.e. @p keep.
- */
-static size_t zxc_map_trim(uint8_t* const base, const size_t off, const size_t region,
-                           const size_t keep, void** const handle) {
-    (void)off;
-    (void)handle;
-    if (keep < region) (void)munmap(base + keep, region - keep);
-    return keep;
-}
-
-/**
- * @brief Backend of @ref zxc_mmap_close (one call covers both map kinds).
- *
- * A read-only view and a decode region both release with a single @c munmap;
- * the kind only matters on Windows.
- *
- * @param[in] m  Live map; @c map_base / @c map_size describe exactly what is
- *               still mapped, the decode path having already trimmed the rest.
+ * @param[in] m  Live map; @c map_base / @c map_size describe what is mapped.
  */
 static void zxc_map_release(zxc_map_t* const m) { (void)munmap(m->map_base, m->map_size); }
 
@@ -520,23 +289,6 @@ static int zxc_desc_valid(const zxc_desc_t d) { return d != INVALID_HANDLE_VALUE
 static void zxc_desc_close(const zxc_desc_t d) { (void)CloseHandle(d); }
 
 /**
- * @brief Reports the two granularities the geometry needs.
- *
- * A file view must start on an *allocation*-granularity boundary (64 KiB), so
- * that is what the flush-right offset is aligned to; the archive slot itself is
- * sized in pages, which is the granularity a view and a @c MEM_DECOMMIT work at.
- *
- * @param[out] off_gran  Allocation granularity.
- * @param[out] page      Page size.
- */
-static void zxc_map_grains(size_t* const off_gran, size_t* const page) {
-    SYSTEM_INFO si;
-    GetSystemInfo(&si);
-    *off_gran = si.dwAllocationGranularity ? (size_t)si.dwAllocationGranularity : 65536U;
-    *page = si.dwPageSize ? (size_t)si.dwPageSize : 4096U;
-}
-
-/**
  * @brief Measures a mappable file.
  *
  * @param[in]  d     Handle to measure.
@@ -578,203 +330,6 @@ static int zxc_win_view(const zxc_desc_t d, void** const view) {
     return ZXC_OK;
 }
 
-/*
- * ----------------------------------------------------------------------------
- * Placeholder mappings: the zero-copy flush-right placement
- * ----------------------------------------------------------------------------
- * MapViewOfFile cannot land inside a plain VirtualAlloc reservation, which is
- * why the naive Win32 port has to copy the archive. The placeholder APIs
- * (Windows 10 1803 / Server 2019) lift exactly that restriction: a reservation
- * can be split into placeholders, and each placeholder replaced -- one by
- * private memory, one by a file view -- giving the same geometry as the POSIX
- * MAP_FIXED path with no copy at all.
- */
-
-/* Flags defined locally so the file still builds against pre-1803 SDKs. */
-#ifndef MEM_RESERVE_PLACEHOLDER
-#define MEM_RESERVE_PLACEHOLDER 0x00040000
-#endif
-#ifndef MEM_REPLACE_PLACEHOLDER
-#define MEM_REPLACE_PLACEHOLDER 0x00004000
-#endif
-#ifndef MEM_PRESERVE_PLACEHOLDER
-#define MEM_PRESERVE_PLACEHOLDER 0x00000002
-#endif
-
-/* The MEM_EXTENDED_PARAMETER argument is always NULL here, so it is typed
- * void* rather than pulling the struct in from a newer SDK. */
-
-/** @brief Signature of @c VirtualAlloc2 (process, base, size, type, prot, ext, count). */
-typedef PVOID(WINAPI* zxc_virtual_alloc2_fn)(HANDLE, PVOID, SIZE_T, ULONG, ULONG, void*, ULONG);
-/** @brief Signature of @c MapViewOfFile3 (section, process, base, offset, size, ...). */
-typedef PVOID(WINAPI* zxc_map_view_of_file3_fn)(HANDLE, HANDLE, PVOID, ULONG64, SIZE_T, ULONG,
-                                                ULONG, void*, ULONG);
-
-/** @brief The two placeholder entry points, resolved at run time. */
-typedef struct {
-    zxc_virtual_alloc2_fn alloc2;  /**< VirtualAlloc2 */
-    zxc_map_view_of_file3_fn map3; /**< MapViewOfFile3 */
-} zxc_win_ext_t;
-
-/**
- * @brief Resolves @c VirtualAlloc2 / @c MapViewOfFile3 dynamically, once.
- *
- * Dynamic resolution (rather than linking @c onecore.lib) keeps a single binary
- * running on Windows older than 1803, where the copy fallback takes over. The
- * @c FARPROC values are copied instead of cast so no toolchain objects to the
- * function-pointer conversion.
- *
- * The answer cannot change while the process lives, so it is cached: a caller
- * decompressing many small archives would otherwise take the loader lock three
- * times per file. Publishing it needs ordering, not just idempotency -- with
- * plain stores a reader can see the flag over a still-empty cache -- hence the
- * Interlocked pair, a full barrier at any @c _WIN32_WINNT and on every
- * toolchain. Two threads may both resolve and write identical bytes; harmless.
- *
- * @param[out] fns  Receives both entry points; cleared first, so the struct is
- *                  never left holding one resolved pointer and one stale value.
- * @return @ref ZXC_OK, or @ref ZXC_ERROR_UNSUPPORTED when this Windows lacks
- *         the placeholder APIs.
- */
-static int zxc_win_ext_resolve(zxc_win_ext_t* const fns) {
-    static zxc_win_ext_t g_cache;
-    static volatile LONG g_state; /* 0 = not tried, 1 = available, -1 = unavailable */
-
-    /* Acquire: a published state implies g_cache is written. */
-    const LONG state = InterlockedCompareExchange(&g_state, 0, 0);
-    if (state != 0) {
-        *fns = g_cache;
-        return (state > 0) ? ZXC_OK : ZXC_ERROR_UNSUPPORTED;
-    }
-
-    fns->alloc2 = NULL;
-    fns->map3 = NULL;
-
-    HMODULE mod = GetModuleHandleW(L"kernelbase.dll");
-    if (!mod) mod = GetModuleHandleW(L"kernel32.dll");
-    if (!mod) {
-        (void)InterlockedExchange(&g_state, -1);
-        return ZXC_ERROR_UNSUPPORTED;
-    }
-
-    const FARPROC p_alloc2 = GetProcAddress(mod, "VirtualAlloc2");
-    const FARPROC p_map3 = GetProcAddress(mod, "MapViewOfFile3");
-    if (!p_alloc2 || !p_map3) {
-        (void)InterlockedExchange(&g_state, -1);
-        return ZXC_ERROR_UNSUPPORTED;
-    }
-
-    ZXC_MEMCPY(&fns->alloc2, &p_alloc2, sizeof(fns->alloc2));
-    ZXC_MEMCPY(&fns->map3, &p_map3, sizeof(fns->map3));
-    g_cache = *fns;
-    /* Release: publish only once g_cache is whole. */
-    (void)InterlockedExchange(&g_state, 1);
-    return ZXC_OK;
-}
-
-/**
- * @brief Creates a copy-on-write section over the whole file.
- *
- * @c PAGE_WRITECOPY needs only @c GENERIC_READ on the file and makes the
- * decoder's writes over consumed compressed bytes private, so the archive on
- * disk is never modified. The size arguments are 0 on purpose: an explicit size
- * beyond the file, with a write-capable protection, would *grow* the file.
- *
- * @param[in]  d        Handle of the archive.
- * @param[out] section  Receives the section handle; set only on success, and
- *                      closed by the caller once a view exists (a live view
- *                      keeps the section alive on its own).
- * @return @ref ZXC_OK, or @ref ZXC_ERROR_IO when the file cannot back a
- *         copy-on-write section, which sends the caller to the copying route.
- */
-static int zxc_win_section_cow(const zxc_desc_t d, HANDLE* const section) {
-    HANDLE s = CreateFileMappingA(d, NULL, PAGE_WRITECOPY, 0, 0, NULL);
-    if (!s) return ZXC_ERROR_IO;
-    *section = s;
-    return ZXC_OK;
-}
-
-/**
- * @brief Places the archive flush-right in a split placeholder reservation.
- *
- *   1. reserve `[0, region)` as one placeholder;
- *   2. split it at @p off, leaving two independently replaceable placeholders;
- *   3. replace `[0, off)` with committed private memory (the decode output);
- *   4. replace `[off, region)` with a @c PAGE_WRITECOPY view of the archive.
- *
- * Every failure path leaves nothing allocated, so the caller can simply fall
- * back to the copying route.
- *
- * @param[in]  section    Copy-on-write section over the archive.
- * @param[in]  comp_size  Archive size in bytes (the view size).
- * @param[in]  off        Flush-right offset, a multiple of the allocation
- *                        granularity (see @ref zxc_map_grains).
- * @param[in]  region     Total reservation size in bytes. `region - off` is
- *                        exactly the page span of @p comp_size, which is what
- *                        lets a view replace that placeholder.
- * @param[out] out_base   Receives the reservation base on success.
- * @param[out] out_view   Receives the mapped view address on success.
- * @return @ref ZXC_OK, @ref ZXC_ERROR_UNSUPPORTED (no placeholder APIs, or this
- *         file cannot back a copy-on-write view), or @ref ZXC_ERROR_MEMORY.
- */
-static int zxc_win_place(const HANDLE section, const size_t comp_size, const size_t off,
-                         const size_t region, uint8_t** const out_base, void** const out_view) {
-    zxc_win_ext_t fns;
-    const int rc = zxc_win_ext_resolve(&fns);
-    if (rc != ZXC_OK) return rc;
-    /* The geometry always leaves room for the output ahead of the archive; bail
-     * out rather than split a placeholder at one of its own edges. */
-    if (off == 0 || off >= region) return ZXC_ERROR_UNSUPPORTED;
-
-    uint8_t* const base = (uint8_t*)fns.alloc2(
-        NULL, NULL, region, MEM_RESERVE | MEM_RESERVE_PLACEHOLDER, PAGE_NOACCESS, NULL, 0);
-    if (!base) return ZXC_ERROR_MEMORY;
-
-    /* Split, so the archive slot can be replaced by a view on its own. Both
-     * halves stay reserved (MEM_PRESERVE_PLACEHOLDER) and become independently
-     * replaceable and independently releasable. */
-    if (!VirtualFree(base, off, MEM_RELEASE | MEM_PRESERVE_PLACEHOLDER)) {
-        (void)VirtualFree(base, 0, MEM_RELEASE);
-        return ZXC_ERROR_UNSUPPORTED;
-    }
-
-    /* [0, off): committed private memory, the decoder's output. */
-    if (!fns.alloc2(NULL, base, off, MEM_RESERVE | MEM_COMMIT | MEM_REPLACE_PLACEHOLDER,
-                    PAGE_READWRITE, NULL, 0)) {
-        (void)VirtualFree(base, 0, MEM_RELEASE);
-        (void)VirtualFree(base + off, 0, MEM_RELEASE);
-        return ZXC_ERROR_MEMORY;
-    }
-
-    /* [off, region): the archive itself, faulted in from the page cache.
-     *
-     * Two view sizes are tried because the documented rule ("the mapped view
-     * must be exactly the size of the placeholder it replaces") and the section
-     * rule ("a view may not extend beyond the section") pull in opposite
-     * directions whenever comp_size is not a whole number of pages, which is
-     * the common case: the placeholder spans roundup(comp_size, page) while the
-     * section is comp_size long. Whether the kernel rounds the requested size
-     * up before comparing it against the placeholder is not something the
-     * documentation settles, so ask for the file's own length first and, if
-     * that is refused, for the placeholder's exact span. A failed map3 consumes
-     * nothing, which is what makes the second attempt safe. */
-    void* view = fns.map3(section, NULL, base + off, 0, comp_size, MEM_REPLACE_PLACEHOLDER,
-                          PAGE_WRITECOPY, NULL, 0);
-    if (!view && (region - off) != comp_size) {
-        view = fns.map3(section, NULL, base + off, 0, region - off, MEM_REPLACE_PLACEHOLDER,
-                        PAGE_WRITECOPY, NULL, 0);
-    }
-    if (!view) {
-        (void)VirtualFree(base, 0, MEM_RELEASE);
-        (void)VirtualFree(base + off, 0, MEM_RELEASE);
-        return ZXC_ERROR_UNSUPPORTED;
-    }
-
-    *out_base = base;
-    *out_view = view;
-    return ZXC_OK;
-}
-
 /**
  * @brief Backend of @ref zxc_mmap_open -- whole-file read-only view.
  *
@@ -796,278 +351,22 @@ static int zxc_map_readonly(const zxc_desc_t d, zxc_map_t* const out) {
     out->size = size;
     out->map_base = view;
     out->map_size = size;
-    out->map_kind = ZXC_MAP_KIND_VIEW;
     return ZXC_OK;
 }
 
 /**
- * @brief Reads exactly @p len bytes at @p offset, short reads included.
+ * @brief Backend of @ref zxc_mmap_close.
  *
- * An @c OVERLAPPED offset is not the Windows @c pread: on a synchronous handle
- * -- what @ref zxc_desc_open and a CRT descriptor both give -- the file pointer
- * still moves to the end of every transfer, which would reposition the caller's
- * descriptor. It is saved and restored instead. @c SetFilePointerEx fails on a
- * handle that has no position (a pipe), which is the guard.
- *
- * @param[in]  d       Handle to read from.
- * @param[out] buf     Destination for @p len bytes.
- * @param[in]  len     Number of bytes to read.
- * @param[in]  offset  Absolute offset to read at.
- * @return @ref ZXC_OK, or @ref ZXC_ERROR_IO on a read error or end of file.
+ * @param[in] m  Live map; the view address is @c map_base, which is what
+ *               @c UnmapViewOfFile wants (it takes no length).
  */
-static int zxc_desc_read_at(const zxc_desc_t d, void* const buf, const size_t len,
-                            const uint64_t offset) {
-    LARGE_INTEGER saved;
-    LARGE_INTEGER zero;
-    saved.QuadPart = 0;
-    zero.QuadPart = 0;
-    const BOOL restore = SetFilePointerEx(d, zero, &saved, FILE_CURRENT);
-
-    uint8_t* p = (uint8_t*)buf;
-    size_t left = len;
-    uint64_t at = offset;
-    int rc = ZXC_OK;
-    while (left > 0) {
-        OVERLAPPED ov;
-        ZXC_MEMSET(&ov, 0, sizeof(ov));
-        ov.Offset = (DWORD)(at & 0xFFFFFFFFU);
-        ov.OffsetHigh = (DWORD)(at >> 32);
-        /* Clamped, not cast: a remaining length that is a multiple of 4 GiB
-         * truncates to a 0-byte request, i.e. a spurious ZXC_ERROR_IO. */
-        const DWORD want = (left > 0x40000000U) ? 0x40000000U : (DWORD)left;
-        DWORD got = 0;
-        if (UNLIKELY(!ReadFile(d, p, want, &got, &ov) || got == 0)) {
-            rc = ZXC_ERROR_IO;
-            break;
-        }
-        p += got;
-        at += got;
-        left -= got;
-    }
-
-    if (restore) (void)SetFilePointerEx(d, saved, NULL, FILE_BEGIN);
-    return rc;
-}
-
-/**
- * @brief Places the archive flush-right in a fresh single region.
- *
- * Prefers the placeholder placement (@ref zxc_win_place, zero-copy). Older
- * Windows, or a file that cannot back a copy-on-write section, fall back to one
- * reservation plus a single copy of the archive: still one region, still no
- * output allocation. @ref zxc_mmap_is_zerocopy reports which route ran.
- *
- * @param[in]  d          Handle of the archive.
- * @param[in]  comp_size  Archive size in bytes.
- * @param[in]  off        Flush-right offset from @ref zxc_map_geometry.
- * @param[in]  region     Total bytes to reserve.
- * @param[out] base       Receives the region base on success.
- * @param[out] handle     Receives the archive view to unmap later, or NULL when
- *                        the copying route ran.
- * @param[out] zerocopy   Receives 1 for the placeholder route, 0 for the copy.
- * @return @ref ZXC_OK, @ref ZXC_ERROR_MEMORY if the region cannot be reserved,
- *         or @ref ZXC_ERROR_IO if the archive cannot be read into it. Nothing
- *         is left allocated on failure.
- */
-static int zxc_map_place(const zxc_desc_t d, const size_t comp_size, const size_t off,
-                         const size_t region, uint8_t** const base, void** const handle,
-                         int* const zerocopy) {
-    uint8_t* p = NULL;
-    void* view = NULL;
-
-    /* 1. Zero-copy: a copy-on-write view of the archive, placed flush-right in
-     *    a split placeholder reservation. */
-    HANDLE section = NULL;
-    if (zxc_win_section_cow(d, &section) == ZXC_OK) {
-        if (zxc_win_place(section, comp_size, off, region, &p, &view) != ZXC_OK) {
-            p = NULL;
-            view = NULL;
-        }
-        /* A mapped view keeps the section alive on its own. */
-        (void)CloseHandle(section);
-    }
-
-    /* 2. Fallback: one reservation and a single copy of the archive into it. */
-    if (!p) {
-        p = (uint8_t*)VirtualAlloc(NULL, region, MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE);
-        if (UNLIKELY(!p)) return ZXC_ERROR_MEMORY;
-        const int rc = zxc_desc_read_at(d, p + off, comp_size, 0);
-        if (UNLIKELY(rc != ZXC_OK)) {
-            (void)VirtualFree(p, 0, MEM_RELEASE);
-            return rc;
-        }
-    }
-
-    *base = p;
-    *handle = view;
-    *zerocopy = (view != NULL);
-    return ZXC_OK;
-}
-
-/**
- * @brief Releases a placement whose decode did not produce a region to keep.
- *
- * @param[in] base    Region base from @ref zxc_map_place.
- * @param[in] region  Its full size in bytes (unused: @c MEM_RELEASE takes the
- *                    whole reservation and insists on a zero size).
- * @param[in] handle  Archive view from @ref zxc_map_place, or NULL.
- */
-static void zxc_map_unplace(uint8_t* const base, const size_t region, void* const handle) {
-    (void)region;
-    if (handle) (void)UnmapViewOfFile(handle);
-    (void)VirtualFree(base, 0, MEM_RELEASE);
-}
-
-/**
- * @brief Gives back everything the decoded payload does not occupy.
- *
- * Windows has no partial @c UnmapViewOfFile, so the archive slot only goes back
- * when the payload ends before it begins: a payload reaching into the slot keeps
- * the whole region, since `[keep, region)` cannot go back while `[off, keep)`
- * holds decoded bytes. The copying route has no view and always decommits its
- * tail. What survives is released by @ref zxc_map_release.
- *
- * @param[in]     base    Region base from @ref zxc_map_place.
- * @param[in]     off     Flush-right offset: where the archive slot begins.
- * @param[in]     region  Full region size in bytes.
- * @param[in]     keep    Page-rounded payload size to keep.
- * @param[in,out] handle  Archive view; cleared if this call unmapped it.
- * @return Bytes still mapped at @p base: @p keep once the tail is back,
- *         @p region when the view could not be given up.
- */
-static size_t zxc_map_trim(uint8_t* const base, const size_t off, const size_t region,
-                           const size_t keep, void** const handle) {
-    if (!*handle) {
-        if (keep < region) (void)VirtualFree(base + keep, region - keep, MEM_DECOMMIT);
-        return keep;
-    }
-    if (keep > off) return region;
-
-    (void)UnmapViewOfFile(*handle);
-    *handle = NULL;
-    if (keep < off) (void)VirtualFree(base + keep, off - keep, MEM_DECOMMIT);
-    return keep;
-}
-
-/**
- * @brief Backend of @ref zxc_mmap_close -- views unmap, reservations release.
- *
- * @param[in] m  Live map. @c map_kind selects the release path and @c map_handle
- *               carries the archive view still to unmap, if the trim could not
- *               already give it back.
- */
-static void zxc_map_release(zxc_map_t* const m) {
-    if (m->map_kind == ZXC_MAP_KIND_VIEW) {
-        (void)UnmapViewOfFile(m->map_base);
-        return;
-    }
-    /* Decode region: an archive view may still sit at its far end, and the
-     * output part is a reservation of its own (a split placeholder replaced by
-     * private memory releases exactly like a plain VirtualAlloc). */
-    if (m->map_handle) (void)UnmapViewOfFile(m->map_handle);
-    (void)VirtualFree(m->map_base, 0, MEM_RELEASE);
-}
+static void zxc_map_release(zxc_map_t* const m) { (void)UnmapViewOfFile(m->map_base); }
 
 // LCOV_EXCL_STOP
 
 #endif /* backend selection */
 
 #if defined(ZXC_MMAP_ENABLED)
-
-/**
- * @brief Answers @ref zxc_decompress_inplace_bound for an on-disk archive.
- *
- * The bound looks at the file header and the file footer and at nothing else,
- * so the two ends are read directly rather than mapping the whole archive just
- * to consult 28 bytes of it -- which also keeps the copying route on Windows
- * from building a second mapping of a file it is about to read anyway.
- *
- * @param[in]  d          Descriptor of the archive.
- * @param[in]  comp_size  Archive size in bytes; the caller has already checked
- *                        it covers a file header and a footer.
- * @param[out] need       Receives the in-place bound in bytes.
- * @return @ref ZXC_OK, @ref ZXC_ERROR_IO if the two ends cannot be read, or
- *         the verdict @ref zxc_inplace_bound_parts reached on an archive it
- *         refused (@ref ZXC_ERROR_BAD_MAGIC, @ref ZXC_ERROR_BAD_HEADER,
- *         @ref ZXC_ERROR_CORRUPT_DATA for a forged footer).
- */
-static int zxc_map_bound(const zxc_desc_t d, const size_t comp_size, size_t* const need) {
-    uint8_t head[ZXC_FILE_HEADER_SIZE];
-    uint8_t foot[ZXC_FILE_FOOTER_SIZE];
-
-    int rc = zxc_desc_read_at(d, head, sizeof(head), 0);
-    if (UNLIKELY(rc != ZXC_OK)) return rc;
-    rc = zxc_desc_read_at(d, foot, sizeof(foot), (uint64_t)comp_size - ZXC_FILE_FOOTER_SIZE);
-    if (UNLIKELY(rc != ZXC_OK)) return rc;  // LCOV_EXCL_LINE
-
-    return zxc_inplace_bound_parts(head, foot, comp_size, need);
-}
-
-/**
- * @brief Backend-independent body of @ref zxc_decompress_mmap.
- *
- * Measure the archive, size its region from the two ends of the file, let the
- * backend place it flush-right, decode into the head of that region, then trim
- * back to the payload. Only the placement, the trim and the unwind differ
- * between POSIX and Windows, and each is one backend hook; the sequence itself
- * -- and every check in it -- exists once.
- *
- * @param[in]  d     Descriptor of the archive to decode.
- * @param[out] out   Receives the decoded region; filled only on success, with
- *                   @c map_kind recording whether the archive was mapped or
- *                   copied into place.
- * @param[in]  opts  Decompression options, or NULL for defaults.
- * @return Decompressed size in bytes (> 0), 0 for an empty frame (nothing is
- *         mapped, @p out stays cleared), or a negative @c zxc_error_t:
- *         @ref ZXC_ERROR_SRC_TOO_SMALL if the file is shorter than a frame,
- *         @ref ZXC_ERROR_BAD_HEADER if it is not a ZXC archive,
- *         @ref ZXC_ERROR_IO on a read or mapping failure,
- *         @ref ZXC_ERROR_MEMORY if the region cannot be reserved, or whatever
- *         @ref zxc_decompress_inplace reports for a corrupt archive.
- */
-static int64_t zxc_map_decompress(const zxc_desc_t d, zxc_map_t* const out,
-                                  const zxc_decompress_opts_t* const opts) {
-    size_t comp_size = 0;
-    int rc = zxc_desc_size(d, &comp_size);
-    if (UNLIKELY(rc != ZXC_OK)) return rc;
-    if (UNLIKELY(comp_size < ZXC_FILE_HEADER_SIZE + ZXC_FILE_FOOTER_SIZE))
-        return ZXC_ERROR_SRC_TOO_SMALL;
-
-    size_t need = 0;
-    rc = zxc_map_bound(d, comp_size, &need);
-    if (UNLIKELY(rc != ZXC_OK)) return rc;
-
-    size_t off_gran = 0;
-    size_t page = 0;
-    zxc_map_grains(&off_gran, &page);
-    size_t off = 0;
-    size_t capacity = 0;
-    size_t region = 0;
-    rc = zxc_map_geometry(comp_size, need, off_gran, page, &off, &capacity, &region);
-    if (UNLIKELY(rc != ZXC_OK)) return rc;  // LCOV_EXCL_LINE
-
-    uint8_t* base = NULL;
-    void* handle = NULL;
-    int zerocopy = 0;
-    rc = zxc_map_place(d, comp_size, off, region, &base, &handle, &zerocopy);
-    if (UNLIKELY(rc != ZXC_OK)) return rc;
-
-    const int64_t decoded = zxc_decompress_inplace(base, capacity, comp_size, opts);
-    if (UNLIKELY(decoded <= 0)) {
-        /* Errors and the empty frame both leave nothing worth handing back. */
-        zxc_map_unplace(base, region, handle);
-        return decoded;
-    }
-
-    const size_t keep = zxc_round_up_pow2((size_t)decoded, page);
-    out->data = base;
-    out->size = (size_t)decoded;
-    out->map_base = base;
-    out->map_size = zxc_map_trim(base, off, region, keep, &handle);
-    out->map_handle = handle; /* non-NULL: a mapping still to release on close */
-    out->map_kind = zerocopy ? ZXC_MAP_KIND_MAPPED : ZXC_MAP_KIND_COPIED;
-    return decoded;
-}
 
 /*
  * ============================================================================
@@ -1082,19 +381,6 @@ static int64_t zxc_map_decompress(const zxc_desc_t d, zxc_map_t* const out,
  */
 // cppcheck-suppress unusedFunction
 int zxc_mmap_supported(void) { return 1; }
-
-/**
- * @brief Reports whether @p map holds the archive without having copied it.
- *
- * Public API; full contract in @c zxc_mmap.h. Every route but one places the
- * archive by mapping it; @ref ZXC_MAP_KIND_COPIED marks the single exception,
- * the pre-1803 Windows fallback.
- */
-// cppcheck-suppress unusedFunction
-int zxc_mmap_is_zerocopy(const zxc_map_t* const map) {
-    if (UNLIKELY(!map || !map->data)) return 0;
-    return map->map_kind != ZXC_MAP_KIND_COPIED;
-}
 
 /**
  * @brief Maps a file read-only, without decoding it.
@@ -1132,41 +418,6 @@ int zxc_mmap_open_fd(const int fd, zxc_map_t* const out) {
 }
 
 /**
- * @brief Decompresses a file into a single mapped region, in place.
- *
- * Public API; full contract in @c zxc_mmap.h.
- */
-// cppcheck-suppress unusedFunction
-int64_t zxc_decompress_mmap(const char* const path, zxc_map_t* const out,
-                            const zxc_decompress_opts_t* const opts) {
-    if (UNLIKELY(!out)) return ZXC_ERROR_NULL_INPUT;
-    zxc_map_reset(out);
-    if (UNLIKELY(!path)) return ZXC_ERROR_NULL_INPUT;
-
-    const zxc_desc_t d = zxc_desc_open(path);
-    if (UNLIKELY(!zxc_desc_valid(d))) return ZXC_ERROR_IO;
-    const int64_t rc = zxc_map_decompress(d, out, opts);
-    zxc_desc_close(d);
-    return rc;
-}
-
-/**
- * @brief Decompresses an already-open file into a single mapped region.
- *
- * Public API; full contract in @c zxc_mmap.h.
- */
-// cppcheck-suppress unusedFunction
-int64_t zxc_decompress_mmap_fd(const int fd, zxc_map_t* const out,
-                               const zxc_decompress_opts_t* const opts) {
-    if (UNLIKELY(!out)) return ZXC_ERROR_NULL_INPUT;
-    zxc_map_reset(out);
-
-    const zxc_desc_t d = zxc_desc_from_fd(fd);
-    if (UNLIKELY(!zxc_desc_valid(d))) return ZXC_ERROR_IO;
-    return zxc_map_decompress(d, out, opts);
-}
-
-/**
  * @brief Releases a region obtained from this API and clears @p map.
  *
  * Public API; full contract in @c zxc_mmap.h.
@@ -1184,13 +435,6 @@ void zxc_mmap_close(zxc_map_t* const map) {
 // cppcheck-suppress unusedFunction
 int zxc_mmap_supported(void) { return 0; }
 
-/** @brief Nothing can be mapped on this target, so nothing is ever zero-copy. */
-// cppcheck-suppress unusedFunction
-int zxc_mmap_is_zerocopy(const zxc_map_t* map) {
-    (void)map;
-    return 0;
-}
-
 /** @brief Unsupported on this target; see @ref zxc_mmap_supported. */
 // cppcheck-suppress unusedFunction
 int zxc_mmap_open(const char* path, zxc_map_t* out) {
@@ -1203,24 +447,6 @@ int zxc_mmap_open(const char* path, zxc_map_t* out) {
 // cppcheck-suppress unusedFunction
 int zxc_mmap_open_fd(int fd, zxc_map_t* out) {
     (void)fd;
-    if (out) zxc_map_reset(out);
-    return ZXC_ERROR_UNSUPPORTED;
-}
-
-/** @brief Unsupported on this target; see @ref zxc_mmap_supported. */
-// cppcheck-suppress unusedFunction
-int64_t zxc_decompress_mmap(const char* path, zxc_map_t* out, const zxc_decompress_opts_t* opts) {
-    (void)path;
-    (void)opts;
-    if (out) zxc_map_reset(out);
-    return ZXC_ERROR_UNSUPPORTED;
-}
-
-/** @brief Unsupported on this target; see @ref zxc_mmap_supported. */
-// cppcheck-suppress unusedFunction
-int64_t zxc_decompress_mmap_fd(int fd, zxc_map_t* out, const zxc_decompress_opts_t* opts) {
-    (void)fd;
-    (void)opts;
     if (out) zxc_map_reset(out);
     return ZXC_ERROR_UNSUPPORTED;
 }

--- a/src/lib/zxc_mmap.c
+++ b/src/lib/zxc_mmap.c
@@ -93,18 +93,26 @@
 #define O_CLOEXEC 0
 #endif
 #elif defined(ZXC_MMAP_WIN32)
-#include <io.h> /* _get_osfhandle */
+#include <io.h>     /* _get_osfhandle */
+#include <stdlib.h> /* _set_thread_local_invalid_parameter_handler */
 #include <windows.h>
 #endif
 
-#if defined(ZXC_MMAP_ENABLED)
-
-/** @brief Release path a @ref zxc_map_t base address needs. */
+/**
+ * @brief Release path a @ref zxc_map_t base address needs, and whether the
+ *        archive got there without a copy.
+ *
+ * The two decode kinds are what @ref zxc_mmap_is_zerocopy reads: every backend
+ * that places the archive by mapping reports @ref ZXC_MAP_KIND_MAPPED, and only
+ * the Win32 pre-1803 route, which copies the archive into its region, reports
+ * @ref ZXC_MAP_KIND_COPIED. Defined outside @c ZXC_MMAP_ENABLED so the
+ * unsupported-platform stubs can share @ref zxc_map_reset.
+ */
 enum {
-    ZXC_MAP_KIND_NONE = 0,       /**< Nothing mapped. */
-    ZXC_MAP_KIND_VIEW = 1,       /**< Read-only file view (@ref zxc_mmap_open). */
-    ZXC_MAP_KIND_REGION = 2,     /**< Decode region, archive copied in (Win32 fallback). */
-    ZXC_MAP_KIND_PLACEHOLDER = 3 /**< Decode region with the archive mapped into it. */
+    ZXC_MAP_KIND_NONE = 0,   /**< Nothing mapped. */
+    ZXC_MAP_KIND_VIEW = 1,   /**< Read-only file view (@ref zxc_mmap_open). */
+    ZXC_MAP_KIND_COPIED = 2, /**< Decode region, archive copied in (Win32 fallback). */
+    ZXC_MAP_KIND_MAPPED = 3  /**< Decode region, archive mapped into it (zero-copy). */
 };
 
 /**
@@ -125,6 +133,8 @@ static void zxc_map_reset(zxc_map_t* const m) {
     m->map_handle = NULL;
     m->map_kind = ZXC_MAP_KIND_NONE;
 }
+
+#if defined(ZXC_MMAP_ENABLED)
 
 /**
  * @brief Rounds @p v up to the next multiple of the power-of-two @p pow2.
@@ -297,85 +307,106 @@ static int zxc_map_readonly(const zxc_desc_t d, zxc_map_t* const out) {
 }
 
 /**
- * @brief Backend of @ref zxc_decompress_mmap -- reserve, map flush-right,
- *        decode, trim.
+ * @brief Reads exactly @p len bytes at @p offset, short reads included.
  *
- * Four steps: measure the archive and probe its in-place bound through a
- * throw-away view, reserve one anonymous region and drop the file over its tail
- * pages with @c MAP_FIXED, decode into the head, then unmap everything the
- * payload does not occupy. Every failure path unmaps what it had taken, so the
- * caller never has to release a partial region.
+ * @c pread leaves the descriptor's file position alone, which is what lets the
+ * @c _fd entry points promise they do not disturb it.
  *
- * @param[in]  d     Descriptor of the archive to decode.
- * @param[out] out   Receives the decoded region; filled only on success.
- * @param[in]  opts  Decompression options, or NULL for defaults.
- * @return Decompressed size in bytes (> 0), 0 for an empty frame (nothing is
- *         mapped, @p out stays cleared), or a negative @c zxc_error_t:
- *         @ref ZXC_ERROR_SRC_TOO_SMALL if the file is shorter than a frame,
- *         @ref ZXC_ERROR_BAD_HEADER if it is not a ZXC archive,
- *         @ref ZXC_ERROR_IO on a mapping failure, @ref ZXC_ERROR_MEMORY if the
- *         region cannot be reserved, or whatever @ref zxc_decompress_inplace
- *         reports for a corrupt archive.
+ * @param[in]  d       Descriptor to read from.
+ * @param[out] buf     Destination for @p len bytes.
+ * @param[in]  len     Number of bytes to read.
+ * @param[in]  offset  Absolute offset to read at.
+ * @return @ref ZXC_OK, or @ref ZXC_ERROR_IO on a read error or end of file.
  */
-static int64_t zxc_map_decompress(const zxc_desc_t d, zxc_map_t* const out,
-                                  const zxc_decompress_opts_t* const opts) {
-    size_t comp_size = 0;
-    int rc = zxc_desc_size(d, &comp_size);
-    if (UNLIKELY(rc != ZXC_OK)) return rc;
-    if (UNLIKELY(comp_size < ZXC_FILE_HEADER_SIZE + ZXC_FILE_FOOTER_SIZE))
-        return ZXC_ERROR_SRC_TOO_SMALL;
+static int zxc_desc_read_at(const zxc_desc_t d, void* const buf, const size_t len,
+                            const uint64_t offset) {
+    uint8_t* p = (uint8_t*)buf;
+    size_t left = len;
+    uint64_t at = offset;
+    while (left > 0) {
+        const ssize_t n = pread(d, p, left, (off_t)at);
+        if (UNLIKELY(n <= 0)) return ZXC_ERROR_IO;  // LCOV_EXCL_LINE
+        p += (size_t)n;
+        at += (uint64_t)n;
+        left -= (size_t)n;
+    }
+    return ZXC_OK;
+}
 
-    /* Probe pass: the bound only reads the file header and footer, so a
-     * throw-away read-only view answers it without copying anything. */
-    void* const probe = mmap(NULL, comp_size, PROT_READ, MAP_PRIVATE, d, 0);
-    if (UNLIKELY(probe == MAP_FAILED)) return ZXC_ERROR_IO;  // LCOV_EXCL_LINE
-    const size_t need = zxc_decompress_inplace_bound(probe, comp_size);
-    (void)munmap(probe, comp_size);
-    if (UNLIKELY(need == 0)) return ZXC_ERROR_BAD_HEADER;
-
-    size_t off_gran = 0, page = 0;
-    zxc_map_grains(&off_gran, &page);
-    size_t off = 0, capacity = 0, region = 0;
-    rc = zxc_map_geometry(comp_size, need, off_gran, page, &off, &capacity, &region);
-    if (UNLIKELY(rc != ZXC_OK)) return rc;  // LCOV_EXCL_LINE
-
-    uint8_t* const base =
+/**
+ * @brief Places the archive flush-right in a fresh single region.
+ *
+ * One anonymous reservation, then the file dropped over its tail pages with
+ * @c MAP_FIXED: that replaces exactly the tail of our own reservation, and
+ * @c MAP_PRIVATE makes the decoder's writes over consumed compressed bytes
+ * copy-on-write, so the archive on disk is never modified.
+ *
+ * @param[in]  d          Descriptor of the archive.
+ * @param[in]  comp_size  Archive size in bytes.
+ * @param[in]  off        Flush-right offset from @ref zxc_map_geometry.
+ * @param[in]  region     Total bytes to reserve.
+ * @param[out] base       Receives the region base on success.
+ * @param[out] handle     Receives the backend release token; always NULL here,
+ *                        a POSIX region needing nothing beyond @c munmap.
+ * @param[out] zerocopy   Receives 1: POSIX has no copying route.
+ * @return @ref ZXC_OK, @ref ZXC_ERROR_MEMORY if the region cannot be reserved,
+ *         or @ref ZXC_ERROR_IO if the file cannot be mapped over its tail.
+ *         Nothing is left mapped on failure.
+ */
+static int zxc_map_place(const zxc_desc_t d, const size_t comp_size, const size_t off,
+                         const size_t region, uint8_t** const base, void** const handle,
+                         int* const zerocopy) {
+    uint8_t* const p =
         (uint8_t*)mmap(NULL, region, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
-    if (UNLIKELY(base == MAP_FAILED)) return ZXC_ERROR_MEMORY;  // LCOV_EXCL_LINE
+    if (UNLIKELY(p == MAP_FAILED)) return ZXC_ERROR_MEMORY;  // LCOV_EXCL_LINE
 
-    /* Land the archive flush-right: MAP_FIXED replaces exactly the tail pages
-     * of our own reservation, and MAP_PRIVATE makes the decoder's writes over
-     * consumed compressed bytes copy-on-write. */
-    if (UNLIKELY(mmap(base + off, comp_size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_FIXED, d,
-                      0) == MAP_FAILED)) {
+    if (UNLIKELY(mmap(p + off, comp_size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_FIXED, d, 0) ==
+                 MAP_FAILED)) {
         // LCOV_EXCL_START
-        (void)munmap(base, region);
+        (void)munmap(p, region);
         return ZXC_ERROR_IO;
         // LCOV_EXCL_STOP
     }
 #if defined(MADV_SEQUENTIAL)
     /* The decoder walks the archive front to back exactly once. */
-    (void)madvise(base + off, comp_size, MADV_SEQUENTIAL);
+    (void)madvise(p + off, comp_size, MADV_SEQUENTIAL);
 #endif
 
-    const int64_t decoded = zxc_decompress_inplace(base, capacity, comp_size, opts);
-    if (UNLIKELY(decoded <= 0)) {
-        /* Errors and the empty frame both leave nothing worth handing back. */
-        (void)munmap(base, region);
-        return decoded;
-    }
+    *base = p;
+    *handle = NULL;
+    *zerocopy = 1;
+    return ZXC_OK;
+}
 
-    /* Trim: give back the margin and the file-backed tail, so what the caller
-     * keeps resident is the payload rather than the in-place bound. */
-    const size_t keep = zxc_round_up_pow2((size_t)decoded, page);
+/**
+ * @brief Releases a placement whose decode did not produce a region to keep.
+ *
+ * @param[in] base    Region base from @ref zxc_map_place.
+ * @param[in] region  Its full size in bytes.
+ * @param[in] handle  Backend token from @ref zxc_map_place (always NULL here).
+ */
+static void zxc_map_unplace(uint8_t* const base, const size_t region, void* const handle) {
+    (void)handle;
+    (void)munmap(base, region);
+}
+
+/**
+ * @brief Gives back everything the decoded payload does not occupy.
+ *
+ * @param[in]     base    Region base from @ref zxc_map_place.
+ * @param[in]     off     Flush-right offset (unused here: @c munmap can carve
+ *                        the archive's own pages out of the region).
+ * @param[in]     region  Full region size in bytes.
+ * @param[in]     keep    Page-rounded payload size to keep.
+ * @param[in,out] handle  Backend token; untouched here.
+ * @return Bytes still mapped at @p base, i.e. @p keep.
+ */
+static size_t zxc_map_trim(uint8_t* const base, const size_t off, const size_t region,
+                           const size_t keep, void** const handle) {
+    (void)off;
+    (void)handle;
     if (keep < region) (void)munmap(base + keep, region - keep);
-
-    out->data = base;
-    out->size = (size_t)decoded;
-    out->map_base = base;
-    out->map_size = keep;
-    out->map_kind = ZXC_MAP_KIND_REGION;
-    return decoded;
+    return keep;
 }
 
 /**
@@ -388,17 +419,6 @@ static int64_t zxc_map_decompress(const zxc_desc_t d, zxc_map_t* const out,
  *               still mapped, the decode path having already trimmed the rest.
  */
 static void zxc_map_release(zxc_map_t* const m) { (void)munmap(m->map_base, m->map_size); }
-
-/**
- * @brief Backend of @ref zxc_mmap_is_zerocopy -- here every region is mapped.
- *
- * @param[in] m  Live map (unused: POSIX has no copying route).
- * @return Always 1.
- */
-static int zxc_map_zerocopy(const zxc_map_t* const m) {
-    (void)m;
-    return 1;
-}
 
 /*
  * ============================================================================
@@ -428,6 +448,27 @@ static zxc_desc_t zxc_desc_open(const char* const path) {
                        FILE_ATTRIBUTE_NORMAL, NULL);
 }
 
+#if defined(_MSC_VER)
+/**
+ * @brief Swallows one CRT invalid-parameter report.
+ *
+ * @c _get_osfhandle does not merely fail on a descriptor the CRT does not know:
+ * it reports an invalid parameter, and the *default* handler terminates the
+ * process (the debug CRT asserts, the release CRT calls @c _invoke_watson). A
+ * caller passing a stale-but-non-negative descriptor must get
+ * @ref ZXC_ERROR_IO, exactly as on POSIX, not a dead process -- so the call is
+ * made under this no-op handler.
+ */
+static void zxc_win_swallow_invalid_param(const wchar_t* expr, const wchar_t* func,
+                                          const wchar_t* file, unsigned int line, uintptr_t res) {
+    (void)expr;
+    (void)func;
+    (void)file;
+    (void)line;
+    (void)res;
+}
+#endif
+
 /**
  * @brief Adopts a caller-owned CRT descriptor (no ownership transfer).
  *
@@ -442,7 +483,19 @@ static zxc_desc_t zxc_desc_open(const char* const path) {
  */
 static zxc_desc_t zxc_desc_from_fd(const int fd) {
     if (fd < 0) return INVALID_HANDLE_VALUE;
-    return (HANDLE)_get_osfhandle(fd);
+#if defined(_MSC_VER)
+    /* Thread-local, so a concurrent thread's diagnostics are left alone; the
+     * previous handler is put back before returning. MinGW's CRT has no such
+     * hook and simply returns -1 for an unknown descriptor. */
+    const _invalid_parameter_handler prev =
+        _set_thread_local_invalid_parameter_handler(zxc_win_swallow_invalid_param);
+    const intptr_t h = _get_osfhandle(fd);
+    (void)_set_thread_local_invalid_parameter_handler(prev);
+#else
+    const intptr_t h = _get_osfhandle(fd);
+#endif
+    if (h == -1 || h == -2) return INVALID_HANDLE_VALUE;
+    return (HANDLE)h;
 }
 
 /**
@@ -560,12 +613,17 @@ typedef struct {
 } zxc_win_ext_t;
 
 /**
- * @brief Resolves @c VirtualAlloc2 / @c MapViewOfFile3 dynamically.
+ * @brief Resolves @c VirtualAlloc2 / @c MapViewOfFile3 dynamically, once.
  *
  * Dynamic resolution (rather than linking @c onecore.lib) keeps a single binary
  * running on Windows older than 1803, where the copy fallback takes over. The
  * @c FARPROC values are copied instead of cast so no toolchain objects to the
  * function-pointer conversion.
+ *
+ * The answer cannot change while the process lives, so it is cached: a caller
+ * decompressing many small archives would otherwise take the loader lock three
+ * times per file. The cache is written idempotently -- two threads racing here
+ * resolve the same pointers and store the same bytes -- so no lock is needed.
  *
  * @param[out] fns  Receives both entry points; cleared first, so the struct is
  *                  never left holding one resolved pointer and one stale value.
@@ -573,19 +631,36 @@ typedef struct {
  *         the placeholder APIs.
  */
 static int zxc_win_ext_resolve(zxc_win_ext_t* const fns) {
+    static zxc_win_ext_t g_cache;
+    static int g_resolved; /* 0 = not tried, 1 = available, -1 = unavailable */
+
+    const int state = g_resolved;
+    if (state != 0) {
+        *fns = g_cache;
+        return (state > 0) ? ZXC_OK : ZXC_ERROR_UNSUPPORTED;
+    }
+
     fns->alloc2 = NULL;
     fns->map3 = NULL;
 
     HMODULE mod = GetModuleHandleW(L"kernelbase.dll");
     if (!mod) mod = GetModuleHandleW(L"kernel32.dll");
-    if (!mod) return ZXC_ERROR_UNSUPPORTED;
+    if (!mod) {
+        g_resolved = -1;
+        return ZXC_ERROR_UNSUPPORTED;
+    }
 
     const FARPROC p_alloc2 = GetProcAddress(mod, "VirtualAlloc2");
     const FARPROC p_map3 = GetProcAddress(mod, "MapViewOfFile3");
-    if (!p_alloc2 || !p_map3) return ZXC_ERROR_UNSUPPORTED;
+    if (!p_alloc2 || !p_map3) {
+        g_resolved = -1;
+        return ZXC_ERROR_UNSUPPORTED;
+    }
 
     ZXC_MEMCPY(&fns->alloc2, &p_alloc2, sizeof(fns->alloc2));
     ZXC_MEMCPY(&fns->map3, &p_map3, sizeof(fns->map3));
+    g_cache = *fns;
+    g_resolved = 1;
     return ZXC_OK;
 }
 
@@ -663,9 +738,24 @@ static int zxc_win_place(const HANDLE section, const size_t comp_size, const siz
         return ZXC_ERROR_MEMORY;
     }
 
-    /* [off, region): the archive itself, faulted in from the page cache. */
-    void* const view = fns.map3(section, NULL, base + off, 0, comp_size, MEM_REPLACE_PLACEHOLDER,
-                                PAGE_WRITECOPY, NULL, 0);
+    /* [off, region): the archive itself, faulted in from the page cache.
+     *
+     * Two view sizes are tried because the documented rule ("the mapped view
+     * must be exactly the size of the placeholder it replaces") and the section
+     * rule ("a view may not extend beyond the section") pull in opposite
+     * directions whenever comp_size is not a whole number of pages, which is
+     * the common case: the placeholder spans roundup(comp_size, page) while the
+     * section is comp_size long. Whether the kernel rounds the requested size
+     * up before comparing it against the placeholder is not something the
+     * documentation settles, so ask for the file's own length first and, if
+     * that is refused, for the placeholder's exact span. A failed map3 consumes
+     * nothing, which is what makes the second attempt safe. */
+    void* view = fns.map3(section, NULL, base + off, 0, comp_size, MEM_REPLACE_PLACEHOLDER,
+                          PAGE_WRITECOPY, NULL, 0);
+    if (!view && (region - off) != comp_size) {
+        view = fns.map3(section, NULL, base + off, 0, region - off, MEM_REPLACE_PLACEHOLDER,
+                        PAGE_WRITECOPY, NULL, 0);
+    }
     if (!view) {
         (void)VirtualFree(base, 0, MEM_RELEASE);
         (void)VirtualFree(base + off, 0, MEM_RELEASE);
@@ -703,57 +793,69 @@ static int zxc_map_readonly(const zxc_desc_t d, zxc_map_t* const out) {
 }
 
 /**
- * @brief Backend of @ref zxc_decompress_mmap -- place (or copy) the archive
- *        flush-right in a single region, decode, trim.
+ * @brief Reads exactly @p len bytes at @p offset, short reads included.
+ *
+ * The offset travels in the @c OVERLAPPED block rather than through a seek, so
+ * the caller's CRT descriptor keeps its file position -- the same promise the
+ * POSIX backend gets from @c pread.
+ *
+ * @param[in]  d       Handle to read from.
+ * @param[out] buf     Destination for @p len bytes.
+ * @param[in]  len     Number of bytes to read.
+ * @param[in]  offset  Absolute offset to read at.
+ * @return @ref ZXC_OK, or @ref ZXC_ERROR_IO on a read error or end of file.
+ */
+static int zxc_desc_read_at(const zxc_desc_t d, void* const buf, const size_t len,
+                            const uint64_t offset) {
+    uint8_t* p = (uint8_t*)buf;
+    size_t left = len;
+    uint64_t at = offset;
+    while (left > 0) {
+        OVERLAPPED ov;
+        ZXC_MEMSET(&ov, 0, sizeof(ov));
+        ov.Offset = (DWORD)(at & 0xFFFFFFFFU);
+        ov.OffsetHigh = (DWORD)(at >> 32);
+        DWORD got = 0;
+        if (UNLIKELY(!ReadFile(d, p, (DWORD)left, &got, &ov) || got == 0)) return ZXC_ERROR_IO;
+        p += got;
+        at += got;
+        left -= got;
+    }
+    return ZXC_OK;
+}
+
+/**
+ * @brief Places the archive flush-right in a fresh single region.
  *
  * Prefers the placeholder placement (@ref zxc_win_place, zero-copy). Older
  * Windows, or a file that cannot back a copy-on-write section, fall back to one
  * reservation plus a single copy of the archive: still one region, still no
  * output allocation. @ref zxc_mmap_is_zerocopy reports which route ran.
  *
- * @param[in]  d     Handle of the archive to decode.
- * @param[out] out   Receives the decoded region; filled only on success, with
- *                   @c map_kind recording which of the two routes produced it.
- * @param[in]  opts  Decompression options, or NULL for defaults.
- * @return Decompressed size in bytes (> 0), 0 for an empty frame (nothing is
- *         mapped, @p out stays cleared), or a negative @c zxc_error_t -- see the
- *         POSIX twin above, whose error contract this shares.
+ * @param[in]  d          Handle of the archive.
+ * @param[in]  comp_size  Archive size in bytes.
+ * @param[in]  off        Flush-right offset from @ref zxc_map_geometry.
+ * @param[in]  region     Total bytes to reserve.
+ * @param[out] base       Receives the region base on success.
+ * @param[out] handle     Receives the archive view to unmap later, or NULL when
+ *                        the copying route ran.
+ * @param[out] zerocopy   Receives 1 for the placeholder route, 0 for the copy.
+ * @return @ref ZXC_OK, @ref ZXC_ERROR_MEMORY if the region cannot be reserved,
+ *         or @ref ZXC_ERROR_IO if the archive cannot be read into it. Nothing
+ *         is left allocated on failure.
  */
-static int64_t zxc_map_decompress(const zxc_desc_t d, zxc_map_t* const out,
-                                  const zxc_decompress_opts_t* const opts) {
-    size_t comp_size = 0;
-    int rc = zxc_desc_size(d, &comp_size);
-    if (UNLIKELY(rc != ZXC_OK)) return rc;
-    if (UNLIKELY(comp_size < ZXC_FILE_HEADER_SIZE + ZXC_FILE_FOOTER_SIZE))
-        return ZXC_ERROR_SRC_TOO_SMALL;
-
-    /* Probe pass: the bound only reads the file header and footer, so a
-     * throw-away read-only view answers it without copying anything. */
-    void* probe = NULL;
-    rc = zxc_win_view(d, &probe);
-    if (UNLIKELY(rc != ZXC_OK)) return rc;
-    const size_t need = zxc_decompress_inplace_bound(probe, comp_size);
-    (void)UnmapViewOfFile(probe);
-    if (UNLIKELY(need == 0)) return ZXC_ERROR_BAD_HEADER;
-
-    size_t off_gran = 0;
-    size_t page = 0;
-    zxc_map_grains(&off_gran, &page);
-    size_t off = 0;
-    size_t capacity = 0;
-    size_t region = 0;
-    rc = zxc_map_geometry(comp_size, need, off_gran, page, &off, &capacity, &region);
-    if (UNLIKELY(rc != ZXC_OK)) return rc;
-
-    uint8_t* base = NULL;
+static int zxc_map_place(const zxc_desc_t d, const size_t comp_size, const size_t off,
+                         const size_t region, uint8_t** const base, void** const handle,
+                         int* const zerocopy) {
+    uint8_t* p = NULL;
     void* view = NULL;
 
     /* 1. Zero-copy: a copy-on-write view of the archive, placed flush-right in
      *    a split placeholder reservation. */
     HANDLE section = NULL;
     if (zxc_win_section_cow(d, &section) == ZXC_OK) {
-        if (zxc_win_place(section, comp_size, off, region, &base, &view) != ZXC_OK) {
-            base = NULL;
+        if (zxc_win_place(section, comp_size, off, region, &p, &view) != ZXC_OK) {
+            p = NULL;
             view = NULL;
         }
         /* A mapped view keeps the section alive on its own. */
@@ -761,49 +863,62 @@ static int64_t zxc_map_decompress(const zxc_desc_t d, zxc_map_t* const out,
     }
 
     /* 2. Fallback: one reservation and a single copy of the archive into it. */
-    if (!base) {
-        base = (uint8_t*)VirtualAlloc(NULL, region, MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE);
-        if (UNLIKELY(!base)) return ZXC_ERROR_MEMORY;
-        void* src = NULL;
-        rc = zxc_win_view(d, &src);
+    if (!p) {
+        p = (uint8_t*)VirtualAlloc(NULL, region, MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE);
+        if (UNLIKELY(!p)) return ZXC_ERROR_MEMORY;
+        const int rc = zxc_desc_read_at(d, p + off, comp_size, 0);
         if (UNLIKELY(rc != ZXC_OK)) {
-            (void)VirtualFree(base, 0, MEM_RELEASE);
+            (void)VirtualFree(p, 0, MEM_RELEASE);
             return rc;
         }
-        ZXC_MEMCPY(base + off, src, comp_size);
-        (void)UnmapViewOfFile(src);
-    }
-    const int placed = (view != NULL);
-
-    const int64_t decoded = zxc_decompress_inplace(base, capacity, comp_size, opts);
-    if (UNLIKELY(decoded <= 0)) {
-        /* Errors and the empty frame both leave nothing worth handing back. */
-        if (view) (void)UnmapViewOfFile(view);
-        (void)VirtualFree(base, 0, MEM_RELEASE);
-        return decoded;
     }
 
-    /* Trim: give back what the payload does not occupy. A view is released as a
-     * whole, so the archive slot can only go back when the payload ends before
-     * that slot begins; the private part is decommitted either way. */
-    const size_t keep = zxc_round_up_pow2((size_t)decoded, page);
-    if (view) {
+    *base = p;
+    *handle = view;
+    *zerocopy = (view != NULL);
+    return ZXC_OK;
+}
+
+/**
+ * @brief Releases a placement whose decode did not produce a region to keep.
+ *
+ * @param[in] base    Region base from @ref zxc_map_place.
+ * @param[in] region  Its full size in bytes (unused: @c MEM_RELEASE takes the
+ *                    whole reservation and insists on a zero size).
+ * @param[in] handle  Archive view from @ref zxc_map_place, or NULL.
+ */
+static void zxc_map_unplace(uint8_t* const base, const size_t region, void* const handle) {
+    (void)region;
+    if (handle) (void)UnmapViewOfFile(handle);
+    (void)VirtualFree(base, 0, MEM_RELEASE);
+}
+
+/**
+ * @brief Gives back everything the decoded payload does not occupy.
+ *
+ * A view is released as a whole, so the archive slot can only go back when the
+ * payload ends before that slot begins; the private part is decommitted either
+ * way. Whatever survives is released by @ref zxc_map_release at close.
+ *
+ * @param[in]     base    Region base from @ref zxc_map_place.
+ * @param[in]     off     Flush-right offset: where the archive slot begins.
+ * @param[in]     region  Full region size in bytes.
+ * @param[in]     keep    Page-rounded payload size to keep.
+ * @param[in,out] handle  Archive view; cleared if this call unmapped it.
+ * @return Bytes still mapped at @p base, i.e. @p keep.
+ */
+static size_t zxc_map_trim(uint8_t* const base, const size_t off, const size_t region,
+                           const size_t keep, void** const handle) {
+    if (*handle) {
         if (keep <= off) {
-            (void)UnmapViewOfFile(view);
-            view = NULL;
+            (void)UnmapViewOfFile(*handle);
+            *handle = NULL;
             if (keep < off) (void)VirtualFree(base + keep, off - keep, MEM_DECOMMIT);
         }
     } else if (keep < region) {
         (void)VirtualFree(base + keep, region - keep, MEM_DECOMMIT);
     }
-
-    out->data = base;
-    out->size = (size_t)decoded;
-    out->map_base = base;
-    out->map_size = keep;
-    out->map_handle = view; /* non-NULL: a view still to unmap on close */
-    out->map_kind = placed ? ZXC_MAP_KIND_PLACEHOLDER : ZXC_MAP_KIND_REGION;
-    return decoded;
+    return keep;
 }
 
 /**
@@ -825,25 +940,113 @@ static void zxc_map_release(zxc_map_t* const m) {
     (void)VirtualFree(m->map_base, 0, MEM_RELEASE);
 }
 
-/**
- * @brief Backend of @ref zxc_mmap_is_zerocopy -- only the copy route copies.
- *
- * @param[in] m  Live map.
- * @return 1 for a read-only view and for a placeholder-placed decode region,
- *         0 for @ref ZXC_MAP_KIND_REGION, the route that copied the archive.
- */
-static int zxc_map_zerocopy(const zxc_map_t* const m) { return m->map_kind != ZXC_MAP_KIND_REGION; }
 // LCOV_EXCL_STOP
 
 #endif /* backend selection */
+
+#if defined(ZXC_MMAP_ENABLED)
+
+/**
+ * @brief Answers @ref zxc_decompress_inplace_bound for an on-disk archive.
+ *
+ * The bound looks at the file header and the file footer and at nothing else,
+ * so the two ends are read directly rather than mapping the whole archive just
+ * to consult 28 bytes of it -- which also keeps the copying route on Windows
+ * from building a second mapping of a file it is about to read anyway.
+ *
+ * @param[in]  d          Descriptor of the archive.
+ * @param[in]  comp_size  Archive size in bytes; the caller has already checked
+ *                        it covers a file header and a footer.
+ * @param[out] need       Receives the in-place bound in bytes.
+ * @return @ref ZXC_OK, @ref ZXC_ERROR_IO if the two ends cannot be read, or
+ *         @ref ZXC_ERROR_BAD_HEADER if they do not describe a ZXC archive.
+ */
+static int zxc_map_bound(const zxc_desc_t d, const size_t comp_size, size_t* const need) {
+    uint8_t head[ZXC_FILE_HEADER_SIZE];
+    uint8_t foot[ZXC_FILE_FOOTER_SIZE];
+
+    int rc = zxc_desc_read_at(d, head, sizeof(head), 0);
+    if (UNLIKELY(rc != ZXC_OK)) return rc;
+    rc = zxc_desc_read_at(d, foot, sizeof(foot), (uint64_t)comp_size - ZXC_FILE_FOOTER_SIZE);
+    if (UNLIKELY(rc != ZXC_OK)) return rc;  // LCOV_EXCL_LINE
+
+    const size_t n = zxc_inplace_bound_parts(head, foot, comp_size);
+    if (UNLIKELY(n == 0)) return ZXC_ERROR_BAD_HEADER;
+    *need = n;
+    return ZXC_OK;
+}
+
+/**
+ * @brief Backend-independent body of @ref zxc_decompress_mmap.
+ *
+ * Measure the archive, size its region from the two ends of the file, let the
+ * backend place it flush-right, decode into the head of that region, then trim
+ * back to the payload. Only the placement, the trim and the unwind differ
+ * between POSIX and Windows, and each is one backend hook; the sequence itself
+ * -- and every check in it -- exists once.
+ *
+ * @param[in]  d     Descriptor of the archive to decode.
+ * @param[out] out   Receives the decoded region; filled only on success, with
+ *                   @c map_kind recording whether the archive was mapped or
+ *                   copied into place.
+ * @param[in]  opts  Decompression options, or NULL for defaults.
+ * @return Decompressed size in bytes (> 0), 0 for an empty frame (nothing is
+ *         mapped, @p out stays cleared), or a negative @c zxc_error_t:
+ *         @ref ZXC_ERROR_SRC_TOO_SMALL if the file is shorter than a frame,
+ *         @ref ZXC_ERROR_BAD_HEADER if it is not a ZXC archive,
+ *         @ref ZXC_ERROR_IO on a read or mapping failure,
+ *         @ref ZXC_ERROR_MEMORY if the region cannot be reserved, or whatever
+ *         @ref zxc_decompress_inplace reports for a corrupt archive.
+ */
+static int64_t zxc_map_decompress(const zxc_desc_t d, zxc_map_t* const out,
+                                  const zxc_decompress_opts_t* const opts) {
+    size_t comp_size = 0;
+    int rc = zxc_desc_size(d, &comp_size);
+    if (UNLIKELY(rc != ZXC_OK)) return rc;
+    if (UNLIKELY(comp_size < ZXC_FILE_HEADER_SIZE + ZXC_FILE_FOOTER_SIZE))
+        return ZXC_ERROR_SRC_TOO_SMALL;
+
+    size_t need = 0;
+    rc = zxc_map_bound(d, comp_size, &need);
+    if (UNLIKELY(rc != ZXC_OK)) return rc;
+
+    size_t off_gran = 0;
+    size_t page = 0;
+    zxc_map_grains(&off_gran, &page);
+    size_t off = 0;
+    size_t capacity = 0;
+    size_t region = 0;
+    rc = zxc_map_geometry(comp_size, need, off_gran, page, &off, &capacity, &region);
+    if (UNLIKELY(rc != ZXC_OK)) return rc;  // LCOV_EXCL_LINE
+
+    uint8_t* base = NULL;
+    void* handle = NULL;
+    int zerocopy = 0;
+    rc = zxc_map_place(d, comp_size, off, region, &base, &handle, &zerocopy);
+    if (UNLIKELY(rc != ZXC_OK)) return rc;
+
+    const int64_t decoded = zxc_decompress_inplace(base, capacity, comp_size, opts);
+    if (UNLIKELY(decoded <= 0)) {
+        /* Errors and the empty frame both leave nothing worth handing back. */
+        zxc_map_unplace(base, region, handle);
+        return decoded;
+    }
+
+    const size_t keep = zxc_round_up_pow2((size_t)decoded, page);
+    out->data = base;
+    out->size = (size_t)decoded;
+    out->map_base = base;
+    out->map_size = zxc_map_trim(base, off, region, keep, &handle);
+    out->map_handle = handle; /* non-NULL: a mapping still to release on close */
+    out->map_kind = zerocopy ? ZXC_MAP_KIND_MAPPED : ZXC_MAP_KIND_COPIED;
+    return decoded;
+}
 
 /*
  * ============================================================================
  * PUBLIC API
  * ============================================================================
  */
-
-#if defined(ZXC_MMAP_ENABLED)
 
 /**
  * @brief Reports whether this build can map files.
@@ -856,13 +1059,14 @@ int zxc_mmap_supported(void) { return 1; }
 /**
  * @brief Reports whether @p map holds the archive without having copied it.
  *
- * Public API; full contract in @c zxc_mmap.h. Delegates to the backend, which
- * knows which placement route produced the region.
+ * Public API; full contract in @c zxc_mmap.h. Every route but one places the
+ * archive by mapping it; @ref ZXC_MAP_KIND_COPIED marks the single exception,
+ * the pre-1803 Windows fallback.
  */
 // cppcheck-suppress unusedFunction
 int zxc_mmap_is_zerocopy(const zxc_map_t* const map) {
     if (UNLIKELY(!map || !map->data)) return 0;
-    return zxc_map_zerocopy(map);
+    return map->map_kind != ZXC_MAP_KIND_COPIED;
 }
 
 /**
@@ -964,7 +1168,7 @@ int zxc_mmap_is_zerocopy(const zxc_map_t* map) {
 // cppcheck-suppress unusedFunction
 int zxc_mmap_open(const char* path, zxc_map_t* out) {
     (void)path;
-    if (out) ZXC_MEMSET(out, 0, sizeof(*out));
+    if (out) zxc_map_reset(out);
     return ZXC_ERROR_UNSUPPORTED;
 }
 
@@ -972,7 +1176,7 @@ int zxc_mmap_open(const char* path, zxc_map_t* out) {
 // cppcheck-suppress unusedFunction
 int zxc_mmap_open_fd(int fd, zxc_map_t* out) {
     (void)fd;
-    if (out) ZXC_MEMSET(out, 0, sizeof(*out));
+    if (out) zxc_map_reset(out);
     return ZXC_ERROR_UNSUPPORTED;
 }
 
@@ -981,7 +1185,7 @@ int zxc_mmap_open_fd(int fd, zxc_map_t* out) {
 int64_t zxc_decompress_mmap(const char* path, zxc_map_t* out, const zxc_decompress_opts_t* opts) {
     (void)path;
     (void)opts;
-    if (out) ZXC_MEMSET(out, 0, sizeof(*out));
+    if (out) zxc_map_reset(out);
     return ZXC_ERROR_UNSUPPORTED;
 }
 
@@ -990,14 +1194,14 @@ int64_t zxc_decompress_mmap(const char* path, zxc_map_t* out, const zxc_decompre
 int64_t zxc_decompress_mmap_fd(int fd, zxc_map_t* out, const zxc_decompress_opts_t* opts) {
     (void)fd;
     (void)opts;
-    if (out) ZXC_MEMSET(out, 0, sizeof(*out));
+    if (out) zxc_map_reset(out);
     return ZXC_ERROR_UNSUPPORTED;
 }
 
 /** @brief Nothing can be mapped on this target, so nothing can be released. */
 // cppcheck-suppress unusedFunction
 void zxc_mmap_close(zxc_map_t* map) {
-    if (map) ZXC_MEMSET(map, 0, sizeof(*map));
+    if (map) zxc_map_reset(map);
 }
 
 #endif /* ZXC_MMAP_ENABLED */

--- a/src/lib/zxc_mmap.c
+++ b/src/lib/zxc_mmap.c
@@ -28,11 +28,15 @@
  * decoder writing over already-consumed compressed bytes is copy-on-write and
  * the archive on disk is never modified.
  *
- * @par Windows geometry (single region, one input copy)
- * @c MapViewOfFile cannot land inside a @c VirtualAlloc reservation without the
- * Win10 placeholder APIs, so the archive is copied once from a read-only view
- * into the same flush-right slot. The decode stays in-place and no output
- * allocation is made.
+ * @par Windows geometry (same, via placeholder mappings)
+ * @c MapViewOfFile cannot land inside a plain @c VirtualAlloc reservation, so
+ * the same placement is built from the Windows 10 1803 placeholder APIs: reserve
+ * `[0, region)` as a placeholder, split it at @c off, then replace the two
+ * halves with committed private memory and a @c PAGE_WRITECOPY view of the
+ * archive. @c VirtualAlloc2 / @c MapViewOfFile3 are resolved at run time, and
+ * anything older (or any file that cannot back a copy-on-write section) falls
+ * back to one reservation plus a single copy of the archive -- still one region,
+ * still no output allocation. @ref zxc_mmap_is_zerocopy tells the two apart.
  *
  * Platforms with no mapping at all (Emscripten, freestanding) compile to stubs
  * returning @ref ZXC_ERROR_UNSUPPORTED, keeping the ABI identical everywhere.
@@ -80,9 +84,10 @@
 
 /** @brief Release path a @ref zxc_map_t base address needs. */
 enum {
-    ZXC_MAP_KIND_NONE = 0,  /**< Nothing mapped. */
-    ZXC_MAP_KIND_VIEW = 1,  /**< Read-only file view (@ref zxc_mmap_open). */
-    ZXC_MAP_KIND_REGION = 2 /**< Decode region (@ref zxc_decompress_mmap). */
+    ZXC_MAP_KIND_NONE = 0,       /**< Nothing mapped. */
+    ZXC_MAP_KIND_VIEW = 1,       /**< Read-only file view (@ref zxc_mmap_open). */
+    ZXC_MAP_KIND_REGION = 2,     /**< Decode region, archive copied in (Win32 fallback). */
+    ZXC_MAP_KIND_PLACEHOLDER = 3 /**< Decode region with the archive mapped into it. */
 };
 
 /**
@@ -106,12 +111,22 @@ static size_t zxc_round_up_pow2(const size_t v, const size_t pow2) {
 /**
  * @brief Computes the single-region geometry for an in-place decode.
  *
+ * Two granularities, because the two ends answer to different rules: a file
+ * mapping must *start* on an allocation-granularity boundary (64 KiB on Windows,
+ * one page on POSIX), while the region it *spans* is page-granular. Sizing the
+ * archive slot to exactly `roundup(comp_size, page)` is what lets Windows
+ * replace that slot with a view of the archive, which insists the view and the
+ * placeholder it replaces cover the same range.
+ *
  * @param[in]  comp_size  Archive size in bytes.
  * @param[in]  need       @ref zxc_decompress_inplace_bound for that archive.
+ * @param[in]  off_gran   Mapping-start granularity (power of two, multiple of
+ *                        @p page).
  * @param[in]  page       Page size (power of two).
- * @param[out] off        Flush-right offset of the archive: page-aligned (so a
- *                        file mapping can start there) and >= @p need -
- *                        @p comp_size (so the in-place margin holds).
+ * @param[out] off        Flush-right offset of the archive: aligned to
+ *                        @p off_gran (so a file mapping can start there) and
+ *                        >= @p need - @p comp_size (so the in-place margin
+ *                        holds).
  * @param[out] capacity   Logical buffer capacity to hand
  *                        @ref zxc_decompress_inplace (@p off + @p comp_size).
  * @param[out] region     Total bytes to reserve: @p capacity rounded out to
@@ -120,11 +135,12 @@ static size_t zxc_round_up_pow2(const size_t v, const size_t pow2) {
  * @return @ref ZXC_OK, or @ref ZXC_ERROR_MEMORY if the geometry overflows
  *         @c size_t.
  */
-static int zxc_map_geometry(const size_t comp_size, const size_t need, const size_t page,
-                            size_t* const off, size_t* const capacity, size_t* const region) {
+static int zxc_map_geometry(const size_t comp_size, const size_t need, const size_t off_gran,
+                            const size_t page, size_t* const off, size_t* const capacity,
+                            size_t* const region) {
     const size_t gap = (need > comp_size) ? need - comp_size : 0;
-    if (UNLIKELY(gap > SIZE_MAX - (page - 1))) return ZXC_ERROR_MEMORY;
-    const size_t o = zxc_round_up_pow2(gap, page);
+    if (UNLIKELY(gap > SIZE_MAX - (off_gran - 1))) return ZXC_ERROR_MEMORY;
+    const size_t o = zxc_round_up_pow2(gap, off_gran);
 
     if (UNLIKELY(comp_size > SIZE_MAX - o)) return ZXC_ERROR_MEMORY;
     if (UNLIKELY(comp_size > SIZE_MAX - (page - 1))) return ZXC_ERROR_MEMORY;
@@ -173,10 +189,18 @@ static int zxc_desc_valid(const zxc_desc_t d) { return d >= 0; }
 /** @brief Closes a descriptor this TU opened; mappings outlive it. */
 static void zxc_desc_close(const zxc_desc_t d) { (void)close(d); }
 
-/** @brief Returns the platform page size (mapping granularity). */
-static size_t zxc_page_size(void) {
+/**
+ * @brief Reports the two granularities the geometry needs.
+ *
+ * On POSIX both are the page size: @c mmap accepts any page-aligned address.
+ *
+ * @param[out] off_gran  Granularity a file mapping must start on.
+ * @param[out] page      Page size.
+ */
+static void zxc_map_grains(size_t* const off_gran, size_t* const page) {
     const long ps = sysconf(_SC_PAGESIZE);
-    return (ps > 0) ? (size_t)ps : 4096u;
+    *page = (ps > 0) ? (size_t)ps : 4096U;
+    *off_gran = *page;
 }
 
 /**
@@ -236,9 +260,10 @@ static int64_t zxc_map_decompress(const zxc_desc_t d, zxc_map_t* const out,
     (void)munmap(probe, comp_size);
     if (UNLIKELY(need == 0)) return ZXC_ERROR_BAD_HEADER;
 
-    const size_t page = zxc_page_size();
+    size_t off_gran = 0, page = 0;
+    zxc_map_grains(&off_gran, &page);
     size_t off = 0, capacity = 0, region = 0;
-    rc = zxc_map_geometry(comp_size, need, page, &off, &capacity, &region);
+    rc = zxc_map_geometry(comp_size, need, off_gran, page, &off, &capacity, &region);
     if (UNLIKELY(rc != ZXC_OK)) return rc;  // LCOV_EXCL_LINE
 
     uint8_t* const base =
@@ -283,6 +308,12 @@ static int64_t zxc_map_decompress(const zxc_desc_t d, zxc_map_t* const out,
 /** @brief Backend of @ref zxc_mmap_close (one call covers both map kinds). */
 static void zxc_map_release(zxc_map_t* const m) { (void)munmap(m->map_base, m->map_size); }
 
+/** @brief Backend of @ref zxc_mmap_is_zerocopy: here every region is mapped. */
+static int zxc_map_zerocopy(const zxc_map_t* const m) {
+    (void)m;
+    return 1;
+}
+
 /*
  * ============================================================================
  * WIN32 BACKEND
@@ -315,11 +346,21 @@ static int zxc_desc_valid(const zxc_desc_t d) { return d != INVALID_HANDLE_VALUE
 /** @brief Closes a handle this TU opened; mappings outlive it. */
 static void zxc_desc_close(const zxc_desc_t d) { (void)CloseHandle(d); }
 
-/** @brief Returns the platform page size (VirtualFree decommit granularity). */
-static size_t zxc_page_size(void) {
+/**
+ * @brief Reports the two granularities the geometry needs.
+ *
+ * A file view must start on an *allocation*-granularity boundary (64 KiB), so
+ * that is what the flush-right offset is aligned to; the archive slot itself is
+ * sized in pages, which is the granularity a view and a @c MEM_DECOMMIT work at.
+ *
+ * @param[out] off_gran  Allocation granularity.
+ * @param[out] page      Page size.
+ */
+static void zxc_map_grains(size_t* const off_gran, size_t* const page) {
     SYSTEM_INFO si;
     GetSystemInfo(&si);
-    return si.dwPageSize ? (size_t)si.dwPageSize : 4096u;
+    *off_gran = si.dwAllocationGranularity ? (size_t)si.dwAllocationGranularity : 65536U;
+    *page = si.dwPageSize ? (size_t)si.dwPageSize : 4096U;
 }
 
 /**
@@ -351,6 +392,150 @@ static int zxc_win_view(const zxc_desc_t d, void** const view) {
     return ZXC_OK;
 }
 
+/*
+ * ----------------------------------------------------------------------------
+ * Placeholder mappings: the zero-copy flush-right placement
+ * ----------------------------------------------------------------------------
+ * MapViewOfFile cannot land inside a plain VirtualAlloc reservation, which is
+ * why the naive Win32 port has to copy the archive. The placeholder APIs
+ * (Windows 10 1803 / Server 2019) lift exactly that restriction: a reservation
+ * can be split into placeholders, and each placeholder replaced -- one by
+ * private memory, one by a file view -- giving the same geometry as the POSIX
+ * MAP_FIXED path with no copy at all.
+ */
+
+/* Flags defined locally so the file still builds against pre-1803 SDKs. */
+#ifndef MEM_RESERVE_PLACEHOLDER
+#define MEM_RESERVE_PLACEHOLDER 0x00040000
+#endif
+#ifndef MEM_REPLACE_PLACEHOLDER
+#define MEM_REPLACE_PLACEHOLDER 0x00004000
+#endif
+#ifndef MEM_PRESERVE_PLACEHOLDER
+#define MEM_PRESERVE_PLACEHOLDER 0x00000002
+#endif
+
+/* The MEM_EXTENDED_PARAMETER argument is always NULL here, so it is typed
+ * void* rather than pulling the struct in from a newer SDK. */
+typedef PVOID(WINAPI* zxc_virtual_alloc2_fn)(HANDLE, PVOID, SIZE_T, ULONG, ULONG, void*, ULONG);
+typedef PVOID(WINAPI* zxc_map_view_of_file3_fn)(HANDLE, HANDLE, PVOID, ULONG64, SIZE_T, ULONG,
+                                                ULONG, void*, ULONG);
+
+/** @brief The two placeholder entry points, resolved at run time. */
+typedef struct {
+    zxc_virtual_alloc2_fn alloc2;  /**< VirtualAlloc2 */
+    zxc_map_view_of_file3_fn map3; /**< MapViewOfFile3 */
+} zxc_win_ext_t;
+
+/**
+ * @brief Resolves @c VirtualAlloc2 / @c MapViewOfFile3 dynamically.
+ *
+ * Dynamic resolution (rather than linking @c onecore.lib) keeps a single binary
+ * running on Windows older than 1803, where the copy fallback takes over. The
+ * @c FARPROC values are copied instead of cast so no toolchain objects to the
+ * function-pointer conversion.
+ *
+ * @return @ref ZXC_OK, or @ref ZXC_ERROR_UNSUPPORTED when this Windows lacks
+ *         the placeholder APIs.
+ */
+static int zxc_win_ext_resolve(zxc_win_ext_t* const fns) {
+    fns->alloc2 = NULL;
+    fns->map3 = NULL;
+
+    HMODULE mod = GetModuleHandleW(L"kernelbase.dll");
+    if (!mod) mod = GetModuleHandleW(L"kernel32.dll");
+    if (!mod) return ZXC_ERROR_UNSUPPORTED;
+
+    const FARPROC p_alloc2 = GetProcAddress(mod, "VirtualAlloc2");
+    const FARPROC p_map3 = GetProcAddress(mod, "MapViewOfFile3");
+    if (!p_alloc2 || !p_map3) return ZXC_ERROR_UNSUPPORTED;
+
+    ZXC_MEMCPY(&fns->alloc2, &p_alloc2, sizeof(fns->alloc2));
+    ZXC_MEMCPY(&fns->map3, &p_map3, sizeof(fns->map3));
+    return ZXC_OK;
+}
+
+/**
+ * @brief Creates a copy-on-write section over the whole file.
+ *
+ * @c PAGE_WRITECOPY needs only @c GENERIC_READ on the file and makes the
+ * decoder's writes over consumed compressed bytes private, so the archive on
+ * disk is never modified. The size arguments are 0 on purpose: an explicit size
+ * beyond the file, with a write-capable protection, would *grow* the file.
+ */
+static int zxc_win_section_cow(const zxc_desc_t d, HANDLE* const section) {
+    HANDLE s = CreateFileMappingA(d, NULL, PAGE_WRITECOPY, 0, 0, NULL);
+    if (!s) return ZXC_ERROR_IO;
+    *section = s;
+    return ZXC_OK;
+}
+
+/**
+ * @brief Places the archive flush-right in a split placeholder reservation.
+ *
+ *   1. reserve `[0, region)` as one placeholder;
+ *   2. split it at @p off, leaving two independently replaceable placeholders;
+ *   3. replace `[0, off)` with committed private memory (the decode output);
+ *   4. replace `[off, region)` with a @c PAGE_WRITECOPY view of the archive.
+ *
+ * Every failure path leaves nothing allocated, so the caller can simply fall
+ * back to the copying route.
+ *
+ * @param[in]  section    Copy-on-write section over the archive.
+ * @param[in]  comp_size  Archive size in bytes (the view size).
+ * @param[in]  off        Flush-right offset, a multiple of the allocation
+ *                        granularity (see @ref zxc_map_grains).
+ * @param[in]  region     Total reservation size in bytes. `region - off` is
+ *                        exactly the page span of @p comp_size, which is what
+ *                        lets a view replace that placeholder.
+ * @param[out] out_base   Receives the reservation base on success.
+ * @param[out] out_view   Receives the mapped view address on success.
+ * @return @ref ZXC_OK, @ref ZXC_ERROR_UNSUPPORTED (no placeholder APIs, or this
+ *         file cannot back a copy-on-write view), or @ref ZXC_ERROR_MEMORY.
+ */
+static int zxc_win_place(const HANDLE section, const size_t comp_size, const size_t off,
+                         const size_t region, uint8_t** const out_base, void** const out_view) {
+    zxc_win_ext_t fns;
+    const int rc = zxc_win_ext_resolve(&fns);
+    if (rc != ZXC_OK) return rc;
+    /* The geometry always leaves room for the output ahead of the archive; bail
+     * out rather than split a placeholder at one of its own edges. */
+    if (off == 0 || off >= region) return ZXC_ERROR_UNSUPPORTED;
+
+    uint8_t* const base = (uint8_t*)fns.alloc2(
+        NULL, NULL, region, MEM_RESERVE | MEM_RESERVE_PLACEHOLDER, PAGE_NOACCESS, NULL, 0);
+    if (!base) return ZXC_ERROR_MEMORY;
+
+    /* Split, so the archive slot can be replaced by a view on its own. Both
+     * halves stay reserved (MEM_PRESERVE_PLACEHOLDER) and become independently
+     * replaceable and independently releasable. */
+    if (!VirtualFree(base, off, MEM_RELEASE | MEM_PRESERVE_PLACEHOLDER)) {
+        (void)VirtualFree(base, 0, MEM_RELEASE);
+        return ZXC_ERROR_UNSUPPORTED;
+    }
+
+    /* [0, off): committed private memory, the decoder's output. */
+    if (!fns.alloc2(NULL, base, off, MEM_RESERVE | MEM_COMMIT | MEM_REPLACE_PLACEHOLDER,
+                    PAGE_READWRITE, NULL, 0)) {
+        (void)VirtualFree(base, 0, MEM_RELEASE);
+        (void)VirtualFree(base + off, 0, MEM_RELEASE);
+        return ZXC_ERROR_MEMORY;
+    }
+
+    /* [off, region): the archive itself, faulted in from the page cache. */
+    void* const view = fns.map3(section, NULL, base + off, 0, comp_size, MEM_REPLACE_PLACEHOLDER,
+                                PAGE_WRITECOPY, NULL, 0);
+    if (!view) {
+        (void)VirtualFree(base, 0, MEM_RELEASE);
+        (void)VirtualFree(base + off, 0, MEM_RELEASE);
+        return ZXC_ERROR_UNSUPPORTED;
+    }
+
+    *out_base = base;
+    *out_view = view;
+    return ZXC_OK;
+}
+
 /** @brief Backend of @ref zxc_mmap_open: whole-file read-only view. */
 static int zxc_map_readonly(const zxc_desc_t d, zxc_map_t* const out) {
     size_t size = 0;
@@ -370,12 +555,13 @@ static int zxc_map_readonly(const zxc_desc_t d, zxc_map_t* const out) {
 }
 
 /**
- * @brief Backend of @ref zxc_decompress_mmap.
+ * @brief Backend of @ref zxc_decompress_mmap: place (or copy) the archive
+ *        flush-right in a single region, decode, trim.
  *
- * Same geometry as POSIX, but the archive is copied once from a read-only view
- * into the flush-right slot: a view cannot be placed inside a @c VirtualAlloc
- * reservation without the Win10-only placeholder APIs. Still a single region
- * and no output allocation.
+ * Prefers the placeholder placement (@ref zxc_win_place, zero-copy). Older
+ * Windows, or a file that cannot back a copy-on-write section, fall back to one
+ * reservation plus a single copy of the archive: still one region, still no
+ * output allocation. @ref zxc_mmap_is_zerocopy reports which route ran.
  */
 static int64_t zxc_map_decompress(const zxc_desc_t d, zxc_map_t* const out,
                                   const zxc_decompress_opts_t* const opts) {
@@ -385,59 +571,97 @@ static int64_t zxc_map_decompress(const zxc_desc_t d, zxc_map_t* const out,
     if (UNLIKELY(comp_size < ZXC_FILE_HEADER_SIZE + ZXC_FILE_FOOTER_SIZE))
         return ZXC_ERROR_SRC_TOO_SMALL;
 
-    void* view = NULL;
-    rc = zxc_win_view(d, &view);
+    /* Probe pass: the bound only reads the file header and footer, so a
+     * throw-away read-only view answers it without copying anything. */
+    void* probe = NULL;
+    rc = zxc_win_view(d, &probe);
+    if (UNLIKELY(rc != ZXC_OK)) return rc;
+    const size_t need = zxc_decompress_inplace_bound(probe, comp_size);
+    (void)UnmapViewOfFile(probe);
+    if (UNLIKELY(need == 0)) return ZXC_ERROR_BAD_HEADER;
+
+    size_t off_gran = 0, page = 0;
+    zxc_map_grains(&off_gran, &page);
+    size_t off = 0, capacity = 0, region = 0;
+    rc = zxc_map_geometry(comp_size, need, off_gran, page, &off, &capacity, &region);
     if (UNLIKELY(rc != ZXC_OK)) return rc;
 
-    const size_t need = zxc_decompress_inplace_bound(view, comp_size);
-    if (UNLIKELY(need == 0)) {
-        (void)UnmapViewOfFile(view);
-        return ZXC_ERROR_BAD_HEADER;
+    uint8_t* base = NULL;
+    void* view = NULL;
+
+    /* 1. Zero-copy: a copy-on-write view of the archive, placed flush-right in
+     *    a split placeholder reservation. */
+    HANDLE section = NULL;
+    if (zxc_win_section_cow(d, &section) == ZXC_OK) {
+        if (zxc_win_place(section, comp_size, off, region, &base, &view) != ZXC_OK) {
+            base = NULL;
+            view = NULL;
+        }
+        /* A mapped view keeps the section alive on its own. */
+        (void)CloseHandle(section);
     }
 
-    const size_t page = zxc_page_size();
-    size_t off = 0, capacity = 0, region = 0;
-    rc = zxc_map_geometry(comp_size, need, page, &off, &capacity, &region);
-    if (UNLIKELY(rc != ZXC_OK)) {
-        (void)UnmapViewOfFile(view);
-        return rc;
+    /* 2. Fallback: one reservation and a single copy of the archive into it. */
+    if (!base) {
+        base = (uint8_t*)VirtualAlloc(NULL, region, MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE);
+        if (UNLIKELY(!base)) return ZXC_ERROR_MEMORY;
+        void* src = NULL;
+        rc = zxc_win_view(d, &src);
+        if (UNLIKELY(rc != ZXC_OK)) {
+            (void)VirtualFree(base, 0, MEM_RELEASE);
+            return rc;
+        }
+        ZXC_MEMCPY(base + off, src, comp_size);
+        (void)UnmapViewOfFile(src);
     }
-
-    uint8_t* const base =
-        (uint8_t*)VirtualAlloc(NULL, region, MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE);
-    if (UNLIKELY(!base)) {
-        (void)UnmapViewOfFile(view);
-        return ZXC_ERROR_MEMORY;
-    }
-    ZXC_MEMCPY(base + off, view, comp_size);
-    (void)UnmapViewOfFile(view);
+    const int placed = (view != NULL);
 
     const int64_t decoded = zxc_decompress_inplace(base, capacity, comp_size, opts);
     if (UNLIKELY(decoded <= 0)) {
+        /* Errors and the empty frame both leave nothing worth handing back. */
+        if (view) (void)UnmapViewOfFile(view);
         (void)VirtualFree(base, 0, MEM_RELEASE);
         return decoded;
     }
 
-    /* Trim: decommit the margin (the reservation itself can only be released
-     * whole, which zxc_mmap_close does). */
+    /* Trim: give back what the payload does not occupy. A view is released as a
+     * whole, so the archive slot can only go back when the payload ends before
+     * that slot begins; the private part is decommitted either way. */
     const size_t keep = zxc_round_up_pow2((size_t)decoded, page);
-    if (keep < region) (void)VirtualFree(base + keep, region - keep, MEM_DECOMMIT);
+    if (view) {
+        if (keep <= off) {
+            (void)UnmapViewOfFile(view);
+            view = NULL;
+            if (keep < off) (void)VirtualFree(base + keep, off - keep, MEM_DECOMMIT);
+        }
+    } else if (keep < region) {
+        (void)VirtualFree(base + keep, region - keep, MEM_DECOMMIT);
+    }
 
     out->data = base;
     out->size = (size_t)decoded;
     out->map_base = base;
     out->map_size = keep;
-    out->map_kind = ZXC_MAP_KIND_REGION;
+    out->map_handle = view; /* non-NULL: a view still to unmap on close */
+    out->map_kind = placed ? ZXC_MAP_KIND_PLACEHOLDER : ZXC_MAP_KIND_REGION;
     return decoded;
 }
 
 /** @brief Backend of @ref zxc_mmap_close: views unmap, reservations release. */
 static void zxc_map_release(zxc_map_t* const m) {
-    if (m->map_kind == ZXC_MAP_KIND_VIEW)
+    if (m->map_kind == ZXC_MAP_KIND_VIEW) {
         (void)UnmapViewOfFile(m->map_base);
-    else
-        (void)VirtualFree(m->map_base, 0, MEM_RELEASE);
+        return;
+    }
+    /* Decode region: an archive view may still sit at its far end, and the
+     * output part is a reservation of its own (a split placeholder replaced by
+     * private memory releases exactly like a plain VirtualAlloc). */
+    if (m->map_handle) (void)UnmapViewOfFile(m->map_handle);
+    (void)VirtualFree(m->map_base, 0, MEM_RELEASE);
 }
+
+/** @brief Backend of @ref zxc_mmap_is_zerocopy: only the copy route copies. */
+static int zxc_map_zerocopy(const zxc_map_t* const m) { return m->map_kind != ZXC_MAP_KIND_REGION; }
 // LCOV_EXCL_STOP
 
 #endif /* backend selection */
@@ -457,6 +681,18 @@ static void zxc_map_release(zxc_map_t* const m) {
  */
 // cppcheck-suppress unusedFunction
 int zxc_mmap_supported(void) { return 1; }
+
+/**
+ * @brief Reports whether @p map holds the archive without having copied it.
+ *
+ * Public API; full contract in @c zxc_mmap.h. Delegates to the backend, which
+ * knows which placement route produced the region.
+ */
+// cppcheck-suppress unusedFunction
+int zxc_mmap_is_zerocopy(const zxc_map_t* const map) {
+    if (!map || !map->data) return 0;
+    return zxc_map_zerocopy(map);
+}
 
 /**
  * @brief Maps a file read-only, without decoding it.
@@ -545,6 +781,13 @@ void zxc_mmap_close(zxc_map_t* const map) {
 /** @brief Reports whether this build can map files (it cannot). */
 // cppcheck-suppress unusedFunction
 int zxc_mmap_supported(void) { return 0; }
+
+/** @brief Nothing can be mapped on this target, so nothing is ever zero-copy. */
+// cppcheck-suppress unusedFunction
+int zxc_mmap_is_zerocopy(const zxc_map_t* map) {
+    (void)map;
+    return 0;
+}
 
 /** @brief Unsupported on this target; see @ref zxc_mmap_supported. */
 // cppcheck-suppress unusedFunction

--- a/tests/test_buffer_api.c
+++ b/tests/test_buffer_api.c
@@ -932,6 +932,47 @@ int test_decompress_inplace(void) {
         ok = 0;
     }
 
+    /* The footer is untrusted: the bound is what sizes an allocation (and, for
+     * the mapped decoder, a reservation), so a forged decompressed size must be
+     * rejected rather than turned into an arbitrary amount of memory. An archive
+     * cannot carry more blocks than comp_size / ZXC_BLOCK_HEADER_SIZE. */
+    {
+        const size_t small = 4096;
+        gen_lz_data(a, small);
+        uint8_t tiny[8192];
+        const int64_t c = zxc_compress(a, small, tiny, sizeof(tiny), NULL);
+        if (c <= 0) {
+            printf("Failed: forged-footer setup compress -> %lld\n", (long long)c);
+            ok = 0;
+        } else {
+            const size_t csz = (size_t)c;
+            if (zxc_decompress_inplace_bound(tiny, csz) == 0) {
+                printf("Failed: bound on the intact archive is 0\n");
+                ok = 0;
+            }
+            /* Footer = last ZXC_FILE_FOOTER_SIZE bytes, decompressed size first. */
+            uint8_t* const footer = tiny + csz - ZXC_FILE_FOOTER_SIZE;
+            uint8_t saved[ZXC_FILE_FOOTER_SIZE];
+            memcpy(saved, footer, sizeof(saved));
+
+            static const uint64_t forged[] = {(uint64_t)1 << 46, UINT64_MAX, UINT64_MAX - 1};
+            for (size_t i = 0; i < sizeof(forged) / sizeof(forged[0]); i++) {
+                for (int b = 0; b < 8; b++) footer[b] = (uint8_t)(forged[i] >> (8 * b));
+                const size_t need = zxc_decompress_inplace_bound(tiny, csz);
+                if (need != 0) {
+                    printf("Failed: forged footer 0x%llx -> bound %zu (want 0)\n",
+                           (unsigned long long)forged[i], need);
+                    ok = 0;
+                }
+            }
+            memcpy(footer, saved, sizeof(saved));
+            if (zxc_decompress_inplace_bound(tiny, csz) == 0) {
+                printf("Failed: restored footer still rejected\n");
+                ok = 0;
+            }
+        }
+    }
+
     free(a);
     if (!ok) return 0;
     printf("PASS\n\n");

--- a/tests/test_common.h
+++ b/tests/test_common.h
@@ -92,8 +92,7 @@ int test_static_ctx_level_raise_rejected(void);
 int test_static_ctx_null_inputs(void);
 
 /* Memory-Mapped API (zxc_mmap.h) */
-int test_mmap_roundtrip(void);
-int test_mmap_dict(void);
+int test_mmap_open(void);
 int test_mmap_errors(void);
 
 /* Stream API */

--- a/tests/test_common.h
+++ b/tests/test_common.h
@@ -91,6 +91,11 @@ int test_static_ctx_block_size_locked(void);
 int test_static_ctx_level_raise_rejected(void);
 int test_static_ctx_null_inputs(void);
 
+/* Memory-Mapped API (zxc_mmap.h) */
+int test_mmap_roundtrip(void);
+int test_mmap_dict(void);
+int test_mmap_errors(void);
+
 /* Stream API */
 int test_null_output_decompression(void);
 int test_invalid_arguments(void);

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -77,8 +77,7 @@ static const test_entry_t g_tests[] = {
     TEST_CASE(test_static_ctx_roundtrip_all_levels),
 
     /* --- Memory-Mapped API --- */
-    TEST_CASE(test_mmap_roundtrip),
-    TEST_CASE(test_mmap_dict),
+    TEST_CASE(test_mmap_open),
     TEST_CASE(test_mmap_errors),
 
     /* --- Stream API --- */

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -76,6 +76,11 @@ static const test_entry_t g_tests[] = {
     TEST_CASE(test_static_ctx_null_inputs),
     TEST_CASE(test_static_ctx_roundtrip_all_levels),
 
+    /* --- Memory-Mapped API --- */
+    TEST_CASE(test_mmap_roundtrip),
+    TEST_CASE(test_mmap_dict),
+    TEST_CASE(test_mmap_errors),
+
     /* --- Stream API --- */
     TEST_CASE(test_null_output_decompression),
     TEST_CASE(test_invalid_arguments),

--- a/tests/test_misc.c
+++ b/tests/test_misc.c
@@ -32,6 +32,8 @@ int test_error_name() {
         {ZXC_ERROR_DICT_REQUIRED, "ZXC_ERROR_DICT_REQUIRED"},
         {ZXC_ERROR_DICT_MISMATCH, "ZXC_ERROR_DICT_MISMATCH"},
         {ZXC_ERROR_DICT_TOO_LARGE, "ZXC_ERROR_DICT_TOO_LARGE"},
+        {ZXC_ERROR_BAD_LEVEL, "ZXC_ERROR_BAD_LEVEL"},
+        {ZXC_ERROR_UNSUPPORTED, "ZXC_ERROR_UNSUPPORTED"},
     };
     const int n = sizeof(cases) / sizeof(cases[0]);
 
@@ -44,6 +46,18 @@ int test_error_name() {
         }
     }
     printf("  [PASS] All %d known error codes\n", n);
+
+    /* The table above is hand-maintained, so it drifts every time an error code
+     * is added. Codes are contiguous, so sweep the whole range instead: any gap
+     * means zxc_error_name fell through to its default for a real code, or that
+     * this test stopped covering the tail of the enum. */
+    for (int code = ZXC_ERROR_UNSUPPORTED; code <= 0; code++) {
+        if (strcmp(zxc_error_name(code), "ZXC_UNKNOWN_ERROR") == 0) {
+            printf("  [FAIL] zxc_error_name(%d) is unnamed (new code without a case?)\n", code);
+            return 0;
+        }
+    }
+    printf("  [PASS] Every code in [%d, 0] is named\n", ZXC_ERROR_UNSUPPORTED);
 
     // Unknown codes should return "ZXC_UNKNOWN_ERROR"
     const char* unk = zxc_error_name(-999);

--- a/tests/test_mmap.c
+++ b/tests/test_mmap.c
@@ -38,6 +38,23 @@ static int write_whole_file(const char* const path, const void* const data, cons
     return (fclose(f) == 0) && w == n;
 }
 
+/* Whether losing the zero-copy placement is a failure or merely a note.
+ *
+ * The placement IS the feature, so a lost one has to fail the suite rather than
+ * print something nobody reads: the decode still returns the right bytes either
+ * way, so no other assertion here would catch it. POSIX has no copying route at
+ * all, hence the unconditional 1. On Windows the fallback is legitimate before
+ * Win10 1803, so a run that knows better (CI on windows-latest) opts in with
+ * ZXC_TEST_REQUIRE_ZEROCOPY=1. */
+static int zerocopy_required(void) {
+#if defined(_WIN32)
+    const char* const env = getenv("ZXC_TEST_REQUIRE_ZEROCOPY");
+    return env != NULL && env[0] != '\0' && env[0] != '0';
+#else
+    return 1;
+#endif
+}
+
 /* A closed map must be inert: cleared fields, and a second close is a no-op. */
 static int check_closed(const char* const label, zxc_map_t* const m) {
     zxc_mmap_close(m);
@@ -73,6 +90,7 @@ static int mmap_case(const char* const label, const uint8_t* const orig, const s
 
     if (!write_whole_file(MMAP_RT_PATH, comp, csz)) {
         printf("Failed [%s]: cannot write " MMAP_RT_PATH "\n", label);
+        remove(MMAP_RT_PATH);
         free(comp);
         return 0;
     }
@@ -83,11 +101,15 @@ static int mmap_case(const char* const label, const uint8_t* const orig, const s
     /* 1. Path API: one call, one mapping, no output allocation. */
     zxc_map_t m;
     const int64_t d = zxc_decompress_mmap(MMAP_RT_PATH, &m, &dop);
-    /* 1 everywhere but pre-1803 Windows, which copies the archive in. A loud
-     * marker: on a modern OS the copy route means the placement failed. */
+    /* 1 everywhere but pre-1803 Windows, which copies the archive in. */
     const int zero_copy = zxc_mmap_is_zerocopy(&m);
-    if (d > 0 && !zero_copy)
+    if (d > 0 && !zero_copy) {
         printf("  [INFO] no zero-copy placement here: the archive was copied into the region\n");
+        if (zerocopy_required()) {
+            printf("Failed [%s]: zero-copy placement lost\n", label);
+            ok = 0;
+        }
+    }
     if (d < 0 || (size_t)d != n || m.size != n || !m.data || memcmp(m.data, orig, n) != 0) {
         printf("Failed [%s]: decompress_mmap ret=%lld want=%zu%s\n", label, (long long)d, n,
                (d == (int64_t)n) ? " (MISMATCH)" : "");
@@ -103,6 +125,7 @@ static int mmap_case(const char* const label, const uint8_t* const orig, const s
     FILE* const f = fopen(MMAP_RT_PATH, "rb");
     if (!f) {
         printf("Failed [%s]: reopen\n", label);
+        remove(MMAP_RT_PATH);
         free(comp);
         return 0;
     }
@@ -318,6 +341,7 @@ int test_mmap_errors(void) {
     static const uint8_t stub[8] = {0};
     if (!write_whole_file(MMAP_ERR_PATH, stub, sizeof(stub))) {
         printf("Failed: cannot write stub\n");
+        remove(MMAP_ERR_PATH);
         return 0;
     }
     if (zxc_decompress_mmap(MMAP_ERR_PATH, &m, NULL) != ZXC_ERROR_SRC_TOO_SMALL) {
@@ -330,6 +354,7 @@ int test_mmap_errors(void) {
     memset(junk, 0x5A, sizeof(junk));
     if (!write_whole_file(MMAP_ERR_PATH, junk, sizeof(junk))) {
         printf("Failed: cannot write junk\n");
+        remove(MMAP_ERR_PATH);
         return 0;
     }
     if (zxc_decompress_mmap(MMAP_ERR_PATH, &m, NULL) != ZXC_ERROR_BAD_HEADER) {

--- a/tests/test_mmap.c
+++ b/tests/test_mmap.c
@@ -53,12 +53,16 @@ static int check_closed(const char* const label, zxc_map_t* const m) {
  * mapped path API, the mapped fd API, and a read-only mapping fed to
  * zxc_decompress. */
 static int mmap_case(const char* const label, const uint8_t* const orig, const size_t n,
-                     const int level, const int checksum) {
+                     const int level, const int checksum, const size_t block_size,
+                     const int seekable) {
     const size_t cbound = (size_t)zxc_compress_bound(n);
     uint8_t* const comp = (uint8_t*)malloc(cbound);
     if (!comp) return 0;
 
-    const zxc_compress_opts_t co = {.level = level, .checksum_enabled = checksum};
+    const zxc_compress_opts_t co = {.level = level,
+                                    .checksum_enabled = checksum,
+                                    .block_size = block_size,
+                                    .seekable = seekable};
     const int64_t c = zxc_compress(orig, n, comp, cbound, &co);
     if (c <= 0) {
         printf("Failed [%s]: compress -> %lld\n", label, (long long)c);
@@ -175,22 +179,34 @@ int test_mmap_roundtrip(void) {
     int ok = 1;
 
     gen_lz_data(a, N);
-    ok &= mmap_case("compressible L3", a, N, 3, 1);
-    ok &= mmap_case("compressible L6", a, N, 6, 0);
+    ok &= mmap_case("compressible L3", a, N, 3, 1, 0, 0);
+    ok &= mmap_case("compressible L6", a, N, 6, 0, 0, 0);
 
     /* High-entropy: comp_size ~ N, so the flush-right archive overlaps the
      * output region and the decoder writes over bytes it has already read. */
     gen_random_data(a, N);
-    ok &= mmap_case("random L1 (overlap)", a, N, 1, 0);
-    ok &= mmap_case("random L7 (overlap)", a, N, 7, 1);
+    ok &= mmap_case("random L1 (overlap)", a, N, 1, 0, 0, 0);
+    ok &= mmap_case("random L7 (overlap)", a, N, 7, 1, 0, 0);
 
     /* Multi-block, and a size that is not a page multiple. */
     gen_binary_data(a, N);
-    ok &= mmap_case("binary 1 MiB+1", a, 1024 * 1024 + 1, 3, 1);
-    ok &= mmap_case("binary 4 KiB-3", a, 4093, 3, 0);
-    ok &= mmap_case("tiny 1 byte", a, 1, 3, 1);
+    ok &= mmap_case("binary 1 MiB+1", a, 1024 * 1024 + 1, 3, 1, 0, 0);
+    ok &= mmap_case("binary 4 KiB-3", a, 4093, 3, 0, 0, 0);
+    ok &= mmap_case("tiny 1 byte", a, 1, 3, 1, 0, 0);
 
+    /* Seekable archives put a seek table between the EOF block and the footer;
+     * those bytes push the flush-right archive left, so the in-place bound has
+     * to reserve them (it did not, and the mapped path silently lost its
+     * margin). Worst shape: many small blocks over incompressible data. */
     free(a);
+    uint8_t* const b = (uint8_t*)malloc(8 * 1024 * 1024);
+    if (!b) return 0;
+    gen_random_data(b, 8 * 1024 * 1024);
+    ok &= mmap_case("seekable random, 4K blocks", b, 8 * 1024 * 1024, 1, 1, ZXC_BLOCK_SIZE_MIN, 1);
+    gen_lz_data(b, 8 * 1024 * 1024);
+    ok &= mmap_case("seekable text, 4K blocks", b, 8 * 1024 * 1024, 3, 1, ZXC_BLOCK_SIZE_MIN, 1);
+    free(b);
+
     if (!ok) return 0;
     printf("PASS\n\n");
     return 1;

--- a/tests/test_mmap.c
+++ b/tests/test_mmap.c
@@ -41,7 +41,7 @@ static int write_whole_file(const char* const path, const void* const data, cons
 /* A closed map must be inert: cleared fields, and a second close is a no-op. */
 static int check_closed(const char* const label, zxc_map_t* const m) {
     zxc_mmap_close(m);
-    if (m->data != NULL || m->size != 0) {
+    if (m->data != NULL || m->size != 0 || zxc_mmap_is_zerocopy(m)) {
         printf("Failed [%s]: close left data=%p size=%zu\n", label, (void*)m->data, m->size);
         return 0;
     }
@@ -79,6 +79,11 @@ static int mmap_case(const char* const label, const uint8_t* const orig, const s
     /* 1. Path API: one call, one mapping, no output allocation. */
     zxc_map_t m;
     const int64_t d = zxc_decompress_mmap(MMAP_RT_PATH, &m, &dop);
+    /* 1 everywhere but pre-1803 Windows, which copies the archive in. A loud
+     * marker: on a modern OS the copy route means the placement failed. */
+    const int zero_copy = zxc_mmap_is_zerocopy(&m);
+    if (d > 0 && !zero_copy)
+        printf("  [INFO] no zero-copy placement here: the archive was copied into the region\n");
     if (d < 0 || (size_t)d != n || m.size != n || !m.data || memcmp(m.data, orig, n) != 0) {
         printf("Failed [%s]: decompress_mmap ret=%lld want=%zu%s\n", label, (long long)d, n,
                (d == (int64_t)n) ? " (MISMATCH)" : "");
@@ -122,7 +127,8 @@ static int mmap_case(const char* const label, const uint8_t* const orig, const s
     zxc_map_t ma;
     const int rc = zxc_mmap_open_fd(zxc_test_fileno(f), &ma);
     fclose(f); /* the mapping outlives the descriptor */
-    if (rc != ZXC_OK || ma.size != csz || !ma.data || memcmp(ma.data, comp, csz) != 0) {
+    if (rc != ZXC_OK || ma.size != csz || !ma.data || !zxc_mmap_is_zerocopy(&ma) ||
+        memcmp(ma.data, comp, csz) != 0) {
         printf("Failed [%s]: mmap_open_fd rc=%d size=%zu want=%zu\n", label, rc, ma.size, csz);
         ok = 0;
     } else {
@@ -149,8 +155,9 @@ static int mmap_case(const char* const label, const uint8_t* const orig, const s
     remove(MMAP_RT_PATH);
     free(comp);
     if (ok)
-        printf("  [PASS] %s (n=%zu, comp=%zu, %s)\n", label, n, csz,
-               csz > n ? "archive spans the whole region" : "archive in margin");
+        printf("  [PASS] %s (n=%zu, comp=%zu, %s, %s)\n", label, n, csz,
+               csz > n ? "archive spans the whole region" : "archive in margin",
+               zero_copy ? "zero-copy" : "archive copied in");
     return ok;
 }
 
@@ -341,6 +348,11 @@ int test_mmap_errors(void) {
     /* A directory is not mappable. */
     if (zxc_mmap_open(".", &m) != ZXC_ERROR_IO) {
         printf("Failed: directory not rejected\n");
+        ok = 0;
+    }
+
+    if (zxc_mmap_is_zerocopy(NULL)) {
+        printf("Failed: is_zerocopy(NULL) != 0\n");
         ok = 0;
     }
 

--- a/tests/test_mmap.c
+++ b/tests/test_mmap.c
@@ -19,6 +19,10 @@
 #include "../include/zxc_mmap.h"
 #include "test_common.h"
 
+#if defined(_WIN32)
+#include <windows.h>
+#endif
+
 #ifdef _MSC_VER
 #define zxc_test_fileno _fileno
 #else
@@ -40,19 +44,37 @@ static int write_whole_file(const char* const path, const void* const data, cons
 
 /* Whether losing the zero-copy placement is a failure or merely a note.
  *
- * The placement IS the feature, so a lost one has to fail the suite rather than
- * print something nobody reads: the decode still returns the right bytes either
- * way, so no other assertion here would catch it. POSIX has no copying route at
- * all, hence the unconditional 1. On Windows the fallback is legitimate before
- * Win10 1803, so a run that knows better (CI on windows-latest) opts in with
- * ZXC_TEST_REQUIRE_ZEROCOPY=1. */
+ * The placement IS the feature and the decode returns the right bytes either
+ * way, so nothing else here would catch its loss. POSIX has no copying route,
+ * hence the unconditional 1. On Windows the fallback is legitimate before
+ * Win10 1803, so the answer comes from the OS -- the placement is available
+ * exactly when the two placeholder entry points resolve. An opt-in env var
+ * would have to be set by every job to assert anything at all. */
 static int zerocopy_required(void) {
 #if defined(_WIN32)
+    /* An explicit answer still wins: a file that cannot back a copy-on-write
+     * section is a legitimate fallback. */
     const char* const env = getenv("ZXC_TEST_REQUIRE_ZEROCOPY");
-    return env != NULL && env[0] != '\0' && env[0] != '0';
+    if (env != NULL && env[0] != '\0') return env[0] != '0';
+
+    HMODULE mod = GetModuleHandleW(L"kernelbase.dll");
+    if (!mod) mod = GetModuleHandleW(L"kernel32.dll");
+    if (!mod) return 0;
+    return GetProcAddress(mod, "VirtualAlloc2") != NULL &&
+           GetProcAddress(mod, "MapViewOfFile3") != NULL;
 #else
     return 1;
 #endif
+}
+
+/* One I/O-failure assertion. Chained with ||, the first failure would hide the
+ * rest and skip the calls whose map still needs closing -- an unexpected
+ * SUCCESS hands back a live region, hence the close on mismatch. */
+static int expect_io(const char* const label, const int64_t got, zxc_map_t* const m) {
+    if (got == ZXC_ERROR_IO) return 1;
+    printf("Failed [%s]: expected ZXC_ERROR_IO, got %lld\n", label, (long long)got);
+    zxc_mmap_close(m);
+    return 0;
 }
 
 /* A closed map must be inert: cleared fields, and a second close is a no-op. */
@@ -329,13 +351,12 @@ int test_mmap_errors(void) {
     zxc_mmap_close(&m);
 
     /* Missing file, and a bad descriptor. */
-    if (zxc_decompress_mmap("zxc_no_such_archive.bin", &m, NULL) != ZXC_ERROR_IO ||
-        zxc_mmap_open("zxc_no_such_archive.bin", &m) != ZXC_ERROR_IO ||
-        zxc_decompress_mmap_fd(-1, &m, NULL) != ZXC_ERROR_IO ||
-        zxc_mmap_open_fd(-1, &m) != ZXC_ERROR_IO) {
-        printf("Failed: missing file / bad fd not reported as ZXC_ERROR_IO\n");
+    if (!expect_io("missing file, decompress",
+                   zxc_decompress_mmap("zxc_no_such_archive.bin", &m, NULL), &m))
         ok = 0;
-    }
+    if (!expect_io("missing file, open", zxc_mmap_open("zxc_no_such_archive.bin", &m), &m)) ok = 0;
+    if (!expect_io("bad fd, decompress", zxc_decompress_mmap_fd(-1, &m, NULL), &m)) ok = 0;
+    if (!expect_io("bad fd, open", zxc_mmap_open_fd(-1, &m), &m)) ok = 0;
 
     /* Too short to hold a frame. */
     static const uint8_t stub[8] = {0};
@@ -357,9 +378,32 @@ int test_mmap_errors(void) {
         remove(MMAP_ERR_PATH);
         return 0;
     }
-    if (zxc_decompress_mmap(MMAP_ERR_PATH, &m, NULL) != ZXC_ERROR_BAD_HEADER) {
-        printf("Failed: junk archive not rejected\n");
+    const int64_t junk_rc = zxc_decompress_mmap(MMAP_ERR_PATH, &m, NULL);
+    if (junk_rc != ZXC_ERROR_BAD_MAGIC) {
+        printf("Failed: junk archive -> %lld, expected ZXC_ERROR_BAD_MAGIC\n", (long long)junk_rc);
         ok = 0;
+    }
+
+    /* Forged footer: the header is intact, so the verdict must blame the data. */
+    uint8_t forged[256];
+    const int64_t fc = zxc_compress(junk, sizeof(junk), forged, sizeof(forged), NULL);
+    if (fc <= 0) {
+        printf("Failed: cannot build archive to forge\n");
+        ok = 0;
+    } else {
+        memset(forged + fc - ZXC_FILE_FOOTER_SIZE, 0xFF, 8); /* dsize = UINT64_MAX */
+        if (!write_whole_file(MMAP_ERR_PATH, forged, (size_t)fc)) {
+            printf("Failed: cannot write forged archive\n");
+            ok = 0;
+        } else {
+            const int64_t d = zxc_decompress_mmap(MMAP_ERR_PATH, &m, NULL);
+            if (d != ZXC_ERROR_CORRUPT_DATA) {
+                printf("Failed: forged footer -> %lld, expected ZXC_ERROR_CORRUPT_DATA\n",
+                       (long long)d);
+                ok = 0;
+            }
+            zxc_mmap_close(&m);
+        }
     }
 
     /* Empty frame: succeeds with nothing to hand back. */

--- a/tests/test_mmap.c
+++ b/tests/test_mmap.c
@@ -1,0 +1,356 @@
+/*
+ * ZXC - High-performance lossless compression
+ *
+ * Copyright (c) 2025-2026 Bertrand Lebonnois and contributors.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/*
+ * Memory-mapped API: zero-copy in-place decode of an on-disk archive
+ * (zxc_decompress_mmap / _fd) and the read-only archive mapping
+ * (zxc_mmap_open / _fd).
+ *
+ * The interesting inputs are the high-entropy ones: their archive is nearly as
+ * large as the payload, so the flush-right file mapping lands INSIDE the output
+ * region and the write cursor sweeps straight through the compressed bytes -
+ * the invariant the whole design rests on.
+ */
+
+#include "../include/zxc_mmap.h"
+#include "test_common.h"
+
+#ifdef _MSC_VER
+#define zxc_test_fileno _fileno
+#else
+#define zxc_test_fileno fileno
+#endif
+
+/* Distinct per-test file names: the suite runs its cases in parallel. */
+#define MMAP_RT_PATH "zxc_mmap_roundtrip.bin"
+#define MMAP_ERR_PATH "zxc_mmap_errors.bin"
+#define MMAP_DICT_PATH "zxc_mmap_dict.bin"
+
+/* Writes `n` bytes to `path` in binary mode. Returns 1 on success. */
+static int write_whole_file(const char* const path, const void* const data, const size_t n) {
+    FILE* const f = fopen(path, "wb");
+    if (!f) return 0;
+    const size_t w = n ? fwrite(data, 1, n, f) : 0;
+    return (fclose(f) == 0) && w == n;
+}
+
+/* A closed map must be inert: cleared fields, and a second close is a no-op. */
+static int check_closed(const char* const label, zxc_map_t* const m) {
+    zxc_mmap_close(m);
+    if (m->data != NULL || m->size != 0) {
+        printf("Failed [%s]: close left data=%p size=%zu\n", label, (void*)m->data, m->size);
+        return 0;
+    }
+    zxc_mmap_close(m); /* idempotent */
+    return 1;
+}
+
+/* Compress `orig`, write the archive to disk, then decode it back through the
+ * mapped path API, the mapped fd API, and a read-only mapping fed to
+ * zxc_decompress. */
+static int mmap_case(const char* const label, const uint8_t* const orig, const size_t n,
+                     const int level, const int checksum) {
+    const size_t cbound = (size_t)zxc_compress_bound(n);
+    uint8_t* const comp = (uint8_t*)malloc(cbound);
+    if (!comp) return 0;
+
+    const zxc_compress_opts_t co = {.level = level, .checksum_enabled = checksum};
+    const int64_t c = zxc_compress(orig, n, comp, cbound, &co);
+    if (c <= 0) {
+        printf("Failed [%s]: compress -> %lld\n", label, (long long)c);
+        free(comp);
+        return 0;
+    }
+    const size_t csz = (size_t)c;
+
+    if (!write_whole_file(MMAP_RT_PATH, comp, csz)) {
+        printf("Failed [%s]: cannot write " MMAP_RT_PATH "\n", label);
+        free(comp);
+        return 0;
+    }
+
+    const zxc_decompress_opts_t dop = {.checksum_enabled = checksum};
+    int ok = 1;
+
+    /* 1. Path API: one call, one mapping, no output allocation. */
+    zxc_map_t m;
+    const int64_t d = zxc_decompress_mmap(MMAP_RT_PATH, &m, &dop);
+    if (d < 0 || (size_t)d != n || m.size != n || !m.data || memcmp(m.data, orig, n) != 0) {
+        printf("Failed [%s]: decompress_mmap ret=%lld want=%zu%s\n", label, (long long)d, n,
+               (d == (int64_t)n) ? " (MISMATCH)" : "");
+        ok = 0;
+    } else {
+        /* The region is the caller's to write into (private mapping). */
+        ((uint8_t*)m.data)[0] ^= 0xFFu;
+        ((uint8_t*)m.data)[n - 1] ^= 0xFFu;
+    }
+    ok &= check_closed(label, &m);
+
+    /* 2. Same through a caller-owned descriptor. */
+    FILE* const f = fopen(MMAP_RT_PATH, "rb");
+    if (!f) {
+        printf("Failed [%s]: reopen\n", label);
+        free(comp);
+        return 0;
+    }
+    /* The archive on disk must be untouched, even though decode #1 wrote over
+     * the compressed bytes it had already consumed (private mapping / COW). */
+    uint8_t* const reread = (uint8_t*)malloc(csz);
+    if (reread) {
+        const size_t got = fread(reread, 1, csz, f);
+        if (got != csz || memcmp(reread, comp, csz) != 0) {
+            printf("Failed [%s]: archive modified on disk by the in-place decode\n", label);
+            ok = 0;
+        }
+        free(reread);
+    }
+
+    zxc_map_t mf;
+    const int64_t df = zxc_decompress_mmap_fd(zxc_test_fileno(f), &mf, &dop);
+    if (df < 0 || (size_t)df != n || !mf.data || memcmp(mf.data, orig, n) != 0) {
+        printf("Failed [%s]: decompress_mmap_fd ret=%lld want=%zu\n", label, (long long)df, n);
+        ok = 0;
+    }
+    ok &= check_closed(label, &mf);
+
+    /* 3. Read-only archive mapping: the mapped bytes ARE the file's bytes, and
+     *    they feed the ordinary buffer API with no input copy. */
+    zxc_map_t ma;
+    const int rc = zxc_mmap_open_fd(zxc_test_fileno(f), &ma);
+    fclose(f); /* the mapping outlives the descriptor */
+    if (rc != ZXC_OK || ma.size != csz || !ma.data || memcmp(ma.data, comp, csz) != 0) {
+        printf("Failed [%s]: mmap_open_fd rc=%d size=%zu want=%zu\n", label, rc, ma.size, csz);
+        ok = 0;
+    } else {
+        uint8_t* const out = (uint8_t*)malloc(n ? n : 1);
+        if (out) {
+            const int64_t dv = zxc_decompress(ma.data, ma.size, out, n, &dop);
+            if (dv != (int64_t)n || memcmp(out, orig, n) != 0) {
+                printf("Failed [%s]: decompress from view ret=%lld\n", label, (long long)dv);
+                ok = 0;
+            }
+            free(out);
+        }
+    }
+    ok &= check_closed(label, &ma);
+
+    /* 4. Path-based read-only mapping. */
+    zxc_map_t mp;
+    if (zxc_mmap_open(MMAP_RT_PATH, &mp) != ZXC_OK || mp.size != csz) {
+        printf("Failed [%s]: mmap_open\n", label);
+        ok = 0;
+    }
+    ok &= check_closed(label, &mp);
+
+    remove(MMAP_RT_PATH);
+    free(comp);
+    if (ok)
+        printf("  [PASS] %s (n=%zu, comp=%zu, %s)\n", label, n, csz,
+               csz > n ? "archive spans the whole region" : "archive in margin");
+    return ok;
+}
+
+int test_mmap_roundtrip(void) {
+    printf("=== TEST: Unit - Mapped zero-copy in-place decode ===\n");
+    if (!zxc_mmap_supported()) {
+        printf("  [SKIP] no file mapping on this platform\n");
+        printf("PASS\n\n");
+        return 1;
+    }
+
+    const size_t N = 2 * 1024 * 1024;
+    uint8_t* const a = (uint8_t*)malloc(N);
+    if (!a) return 0;
+    int ok = 1;
+
+    gen_lz_data(a, N);
+    ok &= mmap_case("compressible L3", a, N, 3, 1);
+    ok &= mmap_case("compressible L6", a, N, 6, 0);
+
+    /* High-entropy: comp_size ~ N, so the flush-right archive overlaps the
+     * output region and the decoder writes over bytes it has already read. */
+    gen_random_data(a, N);
+    ok &= mmap_case("random L1 (overlap)", a, N, 1, 0);
+    ok &= mmap_case("random L7 (overlap)", a, N, 7, 1);
+
+    /* Multi-block, and a size that is not a page multiple. */
+    gen_binary_data(a, N);
+    ok &= mmap_case("binary 1 MiB+1", a, 1024 * 1024 + 1, 3, 1);
+    ok &= mmap_case("binary 4 KiB-3", a, 4093, 3, 0);
+    ok &= mmap_case("tiny 1 byte", a, 1, 3, 1);
+
+    free(a);
+    if (!ok) return 0;
+    printf("PASS\n\n");
+    return 1;
+}
+
+/* Dictionary archives take the bounce-buffer route inside the decoder (the
+ * bounce buffer does not alias the mapped region), so they need their own pass
+ * through the mapped entry point - including the "dict missing" rejection. */
+int test_mmap_dict(void) {
+    printf("=== TEST: Unit - Mapped decode of a dictionary archive ===\n");
+    if (!zxc_mmap_supported()) {
+        printf("  [SKIP] no file mapping on this platform\n");
+        printf("PASS\n\n");
+        return 1;
+    }
+
+    static const uint8_t dict[] =
+        "The quick brown fox jumps over the lazy dog. "
+        "Lorem ipsum dolor sit amet, consectetur adipiscing elit. "
+        "Pack my box with five dozen liquor jugs.";
+    const size_t dict_size = sizeof(dict) - 1;
+
+    const size_t n = 64 * 1024;
+    uint8_t* const src = (uint8_t*)malloc(n);
+    uint8_t* const comp = (uint8_t*)malloc((size_t)zxc_compress_bound(n));
+    if (!src || !comp) {
+        free(src);
+        free(comp);
+        return 0;
+    }
+    for (size_t i = 0; i < n; i++) {
+        src[i] = (i % 7 < 5) ? dict[(i * 31) % (dict_size - 5) + (i % 5)] : (uint8_t)(i ^ (i >> 8));
+    }
+
+    const zxc_compress_opts_t co = {
+        .level = 3, .checksum_enabled = 1, .dict = dict, .dict_size = dict_size};
+    const int64_t c = zxc_compress(src, n, comp, (size_t)zxc_compress_bound(n), &co);
+    int ok = c > 0 && write_whole_file(MMAP_DICT_PATH, comp, (size_t)c);
+    if (!ok) printf("Failed: dict compress/write (%lld)\n", (long long)c);
+
+    if (ok) {
+        const zxc_decompress_opts_t dop = {
+            .checksum_enabled = 1, .dict = dict, .dict_size = dict_size};
+        zxc_map_t m;
+        const int64_t d = zxc_decompress_mmap(MMAP_DICT_PATH, &m, &dop);
+        if (d != (int64_t)n || !m.data || memcmp(m.data, src, n) != 0) {
+            printf("Failed: dict mapped decode ret=%lld want=%zu\n", (long long)d, n);
+            ok = 0;
+        }
+        zxc_mmap_close(&m);
+
+        /* Same archive without the dictionary must be refused, not decoded. */
+        const int64_t nd = zxc_decompress_mmap(MMAP_DICT_PATH, &m, NULL);
+        if (nd != ZXC_ERROR_DICT_REQUIRED) {
+            printf("Failed: missing dict -> %lld (want %d)\n", (long long)nd,
+                   ZXC_ERROR_DICT_REQUIRED);
+            ok = 0;
+        }
+        zxc_mmap_close(&m);
+        if (ok) printf("  [PASS] dict archive (n=%zu, comp=%lld)\n", n, (long long)c);
+    }
+
+    remove(MMAP_DICT_PATH);
+    free(src);
+    free(comp);
+    if (!ok) return 0;
+    printf("PASS\n\n");
+    return 1;
+}
+
+int test_mmap_errors(void) {
+    printf("=== TEST: Unit - Mapped decode error paths ===\n");
+    if (!zxc_mmap_supported()) {
+        printf("  [SKIP] no file mapping on this platform\n");
+        printf("PASS\n\n");
+        return 1;
+    }
+
+    int ok = 1;
+    zxc_map_t m;
+
+    /* NULL out-param is rejected before anything is opened. */
+    if (zxc_decompress_mmap(MMAP_ERR_PATH, NULL, NULL) != ZXC_ERROR_NULL_INPUT ||
+        zxc_mmap_open(MMAP_ERR_PATH, NULL) != ZXC_ERROR_NULL_INPUT) {
+        printf("Failed: NULL out-param not rejected\n");
+        ok = 0;
+    }
+
+    /* NULL path, with the map still cleared so closing it is safe. */
+    m.data = (void*)0x1;
+    m.map_base = (void*)0x1;
+    if (zxc_decompress_mmap(NULL, &m, NULL) != ZXC_ERROR_NULL_INPUT || m.data != NULL ||
+        m.map_base != NULL) {
+        printf("Failed: NULL path not rejected / map not cleared\n");
+        ok = 0;
+    }
+    zxc_mmap_close(&m);
+
+    /* Missing file, and a bad descriptor. */
+    if (zxc_decompress_mmap("zxc_no_such_archive.bin", &m, NULL) != ZXC_ERROR_IO ||
+        zxc_mmap_open("zxc_no_such_archive.bin", &m) != ZXC_ERROR_IO ||
+        zxc_decompress_mmap_fd(-1, &m, NULL) != ZXC_ERROR_IO ||
+        zxc_mmap_open_fd(-1, &m) != ZXC_ERROR_IO) {
+        printf("Failed: missing file / bad fd not reported as ZXC_ERROR_IO\n");
+        ok = 0;
+    }
+
+    /* Too short to hold a frame. */
+    static const uint8_t stub[8] = {0};
+    if (!write_whole_file(MMAP_ERR_PATH, stub, sizeof(stub))) {
+        printf("Failed: cannot write stub\n");
+        return 0;
+    }
+    if (zxc_decompress_mmap(MMAP_ERR_PATH, &m, NULL) != ZXC_ERROR_SRC_TOO_SMALL) {
+        printf("Failed: short file not rejected\n");
+        ok = 0;
+    }
+
+    /* Right length, wrong contents. */
+    uint8_t junk[128];
+    memset(junk, 0x5A, sizeof(junk));
+    if (!write_whole_file(MMAP_ERR_PATH, junk, sizeof(junk))) {
+        printf("Failed: cannot write junk\n");
+        return 0;
+    }
+    if (zxc_decompress_mmap(MMAP_ERR_PATH, &m, NULL) != ZXC_ERROR_BAD_HEADER) {
+        printf("Failed: junk archive not rejected\n");
+        ok = 0;
+    }
+
+    /* Empty frame: succeeds with nothing to hand back. */
+    uint8_t empty[64];
+    const int64_t ec = zxc_compress(NULL, 0, empty, sizeof(empty), NULL);
+    if (ec <= 0 || !write_whole_file(MMAP_ERR_PATH, empty, (size_t)ec)) {
+        printf("Failed: cannot build empty frame\n");
+        ok = 0;
+    } else {
+        const int64_t d = zxc_decompress_mmap(MMAP_ERR_PATH, &m, NULL);
+        if (d != 0 || m.data != NULL || m.size != 0) {
+            printf("Failed: empty frame -> %lld (data=%p)\n", (long long)d, (void*)m.data);
+            ok = 0;
+        }
+        zxc_mmap_close(&m);
+    }
+
+    /* Empty file: nothing to map. */
+    if (!write_whole_file(MMAP_ERR_PATH, NULL, 0)) {
+        printf("Failed: cannot truncate\n");
+        ok = 0;
+    } else if (zxc_mmap_open(MMAP_ERR_PATH, &m) != ZXC_ERROR_SRC_TOO_SMALL) {
+        printf("Failed: empty file not rejected\n");
+        ok = 0;
+    }
+
+    /* A directory is not mappable. */
+    if (zxc_mmap_open(".", &m) != ZXC_ERROR_IO) {
+        printf("Failed: directory not rejected\n");
+        ok = 0;
+    }
+
+    /* zxc_mmap_close tolerates NULL and a zeroed map. */
+    zxc_mmap_close(NULL);
+    memset(&m, 0, sizeof(m));
+    zxc_mmap_close(&m);
+
+    remove(MMAP_ERR_PATH);
+    if (!ok) return 0;
+    printf("PASS\n\n");
+    return 1;
+}

--- a/tests/test_mmap.c
+++ b/tests/test_mmap.c
@@ -6,22 +6,13 @@
  */
 
 /*
- * Memory-mapped API: zero-copy in-place decode of an on-disk archive
- * (zxc_decompress_mmap / _fd) and the read-only archive mapping
- * (zxc_mmap_open / _fd).
- *
- * The interesting inputs are the high-entropy ones: their archive is nearly as
- * large as the payload, so the flush-right file mapping lands INSIDE the output
- * region and the write cursor sweeps straight through the compressed bytes -
- * the invariant the whole design rests on.
+ * Memory-mapped API: read-only whole-file mappings (zxc_mmap_open / _fd) and
+ * the composition that motivates them -- the mapped bytes fed straight to the
+ * buffer API, with no input copy.
  */
 
 #include "../include/zxc_mmap.h"
 #include "test_common.h"
-
-#if defined(_WIN32)
-#include <windows.h>
-#endif
 
 #ifdef _MSC_VER
 #define zxc_test_fileno _fileno
@@ -32,7 +23,6 @@
 /* Distinct per-test file names: the suite runs its cases in parallel. */
 #define MMAP_RT_PATH "zxc_mmap_roundtrip.bin"
 #define MMAP_ERR_PATH "zxc_mmap_errors.bin"
-#define MMAP_DICT_PATH "zxc_mmap_dict.bin"
 
 /* Writes `n` bytes to `path` in binary mode. Returns 1 on success. */
 static int write_whole_file(const char* const path, const void* const data, const size_t n) {
@@ -42,37 +32,12 @@ static int write_whole_file(const char* const path, const void* const data, cons
     return (fclose(f) == 0) && w == n;
 }
 
-/* Whether losing the zero-copy placement is a failure or merely a note.
- *
- * The placement IS the feature and the decode returns the right bytes either
- * way, so nothing else here would catch its loss. POSIX has no copying route,
- * hence the unconditional 1. On Windows the fallback is legitimate before
- * Win10 1803, so the answer comes from the OS -- the placement is available
- * exactly when the two placeholder entry points resolve. An opt-in env var
- * would have to be set by every job to assert anything at all. */
-static int zerocopy_required(void) {
-#if defined(_WIN32)
-    /* An explicit answer still wins: a file that cannot back a copy-on-write
-     * section is a legitimate fallback. */
-    const char* const env = getenv("ZXC_TEST_REQUIRE_ZEROCOPY");
-    if (env != NULL && env[0] != '\0') return env[0] != '0';
-
-    HMODULE mod = GetModuleHandleW(L"kernelbase.dll");
-    if (!mod) mod = GetModuleHandleW(L"kernel32.dll");
-    if (!mod) return 0;
-    return GetProcAddress(mod, "VirtualAlloc2") != NULL &&
-           GetProcAddress(mod, "MapViewOfFile3") != NULL;
-#else
-    return 1;
-#endif
-}
-
 /* One I/O-failure assertion. Chained with ||, the first failure would hide the
  * rest and skip the calls whose map still needs closing -- an unexpected
- * SUCCESS hands back a live region, hence the close on mismatch. */
-static int expect_io(const char* const label, const int64_t got, zxc_map_t* const m) {
+ * SUCCESS hands back a live mapping, hence the close on mismatch. */
+static int expect_io(const char* const label, const int got, zxc_map_t* const m) {
     if (got == ZXC_ERROR_IO) return 1;
-    printf("Failed [%s]: expected ZXC_ERROR_IO, got %lld\n", label, (long long)got);
+    printf("Failed [%s]: expected ZXC_ERROR_IO, got %d\n", label, got);
     zxc_mmap_close(m);
     return 0;
 }
@@ -80,17 +45,17 @@ static int expect_io(const char* const label, const int64_t got, zxc_map_t* cons
 /* A closed map must be inert: cleared fields, and a second close is a no-op. */
 static int check_closed(const char* const label, zxc_map_t* const m) {
     zxc_mmap_close(m);
-    if (m->data != NULL || m->size != 0 || zxc_mmap_is_zerocopy(m)) {
-        printf("Failed [%s]: close left data=%p size=%zu\n", label, (void*)m->data, m->size);
+    if (m->data != NULL || m->size != 0) {
+        printf("Failed [%s]: close left data=%p size=%zu\n", label, (const void*)m->data, m->size);
         return 0;
     }
     zxc_mmap_close(m); /* idempotent */
     return 1;
 }
 
-/* Compress `orig`, write the archive to disk, then decode it back through the
- * mapped path API, the mapped fd API, and a read-only mapping fed to
- * zxc_decompress. */
+/* Compress `orig`, write the archive to disk, then map it back -- by fd and by
+ * path -- and check the mapped bytes are the file's bytes and decode correctly
+ * through the ordinary buffer API. */
 static int mmap_case(const char* const label, const uint8_t* const orig, const size_t n,
                      const int level, const int checksum, const size_t block_size,
                      const int seekable) {
@@ -109,7 +74,6 @@ static int mmap_case(const char* const label, const uint8_t* const orig, const s
         return 0;
     }
     const size_t csz = (size_t)c;
-
     if (!write_whole_file(MMAP_RT_PATH, comp, csz)) {
         printf("Failed [%s]: cannot write " MMAP_RT_PATH "\n", label);
         remove(MMAP_RT_PATH);
@@ -120,65 +84,24 @@ static int mmap_case(const char* const label, const uint8_t* const orig, const s
     const zxc_decompress_opts_t dop = {.checksum_enabled = checksum};
     int ok = 1;
 
-    /* 1. Path API: one call, one mapping, no output allocation. */
-    zxc_map_t m;
-    const int64_t d = zxc_decompress_mmap(MMAP_RT_PATH, &m, &dop);
-    /* 1 everywhere but pre-1803 Windows, which copies the archive in. */
-    const int zero_copy = zxc_mmap_is_zerocopy(&m);
-    if (d > 0 && !zero_copy) {
-        printf("  [INFO] no zero-copy placement here: the archive was copied into the region\n");
-        if (zerocopy_required()) {
-            printf("Failed [%s]: zero-copy placement lost\n", label);
-            ok = 0;
-        }
-    }
-    if (d < 0 || (size_t)d != n || m.size != n || !m.data || memcmp(m.data, orig, n) != 0) {
-        printf("Failed [%s]: decompress_mmap ret=%lld want=%zu%s\n", label, (long long)d, n,
-               (d == (int64_t)n) ? " (MISMATCH)" : "");
-        ok = 0;
-    } else {
-        /* The region is the caller's to write into (private mapping). */
-        ((uint8_t*)m.data)[0] ^= 0xFFu;
-        ((uint8_t*)m.data)[n - 1] ^= 0xFFu;
-    }
-    ok &= check_closed(label, &m);
-
-    /* 2. Same through a caller-owned descriptor. */
+    /* 1. By descriptor. The mapping outlives it, and the file position the
+     *    caller left behind is untouched. */
     FILE* const f = fopen(MMAP_RT_PATH, "rb");
     if (!f) {
-        printf("Failed [%s]: reopen\n", label);
+        printf("Failed [%s]: cannot reopen archive\n", label);
         remove(MMAP_RT_PATH);
         free(comp);
         return 0;
     }
-    /* The archive on disk must be untouched, even though decode #1 wrote over
-     * the compressed bytes it had already consumed (private mapping / COW). */
-    uint8_t* const reread = (uint8_t*)malloc(csz);
-    if (reread) {
-        const size_t got = fread(reread, 1, csz, f);
-        if (got != csz || memcmp(reread, comp, csz) != 0) {
-            printf("Failed [%s]: archive modified on disk by the in-place decode\n", label);
-            ok = 0;
-        }
-        free(reread);
-    }
-
-    zxc_map_t mf;
-    const int64_t df = zxc_decompress_mmap_fd(zxc_test_fileno(f), &mf, &dop);
-    if (df < 0 || (size_t)df != n || !mf.data || memcmp(mf.data, orig, n) != 0) {
-        printf("Failed [%s]: decompress_mmap_fd ret=%lld want=%zu\n", label, (long long)df, n);
-        ok = 0;
-    }
-    ok &= check_closed(label, &mf);
-
-    /* 3. Read-only archive mapping: the mapped bytes ARE the file's bytes, and
-     *    they feed the ordinary buffer API with no input copy. */
     zxc_map_t ma;
     const int rc = zxc_mmap_open_fd(zxc_test_fileno(f), &ma);
-    fclose(f); /* the mapping outlives the descriptor */
-    if (rc != ZXC_OK || ma.size != csz || !ma.data || !zxc_mmap_is_zerocopy(&ma) ||
-        memcmp(ma.data, comp, csz) != 0) {
+    const long pos = ftell(f);
+    fclose(f);
+    if (rc != ZXC_OK || ma.size != csz || !ma.data || memcmp(ma.data, comp, csz) != 0) {
         printf("Failed [%s]: mmap_open_fd rc=%d size=%zu want=%zu\n", label, rc, ma.size, csz);
+        ok = 0;
+    } else if (pos != 0) {
+        printf("Failed [%s]: mmap_open_fd moved the file position to %ld\n", label, pos);
         ok = 0;
     } else {
         uint8_t* const out = (uint8_t*)malloc(n ? n : 1);
@@ -193,25 +116,25 @@ static int mmap_case(const char* const label, const uint8_t* const orig, const s
     }
     ok &= check_closed(label, &ma);
 
-    /* 4. Path-based read-only mapping. */
+    /* 2. By path, and the size the footer advertises is readable through it. */
     zxc_map_t mp;
     if (zxc_mmap_open(MMAP_RT_PATH, &mp) != ZXC_OK || mp.size != csz) {
         printf("Failed [%s]: mmap_open\n", label);
+        ok = 0;
+    } else if (zxc_get_decompressed_size(mp.data, mp.size) != (uint64_t)n) {
+        printf("Failed [%s]: get_decompressed_size through the mapping\n", label);
         ok = 0;
     }
     ok &= check_closed(label, &mp);
 
     remove(MMAP_RT_PATH);
     free(comp);
-    if (ok)
-        printf("  [PASS] %s (n=%zu, comp=%zu, %s, %s)\n", label, n, csz,
-               csz > n ? "archive spans the whole region" : "archive in margin",
-               zero_copy ? "zero-copy" : "archive copied in");
+    if (ok) printf("  [PASS] %s (n=%zu, comp=%zu)\n", label, n, csz);
     return ok;
 }
 
-int test_mmap_roundtrip(void) {
-    printf("=== TEST: Unit - Mapped zero-copy in-place decode ===\n");
+int test_mmap_open(void) {
+    printf("=== TEST: Unit - Read-only archive mapping ===\n");
     if (!zxc_mmap_supported()) {
         printf("  [SKIP] no file mapping on this platform\n");
         printf("PASS\n\n");
@@ -227,29 +150,21 @@ int test_mmap_roundtrip(void) {
     ok &= mmap_case("compressible L3", a, N, 3, 1, 0, 0);
     ok &= mmap_case("compressible L6", a, N, 6, 0, 0, 0);
 
-    /* High-entropy: comp_size ~ N, so the flush-right archive overlaps the
-     * output region and the decoder writes over bytes it has already read. */
     gen_random_data(a, N);
-    ok &= mmap_case("random L1 (overlap)", a, N, 1, 0, 0, 0);
-    ok &= mmap_case("random L7 (overlap)", a, N, 7, 1, 0, 0);
+    ok &= mmap_case("random L1", a, N, 1, 0, 0, 0);
 
-    /* Multi-block, and a size that is not a page multiple. */
+    /* Multi-block, and sizes that are not page multiples. */
     gen_binary_data(a, N);
     ok &= mmap_case("binary 1 MiB+1", a, 1024 * 1024 + 1, 3, 1, 0, 0);
     ok &= mmap_case("binary 4 KiB-3", a, 4093, 3, 0, 0, 0);
     ok &= mmap_case("tiny 1 byte", a, 1, 3, 1, 0, 0);
-
-    /* Seekable archives put a seek table between the EOF block and the footer;
-     * those bytes push the flush-right archive left, so the in-place bound has
-     * to reserve them (it did not, and the mapped path silently lost its
-     * margin). Worst shape: many small blocks over incompressible data. */
     free(a);
+
+    /* A seekable archive maps like any other; the seek table is just bytes. */
     uint8_t* const b = (uint8_t*)malloc(8 * 1024 * 1024);
     if (!b) return 0;
     gen_random_data(b, 8 * 1024 * 1024);
     ok &= mmap_case("seekable random, 4K blocks", b, 8 * 1024 * 1024, 1, 1, ZXC_BLOCK_SIZE_MIN, 1);
-    gen_lz_data(b, 8 * 1024 * 1024);
-    ok &= mmap_case("seekable text, 4K blocks", b, 8 * 1024 * 1024, 3, 1, ZXC_BLOCK_SIZE_MIN, 1);
     free(b);
 
     if (!ok) return 0;
@@ -257,73 +172,8 @@ int test_mmap_roundtrip(void) {
     return 1;
 }
 
-/* Dictionary archives take the bounce-buffer route inside the decoder (the
- * bounce buffer does not alias the mapped region), so they need their own pass
- * through the mapped entry point - including the "dict missing" rejection. */
-int test_mmap_dict(void) {
-    printf("=== TEST: Unit - Mapped decode of a dictionary archive ===\n");
-    if (!zxc_mmap_supported()) {
-        printf("  [SKIP] no file mapping on this platform\n");
-        printf("PASS\n\n");
-        return 1;
-    }
-
-    static const uint8_t dict[] =
-        "The quick brown fox jumps over the lazy dog. "
-        "Lorem ipsum dolor sit amet, consectetur adipiscing elit. "
-        "Pack my box with five dozen liquor jugs.";
-    const size_t dict_size = sizeof(dict) - 1;
-
-    const size_t n = 64 * 1024;
-    uint8_t* const src = (uint8_t*)malloc(n);
-    uint8_t* const comp = (uint8_t*)malloc((size_t)zxc_compress_bound(n));
-    if (!src || !comp) {
-        free(src);
-        free(comp);
-        return 0;
-    }
-    for (size_t i = 0; i < n; i++) {
-        src[i] = (i % 7 < 5) ? dict[(i * 31) % (dict_size - 5) + (i % 5)] : (uint8_t)(i ^ (i >> 8));
-    }
-
-    const zxc_compress_opts_t co = {
-        .level = 3, .checksum_enabled = 1, .dict = dict, .dict_size = dict_size};
-    const int64_t c = zxc_compress(src, n, comp, (size_t)zxc_compress_bound(n), &co);
-    int ok = c > 0 && write_whole_file(MMAP_DICT_PATH, comp, (size_t)c);
-    if (!ok) printf("Failed: dict compress/write (%lld)\n", (long long)c);
-
-    if (ok) {
-        const zxc_decompress_opts_t dop = {
-            .checksum_enabled = 1, .dict = dict, .dict_size = dict_size};
-        zxc_map_t m;
-        const int64_t d = zxc_decompress_mmap(MMAP_DICT_PATH, &m, &dop);
-        if (d != (int64_t)n || !m.data || memcmp(m.data, src, n) != 0) {
-            printf("Failed: dict mapped decode ret=%lld want=%zu\n", (long long)d, n);
-            ok = 0;
-        }
-        zxc_mmap_close(&m);
-
-        /* Same archive without the dictionary must be refused, not decoded. */
-        const int64_t nd = zxc_decompress_mmap(MMAP_DICT_PATH, &m, NULL);
-        if (nd != ZXC_ERROR_DICT_REQUIRED) {
-            printf("Failed: missing dict -> %lld (want %d)\n", (long long)nd,
-                   ZXC_ERROR_DICT_REQUIRED);
-            ok = 0;
-        }
-        zxc_mmap_close(&m);
-        if (ok) printf("  [PASS] dict archive (n=%zu, comp=%lld)\n", n, (long long)c);
-    }
-
-    remove(MMAP_DICT_PATH);
-    free(src);
-    free(comp);
-    if (!ok) return 0;
-    printf("PASS\n\n");
-    return 1;
-}
-
 int test_mmap_errors(void) {
-    printf("=== TEST: Unit - Mapped decode error paths ===\n");
+    printf("=== TEST: Unit - Read-only mapping error paths ===\n");
     if (!zxc_mmap_supported()) {
         printf("  [SKIP] no file mapping on this platform\n");
         printf("PASS\n\n");
@@ -334,8 +184,8 @@ int test_mmap_errors(void) {
     zxc_map_t m;
 
     /* NULL out-param is rejected before anything is opened. */
-    if (zxc_decompress_mmap(MMAP_ERR_PATH, NULL, NULL) != ZXC_ERROR_NULL_INPUT ||
-        zxc_mmap_open(MMAP_ERR_PATH, NULL) != ZXC_ERROR_NULL_INPUT) {
+    if (zxc_mmap_open(MMAP_ERR_PATH, NULL) != ZXC_ERROR_NULL_INPUT ||
+        zxc_mmap_open_fd(0, NULL) != ZXC_ERROR_NULL_INPUT) {
         printf("Failed: NULL out-param not rejected\n");
         ok = 0;
     }
@@ -343,87 +193,19 @@ int test_mmap_errors(void) {
     /* NULL path, with the map still cleared so closing it is safe. */
     m.data = (void*)0x1;
     m.map_base = (void*)0x1;
-    if (zxc_decompress_mmap(NULL, &m, NULL) != ZXC_ERROR_NULL_INPUT || m.data != NULL ||
-        m.map_base != NULL) {
+    if (zxc_mmap_open(NULL, &m) != ZXC_ERROR_NULL_INPUT || m.data != NULL || m.map_base != NULL) {
         printf("Failed: NULL path not rejected / map not cleared\n");
         ok = 0;
     }
     zxc_mmap_close(&m);
 
     /* Missing file, and a bad descriptor. */
-    if (!expect_io("missing file, decompress",
-                   zxc_decompress_mmap("zxc_no_such_archive.bin", &m, NULL), &m))
-        ok = 0;
-    if (!expect_io("missing file, open", zxc_mmap_open("zxc_no_such_archive.bin", &m), &m)) ok = 0;
-    if (!expect_io("bad fd, decompress", zxc_decompress_mmap_fd(-1, &m, NULL), &m)) ok = 0;
-    if (!expect_io("bad fd, open", zxc_mmap_open_fd(-1, &m), &m)) ok = 0;
-
-    /* Too short to hold a frame. */
-    static const uint8_t stub[8] = {0};
-    if (!write_whole_file(MMAP_ERR_PATH, stub, sizeof(stub))) {
-        printf("Failed: cannot write stub\n");
-        remove(MMAP_ERR_PATH);
-        return 0;
-    }
-    if (zxc_decompress_mmap(MMAP_ERR_PATH, &m, NULL) != ZXC_ERROR_SRC_TOO_SMALL) {
-        printf("Failed: short file not rejected\n");
-        ok = 0;
-    }
-
-    /* Right length, wrong contents. */
-    uint8_t junk[128];
-    memset(junk, 0x5A, sizeof(junk));
-    if (!write_whole_file(MMAP_ERR_PATH, junk, sizeof(junk))) {
-        printf("Failed: cannot write junk\n");
-        remove(MMAP_ERR_PATH);
-        return 0;
-    }
-    const int64_t junk_rc = zxc_decompress_mmap(MMAP_ERR_PATH, &m, NULL);
-    if (junk_rc != ZXC_ERROR_BAD_MAGIC) {
-        printf("Failed: junk archive -> %lld, expected ZXC_ERROR_BAD_MAGIC\n", (long long)junk_rc);
-        ok = 0;
-    }
-
-    /* Forged footer: the header is intact, so the verdict must blame the data. */
-    uint8_t forged[256];
-    const int64_t fc = zxc_compress(junk, sizeof(junk), forged, sizeof(forged), NULL);
-    if (fc <= 0) {
-        printf("Failed: cannot build archive to forge\n");
-        ok = 0;
-    } else {
-        memset(forged + fc - ZXC_FILE_FOOTER_SIZE, 0xFF, 8); /* dsize = UINT64_MAX */
-        if (!write_whole_file(MMAP_ERR_PATH, forged, (size_t)fc)) {
-            printf("Failed: cannot write forged archive\n");
-            ok = 0;
-        } else {
-            const int64_t d = zxc_decompress_mmap(MMAP_ERR_PATH, &m, NULL);
-            if (d != ZXC_ERROR_CORRUPT_DATA) {
-                printf("Failed: forged footer -> %lld, expected ZXC_ERROR_CORRUPT_DATA\n",
-                       (long long)d);
-                ok = 0;
-            }
-            zxc_mmap_close(&m);
-        }
-    }
-
-    /* Empty frame: succeeds with nothing to hand back. */
-    uint8_t empty[64];
-    const int64_t ec = zxc_compress(NULL, 0, empty, sizeof(empty), NULL);
-    if (ec <= 0 || !write_whole_file(MMAP_ERR_PATH, empty, (size_t)ec)) {
-        printf("Failed: cannot build empty frame\n");
-        ok = 0;
-    } else {
-        const int64_t d = zxc_decompress_mmap(MMAP_ERR_PATH, &m, NULL);
-        if (d != 0 || m.data != NULL || m.size != 0) {
-            printf("Failed: empty frame -> %lld (data=%p)\n", (long long)d, (void*)m.data);
-            ok = 0;
-        }
-        zxc_mmap_close(&m);
-    }
+    if (!expect_io("missing file", zxc_mmap_open("zxc_no_such_archive.bin", &m), &m)) ok = 0;
+    if (!expect_io("bad fd", zxc_mmap_open_fd(-1, &m), &m)) ok = 0;
 
     /* Empty file: nothing to map. */
     if (!write_whole_file(MMAP_ERR_PATH, NULL, 0)) {
-        printf("Failed: cannot truncate\n");
+        printf("Failed: cannot write empty file\n");
         ok = 0;
     } else if (zxc_mmap_open(MMAP_ERR_PATH, &m) != ZXC_ERROR_SRC_TOO_SMALL) {
         printf("Failed: empty file not rejected\n");
@@ -431,14 +213,23 @@ int test_mmap_errors(void) {
     }
 
     /* A directory is not mappable. */
-    if (zxc_mmap_open(".", &m) != ZXC_ERROR_IO) {
-        printf("Failed: directory not rejected\n");
-        ok = 0;
-    }
+    if (!expect_io("directory", zxc_mmap_open(".", &m), &m)) ok = 0;
 
-    if (zxc_mmap_is_zerocopy(NULL)) {
-        printf("Failed: is_zerocopy(NULL) != 0\n");
+    /* Junk maps fine -- it is only bytes; the buffer API is what rejects it. */
+    uint8_t junk[128];
+    memset(junk, 0x5A, sizeof(junk));
+    if (!write_whole_file(MMAP_ERR_PATH, junk, sizeof(junk))) {
+        printf("Failed: cannot write junk\n");
         ok = 0;
+    } else if (zxc_mmap_open(MMAP_ERR_PATH, &m) != ZXC_OK) {
+        printf("Failed: junk file not mappable\n");
+        ok = 0;
+    } else {
+        if (zxc_get_decompressed_size(m.data, m.size) != 0) {
+            printf("Failed: junk accepted as an archive\n");
+            ok = 0;
+        }
+        ok &= check_closed("junk", &m);
     }
 
     /* zxc_mmap_close tolerates NULL and a zeroed map. */

--- a/wrappers/go/zxc.go
+++ b/wrappers/go/zxc.go
@@ -166,6 +166,7 @@ var (
 	ErrDictMismatch = &Error{Code: int(C.ZXC_ERROR_DICT_MISMATCH), Name: "dictionary ID mismatch"}
 	ErrDictTooLarge = &Error{Code: int(C.ZXC_ERROR_DICT_TOO_LARGE), Name: "dictionary exceeds maximum size"}
 	ErrBadLevel     = &Error{Code: int(C.ZXC_ERROR_BAD_LEVEL), Name: "compression level out of range"}
+	ErrUnsupported  = &Error{Code: int(C.ZXC_ERROR_UNSUPPORTED), Name: "operation not supported on this platform"}
 	ErrInvalidData  = errors.New("zxc: invalid compressed data")
 
 	// ErrBadHufTable is returned when a shared literal Huffman table does not
@@ -217,6 +218,8 @@ func errorFromCode(code C.int64_t) error {
 		return ErrDictTooLarge
 	case int(C.ZXC_ERROR_BAD_LEVEL):
 		return ErrBadLevel
+	case int(C.ZXC_ERROR_UNSUPPORTED):
+		return ErrUnsupported
 	default:
 		return fmt.Errorf("zxc: unknown error (code %d)", int(code))
 	}

--- a/wrappers/nodejs/lib/index.d.ts
+++ b/wrappers/nodejs/lib/index.d.ts
@@ -55,6 +55,7 @@ export const ERROR_DICT_MISMATCH: number;
 /** Dictionary exceeds maximum allowed size. */
 export const ERROR_DICT_TOO_LARGE: number;
 export const ERROR_BAD_LEVEL: number;
+export const ERROR_UNSUPPORTED: number;
 
 export interface CompressOptions {
     /** Compression level (1-7). Defaults to LEVEL_DEFAULT. */

--- a/wrappers/nodejs/lib/index.js
+++ b/wrappers/nodejs/lib/index.js
@@ -38,6 +38,7 @@ const ERROR_DICT_REQUIRED = native.ERROR_DICT_REQUIRED;
 const ERROR_DICT_MISMATCH = native.ERROR_DICT_MISMATCH;
 const ERROR_DICT_TOO_LARGE = native.ERROR_DICT_TOO_LARGE;
 const ERROR_BAD_LEVEL = native.ERROR_BAD_LEVEL;
+const ERROR_UNSUPPORTED = native.ERROR_UNSUPPORTED;
 
 /**
  * Returns the minimum supported compression level (currently 1).
@@ -681,4 +682,5 @@ module.exports = {
   ERROR_DICT_MISMATCH,
   ERROR_DICT_TOO_LARGE,
   ERROR_BAD_LEVEL,
+  ERROR_UNSUPPORTED,
 };

--- a/wrappers/nodejs/src/zxc_addon.cc
+++ b/wrappers/nodejs/src/zxc_addon.cc
@@ -1135,6 +1135,7 @@ static Napi::Object Init(Napi::Env env, Napi::Object exports) {
     exports.Set("ERROR_DICT_MISMATCH", Napi::Number::New(env, ZXC_ERROR_DICT_MISMATCH));
     exports.Set("ERROR_DICT_TOO_LARGE", Napi::Number::New(env, ZXC_ERROR_DICT_TOO_LARGE));
     exports.Set("ERROR_BAD_LEVEL", Napi::Number::New(env, ZXC_ERROR_BAD_LEVEL));
+    exports.Set("ERROR_UNSUPPORTED", Napi::Number::New(env, ZXC_ERROR_UNSUPPORTED));
 
     return exports;
 }

--- a/wrappers/python/src/zxc/__init__.py
+++ b/wrappers/python/src/zxc/__init__.py
@@ -76,6 +76,7 @@ from ._zxc import (
     ERROR_DICT_MISMATCH,
     ERROR_DICT_TOO_LARGE,
     ERROR_BAD_LEVEL,
+    ERROR_UNSUPPORTED,
 )
 
 try:
@@ -143,6 +144,7 @@ __all__ = [
     "ERROR_DICT_MISMATCH",
     "ERROR_DICT_TOO_LARGE",
     "ERROR_BAD_LEVEL",
+    "ERROR_UNSUPPORTED",
 ]
 
 

--- a/wrappers/python/src/zxc/__init__.pyi
+++ b/wrappers/python/src/zxc/__init__.pyi
@@ -35,6 +35,7 @@ ERROR_DICT_REQUIRED: int
 ERROR_DICT_MISMATCH: int
 ERROR_DICT_TOO_LARGE: int
 ERROR_BAD_LEVEL: int
+ERROR_UNSUPPORTED: int
 
 # ---------- types ----------
 class FileLike(Protocol):

--- a/wrappers/python/src/zxc/_zxc.c
+++ b/wrappers/python/src/zxc/_zxc.c
@@ -237,6 +237,7 @@ PyMODINIT_FUNC PyInit__zxc(void) {
     PyModule_AddIntConstant(m, "ERROR_DICT_MISMATCH", ZXC_ERROR_DICT_MISMATCH);
     PyModule_AddIntConstant(m, "ERROR_DICT_TOO_LARGE", ZXC_ERROR_DICT_TOO_LARGE);
     PyModule_AddIntConstant(m, "ERROR_BAD_LEVEL", ZXC_ERROR_BAD_LEVEL);
+    PyModule_AddIntConstant(m, "ERROR_UNSUPPORTED", ZXC_ERROR_UNSUPPORTED);
 
     return m;
 }

--- a/wrappers/rust/zxc-sys/build.rs
+++ b/wrappers/rust/zxc-sys/build.rs
@@ -207,6 +207,7 @@ fn main() {
         .file(src_lib.join("zxc_dict.c"))
         .file(src_lib.join("zxc_dispatch.c"))
         .file(src_lib.join("zxc_driver.c"))
+        .file(src_lib.join("zxc_mmap.c"))
         .file(src_lib.join("zxc_seekable.c"))
         .file(src_lib.join("zxc_pstream.c"))
         .opt_level(3)

--- a/wrappers/rust/zxc-sys/src/lib.rs
+++ b/wrappers/rust/zxc-sys/src/lib.rs
@@ -161,6 +161,9 @@ pub const ZXC_ERROR_DICT_TOO_LARGE: i32 = -17;
 /// Compression level out of range, or not supported by this context's workspace
 pub const ZXC_ERROR_BAD_LEVEL: i32 = -18;
 
+/// The operation is not supported by this build or this platform
+pub const ZXC_ERROR_UNSUPPORTED: i32 = -19;
+
 // =============================================================================
 // Dictionary Constants
 // =============================================================================

--- a/wrappers/rust/zxc/src/error.rs
+++ b/wrappers/rust/zxc/src/error.rs
@@ -13,6 +13,7 @@ use zxc_sys::{
     ZXC_ERROR_BAD_VERSION, ZXC_ERROR_CORRUPT_DATA, ZXC_ERROR_DICT_MISMATCH,
     ZXC_ERROR_DICT_REQUIRED, ZXC_ERROR_DICT_TOO_LARGE, ZXC_ERROR_DST_TOO_SMALL, ZXC_ERROR_IO,
     ZXC_ERROR_MEMORY, ZXC_ERROR_NULL_INPUT, ZXC_ERROR_OVERFLOW, ZXC_ERROR_SRC_TOO_SMALL,
+    ZXC_ERROR_UNSUPPORTED,
 };
 
 /// Errors that can occur during ZXC operations.
@@ -94,6 +95,15 @@ pub enum Error {
     #[error("unsupported option: {0}")]
     Unsupported(&'static str),
 
+    /// The operation is not supported by this build or this platform
+    ///
+    /// Distinct from [`Error::Unsupported`], which reports a Rust-side option
+    /// this wrapper declined: this one is the C library's `ZXC_ERROR_UNSUPPORTED`,
+    /// returned when a whole entry point is compiled out (the memory-mapped API
+    /// on a target with no file mapping, for instance).
+    #[error("operation not supported on this platform")]
+    PlatformUnsupported,
+
     /// The compressed data appears to be invalid or truncated
     #[error("invalid compressed data")]
     InvalidData,
@@ -124,6 +134,7 @@ pub(crate) fn error_from_code(code: i64) -> Error {
         ZXC_ERROR_DICT_MISMATCH => Error::DictMismatch,
         ZXC_ERROR_DICT_TOO_LARGE => Error::DictTooLarge,
         ZXC_ERROR_BAD_LEVEL => Error::BadLevel,
+        ZXC_ERROR_UNSUPPORTED => Error::PlatformUnsupported,
         _ => Error::Unknown(code as i32),
     }
 }


### PR DESCRIPTION
This change introduces a new `zxc_mmap.h` API for decompressing zxc archives directly from files into memory-mapped regions. This eliminates input staging buffers and separate output allocations, leading to:
- Zero-copy reads of compressed data on POSIX systems.
- Single-copy reads on Windows (archive copied once to the region).
- Significant reductions in peak Resident Set Size (RSS), measured at 25 to 50%.

The API also includes functions to map files read-only, allowing existing buffer APIs to consume on-disk archives without an input copy. A new `ZXC_ERROR_UNSUPPORTED` error code is added for platforms where memory mapping is unavailable.