### PR TITLE
build(release): Pin the glibc floor at 2.34, make libzxc.pc relocatable

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -115,17 +115,18 @@ jobs:
           fi
           echo "ARCHIVE=$ARCHIVE" >> "$GITHUB_ENV"
 
-          # Install to staging directory using CMake (Standard way for all OS)
-          cmake --install build --prefix "release_staging/${ARCHIVE_BASE}" --config Release
+          STAGE="release_staging/${ARCHIVE_BASE}"
 
-          # Strip binary on Unix-like systems only (installed to bin/)
+          cmake --install build --prefix "$STAGE" --config Release
+
           if [[ "${{ runner.os }}" != "Windows" ]]; then
-            strip "release_staging/${ARCHIVE_BASE}/bin/${{ matrix.artifact_name }}"
+            strip "$STAGE/bin/${{ matrix.artifact_name }}"
           fi
 
-          cp LICENSE "release_staging/${ARCHIVE_BASE}/LICENSE.txt"
-          cp docs/man/zxc.1.md "release_staging/${ARCHIVE_BASE}/MANUAL.md"
-          cat > "release_staging/${ARCHIVE_BASE}/README.md" <<EOF
+          cp LICENSE "$STAGE/LICENSE.txt"
+          cp docs/man/zxc.1.md "$STAGE/MANUAL.md"
+
+          cat > "$STAGE/README.md" <<EOF
           # ZXC ${VERSION}
 
           Asymmetric Lossless Compression Built for Ultra-Fast Decode

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -140,3 +140,25 @@ jobs:
             cc tests/packaging/consumer.c $flags -o "consumer_$LIB_TYPE"
             LD_LIBRARY_PATH="$libdir" "./consumer_$LIB_TYPE"
           done
+
+      # Release archives are staged with --prefix, then extracted elsewhere: a .pc
+      # that baked its prefix at configure time would point at the runner.
+      - name: Consume via pkg-config after relocation
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          set -euo pipefail
+          cmake --install build_shared --config Release --prefix "$PWD/staged"
+          mv staged relocated
+
+          pc=$(find relocated -name libzxc.pc | head -1)
+          test -n "$pc" || { echo "::error::no libzxc.pc in the staged prefix"; exit 1; }
+
+          PKG_CONFIG_PATH="$PWD/$(dirname "$pc")"
+          export PKG_CONFIG_PATH
+          flags=$(pkg-config --cflags --libs libzxc)
+          echo "pkg-config (relocated): $flags"
+
+          # shellcheck disable=SC2086
+          cc tests/packaging/consumer.c $flags -o consumer_relocated
+          LD_LIBRARY_PATH="$PWD/$(dirname "$(dirname "$pc")")" ./consumer_relocated

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,10 +141,6 @@ else()
     target_compile_definitions(zxc_lib PRIVATE _CRT_SECURE_NO_WARNINGS)
 endif()
 
-target_compile_definitions(zxc_lib PRIVATE
-    $<$<NOT:$<C_COMPILER_ID:MSVC>>:_GNU_SOURCE>
-)
-
 # Coverage flags
 if(ZXC_ENABLE_COVERAGE)
     if(CMAKE_C_COMPILER_ID MATCHES "GNU|Clang")

--- a/cmake/zxcCli.cmake
+++ b/cmake/zxcCli.cmake
@@ -24,9 +24,7 @@ if(ZXC_BUILD_CLI)
     target_compile_options(zxc PRIVATE
         $<$<AND:$<NOT:$<C_COMPILER_ID:MSVC>>,$<BOOL:${ZXC_NATIVE_ARCH}>>:-march=native>)
     target_compile_definitions(zxc PRIVATE
-        $<$<C_COMPILER_ID:MSVC>:_CRT_SECURE_NO_WARNINGS>
-        $<$<NOT:$<C_COMPILER_ID:MSVC>>:_GNU_SOURCE>
-    )
+        $<$<C_COMPILER_ID:MSVC>:_CRT_SECURE_NO_WARNINGS>)
 
     # Coverage flags for CLI
     if(ZXC_ENABLE_COVERAGE)

--- a/cmake/zxcCompilerFlags.cmake
+++ b/cmake/zxcCompilerFlags.cmake
@@ -12,11 +12,17 @@ set(CMAKE_C_STANDARD 17)
 set(CMAKE_C_STANDARD_REQUIRED ON)
 set(CMAKE_C_EXTENSIONS OFF)
 
