### PR TITLE
build(release): Pin the glibc floor at 2.34, make libzxc.pc relocatable

### DIFF
--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -14,6 +14,7 @@ for fuzzer in $FUZZERS; do
     $CC $CFLAGS -I include \
         -I src/lib/vendors \
         -DZXC_FUNCTION_SUFFIX=_default -DZXC_ONLY_DEFAULT \
+        -D_POSIX_C_SOURCE=200809L -D_XOPEN_SOURCE=700 -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE \
         $LIB_SOURCES \
         tests/fuzz_${fuzzer}.c \
         -o $OUT/zxc_fuzzer_${fuzzer} \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -115,17 +115,18 @@ jobs:
           fi
           echo "ARCHIVE=$ARCHIVE" >> "$GITHUB_ENV"
 
-          # Install to staging directory using CMake (Standard way for all OS)
-          cmake --install build --prefix "release_staging/${ARCHIVE_BASE}" --config Release
+          STAGE="release_staging/${ARCHIVE_BASE}"
 
-          # Strip binary on Unix-like systems only (installed to bin/)
+          cmake --install build --prefix "$STAGE" --config Release
+
           if [[ "${{ runner.os }}" != "Windows" ]]; then
-            strip "release_staging/${ARCHIVE_BASE}/bin/${{ matrix.artifact_name }}"
+            strip "$STAGE/bin/${{ matrix.artifact_name }}"
           fi
 
-          cp LICENSE "release_staging/${ARCHIVE_BASE}/LICENSE.txt"
-          cp docs/man/zxc.1.md "release_staging/${ARCHIVE_BASE}/MANUAL.md"
-          cat > "release_staging/${ARCHIVE_BASE}/README.md" <<EOF
+          cp LICENSE "$STAGE/LICENSE.txt"
+          cp docs/man/zxc.1.md "$STAGE/MANUAL.md"
+
+          cat > "$STAGE/README.md" <<EOF
           # ZXC ${VERSION}
 
           Asymmetric Lossless Compression Built for Ultra-Fast Decode

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -119,10 +119,6 @@ jobs:
 
           cmake --install build --prefix "$STAGE" --config Release
 
-          if [[ "${{ runner.os }}" != "Windows" ]]; then
-            strip "$STAGE/bin/${{ matrix.artifact_name }}"
-          fi
-
           cp LICENSE "$STAGE/LICENSE.txt"
           cp docs/man/zxc.1.md "$STAGE/MANUAL.md"
 

--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -126,7 +126,7 @@ jobs:
         run: |
           mkdir -p build-cov
           CFLAGS="-g -O1 -fprofile-instr-generate -fcoverage-mapping"
-          DEFS="-DZXC_FUNCTION_SUFFIX=_default -DZXC_ONLY_DEFAULT"
+          DEFS="-DZXC_FUNCTION_SUFFIX=_default -DZXC_ONLY_DEFAULT -D_POSIX_C_SOURCE=200809L -D_XOPEN_SOURCE=700 -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE"
           INCLUDES="-I include -I src/lib/vendors"
           SOURCES="src/lib/zxc_common.c src/lib/zxc_compress.c src/lib/zxc_decompress.c src/lib/zxc_dict.c src/lib/zxc_driver.c src/lib/zxc_dispatch.c src/lib/zxc_huffman.c src/lib/zxc_pivco_tables.c src/lib/zxc_seekable.c src/lib/zxc_pstream.c"
 

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -140,3 +140,25 @@ jobs:
             cc tests/packaging/consumer.c $flags -o "consumer_$LIB_TYPE"
             LD_LIBRARY_PATH="$libdir" "./consumer_$LIB_TYPE"
           done
