### PR TITLE
fix(cctx): Reset dict_size in compression context

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -46,8 +46,7 @@ jobs:
 
       - name: Clone LZbench
         run: |
-          # git clone --depth 1 https://github.com/inikep/lzbench "${LZBENCH_DIR}"
-          git clone -b zxc-0.13.2 https://github.com/hellobertrand/lzbench "${LZBENCH_DIR}"
+          git clone --depth 1 https://github.com/inikep/lzbench "${LZBENCH_DIR}"
 
       - name: Copy Lib ZXC
         run: |

--- a/src/lib/zxc_dispatch.c
+++ b/src/lib/zxc_dispatch.c
@@ -1368,6 +1368,9 @@ int64_t zxc_compress_cctx(zxc_cctx* cctx, const void* RESTRICT src, const size_t
         cctx->inner.checksum_enabled = checksum_enabled;
     }
 
+    /* Shared context: zxc_compress_block leaves its dictionary here. */
+    cctx->inner.dict_size = 0;
+
     zxc_cctx_t* const ctx = &cctx->inner;
 
     uint8_t* op = (uint8_t*)dst;


### PR DESCRIPTION
The `zxc_compress_cctx` function now explicitly resets `cctx->inner.dict_size` to `0` to ensure a consistent initial state for every compression operation. This prevents potential issues where a reused context might carry over an incorrect dictionary size from a previous operation.

Additionally, the benchmark workflow is updated to clone the official `inikep/lzbench` repository. This ensures that performance benchmarks are conducted against the standard `lzbench` tool, aligning with general development and testing practices.