-# Enable _GNU_SOURCE for ftello/fseeko on Linux
-# Enable 64-bit off_t on 32-bit Linux to prevent fseeko/ftello/pread truncation
-if(UNIX AND NOT APPLE)
+# The code needs POSIX.1-2008 plus realpath, which musl gates behind
+# _XOPEN_SOURCE. Linux stops short of _GNU_SOURCE: it makes glibc >= 2.38
+# redirect strtol/strtoll to __isoc23_*, raising the ABI floor from 2.34 to
+# 2.38. The BSDs keep it: _POSIX_C_SOURCE would clear __BSD_VISIBLE.
+# _FILE_OFFSET_BITS=64 keeps off_t 64-bit on 32-bit Linux.
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    add_compile_definitions(_POSIX_C_SOURCE=200809L _XOPEN_SOURCE=700
+                            _FILE_OFFSET_BITS=64 _LARGEFILE_SOURCE)
+elseif(UNIX AND NOT APPLE)
     add_compile_definitions(_GNU_SOURCE _FILE_OFFSET_BITS=64 _LARGEFILE_SOURCE)
-elseif(APPLE)
+elseif(NOT MSVC)
     add_compile_definitions(_GNU_SOURCE)
 endif()
 

--- a/cmake/zxcInstall.cmake
+++ b/cmake/zxcInstall.cmake
@@ -22,6 +22,19 @@ if(ZXC_INSTALL)
         set(ZXC_PC_LIBS_PRIVATE "")
     endif()
 
+    # ${pcfiledir} keeps the file relocatable: `cmake --install --prefix` does not
+    # rewrite an already-configured file, and archives get extracted anywhere. The
+    # depth follows CMAKE_INSTALL_LIBDIR (lib, lib64, lib/<multiarch>).
+    set(ZXC_PKGCONFIG_DIR "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
+    if(IS_ABSOLUTE "${ZXC_PKGCONFIG_DIR}")
+        set(ZXC_PKGCONFIG_PREFIX "${CMAKE_INSTALL_PREFIX}")
+    else()
+        file(RELATIVE_PATH ZXC_PKGCONFIG_PREFIX
+             "${CMAKE_INSTALL_PREFIX}/${ZXC_PKGCONFIG_DIR}" "${CMAKE_INSTALL_PREFIX}")
+        string(REGEX REPLACE "/+$" "" ZXC_PKGCONFIG_PREFIX "${ZXC_PKGCONFIG_PREFIX}")
+        set(ZXC_PKGCONFIG_PREFIX "\${pcfiledir}/${ZXC_PKGCONFIG_PREFIX}")
+    endif()
+
     configure_file(
         ${CMAKE_CURRENT_SOURCE_DIR}/libzxc.pc.in
         ${CMAKE_CURRENT_BINARY_DIR}/libzxc.pc
@@ -64,7 +77,7 @@ if(ZXC_INSTALL)
     endif()
 
     install(FILES ${CMAKE_CURRENT_BINARY_DIR}/libzxc.pc
-        DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
+        DESTINATION ${ZXC_PKGCONFIG_DIR}
     )
 
     # CMake package config files for find_package(zxc)

--- a/libzxc.pc.in
+++ b/libzxc.pc.in
@@ -1,4 +1,4 @@
-prefix=@CMAKE_INSTALL_PREFIX@
+prefix=@ZXC_PKGCONFIG_PREFIX@
 exec_prefix=${prefix}
 libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
 includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@

--- a/meson.build
+++ b/meson.build
@@ -46,7 +46,8 @@ endif
 # =============================================================================
 
 if host_machine.system() == 'linux'
-  add_project_arguments('-D_GNU_SOURCE', '-D_FILE_OFFSET_BITS=64',
+  add_project_arguments('-D_POSIX_C_SOURCE=200809L', '-D_XOPEN_SOURCE=700',
+                        '-D_FILE_OFFSET_BITS=64',
                         '-D_LARGEFILE_SOURCE', language : 'c')
 elif host_machine.system() == 'darwin'
   add_project_arguments('-D_GNU_SOURCE', language : 'c')


### PR DESCRIPTION
Explicitly request POSIX.1-2008 and _XOPEN_SOURCE, bringing the glibc floor back down to 2.34 on x86_64 and arm64 across both CMake and Meson builds.

libzxc.pc previously baked a hardcoded /usr/local prefix at configure time, breaking users extracting pre-built archives into custom locations. Fix hardcoded path.