+
+      # Release archives are staged with --prefix, then extracted elsewhere: a .pc
+      # that baked its prefix at configure time would point at the runner.
+      - name: Consume via pkg-config after relocation
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          set -euo pipefail
+          cmake --install build_shared --config Release --prefix "$PWD/staged"
+          mv staged relocated
+
+          pc=$(find relocated -name libzxc.pc | head -1)
+          test -n "$pc" || { echo "::error::no libzxc.pc in the staged prefix"; exit 1; }
+
+          PKG_CONFIG_PATH="$PWD/$(dirname "$pc")"
+          export PKG_CONFIG_PATH
+          flags=$(pkg-config --cflags --libs libzxc)
+          echo "pkg-config (relocated): $flags"
+
+          # shellcheck disable=SC2086
+          cc tests/packaging/consumer.c $flags -o consumer_relocated
+          LD_LIBRARY_PATH="$PWD/$(dirname "$(dirname "$pc")")" ./consumer_relocated

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -4,8 +4,9 @@ name: Packaging (Consumer Integration)
 # that let the Windows static packaging break ship (libzxc.pc did not propagate
 # ZXC_STATIC_DEFINE, so consumers got unresolved __imp_zxc_*).
 #
-# Three consumption paths, static and shared: find_package(zxc), pkg-config,
-# and direct integration (-I + raw library, no defines at all).
+# Four consumption paths, static and shared: find_package(zxc), pkg-config,
+# direct integration (-I + raw library, no defines at all), and pkg-config from
+# a relocated install prefix.
 
 on:
   workflow_dispatch:
@@ -148,17 +149,31 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          cmake --install build_shared --config Release --prefix "$PWD/staged"
-          mv staged relocated
+          for LIB_TYPE in static shared; do
+            rm -rf staged relocated
+            cmake --install "build_$LIB_TYPE" --config Release --prefix "$PWD/staged"
+            mv staged relocated
 
-          pc=$(find relocated -name libzxc.pc | head -1)
-          test -n "$pc" || { echo "::error::no libzxc.pc in the staged prefix"; exit 1; }
+            pc=$(find relocated -name libzxc.pc | head -1)
+            test -n "$pc" || { echo "::error::no libzxc.pc in the staged $LIB_TYPE prefix"; exit 1; }
+            PKG_CONFIG_PATH="$PWD/$(dirname "$pc")"
+            export PKG_CONFIG_PATH
 
-          PKG_CONFIG_PATH="$PWD/$(dirname "$pc")"
-          export PKG_CONFIG_PATH
-          flags=$(pkg-config --cflags --libs libzxc)
-          echo "pkg-config (relocated): $flags"
+            # Ask the file under test rather than re-deriving from its path.
+            prefix=$(pkg-config --variable=prefix libzxc)
+            case "$prefix/" in
+              "$PWD/relocated/"*) ;;
+              *) echo "::error::$LIB_TYPE libzxc.pc resolves to $prefix, outside the relocated tree"
+                 cat "$pc"; exit 1 ;;
+            esac
 
-          # shellcheck disable=SC2086
-          cc tests/packaging/consumer.c $flags -o consumer_relocated
-          LD_LIBRARY_PATH="$PWD/$(dirname "$(dirname "$pc")")" ./consumer_relocated
+            STATIC_ARG=""
+            if [ "$LIB_TYPE" = static ]; then STATIC_ARG="--static"; fi
+            flags=$(pkg-config $STATIC_ARG --cflags --libs libzxc)
+            echo "pkg-config ($LIB_TYPE, relocated): $flags"
+
+            # shellcheck disable=SC2086
+            cc tests/packaging/consumer.c $flags -o "consumer_relocated_$LIB_TYPE"
+            LD_LIBRARY_PATH="$(pkg-config --variable=libdir libzxc)" \
+              "./consumer_relocated_$LIB_TYPE"
+          done

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,10 +141,6 @@ else()
     target_compile_definitions(zxc_lib PRIVATE _CRT_SECURE_NO_WARNINGS)
 endif()
 
-target_compile_definitions(zxc_lib PRIVATE
-    $<$<NOT:$<C_COMPILER_ID:MSVC>>:_GNU_SOURCE>
-)
-
 # Coverage flags
 if(ZXC_ENABLE_COVERAGE)
     if(CMAKE_C_COMPILER_ID MATCHES "GNU|Clang")

