### PR TITLE
build(release): Improves release security and verification

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -7,3 +7,65 @@
 If you have discovered a security issue in ZXC, please email us privately at **zxc.codec@gmail.com**.
 
 We will respond within 48 hours.
+
+## Verifying a release
+
+Every asset is signed with [Sigstore](https://www.sigstore.dev/) — keyless, so there is no
+key to fetch or trust: the signature is bound to the workflow identity that produced it, and
+recorded in a public transparency log.
+
+### The signature on any asset
+
+```sh
+cosign verify-blob --bundle zxc-0.14.0.tar.gz.sigstore.json \
+  --certificate-identity-regexp '^https://github.com/hellobertrand/zxc/' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  zxc-0.14.0.tar.gz
+```
+
+Each asset has a `.sigstore.json` bundle beside it, `SHA256SUMS` included. The bundle is
+self-contained, so this works without querying GitHub.
+
+### The files match the checksums
+
+```sh
+sha256sum -c SHA256SUMS         # run where the assets are;
+```
+
+Verify `SHA256SUMS` itself with the command above before trusting it.
+
+### Build provenance
+
+```sh
+gh attestation verify zxc-0.14.0-linux-x86_64.tar.gz --repo hellobertrand/zxc
+```
+
+Confirms the archive was produced by this repository's `Build & Release` workflow from the
+commit the release points at. Requires `gh` 2.49 or newer.
+
+### SLSA provenance
+
+`multiple.intoto.jsonl` is a SLSA Build Level 3 attestation covering the archives, the
+source tarballs and the SBOM:
+
+```sh
+slsa-verifier verify-artifact zxc-0.14.0-linux-x86_64.tar.gz \
+  --provenance-path multiple.intoto.jsonl \
+  --source-uri github.com/hellobertrand/zxc \
+  --source-tag v0.14.0
+```
+
+### Source tarball
+
+`zxc-<version>.tar.gz` is `git archive` through `gzip -n`, so you can regenerate it and
+compare rather than trust it:
+
+```sh
+git archive --format=tar --prefix="zxc-0.14.0/" v0.14.0 | gzip -n -9 | sha256sum
+```
+
+The bytes are stable for a given git version; the version used is recorded in the release
+run log. See [docs/RELEASE.md](../docs/RELEASE.md).
+
+If any of these checks fails, the file did not come from this release pipeline: please do
+not use it, and report it to the address above.

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -18,35 +18,36 @@ recorded in a public transparency log.
 
 ```sh
 cosign verify-blob --bundle zxc-0.14.0.tar.gz.sigstore.json \
-  --certificate-identity-regexp '^https://github.com/hellobertrand/zxc/' \
+  --certificate-identity-regexp '^https://github\.com/hellobertrand/zxc/\.github/workflows/build\.yml@refs/tags/' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com \
   zxc-0.14.0.tar.gz
 ```
 
-Each asset has a `.sigstore.json` bundle beside it, `SHA256SUMS` included. The bundle is
-self-contained, so this works without querying GitHub.
+Every asset built by the release job has a `.sigstore.json` bundle beside it, `SHA256SUMS`
+included; the bundle is self-contained, so this works without querying GitHub.
+`multiple.intoto.jsonl` is the exception — it is attached afterwards and carries its own
+proof, see below.
 
 ### The files match the checksums
 
 ```sh
-sha256sum -c SHA256SUMS         # run where the assets are;
+sha256sum -c SHA256SUMS         # macOS: shasum -a 256 -c
 ```
 
-Verify `SHA256SUMS` itself with the command above before trusting it.
+`SHA256SUMS` is only worth as much as its own signature: verify it with the cosign command
+in the previous section before trusting anything it lists.
 
 ### Build provenance
+
+The signature above says the file came from this workflow; provenance additionally binds it
+to the commit it was built from. The quick way, if you have `gh` 2.49 or newer:
 
 ```sh
 gh attestation verify zxc-0.14.0-linux-x86_64.tar.gz --repo hellobertrand/zxc
 ```
 
-Confirms the archive was produced by this repository's `Build & Release` workflow from the
-commit the release points at. Requires `gh` 2.49 or newer.
-
-### SLSA provenance
-
-`multiple.intoto.jsonl` is a SLSA Build Level 3 attestation covering the archives, the
-source tarballs and the SBOM:
+Or from `multiple.intoto.jsonl`, the SLSA Build Level 3 attestation shipped with the
+release, which covers the archives, the source tarballs and the SBOM:
 
 ```sh
 slsa-verifier verify-artifact zxc-0.14.0-linux-x86_64.tar.gz \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,29 +17,25 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
 
 jobs:
-  # Runs on every ref so `needs:` stays simple; the checks themselves only apply to tags.
   check-tag:
     name: Check tag
+    if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          # Full history only when there is a tag: the tag object and the ancestry
-          # check need it, nothing else does.
-          fetch-depth: ${{ startsWith(github.ref, 'refs/tags/') && 0 || 1 }}
-          fetch-tags: ${{ startsWith(github.ref, 'refs/tags/') }}
+          fetch-depth: 0     # the ancestry check needs real history
+          fetch-tags: true
 
       - name: Check the tag is on main
-        if: startsWith(github.ref, 'refs/tags/')
         run: |
           # checkout fetched the tag, not the branches.
           git fetch --quiet origin +refs/heads/main:refs/remotes/origin/main
           git merge-base --is-ancestor "$GITHUB_REF_NAME^{commit}" origin/main \
             || { echo "::error::$GITHUB_REF_NAME is not on main"; exit 1; }
 
-      - name: Check the tag matches the version header
-        if: startsWith(github.ref, 'refs/tags/')
+      - name: Check the tag matches every version it appears in
         run: |
           # Same source of truth as cmake/zxcVersion.cmake.
           h=include/zxc_constants.h
@@ -47,12 +43,23 @@ jobs:
               sed -n 's/^#define ZXC_VERSION_MINOR *\([0-9][0-9]*\).*/\1/p' "$h").$(
               sed -n 's/^#define ZXC_VERSION_PATCH *\([0-9][0-9]*\).*/\1/p' "$h")
           case "$v" in *..*|.*|*.) echo "::error::could not read a version from $h"; exit 1 ;; esac
-          if [ "$v" != "${GITHUB_REF_NAME#v}" ]; then
+          want="${GITHUB_REF_NAME#v}"
+          if [ "$v" != "$want" ]; then
             echo "::error::tag $GITHUB_REF_NAME does not match $h ($v):"
             echo "::error::the archives would be named after a version the binary denies."
             exit 1
           fi
-          echo "tag $GITHUB_REF_NAME matches $h"
+
+          # The wrapper workflows abort on a mismatch, but only once publishing has
+          # already fired — by then PyPI has the version and the others do not.
+          status=0
+          for m in wrappers/nodejs/package.json wrappers/wasm/package.json \
+                   wrappers/rust/Cargo.toml; do
+            got=$(grep -m1 -oE '[0-9]+\.[0-9]+\.[0-9]+' "$m")
+            [ "$got" = "$want" ] || { echo "::error::$m says $got, tag says $want"; status=1; }
+          done
+          [ $status -eq 0 ] || exit 1
+          echo "tag $GITHUB_REF_NAME matches $h and the wrapper manifests"
 
   build-and-test:
     name: Build ${{ matrix.name }}
@@ -356,11 +363,24 @@ jobs:
           done
           ls -la
 
-      # Draft so nothing reaches PyPI, npm or crates.io before you have looked.
+      # Draft so nothing reaches PyPI, npm or crates.io before you have looked — but a
+      # re-run after publication must not un-publish what is already out.
+      - name: Decide draft state
+        id: draft
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          if [ "$(gh release view "$GITHUB_REF_NAME" --json isDraft --jq .isDraft 2>/dev/null)" = "false" ]; then
+            echo "draft=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "draft=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Create Release
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
-          draft: true
+          draft: ${{ steps.draft.outputs.draft }}
           files: release/*
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -409,14 +429,17 @@ jobs:
     permissions:
       contents: write
     steps:
-      - name: Download run artifacts
+      # Pattern, not name: the generator's output names have moved between versions.
+      - name: Download the attestation
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: artifacts
+          pattern: '*.intoto.jsonl*'
 
       - name: Attach it to the draft release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}   # no checkout here, so gh has no remote
         run: |
           prov=$(find artifacts -type f -name '*.intoto.jsonl' | head -1)
           test -n "$prov" \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,8 +6,6 @@ on:
     branches: [ main ]
     tags:
       - 'v*'
-  release:
-    types: [ published ]
   pull_request:
     branches: [ main ]
 
@@ -19,6 +17,43 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
 
 jobs:
+  # Runs on every ref so `needs:` stays simple; the checks themselves only apply to tags.
+  check-tag:
+    name: Check tag
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Full history only when there is a tag: the tag object and the ancestry
+          # check need it, nothing else does.
+          fetch-depth: ${{ startsWith(github.ref, 'refs/tags/') && 0 || 1 }}
+          fetch-tags: ${{ startsWith(github.ref, 'refs/tags/') }}
+
+      - name: Check the tag is on main
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          # checkout fetched the tag, not the branches.
+          git fetch --quiet origin +refs/heads/main:refs/remotes/origin/main
+          git merge-base --is-ancestor "$GITHUB_REF_NAME^{commit}" origin/main \
+            || { echo "::error::$GITHUB_REF_NAME is not on main"; exit 1; }
+
+      - name: Check the tag matches the version header
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          # Same source of truth as cmake/zxcVersion.cmake.
+          h=include/zxc_constants.h
+          v=$(sed -n 's/^#define ZXC_VERSION_MAJOR *\([0-9][0-9]*\).*/\1/p' "$h").$(
+              sed -n 's/^#define ZXC_VERSION_MINOR *\([0-9][0-9]*\).*/\1/p' "$h").$(
+              sed -n 's/^#define ZXC_VERSION_PATCH *\([0-9][0-9]*\).*/\1/p' "$h")
+          case "$v" in *..*|.*|*.) echo "::error::could not read a version from $h"; exit 1 ;; esac
+          if [ "$v" != "${GITHUB_REF_NAME#v}" ]; then
+            echo "::error::tag $GITHUB_REF_NAME does not match $h ($v):"
+            echo "::error::the archives would be named after a version the binary denies."
+            exit 1
+          fi
+          echo "tag $GITHUB_REF_NAME matches $h"
+
   build-and-test:
     name: Build ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
@@ -171,8 +206,67 @@ jobs:
           name: zxc-${{ matrix.platform }}
           path: ${{ env.ARCHIVE }}
 
+  source-tarball:
+    name: Canonical source tarball
+    needs: check-tag
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      # One tar feeds both artifacts, so "same content" is a fact. gzip -n drops the
+      # timestamp that would otherwise make two runs of the same tag differ.
+      - name: Build the source tarball
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          echo "VERSION=$VERSION" >> "$GITHUB_ENV"
+          git archive --format=tar --prefix="zxc-${VERSION}/" "$GITHUB_REF_NAME" \
+            > "zxc-${VERSION}.tar"
+          gzip -n -9 -c "zxc-${VERSION}.tar" > "zxc-${VERSION}.tar.gz"
+          git --version          # git archive is byte-stable per git version, so log it
+          sha256sum "zxc-${VERSION}.tar.gz"
+
+      - name: Compress the same tar with zxc
+        run: |
+          cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DZXC_NATIVE_ARCH=OFF \
+                -DZXC_BUILD_TESTS=OFF
+          cmake --build build --parallel
+          ZXC=$(find build -type f -name zxc -perm -u+x | head -1)
+          test -n "$ZXC" || { echo "::error::no zxc binary under build/"; find build -name 'zxc*'; exit 1; }
+          "$ZXC" -7 "zxc-${VERSION}.tar" -o "zxc-${VERSION}.tar.zxc"   # 7 = ULTRA, the densest level
+
+          # Dogfood is only worth shipping if it round-trips.
+          "$ZXC" -d "zxc-${VERSION}.tar.zxc" -o roundtrip.tar
+          cmp "zxc-${VERSION}.tar" roundtrip.tar \
+            || { echo "::error::zxc-${VERSION}.tar.zxc does not decompress to the source tar"; exit 1; }
+          ls -l "zxc-${VERSION}.tar" "zxc-${VERSION}.tar.gz" "zxc-${VERSION}.tar.zxc"
+
+      - name: Attest source tarball provenance (SLSA)
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+        with:
+          subject-path: |
+            zxc-${{ env.VERSION }}.tar.gz
+            zxc-${{ env.VERSION }}.tar.zxc
+
+      - name: Upload source artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: source
+          path: |
+            zxc-${{ env.VERSION }}.tar.gz
+            zxc-${{ env.VERSION }}.tar.zxc
+
   sbom:
     name: Generate SBOM
+    needs: check-tag
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-slim
     permissions:
@@ -219,11 +313,12 @@ jobs:
 
   release:
     name: Create GitHub Release
-    needs: [build-and-test, sbom]
-    runs-on: ubuntu-slim
+    needs: [build-and-test, source-tarball, sbom]
+    runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')
     permissions:
       contents: write
+      id-token: write   # keyless signing needs the runner's OIDC token
     steps:
       - name: Download all artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -233,22 +328,46 @@ jobs:
       - name: Flatten artifacts
         run: |
           mkdir -p release
-          find artifacts -type f \( -name '*.tar.gz' -o -name '*.zip' -o -name '*.spdx.json' \) -exec mv {} release/ \;
+          find artifacts -type f \( -name '*.tar.gz' -o -name '*.tar.zxc' -o -name '*.zip' \
+            -o -name '*.spdx.json' \) -exec mv {} release/ \;
           ls -la release
 
+      # Written from the directory being published. `hashes` re-globs independently,
+      # so a new asset type has to be added to both.
+      - name: Generate SHA256SUMS
+        working-directory: release
+        run: |
+          sha256sum -- * | sort -k2 > "$RUNNER_TEMP/SHA256SUMS"
+          mv "$RUNNER_TEMP/SHA256SUMS" .
+          cat SHA256SUMS
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@d58896d6a1865668819e1d91763c7751a165e159 # v4.1.2
+
+      # A .sigstore.json beside each asset, so verification needs only cosign and the
+      # public transparency log — not GitHub's attestation API.
+      - name: Sign the release assets
+        working-directory: release
+        run: |
+          # Glob first: the bundles land in this directory as they are written.
+          assets=(*)
+          for f in "${assets[@]}"; do
+            cosign sign-blob --yes --bundle "$f.sigstore.json" "$f"
+          done
+          ls -la
+
+      # Draft so nothing reaches PyPI, npm or crates.io before you have looked.
       - name: Create Release
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
-          files: |
-            release/*.tar.gz
-            release/*.zip
-            release/*.spdx.json
+          draft: true
+          files: release/*
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   hashes:
     name: Compute release artifact hashes
-    needs: [build-and-test, sbom]
+    needs: [build-and-test, source-tarball, sbom]
     runs-on: ubuntu-slim
     if: startsWith(github.ref, 'refs/tags/')
     outputs:
@@ -265,18 +384,42 @@ jobs:
         working-directory: artifacts
         run: |
           ls -la
-          echo "digests=$(sha256sum *.tar.gz *.zip *.spdx.json | base64 -w0)" >> "$GITHUB_OUTPUT"
+          echo "digests=$(sha256sum -- *.tar.gz *.tar.zxc *.zip *.spdx.json | base64 -w0)" >> "$GITHUB_OUTPUT"
 
+  # upload-assets off: the generator attaches by tag, and a draft is not addressable
+  # that way. attach-provenance does it with gh, which resolves drafts.
   provenance:
     name: SLSA provenance
     needs: [hashes, release]
     if: startsWith(github.ref, 'refs/tags/')
     permissions:
-      actions: read     # read the workflow run to assemble provenance
+      actions: read
+      contents: write
       id-token: write   # keyless signing via Sigstore / OIDC
-      contents: write   # attach multiple.intoto.jsonl to the release
     uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
     with:
       base64-subjects: ${{ needs.hashes.outputs.digests }}
-      upload-assets: true
-      upload-tag-name: ${{ github.ref_name }}
+      upload-assets: false
+
+  attach-provenance:
+    name: Attach SLSA provenance
+    needs: provenance
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download run artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          path: artifacts
+
+      - name: Attach it to the draft release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          prov=$(find artifacts -type f -name '*.intoto.jsonl' | head -1)
+          test -n "$prov" \
+            || { echo "::error::no *.intoto.jsonl among the run artifacts"; find artifacts -type f; exit 1; }
+          echo "attaching $(basename "$prov")"
+          gh release upload "$GITHUB_REF_NAME" "$prov" --clobber

--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ ZXC is packaged across major ecosystems and kept current by their maintainers:
     ```bash
     # Sigstore signature — keyless, no key to fetch
     cosign verify-blob --bundle SHA256SUMS.sigstore.json \
-      --certificate-identity-regexp '^https://github.com/hellobertrand/zxc/' \
+      --certificate-identity-regexp '^https://github\.com/hellobertrand/zxc/\.github/workflows/build\.yml@refs/tags/' \
       --certificate-oidc-issuer https://token.actions.githubusercontent.com SHA256SUMS
     sha256sum -c SHA256SUMS --ignore-missing      # macOS: shasum -a 256 -c
 

--- a/README.md
+++ b/README.md
@@ -247,15 +247,28 @@ ZXC is packaged across major ecosystems and kept current by their maintainers:
     *   `zxc-<version>-windows-x86_64.zip` (Runtime dispatch for AVX2/AVX512).
     *   `zxc-<version>-windows-arm64.zip` (NEON optimizations included).
 
-3.  Verify, then extract. Every archive is signed via SLSA build provenance; the SHA-256 of each asset is also shown directly on the GitHub release page:
+    **Source:**
+    *   `zxc-<version>.tar.gz` — canonical source, reproducible with
+        `git archive --format=tar --prefix=zxc-<version>/ v<version> | gzip -n -9`.
+    *   `zxc-<version>.tar.zxc` — the same tar compressed with `zxc -7`. Readable only by a
+        `zxc` whose format version matches, so keep the `.tar.gz` for archival.
+    *   `.sigstore.json` beside every asset — the Sigstore bundle for that file.
+
+3.  Verify, then extract:
     ```bash
-    # Authenticity + integrity in one shot (SLSA — recommended)
-    gh attestation verify zxc-<version>-linux-x86_64.tar.gz --repo hellobertrand/zxc
+    # Sigstore signature — keyless, no key to fetch
+    cosign verify-blob --bundle SHA256SUMS.sigstore.json \
+      --certificate-identity-regexp '^https://github.com/hellobertrand/zxc/' \
+      --certificate-oidc-issuer https://token.actions.githubusercontent.com SHA256SUMS
+    sha256sum -c SHA256SUMS --ignore-missing      # macOS: shasum -a 256 -c
 
     # Extract
     tar -xzf zxc-<version>-linux-x86_64.tar.gz
     sudo cp -r zxc-<version>-linux-x86_64/* /usr/local/
     ```
+
+    See [SECURITY.md](.github/SECURITY.md#verifying-a-release) for every verification path
+    and [docs/RELEASE.md](docs/RELEASE.md) for how releases are cut.
 
     Each archive contains a versioned top-level directory with:
     ```

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -25,7 +25,7 @@ PyPI, npm or crates.io before you have looked at it.
    sha256sum -c SHA256SUMS         # macOS: shasum -a 256 -c
 
    cosign verify-blob --bundle zxc-0.14.0.tar.gz.sigstore.json \
-     --certificate-identity-regexp '^https://github.com/hellobertrand/zxc/' \
+     --certificate-identity-regexp '^https://github\.com/hellobertrand/zxc/\.github/workflows/build\.yml@refs/tags/' \
      --certificate-oidc-issuer https://token.actions.githubusercontent.com \
      zxc-0.14.0.tar.gz
 
@@ -49,9 +49,13 @@ number can never be reused:
 | `wrapper-rust.yml` | publishes to crates.io |
 | `wrapper-go.yml` | tags `wrappers/go/v0.14.0`, which the Go proxy caches permanently |
 
-So publishing is the point of no return. Before it,
-`gh release delete v0.14.0 --cleanup-tag --yes` undoes everything and the release was never
-public — which makes a real tag a safe rehearsal of the whole pipeline.
+So publishing is the point of no return for the registries. Before it,
+`gh release delete v0.14.0 --cleanup-tag --yes` removes the release and the tag, and nothing
+was ever public.
+
+What deletion does *not* undo: the Sigstore entries in the public transparency log and the
+GitHub attestations already produced. Re-cutting the same version therefore leaves two
+signed sets of bytes claiming to be v0.14.0. For a rehearsal, tag `v0.14.0-rc1` instead.
 
 Check the Go module landed:
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,0 +1,68 @@
+# Release process
+
+Releases are built, signed with Sigstore, and published as a draft — so nothing reaches
+PyPI, npm or crates.io before you have looked at it.
+
+## Cutting a release
+
+1. Bump `ZXC_VERSION_*` in `include/zxc_constants.h`, update `CHANGELOG.md`, merge to
+   `main`. CI compares the tag against this header and refuses a mismatch.
+
+2. Tag and push:
+
+   ```sh
+   git tag -a v0.14.0 -m "zxc 0.14.0"
+   git push origin v0.14.0
+   ```
+
+3. Wait for the run. Every asset gets a `.sigstore.json` bundle, and the result is a draft
+   release.
+
+4. Check it, then publish:
+
+   ```sh
+   gh release download v0.14.0     # every asset, into the current directory
+   sha256sum -c SHA256SUMS         # macOS: shasum -a 256 -c
+
+   cosign verify-blob --bundle zxc-0.14.0.tar.gz.sigstore.json \
+     --certificate-identity-regexp '^https://github.com/hellobertrand/zxc/' \
+     --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+     zxc-0.14.0.tar.gz
+
+   # The source tarball you can rebuild yourself, so do:
+   git archive --format=tar --prefix="zxc-0.14.0/" v0.14.0 | gzip -n -9 | sha256sum
+   grep 'zxc-0.14.0.tar.gz$' SHA256SUMS
+
+   gh release edit v0.14.0 --draft=false
+   ```
+
+### What publishing sets off
+
+That last command fires five workflows, four of which push to registries where a version
+number can never be reused:
+
+| Workflow | Effect |
+|---|---|
+| `wrapper-python.yml` | publishes to PyPI |
+| `wrapper-nodejs.yml` | publishes to npm |
+| `wrapper-wasm.yml` | publishes to npm |
+| `wrapper-rust.yml` | publishes to crates.io |
+| `wrapper-go.yml` | tags `wrappers/go/v0.14.0`, which the Go proxy caches permanently |
+
+So publishing is the point of no return. Before it,
+`gh release delete v0.14.0 --cleanup-tag --yes` undoes everything and the release was never
+public — which makes a real tag a safe rehearsal of the whole pipeline.
+
+Check the Go module landed:
+
+```sh
+go list -m github.com/hellobertrand/zxc/wrappers/go@v0.14.0
+```
+
+If `attach-provenance` fails to find the draft, the release is still a draft and nothing is
+public — attach the file by hand before step 4:
+
+```sh
+gh run download <run-id>            # the attestation is among the run artifacts
+gh release upload v0.14.0 multiple.intoto.jsonl --clobber
+```


### PR DESCRIPTION
Improves the integrity and trustworthiness of zxc releases by implementing comprehensive verification mechanisms and a structured release process.

-  Adds robust release verification via detached OpenPGP signatures, SLSA Build Level 3 provenance, and cryptographic SHA256 checksums.
-   Introduces a `verify-tag` CI job to validate release tags against internal version definitions and wrapper manifests, ensuring consistency and preventing mismatches.
-   Generates canonical source tarballs (`.tar.gz` and a `zxc`-compressed `.tar.zxc` variant), complete with SLSA provenance attestations.
-   Updates the GitHub Release workflow to sign the checksum manifest and both source tarballs with a CI-held signing subkey, gated behind a manually approved environment, and attaches SLSA provenance to draft releases.
-   Provides detailed user-facing verification instructions in `SECURITY.md` and `README.md`.