### PR TITLE
fix(packaging): Prevent Windows static library linking failures

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -1,0 +1,142 @@
+name: Packaging (Consumer Integration)
+
+# Validates what an *installed* ZXC hands to a downstream project -- the gap
+# that let the Windows static packaging break ship (libzxc.pc did not propagate
+# ZXC_STATIC_DEFINE, so consumers got unresolved __imp_zxc_*).
+#
+# Three consumption paths, static and shared: find_package(zxc), pkg-config,
+# and direct integration (-I + raw library, no defines at all).
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+permissions:
+  contents: read
+
+concurrency:
+  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+
+jobs:
+  consume:
+    name: "Consume installed ZXC (${{ matrix.name }})"
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Linux GCC
+            runner: ubuntu-latest
+          - name: Windows MSVC
+            runner: windows-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Build & install ZXC (static and shared)
+        shell: bash
+        run: |
+          set -euo pipefail
+          for LIB_TYPE in static shared; do
+            SHARED_FLAG=OFF
+            if [ "$LIB_TYPE" = shared ]; then SHARED_FLAG=ON; fi
+            cmake -S . -B "build_$LIB_TYPE" \
+              -DCMAKE_BUILD_TYPE=Release \
+              -DCMAKE_INSTALL_PREFIX="$PWD/inst_$LIB_TYPE" \
+              -DZXC_NATIVE_ARCH=OFF \
+              -DZXC_BUILD_TESTS=OFF \
+              -DZXC_BUILD_CLI=OFF \
+              -DBUILD_SHARED_LIBS="$SHARED_FLAG"
+            cmake --build "build_$LIB_TYPE" --config Release -j
+            cmake --install "build_$LIB_TYPE" --config Release
+          done
+
+      # The flags themselves, before any consumer sees them. Cheap, and pins the
+      # exact two regressions this workflow exists for.
+      - name: Check generated libzxc.pc
+        shell: bash
+        run: |
+          set -euo pipefail
+          find inst_static inst_shared -name libzxc.pc | while read -r pc; do cat "$pc"; done
+
+          static_pc=$(find inst_static -name libzxc.pc)
+          shared_pc=$(find inst_shared -name libzxc.pc)
+
+          grep -q -- '-DZXC_STATIC_DEFINE' "$static_pc" \
+            || { echo "::error::static libzxc.pc is missing -DZXC_STATIC_DEFINE"; exit 1; }
+          grep -q -- '-DZXC_DLL_IMPORT' "$shared_pc" \
+            || { echo "::error::shared libzxc.pc is missing -DZXC_DLL_IMPORT"; exit 1; }
+
+          # -pthread is a POSIX toolchain flag; MSVC ignores it with LNK4044.
+          if [ "$RUNNER_OS" = Windows ]; then
+            if grep -q -- '-pthread' "$static_pc" "$shared_pc"; then
+              echo "::error::libzxc.pc emits -pthread on a non-pthread toolchain"; exit 1
+            fi
+          else
+            grep -q 'Libs.private:.*-pthread' "$static_pc" \
+              || { echo "::error::static libzxc.pc lost -pthread on a pthread toolchain"; exit 1; }
+          fi
+
+      - name: Consume via find_package(zxc)
+        shell: bash
+        run: |
+          set -euo pipefail
+          for LIB_TYPE in static shared; do
+            cmake -S tests/packaging -B "cm_$LIB_TYPE" \
+              -DCMAKE_BUILD_TYPE=Release \
+              -DZXC_CONSUME_MODE=find_package \
+              -DCMAKE_PREFIX_PATH="$PWD/inst_$LIB_TYPE"
+            cmake --build "cm_$LIB_TYPE" --config Release
+          done
+
+      # No defines, no usage requirements: only zxc_export.h's own default keeps
+      # this linking. The case that produced unresolved __imp_zxc_* on Windows.
+      - name: Consume by direct integration (no defines)
+        shell: bash
+        run: |
+          set -euo pipefail
+          lib=$(find inst_static -name 'libzxc.a' -o -name 'zxc.lib' -o -name 'libzxc.lib' | head -1)
+          test -n "$lib" || { echo "::error::no static library found in inst_static"; exit 1; }
+          cmake -S tests/packaging -B cm_direct \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DZXC_CONSUME_MODE=direct \
+            -DZXC_INCLUDE_DIR="$PWD/inst_static/include" \
+            -DZXC_LIBRARY="$PWD/$lib"
+          cmake --build cm_direct --config Release
+
+      # The path that was broken: the .pc file is the whole contract. POSIX only;
+      # the .pc content check above covers Windows.
+      - name: Consume via pkg-config
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          set -euo pipefail
+          command -v pkg-config >/dev/null \
+            || { echo "::error::pkg-config is not installed on this runner"; exit 1; }
+
+          for LIB_TYPE in static shared; do
+            # CMAKE_INSTALL_LIBDIR is not always "lib" (lib64, multiarch), so
+            # locate the .pc instead of assuming its path.
+            pc=$(find "inst_$LIB_TYPE" -name libzxc.pc | head -1)
+            test -n "$pc" || { echo "::error::no libzxc.pc in inst_$LIB_TYPE"; exit 1; }
+            PKG_CONFIG_PATH="$PWD/$(dirname "$pc")"
+            export PKG_CONFIG_PATH
+            libdir="$PWD/$(dirname "$(dirname "$pc")")"
+
+            STATIC_ARG=""
+            if [ "$LIB_TYPE" = static ]; then STATIC_ARG="--static"; fi
+
+            # Via a variable, not inline: a bare $(pkg-config ...) that fails is
+            # swallowed by errexit and cc would run with no flags at all.
+            flags=$(pkg-config $STATIC_ARG --cflags --libs libzxc)
+            echo "pkg-config ($LIB_TYPE): $flags"
+
+            # shellcheck disable=SC2086
+            cc tests/packaging/consumer.c $flags -o "consumer_$LIB_TYPE"
+            LD_LIBRARY_PATH="$libdir" "./consumer_$LIB_TYPE"
+          done

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,6 +90,7 @@ if(BUILD_SHARED_LIBS)
             VISIBILITY_INLINES_HIDDEN YES
         )
     endif()
