### PR TITLE
build(release): Improve release verifiability and automation

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -7,3 +7,75 @@
 If you have discovered a security issue in ZXC, please email us privately at **zxc.codec@gmail.com**.
 
 We will respond within 48 hours.
+
+## Verifying a release
+
+Four independent checks, from the strongest claim to the most convenient. The first is the
+only one that attests a **human** decision; the others attest the build machinery.
+
+### The tag was signed by the maintainer
+
+```sh
+curl -sS https://github.com/hellobertrand.gpg | gpg --import
+git fetch --tags
+git verify-tag v<version>
+```
+
+Releases up to 0.13.3 carry a lightweight tag, which holds no signature of its own. Verify
+the commit it points at instead:
+
+```sh
+git verify-commit v<version>
+```
+
+The keys come straight from GitHub — the same ones behind the "Verified" badge on the
+commits. Signing key: `CFC1 8791 C7DB A33B A5B8  5506 C6A2 4372 A165 64D6`.
+
+The tag is the one thing a person signs; everything else is attested by the build itself,
+below.
+
+### The files match the checksums
+
+```sh
+sha256sum -c sha256sums --ignore-missing   # only the assets you downloaded
+```
+
+`sha256sums` is a convenience for checking a download in one pass; what actually attests
+the files is the build provenance below.
+
+### Build provenance
+
+```sh
+gh attestation verify zxc-<version>-linux-x86_64.tar.gz --repo hellobertrand/zxc
+```
+
+Confirms the archive was produced by this repository's `Build & Release` workflow from the
+commit the release points at. Requires `gh` 2.49 or newer. The source tarball, the `.tar.zxc`
+and the SBOM are attested the same way.
+
+### SLSA provenance
+
+`multiple.intoto.jsonl` is a SLSA Build Level 3 attestation covering the archives, the
+source tarballs and the SBOM:
+
+```sh
+slsa-verifier verify-artifact zxc-<version>-linux-x86_64.tar.gz \
+  --provenance-path multiple.intoto.jsonl \
+  --source-uri github.com/hellobertrand/zxc \
+  --source-tag v<version>
+```
+
+### Source tarball
+
+`zxc-<version>.tar.gz` is `git archive` through `gzip -n`, so you can regenerate it and
+compare rather than trust it:
+
+```sh
+git archive --format=tar --prefix="zxc-<version>/" v<version> | gzip -n -9 | sha256sum
+```
+
+The bytes are stable for a given git version; the version used is recorded in the release
+run log.
+
+If any of these checks fails, the file did not come from this release pipeline: please do
+not use it, and report it to the address above.

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -10,72 +10,11 @@ We will respond within 48 hours.
 
 ## Verifying a release
 