--- a/cmake/zxcCli.cmake
+++ b/cmake/zxcCli.cmake
@@ -24,9 +24,7 @@ if(ZXC_BUILD_CLI)
     target_compile_options(zxc PRIVATE
         $<$<AND:$<NOT:$<C_COMPILER_ID:MSVC>>,$<BOOL:${ZXC_NATIVE_ARCH}>>:-march=native>)
     target_compile_definitions(zxc PRIVATE
-        $<$<C_COMPILER_ID:MSVC>:_CRT_SECURE_NO_WARNINGS>
-        $<$<NOT:$<C_COMPILER_ID:MSVC>>:_GNU_SOURCE>
-    )
+        $<$<C_COMPILER_ID:MSVC>:_CRT_SECURE_NO_WARNINGS>)
 
     # Coverage flags for CLI
     if(ZXC_ENABLE_COVERAGE)

--- a/cmake/zxcCli.cmake
+++ b/cmake/zxcCli.cmake
@@ -22,9 +22,9 @@ if(ZXC_BUILD_CLI)
 
     zxc_apply_common_flags(zxc)
     target_compile_options(zxc PRIVATE
-        $<$<AND:$<NOT:$<C_COMPILER_ID:MSVC>>,$<BOOL:${ZXC_NATIVE_ARCH}>>:-march=native>)
+        $<$<AND:$<NOT:$<BOOL:${MSVC}>>,$<BOOL:${ZXC_NATIVE_ARCH}>>:-march=native>)
     target_compile_definitions(zxc PRIVATE
-        $<$<C_COMPILER_ID:MSVC>:_CRT_SECURE_NO_WARNINGS>)
+        $<$<BOOL:${MSVC}>:_CRT_SECURE_NO_WARNINGS>)
 
     # Coverage flags for CLI
     if(ZXC_ENABLE_COVERAGE)

--- a/cmake/zxcCompilerFlags.cmake
+++ b/cmake/zxcCompilerFlags.cmake
@@ -12,11 +12,17 @@ set(CMAKE_C_STANDARD 17)
 set(CMAKE_C_STANDARD_REQUIRED ON)
 set(CMAKE_C_EXTENSIONS OFF)
 
-# Enable _GNU_SOURCE for ftello/fseeko on Linux
-# Enable 64-bit off_t on 32-bit Linux to prevent fseeko/ftello/pread truncation
-if(UNIX AND NOT APPLE)
+# The code needs POSIX.1-2008 plus realpath, which musl gates behind
+# _XOPEN_SOURCE. Linux stops short of _GNU_SOURCE: it makes glibc >= 2.38
+# redirect strtol/strtoll to __isoc23_*, raising the ABI floor from 2.34 to
+# 2.38. The BSDs keep it: _POSIX_C_SOURCE would clear __BSD_VISIBLE.
+# _FILE_OFFSET_BITS=64 keeps off_t 64-bit on 32-bit Linux.
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    add_compile_definitions(_POSIX_C_SOURCE=200809L _XOPEN_SOURCE=700
+                            _FILE_OFFSET_BITS=64 _LARGEFILE_SOURCE)
+elseif(UNIX AND NOT APPLE)
     add_compile_definitions(_GNU_SOURCE _FILE_OFFSET_BITS=64 _LARGEFILE_SOURCE)
-elseif(APPLE)
+elseif(NOT MSVC)
     add_compile_definitions(_GNU_SOURCE)
 endif()
 

--- a/cmake/zxcInstall.cmake
+++ b/cmake/zxcInstall.cmake
@@ -22,9 +22,6 @@ if(ZXC_INSTALL)
         set(ZXC_PC_LIBS_PRIVATE "")
     endif()
 
