### PR TITLE
ci(wasm): Publish the WebAssembly build to npm

### DIFF
--- a/.github/workflows/wrapper-wasm.yml
+++ b/.github/workflows/wrapper-wasm.yml
@@ -72,3 +72,74 @@ jobs:
             wrappers/wasm/package.json
             wrappers/wasm/README.md
           retention-days: 30
+
+  publish:
+    name: Publish to npm
+    needs: wasm-build
+    if: github.event_name == 'release'
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Setup Emscripten
+        uses: mymindstorm/setup-emsdk@4528d102f7230f0e7b276855c01ea1159be0e984 # v16
+        with:
+          version: 3.1.56
+
+      - name: Build
+        run: |
+          emcmake cmake -B build-wasm -DCMAKE_BUILD_TYPE=Release
+          cmake --build build-wasm --parallel
+
+      - name: Stage package contents
+        # zxc_wasm.js dynamically imports its sibling ./zxc.js, so both
+        # Emscripten outputs must ship next to it (see package.json "files").
+        run: cp build-wasm/zxc.js build-wasm/zxc.wasm wrappers/wasm/
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: '22'
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Verify Version Matches Release Tag
+        working-directory: ./wrappers/wasm
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          # Remove 'v' prefix if present
+          RELEASE_VERSION="${RELEASE_TAG#v}"
+
+          PACKAGE_VERSION=$(node -p "require('./package.json').version")
+
+          if [ "$RELEASE_VERSION" != "$PACKAGE_VERSION" ]; then
+            echo "Version mismatch: Release tag is $RELEASE_VERSION but package.json has $PACKAGE_VERSION"
+            exit 1
+          fi
+
+          echo "Version matches: $RELEASE_VERSION"
+
+      - name: Verify Package Contents
+        working-directory: ./wrappers/wasm
+        run: |
+          npm pack --dry-run
+          # The tarball is useless without the Emscripten outputs.
+          for f in zxc_wasm.js zxc.js zxc.wasm; do
+            test -f "$f" || { echo "Missing $f"; exit 1; }
+          done
+
+      - name: Publish to npm
+        working-directory: ./wrappers/wasm
+        run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Summary
+        if: success()
+        run: |
+          echo "Successfully published zxc-wasm to npm!"
+          echo "Package: https://www.npmjs.com/package/zxc-wasm"

--- a/.gitignore
+++ b/.gitignore
@@ -82,6 +82,11 @@ searchdata.xml
 # Coverage
 build-cov/
 
+# WASM build outputs staged into the npm package
+build-wasm/
+wrappers/wasm/zxc.js
+wrappers/wasm/zxc.wasm
+
 # Meson
 builddir*/
 subprojects/

--- a/README.md
+++ b/README.md
@@ -747,7 +747,7 @@ Official wrappers maintained in this repository:
 | **Python**| [`PyPI`](https://pypi.org/project/zxc-compress) | `pip install zxc-compress` | [README](wrappers/python/README.md) | [@nuberchardzer1](https://github.com/nuberchardzer1) |
 | **Node.js**| [`npm`](https://www.npmjs.com/package/zxc-compress) | `npm install zxc-compress` | [README](wrappers/nodejs/README.md) | [@hellobertrand](https://github.com/hellobertrand) |
 | **Go** | `go get` | `go get github.com/hellobertrand/zxc/wrappers/go` | [README](wrappers/go/README.md) | [@hellobertrand](https://github.com/hellobertrand) |
-| **WASM** | Build from source | `emcmake cmake -B build-wasm && cmake --build build-wasm` | [README](wrappers/wasm/README.md) | [@hellobertrand](https://github.com/hellobertrand) |
+| **WASM** | [`npm`](https://www.npmjs.com/package/zxc-wasm) | `npm install zxc-wasm` | [README](wrappers/wasm/README.md) | [@hellobertrand](https://github.com/hellobertrand) |
 
 Community-maintained bindings:
 

--- a/wrappers/wasm/README.md
+++ b/wrappers/wasm/README.md
@@ -12,10 +12,21 @@ High-performance lossless compression for the browser and Node.js via WebAssembl
 
 ## Quick Start
 
+### Install
+
+```bash
+npm install zxc-wasm
+```
+
+The package ships the Emscripten build (`zxc.js` + `zxc.wasm`) next to the ES
+module wrapper, so no toolchain is required to consume it. To build it yourself
+instead, see [Building from Source](#building-from-source) and import
+`./zxc_wasm.js` by path.
+
 ### Browser (ES Module)
 
 ```js
-import createZXC from './zxc_wasm.js';
+import createZXC from 'zxc-wasm';
 
 const zxc = await createZXC();
 


### PR DESCRIPTION
The release workflow now builds with Emscripten, stages zxc.js and zxc.wasm next to zxc_wasm.js (which imports its sibling at runtime), checks the package version against the release tag, and publishes with provenance, mirroring the Node.js wrapper.