-Four independent checks, from the strongest claim to the most convenient. The first is the
-only one that attests a **human** decision; the others attest the build machinery.
+Every release ships a `sha256sums` manifest signed with minisign, and each archive carries a
+GitHub build attestation. See [the README](../README.md#installation) for the two commands.
 
-### The tag was signed by the maintainer
+Release tags are signed with the maintainer's PGP key
+`CFC1 8791 C7DB A33B A5B8  5506 C6A2 4372 A165 64D6`, published at
+<https://github.com/hellobertrand.gpg>.
 
-```sh
-curl -sS https://github.com/hellobertrand.gpg | gpg --import
-git fetch --tags
-git verify-tag v<version>
-```
-
-Releases up to 0.13.3 carry a lightweight tag, which holds no signature of its own. Verify
-the commit it points at instead:
-
-```sh
-git verify-commit v<version>
-```
-
-The keys come straight from GitHub — the same ones behind the "Verified" badge on the
-commits. Signing key: `CFC1 8791 C7DB A33B A5B8  5506 C6A2 4372 A165 64D6`.
-
-The tag is the one thing a person signs; everything else is attested by the build itself,
-below.
-
-### The files match the checksums
-
-```sh
-sha256sum -c sha256sums --ignore-missing   # only the assets you downloaded
-```
-
-`sha256sums` is a convenience for checking a download in one pass; what actually attests
-the files is the build provenance below.
-
-### Build provenance
-
-```sh
-gh attestation verify zxc-<version>-linux-x86_64.tar.gz --repo hellobertrand/zxc
-```
-
-Confirms the archive was produced by this repository's `Build & Release` workflow from the
-commit the release points at. Requires `gh` 2.49 or newer. The source tarball, the `.tar.zxc`
-and the SBOM are attested the same way.
-
-### SLSA provenance
-
-`multiple.intoto.jsonl` is a SLSA Build Level 3 attestation covering the archives, the
-source tarballs and the SBOM:
-
-```sh
-slsa-verifier verify-artifact zxc-<version>-linux-x86_64.tar.gz \
-  --provenance-path multiple.intoto.jsonl \
-  --source-uri github.com/hellobertrand/zxc \
-  --source-tag v<version>
-```
-
-### Source tarball
-
-`zxc-<version>.tar.gz` is `git archive` through `gzip -n`, so you can regenerate it and
-compare rather than trust it:
-
-```sh
-git archive --format=tar --prefix="zxc-<version>/" v<version> | gzip -n -9 | sha256sum
-```
-
-The bytes are stable for a given git version; the version used is recorded in the release
-run log.
-
-If any of these checks fails, the file did not come from this release pipeline: please do
-not use it, and report it to the address above.
+If a check fails, please do not use the file and report it to the address above.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,7 @@ on:
   workflow_dispatch:
   push:
     branches: [ main ]
+    tags: [ 'v*' ]      # pre-flight: build and test before the release goes public
   pull_request:
     branches: [ main ]
   release:
@@ -13,7 +14,7 @@ permissions:
   contents: read
 
 concurrency:
-  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/tags/') }}
+  cancel-in-progress: ${{ github.event_name != 'release' }}
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
 
 jobs:
@@ -102,7 +103,7 @@ jobs:
           ./tests/test_cli.sh "$ZXC_BIN"
 
       - name: Package Release (Archive)
-        if: startsWith(github.ref, 'refs/tags/')
+        if: github.event_name == 'release'
         shell: bash
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
@@ -131,7 +132,7 @@ jobs:
 
           **Contents:**
           - \`bin/\` — \`zxc\` CLI compressor/decompressor
-          - \`lib/\` — shared and static libraries
+          - \`lib/\` — \`libzxc.a\` static library, pkg-config and CMake files
           - \`include/\` — C headers
 
           **CLI usage:** See [MANUAL.md](MANUAL.md) for the full reference (synopsis, options, examples).
@@ -157,13 +158,13 @@ jobs:
           fi
 
       - name: Attest build provenance (SLSA)
-        if: startsWith(github.ref, 'refs/tags/')
+        if: github.event_name == 'release'
         uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
         with:
           subject-path: ${{ env.ARCHIVE }}
 
       - name: Upload Artifacts
-        if: startsWith(github.ref, 'refs/tags/')
+        if: github.event_name == 'release'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: zxc-${{ matrix.platform }}
@@ -171,7 +172,7 @@ jobs:
 
   source-tarball:
     name: Canonical source tarball
-    if: startsWith(github.ref, 'refs/tags/')
+    if: github.event_name == 'release'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -180,9 +181,6 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          fetch-depth: 0
-          fetch-tags: true
 
       - name: Build the source tarball
         run: |
@@ -191,7 +189,6 @@ jobs:
           git archive --format=tar --prefix="zxc-${VERSION}/" "$GITHUB_SHA" \
             > "zxc-${VERSION}.tar"
           gzip -n -9 -c "zxc-${VERSION}.tar" > "zxc-${VERSION}.tar.gz"
-          git --version          # git archive is byte-stable per git version, so log it
           sha256sum "zxc-${VERSION}.tar.gz"
 
       - name: Compress the same tar with zxc
@@ -202,7 +199,6 @@ jobs:
           ZXC=$(find build -type f -name zxc -perm -u+x | head -1)
           test -n "$ZXC" || { echo "::error::no zxc binary under build/"; find build -name 'zxc*'; exit 1; }
           "$ZXC" -7 "zxc-${VERSION}.tar" -o "zxc-${VERSION}.tar.zxc"   # 7 = ULTRA, the densest level
-          ls -l "zxc-${VERSION}.tar" "zxc-${VERSION}.tar.gz" "zxc-${VERSION}.tar.zxc"
 
       - name: Attest source tarball provenance (SLSA)
         uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
@@ -221,7 +217,7 @@ jobs:
 
   sbom:
     name: Generate SBOM
-    if: startsWith(github.ref, 'refs/tags/')
+    if: github.event_name == 'release'
     runs-on: ubuntu-slim
     permissions:
       contents: read
@@ -270,11 +266,11 @@ jobs:
     needs: [build-and-test, source-tarball, sbom]
     outputs:
       digests: ${{ steps.sums.outputs.digests }}
-    runs-on: ubuntu-slim
-    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    if: github.event_name == 'release'
+    environment: release-signing
     permissions:
       contents: write
-      actions: write
     steps:
       - name: Download all artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -292,6 +288,7 @@ jobs:
         id: sums
         working-directory: release
         run: |
+          set -euo pipefail
           sha256sum -- * | LC_ALL=C sort -k2 > "$RUNNER_TEMP/sha256sums"
           mv "$RUNNER_TEMP/sha256sums" .
           cat sha256sums
@@ -299,27 +296,31 @@ jobs:
           # two can no longer describe different sets of files.
           echo "digests=$(base64 -w0 < sha256sums)" >> "$GITHUB_OUTPUT"
 
+      - name: Sign sha256sums with minisign
+        working-directory: release
+        env:
+          MINISIGN_SECRET_KEY: ${{ secrets.MINISIGN_SECRET_KEY }}
+          MINISIGN_PASSWORD: ${{ secrets.MINISIGN_PASSWORD }}
+        run: |
+          set -euo pipefail
+          sudo apt-get update -qq && sudo apt-get install -y --no-install-recommends minisign
+          # Never inside release/: the next step uploads that whole directory.
+          key="$RUNNER_TEMP/ms.key"
+          trap 'rm -f "$key"' EXIT
+          umask 077 && printf '%s\n' "$MINISIGN_SECRET_KEY" > "$key"
+          # The password goes on stdin, never on the command line.
+          printf '%s\n' "$MINISIGN_PASSWORD" | minisign -S -s "$key" -m sha256sums
+
       - name: Attach them to the release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
         run: gh release upload "$GITHUB_REF_NAME" release/* --clobber
 
-      # Only once every asset is on the release: the wrappers publish to registries
-      # where a version number can never be reused.
-      - name: Release the wrappers
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GH_REPO: ${{ github.repository }}
-        run: |
-          for w in wrapper-python wrapper-nodejs wrapper-wasm wrapper-rust wrapper-go; do
-            gh workflow run "$w.yml" --ref "$GITHUB_REF_NAME"
-          done
-
   provenance:
     name: SLSA provenance
     needs: release
-    if: startsWith(github.ref, 'refs/tags/')
+    if: github.event_name == 'release'
     permissions:
       actions: read
       contents: write
@@ -332,7 +333,7 @@ jobs:
   attach-provenance:
     name: Attach SLSA provenance
     needs: provenance
-    if: startsWith(github.ref, 'refs/tags/')
+    if: github.event_name == 'release'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -340,16 +341,39 @@ jobs:
       - name: Download the attestation
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          path: artifacts
-          pattern: '*.intoto.jsonl*'
+          name: ${{ needs.provenance.outputs.provenance-name }}
 
-      - name: Attach it to the draft release
+      - name: Attach it to the release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
+          PROV: ${{ needs.provenance.outputs.provenance-name }}
+        run: gh release upload "$GITHUB_REF_NAME" "$PROV" --clobber
+
+  # Last: a registry version can never be reused, so nothing is published until the
+  # release itself is complete and its provenance is attached.
+  release-wrappers:
+    name: Release the wrappers
+    needs: attach-provenance
+    if: github.event_name == 'release'
+    runs-on: ubuntu-slim
+    permissions:
+      actions: write
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GH_REPO: ${{ github.repository }}
+    steps:
+      - name: Dispatch every wrapper
         run: |
-          prov=$(find artifacts -type f -name '*.intoto.jsonl' | head -1)
-          test -n "$prov" \
-            || { echo "::error::no *.intoto.jsonl among the run artifacts"; find artifacts -type f; exit 1; }
-          echo "attaching $(basename "$prov")"
-          gh release upload "$GITHUB_REF_NAME" "$prov" --clobber
+          # No `set -e` short-circuit: one failed dispatch must not strand the others.
+          rc=0
+          for w in wrapper-python wrapper-nodejs wrapper-wasm wrapper-rust wrapper-go; do
+            gh workflow run "$w.yml" --ref "$GITHUB_REF_NAME" || { echo "::error::$w not dispatched"; rc=1; }
+          done
+          # A dispatch only means accepted. Green here does not mean the packages shipped.
+          sleep 10
+          for w in wrapper-python wrapper-nodejs wrapper-wasm wrapper-rust wrapper-go; do
+            gh run list --workflow "$w.yml" --branch "$GITHUB_REF_NAME" --limit 1 \
+              --json url,status --jq '"  \(.[0].status)  \(.[0].url)"' || true
+          done
+          exit $rc

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,18 +4,16 @@ on:
   workflow_dispatch:
   push:
     branches: [ main ]
-    tags:
-      - 'v*'
-  release:
-    types: [ published ]
   pull_request:
     branches: [ main ]
+  release:
+    types: [ published ]
 
 permissions:
   contents: read
 
 concurrency:
-  cancel-in-progress: true
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/tags/') }}
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
 
 jobs:
@@ -171,6 +169,56 @@ jobs:
           name: zxc-${{ matrix.platform }}
           path: ${{ env.ARCHIVE }}
 
+  source-tarball:
+    name: Canonical source tarball
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Build the source tarball
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          echo "VERSION=$VERSION" >> "$GITHUB_ENV"
+          git archive --format=tar --prefix="zxc-${VERSION}/" "$GITHUB_SHA" \
+            > "zxc-${VERSION}.tar"
+          gzip -n -9 -c "zxc-${VERSION}.tar" > "zxc-${VERSION}.tar.gz"
+          git --version          # git archive is byte-stable per git version, so log it
+          sha256sum "zxc-${VERSION}.tar.gz"
+
+      - name: Compress the same tar with zxc
+        run: |
+          cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DZXC_NATIVE_ARCH=OFF \
+                -DZXC_BUILD_TESTS=OFF
+          cmake --build build --parallel
+          ZXC=$(find build -type f -name zxc -perm -u+x | head -1)
+          test -n "$ZXC" || { echo "::error::no zxc binary under build/"; find build -name 'zxc*'; exit 1; }
+          "$ZXC" -7 "zxc-${VERSION}.tar" -o "zxc-${VERSION}.tar.zxc"   # 7 = ULTRA, the densest level
+          ls -l "zxc-${VERSION}.tar" "zxc-${VERSION}.tar.gz" "zxc-${VERSION}.tar.zxc"
+
+      - name: Attest source tarball provenance (SLSA)
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+        with:
+          subject-path: |
+            zxc-${{ env.VERSION }}.tar.gz
+            zxc-${{ env.VERSION }}.tar.zxc
+
+      - name: Upload source artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: source
+          path: |
+            zxc-${{ env.VERSION }}.tar.gz
+            zxc-${{ env.VERSION }}.tar.zxc
+
   sbom:
     name: Generate SBOM
     if: startsWith(github.ref, 'refs/tags/')
@@ -218,12 +266,15 @@ jobs:
           path: zxc-${{ steps.ref.outputs.version }}-sbom.spdx.json
 
   release:
-    name: Create GitHub Release
-    needs: [build-and-test, sbom]
+    name: Upload the release assets
+    needs: [build-and-test, source-tarball, sbom]
+    outputs:
+      digests: ${{ steps.sums.outputs.digests }}
     runs-on: ubuntu-slim
     if: startsWith(github.ref, 'refs/tags/')
     permissions:
       contents: write
+      actions: write
     steps:
       - name: Download all artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -233,50 +284,72 @@ jobs:
       - name: Flatten artifacts
         run: |
           mkdir -p release
-          find artifacts -type f \( -name '*.tar.gz' -o -name '*.zip' -o -name '*.spdx.json' \) -exec mv {} release/ \;
+          find artifacts -type f \( -name '*.tar.gz' -o -name '*.tar.zxc' -o -name '*.zip' \
+            -o -name '*.spdx.json' \) -exec mv {} release/ \;
           ls -la release
 
-      - name: Create Release
-        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
-        with:
-          files: |
-            release/*.tar.gz
-            release/*.zip
-            release/*.spdx.json
+      - name: Generate sha256sums
+        id: sums
+        working-directory: release
+        run: |
+          sha256sum -- * | LC_ALL=C sort -k2 > "$RUNNER_TEMP/sha256sums"
+          mv "$RUNNER_TEMP/sha256sums" .
+          cat sha256sums
+          # The same inventory feeds the signed manifest and the SLSA subjects, so the
+          # two can no longer describe different sets of files.
+          echo "digests=$(base64 -w0 < sha256sums)" >> "$GITHUB_OUTPUT"
+
+      - name: Attach them to the release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: gh release upload "$GITHUB_REF_NAME" release/* --clobber
 
-  hashes:
-    name: Compute release artifact hashes
-    needs: [build-and-test, sbom]
-    runs-on: ubuntu-slim
-    if: startsWith(github.ref, 'refs/tags/')
-    outputs:
-      digests: ${{ steps.hash.outputs.digests }}
-    steps:
-      - name: Download all artifacts
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          path: artifacts
-          merge-multiple: true
-
-      - name: Generate subject digests (base64 sha256sum)
-        id: hash
-        working-directory: artifacts
+      # Only once every asset is on the release: the wrappers publish to registries
+      # where a version number can never be reused.
+      - name: Release the wrappers
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
         run: |
-          ls -la
-          echo "digests=$(sha256sum *.tar.gz *.zip *.spdx.json | base64 -w0)" >> "$GITHUB_OUTPUT"
+          for w in wrapper-python wrapper-nodejs wrapper-wasm wrapper-rust wrapper-go; do
+            gh workflow run "$w.yml" --ref "$GITHUB_REF_NAME"
+          done
 
   provenance:
     name: SLSA provenance
-    needs: [hashes, release]
+    needs: release
     if: startsWith(github.ref, 'refs/tags/')
     permissions:
-      actions: read     # read the workflow run to assemble provenance
+      actions: read
+      contents: write
       id-token: write   # keyless signing via Sigstore / OIDC
-      contents: write   # attach multiple.intoto.jsonl to the release
     uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
     with:
-      base64-subjects: ${{ needs.hashes.outputs.digests }}
-      upload-assets: true
-      upload-tag-name: ${{ github.ref_name }}
+      base64-subjects: ${{ needs.release.outputs.digests }}
+      upload-assets: false
+
+  attach-provenance:
+    name: Attach SLSA provenance
+    needs: provenance
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download the attestation
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          path: artifacts
+          pattern: '*.intoto.jsonl*'
+
+      - name: Attach it to the draft release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          prov=$(find artifacts -type f -name '*.intoto.jsonl' | head -1)
+          test -n "$prov" \
+            || { echo "::error::no *.intoto.jsonl among the run artifacts"; find artifacts -type f; exit 1; }
+          echo "attaching $(basename "$prov")"
+          gh release upload "$GITHUB_REF_NAME" "$prov" --clobber

--- a/.github/workflows/wrapper-go.yml
+++ b/.github/workflows/wrapper-go.yml
@@ -2,8 +2,6 @@ name: Wrapper Go
 
 on:
   workflow_dispatch:
-  release:
-    types: [ published ]
 
 permissions:
   contents: read
@@ -97,7 +95,7 @@ jobs:
   tag-module:
     name: Tag Go Module
     needs: test
-    if: github.event_name == 'release'
+    if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-slim
     permissions:
       contents: write
@@ -106,11 +104,11 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ github.event.release.tag_name }}
+          ref: ${{ github.ref_name }}
 
       - name: Tag the Go submodule
         env:
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_TAG: ${{ github.ref_name }}
         run: |
           # Go resolves versions of a submodule from tags prefixed with the
           # module directory. Without this tag, `go get ...@v0.13.3` fails and
@@ -122,8 +120,7 @@ jobs:
             exit 0
           fi
 
-          # Lightweight tag on the release commit: no tagger identity needed,
-          # and the prefix keeps it clear of the 'v*' trigger in build.yml.
+          # Lightweight tag on the release commit: no tagger identity needed.
           git tag "${MODULE_TAG}" HEAD
           git push origin "${MODULE_TAG}"
 

--- a/.github/workflows/wrapper-nodejs.yml
+++ b/.github/workflows/wrapper-nodejs.yml
@@ -2,8 +2,6 @@ name: Wrapper Node.js
 
 on:
   workflow_dispatch:
-  release:
-    types: [ published ]
 
 permissions:
   contents: read
@@ -116,7 +114,7 @@ jobs:
     name: Publish to npm
     needs: [build, test]
     runs-on: ubuntu-slim
-    if: github.event_name == 'release'
+    if: startsWith(github.ref, 'refs/tags/')
     permissions:
       id-token: write
     defaults:
@@ -135,7 +133,7 @@ jobs:
 
       - name: Verify Version Matches Release Tag
         env:
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_TAG: ${{ github.ref_name }}
         run: |
           # Remove 'v' prefix if present
           RELEASE_VERSION="${RELEASE_TAG#v}"

--- a/.github/workflows/wrapper-python.yml
+++ b/.github/workflows/wrapper-python.yml
@@ -2,8 +2,6 @@ name: Wrapper Python
 
 on:
   workflow_dispatch:
-  release:
-    types: [ published ]
 
 permissions:
   contents: read
@@ -141,7 +139,7 @@ jobs:
     name: Publish to PyPI
     needs: [build_wheels, build_sdist, test_wheels]
     runs-on: ubuntu-latest
-    if: github.event_name == 'release'
+    if: startsWith(github.ref, 'refs/tags/')
     permissions:
       id-token: write
 

--- a/.github/workflows/wrapper-python.yml
+++ b/.github/workflows/wrapper-python.yml
@@ -150,6 +150,20 @@ jobs:
           path: dist
           merge-multiple: true
 
+      - name: Verify Version Matches Release Tag
+        env:
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          want="${RELEASE_TAG#v}"
+          got=$(ls dist/*.tar.gz | head -1 | sed 's|.*/zxc-\(.*\)\.tar\.gz|\1|')
+          if [ "$got" != "$want" ]; then
+            echo "::error::Version mismatch: release tag is $want but the sdist is $got"
+            ls dist/
+            exit 1
+          fi
+          echo "sdist version $got matches $RELEASE_TAG"
+
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:

--- a/.github/workflows/wrapper-rust.yml
+++ b/.github/workflows/wrapper-rust.yml
@@ -2,8 +2,6 @@ name: Wrapper Rust
 
 on:
   workflow_dispatch:
-  release:
-    types: [ published ]
 
 permissions:
   contents: read
@@ -60,7 +58,7 @@ jobs:
     name: Publish to crates.io
     needs: [test]
     runs-on: ubuntu-slim
-    if: github.event_name == 'release'
+    if: startsWith(github.ref, 'refs/tags/')
     defaults:
       run:
         working-directory: ./wrappers/rust
@@ -77,7 +75,7 @@ jobs:
 
       - name: Verify Version Matches Release Tag
         env:
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_TAG: ${{ github.ref_name }}
         run: |
           # Remove 'v' prefix if present
           RELEASE_VERSION="${RELEASE_TAG#v}"

--- a/.github/workflows/wrapper-wasm.yml
+++ b/.github/workflows/wrapper-wasm.yml
@@ -7,8 +7,6 @@ name: Wrapper WASM
 
 on:
   workflow_dispatch:
-  release:
-    types: [ published ]
   push:
     branches: [ main ]
     paths:
@@ -76,7 +74,7 @@ jobs:
   publish:
     name: Publish to npm
     needs: wasm-build
-    if: github.event_name == 'release'
+    if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -109,7 +107,7 @@ jobs:
       - name: Verify Version Matches Release Tag
         working-directory: ./wrappers/wasm
         env:
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_TAG: ${{ github.ref_name }}
         run: |
           # Remove 'v' prefix if present
           RELEASE_VERSION="${RELEASE_TAG#v}"

--- a/README.md
+++ b/README.md
@@ -255,8 +255,9 @@ ZXC is packaged across major ecosystems and kept current by their maintainers:
 
 3.  Verify, then extract:
     ```bash
-    # Integrity of what you downloaded
-    sha256sum -c sha256sums --ignore-missing      # macOS: shasum -a 256 -c
+    # Integrity: the manifest is signed, so verify it before trusting it
+    minisign -Vm sha256sums -P 'RWQV0cpiyJYPkxF5iIysJzKNtzcGphqeyyFkiFErLMo5UZkWisGBxkNB'
+    sha256sum -c sha256sums --ignore-missing      # macOS: grep <file> sha256sums | shasum -a 256 -c
 
     # Authenticity: this workflow, from the commit the release points at
     gh attestation verify zxc-<version>-linux-x86_64.tar.gz --repo hellobertrand/zxc
@@ -267,8 +268,7 @@ ZXC is packaged across major ecosystems and kept current by their maintainers:
     ```
 
     Release tags are PGP-signed: `curl -sS https://github.com/hellobertrand.gpg | gpg --import`
-    then `git verify-tag v<version>`. See
-    [SECURITY.md](.github/SECURITY.md#verifying-a-release) for every verification path.
+    then `git verify-tag v<version>`.
 
     Each archive contains a versioned top-level directory with:
     ```

--- a/README.md
+++ b/README.md
@@ -247,15 +247,28 @@ ZXC is packaged across major ecosystems and kept current by their maintainers:
     *   `zxc-<version>-windows-x86_64.zip` (Runtime dispatch for AVX2/AVX512).
     *   `zxc-<version>-windows-arm64.zip` (NEON optimizations included).
 
-3.  Verify, then extract. Every archive is signed via SLSA build provenance; the SHA-256 of each asset is also shown directly on the GitHub release page:
+    **Source:**
+    *   `zxc-<version>.tar.gz` — canonical source, reproducible with
+        `git archive --format=tar --prefix=zxc-<version>/ v<version> | gzip -n -9`.
+    *   `zxc-<version>.tar.zxc` — the same tar compressed with `zxc -7`. Readable only by a
+        `zxc` whose format version matches, so keep the `.tar.gz` for archival.
+
+3.  Verify, then extract:
     ```bash
-    # Authenticity + integrity in one shot (SLSA — recommended)
+    # Integrity of what you downloaded
+    sha256sum -c sha256sums --ignore-missing      # macOS: shasum -a 256 -c
+
+    # Authenticity: this workflow, from the commit the release points at
     gh attestation verify zxc-<version>-linux-x86_64.tar.gz --repo hellobertrand/zxc
 
     # Extract
     tar -xzf zxc-<version>-linux-x86_64.tar.gz
     sudo cp -r zxc-<version>-linux-x86_64/* /usr/local/
     ```
+
+    Release tags are PGP-signed: `curl -sS https://github.com/hellobertrand.gpg | gpg --import`
+    then `git verify-tag v<version>`. See
+    [SECURITY.md](.github/SECURITY.md#verifying-a-release) for every verification path.
 
     Each archive contains a versioned top-level directory with:
     ```


### PR DESCRIPTION
Add canonical source tarballs (.tar.gz and .tar.zxc) to releases.
Add sha256sum file and sign it with minisign. 
Update SECURITY.md and README.md with instructions for verifying release integrity and authenticity.

Refine GitHub Actions workflows to centralize asset uploading, generate SLSA provenance, and orchestrate wrapper publishing. 