-    # ${pcfiledir} keeps the file relocatable: `cmake --install --prefix` does not
-    # rewrite an already-configured file, and archives get extracted anywhere. The
-    # depth follows CMAKE_INSTALL_LIBDIR (lib, lib64, lib/<multiarch>).
     set(ZXC_PKGCONFIG_DIR "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
     if(IS_ABSOLUTE "${ZXC_PKGCONFIG_DIR}")
         set(ZXC_PKGCONFIG_PREFIX "${CMAKE_INSTALL_PREFIX}")
@@ -34,6 +31,14 @@ if(ZXC_INSTALL)
         string(REGEX REPLACE "/+$" "" ZXC_PKGCONFIG_PREFIX "${ZXC_PKGCONFIG_PREFIX}")
         set(ZXC_PKGCONFIG_PREFIX "\${pcfiledir}/${ZXC_PKGCONFIG_PREFIX}")
     endif()
+
+    foreach(d LIBDIR INCLUDEDIR)
+        if(IS_ABSOLUTE "${CMAKE_INSTALL_${d}}")
+            set(ZXC_PKGCONFIG_${d} "${CMAKE_INSTALL_${d}}")
+        else()
+            set(ZXC_PKGCONFIG_${d} "\${prefix}/${CMAKE_INSTALL_${d}}")
+        endif()
+    endforeach()
 
     configure_file(
         ${CMAKE_CURRENT_SOURCE_DIR}/libzxc.pc.in
@@ -60,9 +65,6 @@ if(ZXC_INSTALL)
         )
         # "unzxc" alias: a symlink to zxc that defaults to decompression.
         # Symbolic links are POSIX-only; skipped on Windows.
-        # \${CMAKE_INSTALL_PREFIX} is escaped so it expands at install time:
-        # CMAKE_INSTALL_FULL_BINDIR bakes the configure-time prefix and would
-        # ignore `cmake --install --prefix`.
         if(NOT WIN32)
             if(IS_ABSOLUTE "${CMAKE_INSTALL_BINDIR}")
                 set(ZXC_SYMLINK_BINDIR "${CMAKE_INSTALL_BINDIR}")

--- a/cmake/zxcInstall.cmake
+++ b/cmake/zxcInstall.cmake
@@ -22,6 +22,19 @@ if(ZXC_INSTALL)
         set(ZXC_PC_LIBS_PRIVATE "")
     endif()
 
+    # ${pcfiledir} keeps the file relocatable: `cmake --install --prefix` does not
+    # rewrite an already-configured file, and archives get extracted anywhere. The
+    # depth follows CMAKE_INSTALL_LIBDIR (lib, lib64, lib/<multiarch>).
+    set(ZXC_PKGCONFIG_DIR "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
+    if(IS_ABSOLUTE "${ZXC_PKGCONFIG_DIR}")
+        set(ZXC_PKGCONFIG_PREFIX "${CMAKE_INSTALL_PREFIX}")
+    else()
+        file(RELATIVE_PATH ZXC_PKGCONFIG_PREFIX
+             "${CMAKE_INSTALL_PREFIX}/${ZXC_PKGCONFIG_DIR}" "${CMAKE_INSTALL_PREFIX}")
+        string(REGEX REPLACE "/+$" "" ZXC_PKGCONFIG_PREFIX "${ZXC_PKGCONFIG_PREFIX}")
+        set(ZXC_PKGCONFIG_PREFIX "\${pcfiledir}/${ZXC_PKGCONFIG_PREFIX}")
+    endif()
+
     configure_file(
         ${CMAKE_CURRENT_SOURCE_DIR}/libzxc.pc.in
         ${CMAKE_CURRENT_BINARY_DIR}/libzxc.pc
@@ -64,7 +77,7 @@ if(ZXC_INSTALL)
     endif()
 
     install(FILES ${CMAKE_CURRENT_BINARY_DIR}/libzxc.pc
-        DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
+        DESTINATION ${ZXC_PKGCONFIG_DIR}
     )
 
     # CMake package config files for find_package(zxc)

--- a/cmake/zxcTests.cmake
+++ b/cmake/zxcTests.cmake
@@ -76,10 +76,10 @@ if(ZXC_BUILD_TESTS)
 
     zxc_apply_common_flags(zxc_test)
     target_compile_options(zxc_test PRIVATE
-        $<$<AND:$<NOT:$<C_COMPILER_ID:MSVC>>,$<BOOL:${ZXC_NATIVE_ARCH}>>:-march=native>)
+        $<$<AND:$<NOT:$<BOOL:${MSVC}>>,$<BOOL:${ZXC_NATIVE_ARCH}>>:-march=native>)
     # Propagate definitions
     target_compile_definitions(zxc_test PRIVATE
-        $<$<C_COMPILER_ID:MSVC>:_CRT_SECURE_NO_WARNINGS>)
+        $<$<BOOL:${MSVC}>:_CRT_SECURE_NO_WARNINGS>)
 
     # Coverage flags for Tests
     if(ZXC_ENABLE_COVERAGE)
@@ -106,7 +106,7 @@ if(ZXC_BUILD_TESTS)
     target_link_libraries(zxc_conformance_test PRIVATE zxc_lib)
     target_include_directories(zxc_conformance_test PRIVATE ${CMAKE_SOURCE_DIR}/include)
     target_compile_definitions(zxc_conformance_test PRIVATE
-        $<$<C_COMPILER_ID:MSVC>:_CRT_SECURE_NO_WARNINGS>)
+        $<$<BOOL:${MSVC}>:_CRT_SECURE_NO_WARNINGS>)
     if(ZXC_ENABLE_COVERAGE)
         target_link_options(zxc_conformance_test PRIVATE --coverage)
     endif()