+    target_compile_definitions(zxc_lib INTERFACE ZXC_DLL_IMPORT)
 else()
     # For static libraries, define ZXC_STATIC_DEFINE to avoid dllimport/dllexport
     target_compile_definitions(zxc_lib PUBLIC ZXC_STATIC_DEFINE)

--- a/cmake/zxcInstall.cmake
+++ b/cmake/zxcInstall.cmake
@@ -8,6 +8,20 @@
 if(ZXC_INSTALL)
     include(GNUInstallDirs)
 
+    # A pkg-config consumer gets no CMake usage requirements, so the .pc must
+    # carry them: the export macro matching the build, and -pthread only when
+    # FindThreads actually picked pthreads (MSVC ignores it with LNK4044).
+    if(BUILD_SHARED_LIBS)
+        set(ZXC_PC_CFLAGS "-DZXC_DLL_IMPORT")
+    else()
+        set(ZXC_PC_CFLAGS "-DZXC_STATIC_DEFINE")
+    endif()
+    if(CMAKE_USE_PTHREADS_INIT)
+        set(ZXC_PC_LIBS_PRIVATE "-pthread")
+    else()
+        set(ZXC_PC_LIBS_PRIVATE "")
+    endif()
+
     configure_file(
         ${CMAKE_CURRENT_SOURCE_DIR}/libzxc.pc.in
         ${CMAKE_CURRENT_BINARY_DIR}/libzxc.pc

--- a/docs/API.md
+++ b/docs/API.md
@@ -92,17 +92,38 @@ libzxc uses an **opt-in** export strategy:
 | Build type | How symbols are exposed |
 |-----------|------------------------|
 | **Shared library** | Default visibility is `hidden`.  Only functions annotated with `ZXC_EXPORT` are exported.  Internal FMV variants (`_default`, `_neon32`, `_avx2`, `_avx512`) are hidden. |
-| **Static library** | Define `ZXC_STATIC_DEFINE` (set automatically by CMake) to disable import/export annotations. |
+| **Static library** | Define `ZXC_STATIC_DEFINE` (set automatically by CMake, Meson and pkg-config) to disable import/export annotations. |
 
 ### Macros
 
 | Macro | Purpose |
 |-------|---------|
-| `ZXC_EXPORT` | Marks a symbol as part of the public API (`__declspec(dllexport/dllimport)` on Windows, `visibility("default")` on GCC/Clang). |
+| `ZXC_EXPORT` | Marks a symbol as part of the public API (`__declspec(dllexport)` when building the Windows DLL, `visibility("default")` on GCC/Clang). |
 | `ZXC_NO_EXPORT` | Forces a symbol to be hidden (`visibility("hidden")`). |
 | `ZXC_DEPRECATED` | Emits a compiler warning when a deprecated symbol is used. |
 | `ZXC_STATIC_DEFINE` | Define when building or consuming as a static library. |
+| `ZXC_DLL_IMPORT` | Windows only, optional: define when consuming `zxc.dll` to declare the API `__declspec(dllimport)`. |
 | `zxc_lib_EXPORTS` | Set automatically by CMake when building the shared library. Do not define manually. |
+
+### Windows: `dllimport` is opt-in
+
+On Windows the header leaves the declarations **unannotated** unless you ask
+for `dllimport` via `ZXC_DLL_IMPORT`. The public API is functions only, so an
+unannotated declaration links against a DLL import library perfectly well — the
+linker just inserts a call thunk. The reverse is not true: `dllimport` against a
+**static** library is a hard link failure (`unresolved external symbol
+__imp_zxc_*`). Defaulting to "no annotation" means a consumer who forgets a
+define pays one indirect jump per call instead of failing to build.
+
+You rarely need to set either macro by hand. Each integration path propagates
+the right one:
+
+| Path | Static build | Shared build |
+|------|--------------|--------------|
+| `find_package(zxc)` | `ZXC_STATIC_DEFINE` | `ZXC_DLL_IMPORT` |
+| Meson subproject / `dependency('libzxc')` | `ZXC_STATIC_DEFINE` | `ZXC_DLL_IMPORT` |
+| `pkg-config --cflags libzxc` | `ZXC_STATIC_DEFINE` | `ZXC_DLL_IMPORT` |
+| Vendored sources / hand-rolled build | *(nothing needed)* | set `zxc_lib_EXPORTS` when building the DLL |
 
 ---
 

--- a/include/zxc_export.h
+++ b/include/zxc_export.h
@@ -16,8 +16,13 @@
  *   library to disable import/export annotations.
  * - When building the shared library the CMake target defines
  *   @c zxc_lib_EXPORTS automatically, selecting `dllexport` / `visibility("default")`.
- * - When consuming the shared library neither macro is defined, so the header
- *   selects `dllimport` / `visibility("default")`.
+ * - When consuming the library neither macro is defined, so the header selects
+ *   `visibility("default")` on ELF and **no annotation** on Windows.
+ *
+ * On Windows `dllimport` is opt-in via @c ZXC_DLL_IMPORT: unannotated
+ * declarations still link against a DLL (call thunk), while `dllimport`
+ * against a static library fails with unresolved `__imp_zxc_*`. CMake, Meson
+ * and pkg-config set the right macro for you.
  */
 
 #ifndef ZXC_EXPORT_H
@@ -36,7 +41,8 @@
  * @brief Marks a symbol as part of the public shared-library API.
  *
  * Expands to nothing when building a static library (@c ZXC_STATIC_DEFINE),
- * to `__declspec(dllexport)` or `__declspec(dllimport)` on Windows, or
+ * to `__declspec(dllexport)` when building the Windows DLL, to
+ * `__declspec(dllimport)` when consuming it with @c ZXC_DLL_IMPORT defined, or
  * to `__attribute__((visibility("default")))` on GCC/Clang.
  */
 #define ZXC_EXPORT
@@ -62,8 +68,12 @@
 #endif
 #else
 /* Consuming the library */
-#ifdef _WIN32
+#if defined(_WIN32) && defined(ZXC_DLL_IMPORT)
 #define ZXC_EXPORT __declspec(dllimport)
+#elif defined(_WIN32)
+/* Static library, vendored sources, or a DLL consumed without ZXC_DLL_IMPORT:
+   no annotation links in every case. */
+#define ZXC_EXPORT
 #else
 #define ZXC_EXPORT __attribute__((visibility("default")))
 #endif

--- a/libzxc.pc.in
+++ b/libzxc.pc.in
@@ -9,5 +9,5 @@ URL: https://github.com/hellobertrand/zxc
 License: BSD 3-Clause
 Version: @PROJECT_VERSION@
 Libs: -L${libdir} -lzxc
-Libs.private: -pthread
-Cflags: -I${includedir}
+Libs.private: @ZXC_PC_LIBS_PRIVATE@
+Cflags: -I${includedir} @ZXC_PC_CFLAGS@

--- a/meson.build
+++ b/meson.build
@@ -31,6 +31,16 @@ zxc_soversion = '4'
 building_static = get_option('default_library') == 'static'
 lib_export_args = building_static ? ['-DZXC_STATIC_DEFINE'] : ['-Dzxc_lib_EXPORTS']
 
+if building_static
+  lib_consumer_args = ['-DZXC_STATIC_DEFINE']
+elif get_option('default_library') == 'shared'
+  lib_consumer_args = ['-DZXC_DLL_IMPORT']
+else
+  # default_library=both: the consumer picks static or shared per dependency, so
+  # neither define is knowably right. Staying silent links against either.
+  lib_consumer_args = []
+endif
+
 # =============================================================================
 # Platform defines
 # =============================================================================
@@ -123,7 +133,7 @@ libzxc = library('zxc',
 libzxc_dep = declare_dependency(
   link_with : libzxc,
   include_directories : inc_public,
-  compile_args : building_static ? ['-DZXC_STATIC_DEFINE'] : [],
+  compile_args : lib_consumer_args,
 )
 meson.override_dependency('libzxc', libzxc_dep)
 
@@ -153,6 +163,7 @@ pkgconfig.generate(libzxc,
   description : 'High-performance asymmetric lossless compression',
   version : meson.project_version(),
   url : 'https://github.com/hellobertrand/zxc',
+  extra_cflags : lib_consumer_args,
 )
 
 install_headers(

--- a/tests/packaging/CMakeLists.txt
+++ b/tests/packaging/CMakeLists.txt
@@ -1,0 +1,34 @@
+# ZXC - High-performance lossless compression
+#
+# Copyright (c) 2025-2026 Bertrand Lebonnois and contributors.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# Standalone downstream project used by .github/workflows/packaging.yml, never
+# built as part of ZXC: it is configured against an install prefix.
+#
+#   ZXC_CONSUME_MODE=find_package  usage requirements from zxc-targets.cmake
+#   ZXC_CONSUME_MODE=direct        include dir + library path, no defines
+
+cmake_minimum_required(VERSION 3.16)
+project(zxc_packaging_consumer C)
+
+set(ZXC_CONSUME_MODE "find_package" CACHE STRING "How to consume ZXC (find_package|direct)")
+
+add_executable(consumer consumer.c)
+
+if(ZXC_CONSUME_MODE STREQUAL "find_package")
+    find_package(zxc REQUIRED)
+    target_link_libraries(consumer PRIVATE zxc::zxc_lib)
+elseif(ZXC_CONSUME_MODE STREQUAL "direct")
+    if(NOT ZXC_INCLUDE_DIR OR NOT ZXC_LIBRARY)
+        message(FATAL_ERROR "direct mode needs -DZXC_INCLUDE_DIR=... -DZXC_LIBRARY=...")
+    endif()
+    target_include_directories(consumer PRIVATE ${ZXC_INCLUDE_DIR})
+    target_link_libraries(consumer PRIVATE ${ZXC_LIBRARY})
+    if(NOT WIN32)
+        find_package(Threads REQUIRED)
+        target_link_libraries(consumer PRIVATE Threads::Threads)
+    endif()
+else()
+    message(FATAL_ERROR "unknown ZXC_CONSUME_MODE '${ZXC_CONSUME_MODE}'")
+endif()

--- a/tests/packaging/consumer.c
+++ b/tests/packaging/consumer.c
@@ -1,0 +1,59 @@
+/*
+ * ZXC - High-performance lossless compression
+ *
+ * Copyright (c) 2025-2026 Bertrand Lebonnois and contributors.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/*
+ * Downstream consumer smoke test for an *installed* ZXC, built by
+ * .github/workflows/packaging.yml via find_package, pkg-config and raw -I/-l.
+ * Touches enough of the API to make the link step meaningful: a mismatched
+ * zxc_export.h shows up here as unresolved __imp_zxc_* on Windows.
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <zxc.h>
+
+int main(void) {
+    static char input[64 * 1024];
+    for (size_t i = 0; i < sizeof(input); i++) {
+        input[i] = (char)('a' + (i % 23));
+    }
+
+    const uint64_t bound = zxc_compress_bound(sizeof(input));
+    static char compressed[128 * 1024];
+    if (bound > sizeof(compressed)) {
+        fprintf(stderr, "consumer: bound %llu exceeds the test buffer\n",
+                (unsigned long long)bound);
+        return 1;
+    }
+
+    const int64_t csize = zxc_compress(input, sizeof(input), compressed, sizeof(compressed), NULL);
+    if (csize <= 0) {
+        fprintf(stderr, "consumer: zxc_compress failed: %s\n", zxc_error_name((int)csize));
+        return 1;
+    }
+
+    if (zxc_get_decompressed_size(compressed, (size_t)csize) != sizeof(input)) {
+        fprintf(stderr, "consumer: zxc_get_decompressed_size disagrees with the input\n");
+        return 1;
+    }
+
+    static char output[sizeof(input)];
+    const int64_t dsize = zxc_decompress(compressed, (size_t)csize, output, sizeof(output), NULL);
+    if (dsize != (int64_t)sizeof(input)) {
+        fprintf(stderr, "consumer: zxc_decompress failed: %s\n", zxc_error_name((int)dsize));
+        return 1;
+    }
+
+    if (memcmp(input, output, sizeof(input)) != 0) {
+        fprintf(stderr, "consumer: roundtrip mismatch\n");
+        return 1;
+    }
+
+    printf("consumer: zxc %s roundtrip OK (%zu -> %lld bytes)\n", zxc_version_string(),
+           sizeof(input), (long long)csize);
+    return 0;
+}


### PR DESCRIPTION
On Windows, `__declspec(dllimport)` declarations cause hard link failures when used with static libraries. This change makes `ZXC_DLL_IMPORT` opt-in, allowing unannotated declarations to link against a DLL while avoiding static link issues.

All build system integrations (CMake, Meson, pkg-config) are updated to correctly propagate `ZXC_DLL_IMPORT` for shared library consumption or `ZXC_STATIC_DEFINE` for static libraries. A new CI workflow validates these integration scenarios on both Linux and Windows.
