### PR TITLE
fix(lib): Validates in-place footer size and buffer separation

### DIFF
--- a/src/lib/zxc_dispatch.c
+++ b/src/lib/zxc_dispatch.c
@@ -1017,6 +1017,33 @@ static int64_t zxc_decompress_frame(const uint8_t* src, const size_t src_size, u
 }
 
 /**
+ * @brief Whether a footer's decompressed size is reachable for this archive.
+ *
+ * The footer is untrusted, and a forged size becomes an arbitrary allocation
+ * before decoding ever fails. Every block costs at least
+ * @ref ZXC_BLOCK_HEADER_SIZE compressed bytes and decodes to at most one block
+ * size, which bounds the ratio an authentic archive can reach. It also keeps
+ * the block count in @ref zxc_inplace_margin from overflowing. Shared by
+ * @ref zxc_inplace_probe and @ref zxc_get_decompressed_size so the two cannot
+ * drift apart.
+ *
+ * The division form keeps the compare overflow-free: the usual ceil wraps on a
+ * forged @p dsize near @c UINT64_MAX.
+ *
+ * @param[in] dsize      Decompressed size read from the footer.
+ * @param[in] chunk_size Block size from the file header; never 0 after a
+ *                       @ref ZXC_OK from @ref zxc_read_file_header.
+ * @param[in] comp_size  Size of the whole archive in bytes.
+ * @return 1 when @p dsize is reachable, 0 for a forged footer.
+ */
+static int zxc_footer_dsize_plausible(const uint64_t dsize, const size_t chunk_size,
+                                      const size_t comp_size) {
+    const uint64_t blocks_needed =
+        dsize / (uint64_t)chunk_size + (dsize % (uint64_t)chunk_size != 0);
+    return blocks_needed <= (uint64_t)(comp_size / ZXC_BLOCK_HEADER_SIZE);
+}
+
+/**
  * @brief Bytes an in-place decode needs on top of the decompressed size.
  *
  * Flush-right placement puts block 0 at `capacity - comp_size`, so the read
@@ -1064,6 +1091,9 @@ static uint64_t zxc_inplace_margin(const uint64_t dsize, const size_t chunk_size
  * and @ref zxc_decompress_inplace always agree on what a buffer of at least
  * the bound must satisfy.
  *
+ * The footer is untrusted input, so its size goes through the same
+ * @ref zxc_footer_dsize_plausible check @ref zxc_get_decompressed_size applies.
+ *
  * @param[in]  comp      Compressed archive; only the header and footer are read.
  * @param[in]  comp_size Size of the archive in bytes. The caller guarantees it
  *                       covers at least the file header and footer.
@@ -1079,8 +1109,13 @@ static int zxc_inplace_probe(const uint8_t* comp, const size_t comp_size, uint64
     uint32_t did = 0;
     if (UNLIKELY(zxc_read_file_header(comp, comp_size, &chunk_size, &has_cs, &did) != ZXC_OK))
         return ZXC_ERROR_BAD_HEADER;
-    *dsize = zxc_le64(comp + comp_size - ZXC_FILE_FOOTER_SIZE);
-    *margin = zxc_inplace_margin(*dsize, chunk_size, has_cs);
+
+    const uint64_t d = zxc_le64(comp + comp_size - ZXC_FILE_FOOTER_SIZE);
+    if (UNLIKELY(!zxc_footer_dsize_plausible(d, chunk_size, comp_size)))
+        return ZXC_ERROR_CORRUPT_DATA;
+
+    *dsize = d;
+    *margin = zxc_inplace_margin(d, chunk_size, has_cs);
     return ZXC_OK;
 }
 
@@ -1126,8 +1161,11 @@ size_t zxc_decompress_inplace_bound(const void* src, const size_t src_size) {
  * @param[in]     buffer_capacity  Total size of @p buffer in bytes.
  * @param[in]     comp_size        Size of the compressed archive in bytes.
  * @param[in]     opts             Decompression options, or NULL for defaults.
- * @return Decompressed size in bytes, or a negative @ref zxc_error_t code
- *         (`ZXC_ERROR_DST_TOO_SMALL` if the buffer lacks the safety margin).
+ * @return Decompressed size in bytes, or a negative @ref zxc_error_t code:
+ *         @ref ZXC_ERROR_DST_TOO_SMALL if the buffer lacks the safety margin,
+ *         otherwise the @ref zxc_inplace_probe verdict
+ *         (@ref ZXC_ERROR_BAD_MAGIC, @ref ZXC_ERROR_BAD_HEADER, or
+ *         @ref ZXC_ERROR_CORRUPT_DATA for a forged footer).
  */
 // cppcheck-suppress unusedFunction
 int64_t zxc_decompress_inplace(void* buffer, const size_t buffer_capacity, const size_t comp_size,
@@ -1139,8 +1177,8 @@ int64_t zxc_decompress_inplace(void* buffer, const size_t buffer_capacity, const
     const uint8_t* const comp = buf + (buffer_capacity - comp_size); /* flush-right */
     uint64_t dsize = 0;
     uint64_t margin = 0;
-    if (UNLIKELY(zxc_inplace_probe(comp, comp_size, &dsize, &margin) != ZXC_OK))
-        return ZXC_ERROR_BAD_HEADER;
+    const int rc = zxc_inplace_probe(comp, comp_size, &dsize, &margin);
+    if (UNLIKELY(rc != ZXC_OK)) return rc;
     if (UNLIKELY(dsize > (uint64_t)buffer_capacity || (uint64_t)buffer_capacity - dsize < margin))
         return ZXC_ERROR_DST_TOO_SMALL;
     return zxc_decompress_frame(comp, comp_size, buf, buffer_capacity, opts);
@@ -1149,13 +1187,10 @@ int64_t zxc_decompress_inplace(void* buffer, const size_t buffer_capacity, const
 /**
  * @brief Reads the decompressed size from a ZXC-compressed buffer.
  *
- * The size is stored in the file footer (last @ref ZXC_FILE_FOOTER_SIZE bytes).
- * The footer is untrusted input, so the value is checked for plausibility
- * against the archive itself: every decoded block costs at least
- * @ref ZXC_BLOCK_HEADER_SIZE compressed bytes and expands to at most one
- * block size, which bounds the ratio an authentic archive can reach. A size
- * beyond that bound (a forged footer) returns 0, so callers sizing an output
- * allocation from this value inherit the check.
+ * The size is stored in the file footer (last @ref ZXC_FILE_FOOTER_SIZE bytes)
+ * and is untrusted, so it goes through @ref zxc_footer_dsize_plausible: a
+ * forged size returns 0, and callers sizing an output allocation from this
+ * value inherit the check.
  *
  * @param[in] src      Compressed data.
  * @param[in] src_size Size of @p src in bytes.
@@ -1175,12 +1210,7 @@ uint64_t zxc_get_decompressed_size(const void* src, const size_t src_size) {
     const uint8_t* const footer = p + src_size - ZXC_FILE_FOOTER_SIZE;
     const uint64_t dsize = zxc_le64(footer);
 
-    /* Plausibility: at most src_size / ZXC_BLOCK_HEADER_SIZE blocks, each
-     * decoding to at most chunk_size. The division form keeps the compare
-     * overflow-free - a ceil would wrap on a forged dsize near UINT64_MAX. */
-    const uint64_t blocks_needed =
-        chunk_size ? dsize / (uint64_t)chunk_size + (dsize % (uint64_t)chunk_size != 0) : 0;
-    if (UNLIKELY(blocks_needed > (uint64_t)(src_size / ZXC_BLOCK_HEADER_SIZE))) return 0;
+    if (UNLIKELY(!zxc_footer_dsize_plausible(dsize, chunk_size, src_size))) return 0;
 
     return dsize;
 }

--- a/src/lib/zxc_dispatch.c
+++ b/src/lib/zxc_dispatch.c
@@ -1019,16 +1019,14 @@ static int64_t zxc_decompress_frame(const uint8_t* src, const size_t src_size, u
 /**
  * @brief Whether a footer's decompressed size is reachable for this archive.
  *
- * The footer is untrusted, and a forged size becomes an arbitrary allocation
- * before decoding ever fails. Every block costs at least
+ * The footer is untrusted and its size becomes the caller's allocation, so it is
+ * capped by what the archive could physically hold: every block costs at least
  * @ref ZXC_BLOCK_HEADER_SIZE compressed bytes and decodes to at most one block
- * size, which bounds the ratio an authentic archive can reach. It also keeps
- * the block count in @ref zxc_inplace_margin from overflowing. Shared by
- * @ref zxc_inplace_probe and @ref zxc_get_decompressed_size so the two cannot
- * drift apart.
+ * size. The cap also keeps @ref zxc_inplace_margin's block count from
+ * overflowing. Shared with @ref zxc_get_decompressed_size so the two readers
+ * cannot drift apart.
  *
- * The division form keeps the compare overflow-free: the usual ceil wraps on a
- * forged @p dsize near @c UINT64_MAX.
+ * Division rather than the usual ceil, which would wrap near @c UINT64_MAX.
  *
  * @param[in] dsize      Decompressed size read from the footer.
  * @param[in] chunk_size Block size from the file header; never 0 after a
@@ -1091,18 +1089,20 @@ static uint64_t zxc_inplace_margin(const uint64_t dsize, const size_t chunk_size
  * and @ref zxc_decompress_inplace always agree on what a buffer of at least
  * the bound must satisfy.
  *
- * The footer is untrusted input, so its size goes through the same
- * @ref zxc_footer_dsize_plausible check @ref zxc_get_decompressed_size applies.
+ * The footer is untrusted, so its size goes through
+ * @ref zxc_footer_dsize_plausible like @ref zxc_get_decompressed_size does.
  *
  * @param[in]  comp      Compressed archive; only the header and footer are read.
  * @param[in]  comp_size Size of the archive in bytes. The caller guarantees it
  *                       covers at least the file header and footer.
  * @param[out] dsize     Decompressed size read from the footer.
  * @param[out] margin    In-place margin for @p dsize, from @ref zxc_inplace_margin.
+ * @param[out] floor     Minimum @c off: what has to separate the flush-right
+ *                       archive from the head of the buffer.
  * @return ZXC_OK, or a negative @ref zxc_error_t on an invalid archive.
  */
 static int zxc_inplace_probe(const uint8_t* comp, const size_t comp_size, uint64_t* dsize,
-                             uint64_t* margin) {
+                             uint64_t* margin, uint64_t* floor) {
     if (UNLIKELY(zxc_le32(comp) != ZXC_MAGIC_WORD)) return ZXC_ERROR_BAD_MAGIC;
     size_t chunk_size = 0;
     int has_cs = 0;
@@ -1116,6 +1116,7 @@ static int zxc_inplace_probe(const uint8_t* comp, const size_t comp_size, uint64
 
     *dsize = d;
     *margin = zxc_inplace_margin(d, chunk_size, has_cs);
+    *floor = (uint64_t)chunk_size + (uint64_t)ZXC_DECOMPRESS_TAIL_PAD;
     return ZXC_OK;
 }
 
@@ -1129,6 +1130,11 @@ static int zxc_inplace_probe(const uint8_t* comp, const size_t comp_size, uint64
  * compressed data placed flush-right, the write cursor never overtaking the
  * read cursor.
  *
+ * Because src_size is attacker-controlled, inserted padding bytes can slide decoding dangerously
+ * close to the output boundary. Enforcing a minimum bound via src_size + floor maintains the
+ * required separation regardless of archive padding. For authentic archives, this adjustment grows
+ * the bound by at most 16 bytes and guarantees it never shrinks.
+ *
  * @param[in] src      Compressed archive (only header + footer are read).
  * @param[in] src_size Size of the archive in bytes.
  * @return Required buffer size in bytes, or 0 if @p src is not a valid archive.
@@ -1138,10 +1144,17 @@ size_t zxc_decompress_inplace_bound(const void* src, const size_t src_size) {
     if (UNLIKELY(!src || src_size < ZXC_FILE_HEADER_SIZE + ZXC_FILE_FOOTER_SIZE)) return 0;
     uint64_t dsize = 0;
     uint64_t margin = 0;
-    if (UNLIKELY(zxc_inplace_probe((const uint8_t*)src, src_size, &dsize, &margin) != ZXC_OK))
+    uint64_t floor = 0;
+    if (UNLIKELY(zxc_inplace_probe((const uint8_t*)src, src_size, &dsize, &margin, &floor) !=
+                 ZXC_OK))
         return 0;
     if (UNLIKELY(margin > (uint64_t)SIZE_MAX || dsize > (uint64_t)SIZE_MAX - margin)) return 0;
-    return (size_t)(dsize + margin);
+    const uint64_t by_payload = dsize + margin;
+
+    if (UNLIKELY(floor > (uint64_t)SIZE_MAX - (uint64_t)src_size)) return 0;
+    const uint64_t by_placement = (uint64_t)src_size + floor;
+
+    return (size_t)(by_payload > by_placement ? by_payload : by_placement);
 }
 
 /**
@@ -1162,10 +1175,10 @@ size_t zxc_decompress_inplace_bound(const void* src, const size_t src_size) {
  * @param[in]     comp_size        Size of the compressed archive in bytes.
  * @param[in]     opts             Decompression options, or NULL for defaults.
  * @return Decompressed size in bytes, or a negative @ref zxc_error_t code:
- *         @ref ZXC_ERROR_DST_TOO_SMALL if the buffer lacks the safety margin,
+ *         @ref ZXC_ERROR_DST_TOO_SMALL if the buffer is short of either margin,
  *         otherwise the @ref zxc_inplace_probe verdict
- *         (@ref ZXC_ERROR_BAD_MAGIC, @ref ZXC_ERROR_BAD_HEADER, or
- *         @ref ZXC_ERROR_CORRUPT_DATA for a forged footer).
+ *         (@ref ZXC_ERROR_BAD_MAGIC, @ref ZXC_ERROR_BAD_HEADER,
+ *         @ref ZXC_ERROR_CORRUPT_DATA).
  */
 // cppcheck-suppress unusedFunction
 int64_t zxc_decompress_inplace(void* buffer, const size_t buffer_capacity, const size_t comp_size,
@@ -1177,20 +1190,23 @@ int64_t zxc_decompress_inplace(void* buffer, const size_t buffer_capacity, const
     const uint8_t* const comp = buf + (buffer_capacity - comp_size); /* flush-right */
     uint64_t dsize = 0;
     uint64_t margin = 0;
-    const int rc = zxc_inplace_probe(comp, comp_size, &dsize, &margin);
+    uint64_t floor = 0;
+    const int rc = zxc_inplace_probe(comp, comp_size, &dsize, &margin, &floor);
     if (UNLIKELY(rc != ZXC_OK)) return rc;
     if (UNLIKELY(dsize > (uint64_t)buffer_capacity || (uint64_t)buffer_capacity - dsize < margin))
         return ZXC_ERROR_DST_TOO_SMALL;
+    /* The check above sizes the buffer against the payload, this one against the
+     * archive where it actually lies. Only the second bounds the read/write gap. */
+    if (UNLIKELY((uint64_t)(buffer_capacity - comp_size) < floor)) return ZXC_ERROR_DST_TOO_SMALL;
     return zxc_decompress_frame(comp, comp_size, buf, buffer_capacity, opts);
 }
 
 /**
  * @brief Reads the decompressed size from a ZXC-compressed buffer.
  *
- * The size is stored in the file footer (last @ref ZXC_FILE_FOOTER_SIZE bytes)
- * and is untrusted, so it goes through @ref zxc_footer_dsize_plausible: a
- * forged size returns 0, and callers sizing an output allocation from this
- * value inherit the check.
+ * The size sits in the file footer (last @ref ZXC_FILE_FOOTER_SIZE bytes) and is
+ * untrusted, so it goes through @ref zxc_footer_dsize_plausible: a forged size
+ * returns 0, and callers sizing an allocation from it inherit the check.
  *
  * @param[in] src      Compressed data.
  * @param[in] src_size Size of @p src in bytes.

--- a/tests/test_buffer_api.c
+++ b/tests/test_buffer_api.c
@@ -890,6 +890,60 @@ static int inplace_case(const char* label, const uint8_t* orig, size_t n, int le
     return 1;
 }
 
+/* The footer is untrusted: a size it cannot possibly hold must not become the
+ * caller's allocation. One flipped byte in a 354-byte archive used to answer a
+ * 68 GB bound, and the decoder blamed the header for a bad footer. */
+static int inplace_forged_footer(void) {
+    uint8_t in[4096];
+    for (size_t i = 0; i < sizeof(in); i++) in[i] = (uint8_t)(i * 7);
+    uint8_t comp[8192];
+    const int64_t c = zxc_compress(in, sizeof(in), comp, sizeof(comp), NULL);
+    if (c <= 0) {
+        printf("Failed [forged footer]: compress -> %lld\n", (long long)c);
+        return 0;
+    }
+    const size_t csz = (size_t)c;
+    const size_t need = zxc_decompress_inplace_bound(comp, csz);
+    uint8_t* const buf = (uint8_t*)malloc(need);
+    if (!buf) return 0;
+    uint8_t bad[8192];
+    int ok = 1;
+
+    /* A size no archive of this length can reach. */
+    memcpy(bad, comp, csz);
+    bad[csz - ZXC_FILE_FOOTER_SIZE + 4] = 0x10; /* ~68 GB */
+    const size_t inflated = zxc_decompress_inplace_bound(bad, csz);
+    if (inflated != 0) {
+        printf("Failed [forged footer]: bound %zu, want 0\n", inflated);
+        ok = 0;
+    }
+
+    /* The verdict must name the footer, not the header, which is intact. */
+    memcpy(bad, comp, csz);
+    memset(bad + csz - ZXC_FILE_FOOTER_SIZE, 0xFF, 8);
+    memcpy(buf + need - csz, bad, csz);
+    int64_t d = zxc_decompress_inplace(buf, need, csz, NULL);
+    if (d != ZXC_ERROR_CORRUPT_DATA) {
+        printf("Failed [forged footer]: inplace %lld, want %d\n", (long long)d,
+               ZXC_ERROR_CORRUPT_DATA);
+        ok = 0;
+    }
+
+    memcpy(bad, comp, csz);
+    bad[0] ^= 0xFF;
+    memcpy(buf + need - csz, bad, csz);
+    d = zxc_decompress_inplace(buf, need, csz, NULL);
+    if (d != ZXC_ERROR_BAD_MAGIC) {
+        printf("Failed [forged footer]: bad magic %lld, want %d\n", (long long)d,
+               ZXC_ERROR_BAD_MAGIC);
+        ok = 0;
+    }
+
+    free(buf);
+    if (ok) printf("  [PASS] forged footer refused, verdict names the footer\n");
+    return ok;
+}
+
 int test_decompress_inplace(void) {
     printf("=== TEST: Unit - In-place decompression (single buffer) ===\n");
     const size_t N = 2 * 1024 * 1024;
@@ -931,6 +985,8 @@ int test_decompress_inplace(void) {
         printf("Failed: bound on garbage != 0\n");
         ok = 0;
     }
+
+    ok &= inplace_forged_footer();
 
     free(a);
     if (!ok) return 0;

--- a/tests/test_buffer_api.c
+++ b/tests/test_buffer_api.c
@@ -890,9 +890,9 @@ static int inplace_case(const char* label, const uint8_t* orig, size_t n, int le
     return 1;
 }
 
-/* The footer is untrusted: a size it cannot possibly hold must not become the
- * caller's allocation. One flipped byte in a 354-byte archive used to answer a
- * 68 GB bound, and the decoder blamed the header for a bad footer. */
+/* A footer size the archive cannot possibly hold must not become the caller's
+ * allocation: one flipped byte in a 354-byte archive used to answer a 68 GB
+ * bound, and the decoder blamed the header for it. */
 static int inplace_forged_footer(void) {
     uint8_t in[4096];
     for (size_t i = 0; i < sizeof(in); i++) in[i] = (uint8_t)(i * 7);
@@ -944,6 +944,85 @@ static int inplace_forged_footer(void) {
     return ok;
 }
 
+/* The read/write separation is a difference between the bound and the archive
+ * size, and the archive size is attacker-controlled: bytes between the EOF block
+ * and the footer are skipped by the frame loop, so a padded archive still
+ * decodes while each padding byte slides it closer to the output. */
+static int inplace_padded_archive(void) {
+    const size_t N = 64 * 1024;
+    uint8_t* const orig = (uint8_t*)malloc(N);
+    if (!orig) return 0;
+    gen_random_data(orig, N); /* all-RAW: the worst case for the separation */
+
+    const size_t cbound = (size_t)zxc_compress_bound(N);
+    uint8_t* const comp = (uint8_t*)malloc(cbound);
+    if (!comp) {
+        free(orig);
+        return 0;
+    }
+    const zxc_compress_opts_t co = {.level = 1, .block_size = ZXC_BLOCK_SIZE_MIN};
+    const int64_t c = zxc_compress(orig, N, comp, cbound, &co);
+    if (c <= 0) {
+        printf("Failed [padded archive]: compress -> %lld\n", (long long)c);
+        free(comp);
+        free(orig);
+        return 0;
+    }
+    const size_t csz = (size_t)c;
+
+    int ok = 1;
+    const size_t pads[] = {1, 4096, 20000, 100000};
+    for (size_t i = 0; i < sizeof(pads) / sizeof(pads[0]); i++) {
+        const size_t pad = pads[i];
+        const size_t c2 = csz + pad;
+        uint8_t* const a = (uint8_t*)malloc(c2);
+        if (!a) {
+            ok = 0;
+            break;
+        }
+        memcpy(a, comp, csz - ZXC_FILE_FOOTER_SIZE);
+        memset(a + csz - ZXC_FILE_FOOTER_SIZE, 0xAA, pad);
+        memcpy(a + csz - ZXC_FILE_FOOTER_SIZE + pad, comp + csz - ZXC_FILE_FOOTER_SIZE,
+               ZXC_FILE_FOOTER_SIZE);
+
+        const size_t need = zxc_decompress_inplace_bound(a, c2);
+        if (need < c2) {
+            printf("Failed [padded archive]: pad=%zu bound %zu < archive %zu\n", pad, need, c2);
+            ok = 0;
+        } else {
+            uint8_t* const buf = (uint8_t*)malloc(need);
+            if (buf) {
+                memcpy(buf + need - c2, a, c2);
+                const int64_t d = zxc_decompress_inplace(buf, need, c2, NULL);
+                if (d != (int64_t)N || memcmp(buf, orig, N) != 0) {
+                    printf("Failed [padded archive]: pad=%zu inplace %lld want %zu\n", pad,
+                           (long long)d, N);
+                    ok = 0;
+                }
+                free(buf);
+            }
+        }
+        free(a);
+    }
+
+    /* The bound an authentic archive gets must not have moved. */
+    const size_t plain = zxc_decompress_inplace_bound(comp, csz);
+    uint8_t* const buf = (uint8_t*)malloc(plain);
+    if (buf) {
+        memcpy(buf + plain - csz, comp, csz);
+        if (zxc_decompress_inplace(buf, plain, csz, NULL) != (int64_t)N) {
+            printf("Failed [padded archive]: unpadded archive regressed\n");
+            ok = 0;
+        }
+        free(buf);
+    }
+
+    free(comp);
+    free(orig);
+    if (ok) printf("  [PASS] padded archive keeps its read/write separation\n");
+    return ok;
+}
+
 int test_decompress_inplace(void) {
     printf("=== TEST: Unit - In-place decompression (single buffer) ===\n");
     const size_t N = 2 * 1024 * 1024;
@@ -987,6 +1066,7 @@ int test_decompress_inplace(void) {
     }
 
     ok &= inplace_forged_footer();
+    ok &= inplace_padded_archive();
 
     free(a);
     if (!ok) return 0;


### PR DESCRIPTION
Enhances the security and robustness of in-place decompression:

*   **Mitigates forged footer attacks**: Introduces a new function to validate the decompressed size read from the archive footer, preventing excessive memory allocations from untrusted input.
*   **Ensures robust buffer separation**: Addresses a vulnerability where attacker-controlled padding in a compressed archive could reduce the required read/write separation during in-place decompression. A new minimum buffer floor is enforced to guarantee sufficient margin.
*   **Centralizes validation logic**: Consolidates footer plausibility checks into a shared function for consistent validation across relevant decompression paths.
*   **Improves error reporting**: Returns `ZXC_ERROR_CORRUPT_DATA` when detecting a forged footer during in-place decompression, providing more precise feedback.