@@ -127,7 +127,7 @@ if(ZXC_BUILD_TESTS)
         ${CMAKE_SOURCE_DIR}/src/lib
         ${RAPIDHASH_INCLUDE_DIR})
     target_compile_definitions(zxc_format_golden_test PRIVATE
-        $<$<C_COMPILER_ID:MSVC>:_CRT_SECURE_NO_WARNINGS>)
+        $<$<BOOL:${MSVC}>:_CRT_SECURE_NO_WARNINGS>)
     if(ZXC_ENABLE_COVERAGE)
         target_link_options(zxc_format_golden_test PRIVATE --coverage)
     endif()
@@ -141,7 +141,7 @@ if(ZXC_BUILD_TESTS)
     target_link_libraries(zxc_golden_gen PRIVATE zxc_lib)
     target_include_directories(zxc_golden_gen PRIVATE ${CMAKE_SOURCE_DIR}/include)
     target_compile_definitions(zxc_golden_gen PRIVATE
-        $<$<C_COMPILER_ID:MSVC>:_CRT_SECURE_NO_WARNINGS>)
+        $<$<BOOL:${MSVC}>:_CRT_SECURE_NO_WARNINGS>)
     if(ZXC_ENABLE_COVERAGE)
         # Links the coverage-instrumented zxc_lib, so it needs the gcov runtime.
         target_link_options(zxc_golden_gen PRIVATE --coverage)
@@ -156,7 +156,7 @@ if(ZXC_BUILD_TESTS)
         ${CMAKE_SOURCE_DIR}/src/lib
         ${RAPIDHASH_INCLUDE_DIR})
     target_compile_definitions(zxc_invalid_gen PRIVATE
-        $<$<C_COMPILER_ID:MSVC>:_CRT_SECURE_NO_WARNINGS>)
+        $<$<BOOL:${MSVC}>:_CRT_SECURE_NO_WARNINGS>)
     if(ZXC_ENABLE_COVERAGE)
         target_link_options(zxc_invalid_gen PRIVATE --coverage)
     endif()

--- a/libzxc.pc.in
+++ b/libzxc.pc.in
@@ -1,7 +1,7 @@
 prefix=@ZXC_PKGCONFIG_PREFIX@
 exec_prefix=${prefix}
-libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
-includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+libdir=@ZXC_PKGCONFIG_LIBDIR@
+includedir=@ZXC_PKGCONFIG_INCLUDEDIR@
 
 Name: libzxc
 Description: High-performance asymmetric lossless compression

--- a/libzxc.pc.in
+++ b/libzxc.pc.in
@@ -1,4 +1,4 @@
-prefix=@CMAKE_INSTALL_PREFIX@
+prefix=@ZXC_PKGCONFIG_PREFIX@
 exec_prefix=${prefix}
 libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
 includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@

--- a/meson.build
+++ b/meson.build
@@ -6,7 +6,8 @@
 project('zxc', 'c',
   version : '0.13.3',
   license : 'BSD-3-Clause',
-  default_options : ['c_std=c17', 'buildtype=release', 'warning_level=2'],
+  default_options : ['c_std=c17', 'buildtype=release', 'warning_level=2',
+                     'pkgconfig.relocatable=true'],
   meson_version : '>= 0.63.0',
 )
 

--- a/meson.build
+++ b/meson.build
@@ -46,7 +46,8 @@ endif
 # =============================================================================
 
 if host_machine.system() == 'linux'
-  add_project_arguments('-D_GNU_SOURCE', '-D_FILE_OFFSET_BITS=64',
+  add_project_arguments('-D_POSIX_C_SOURCE=200809L', '-D_XOPEN_SOURCE=700',
+                        '-D_FILE_OFFSET_BITS=64',
                         '-D_LARGEFILE_SOURCE', language : 'c')
 elif host_machine.system() == 'darwin'
   add_project_arguments('-D_GNU_SOURCE', language : 'c')

--- a/wrappers/rust/zxc-sys/build.rs
+++ b/wrappers/rust/zxc-sys/build.rs
@@ -104,6 +104,33 @@ fn extract_compression_levels(include_dir: &Path) -> (i32, i32, i32, i32, i32, i
     )
 }
 
+/// Feature-test macros, mirroring `cmake/zxcCompilerFlags.cmake`. Without them
+/// the sources see ISO C alone: on 32-bit Linux targets `off_t` stays 32-bit and
+// in zxc_driver.c truncate past 2 GB.
+fn apply_feature_macros(build: &mut cc::Build) {
+    let target = env::var("TARGET").unwrap_or_default();
+    if target.contains("msvc") {
+        // The MSVC CRT needs none of these; _fseeki64 is already 64-bit.
+    } else if target.contains("android") {
+        // Bionic exposes these regardless, and _FILE_OFFSET_BITS=64 is only
+        // partially honoured below API 24.
+    } else if target.contains("linux") {
+        build
+            .define("_POSIX_C_SOURCE", "200809L")
+            .define("_XOPEN_SOURCE", "700")
+            .define("_FILE_OFFSET_BITS", "64")
+            .define("_LARGEFILE_SOURCE", None);
+    } else if target.contains("apple") || target.contains("windows") {
+        build.define("_GNU_SOURCE", None);
+    } else {
+        // The BSDs keep _GNU_SOURCE: _POSIX_C_SOURCE would clear __BSD_VISIBLE.
+        build
+            .define("_GNU_SOURCE", None)
+            .define("_FILE_OFFSET_BITS", "64")
+            .define("_LARGEFILE_SOURCE", None);
+    }
+}
+
 /// Compiles one FMV variant of the three per-ISA translation units
 /// (zxc_compress.c, zxc_decompress.c, zxc_huffman.c) with the given function
 /// suffix and ISA flags.
@@ -119,6 +146,7 @@ fn compile_variant(include_dir: &Path, src_lib: &Path, suffix: &str, flags: &[&s
             .define("ZXC_FUNCTION_SUFFIX", suffix)
             .opt_level(3)
             .warnings(false);
+        apply_feature_macros(&mut build);
         for flag in flags {
             build.flag_if_supported(flag);
         }
@@ -212,6 +240,7 @@ fn main() {
         .opt_level(3)
         .warnings(false)
         .flag_if_supported("-pthread");
+    apply_feature_macros(&mut core_build);
 
     core_build.compile("zxc_core");
 
@@ -282,6 +311,7 @@ fn main() {
         .file(src_lib.join("zxc_pivco_tables.c"))
         .opt_level(3)
         .warnings(false);
+    apply_feature_macros(&mut pivco_tables);
     pivco_tables.compile("zxc_pivco_tables");
 
     // Threading support (not needed on Windows, which uses kernel32)


### PR DESCRIPTION
Explicitly request POSIX.1-2008 and _XOPEN_SOURCE, bringing the glibc floor back down to 2.34 on x86_64 and arm64 across both CMake and Meson builds.

libzxc.pc previously baked a hardcoded /usr/local prefix at configure time, breaking users extracting pre-built archives into custom locations. Fix hardcoded path.