### PR TITLE
ci(workflows): Enforce 10-minute timeout for CI jobs

### DIFF
--- a/.github/workflows/multiarch.yml
+++ b/.github/workflows/multiarch.yml
@@ -21,6 +21,7 @@ jobs:
   build-tier1:
     name: "Tier 1: ${{ matrix.name }}"
     runs-on: ${{ matrix.runner }}
+    timeout-minutes: 10
     strategy:
       fail-fast: false
       matrix:
@@ -157,6 +158,7 @@ jobs:
   build-tier2:
     name: "Tier 2: ${{ matrix.name }}"
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     container: debian:trixie
     strategy:
       fail-fast: false
@@ -296,6 +298,7 @@ jobs:
   build-tier2-amd64-sde:
     name: "Tier 2: Linux amd64 (${{ matrix.tier }})"
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     strategy:
       fail-fast: false
       matrix:
@@ -369,6 +372,7 @@ jobs:
   build-tier3:
     name: "Tier 3: ${{ matrix.name }}"
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     container: debian:trixie
     strategy:
       fail-fast: false

--- a/.github/workflows/multicomp.yml
+++ b/.github/workflows/multicomp.yml
@@ -21,6 +21,7 @@ jobs:
   clang:
     name: "Clang ${{ matrix.version }} (${{ matrix.os }})"
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
     strategy:
       fail-fast: false
       matrix:
@@ -88,6 +89,7 @@ jobs:
   clang-macos:
     name: "Apple Clang (macOS 14)"
     runs-on: macos-14
+    timeout-minutes: 10
     strategy:
       fail-fast: false
 
@@ -126,6 +128,7 @@ jobs:
   gcc:
     name: "GCC ${{ matrix.version }} (${{ matrix.os }})"
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
     strategy:
       fail-fast: false
       matrix:
@@ -191,6 +194,7 @@ jobs:
   mingw:
     name: "MinGW ${{ matrix.name }}"
     runs-on: windows-latest
+    timeout-minutes: 10
     strategy:
       fail-fast: false
       matrix:
@@ -251,6 +255,7 @@ jobs:
   gcc-arm:
     name: "GCC ARM ${{ matrix.name }}"
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     strategy:
       fail-fast: false
       matrix:
@@ -316,6 +321,7 @@ jobs:
   meson:
     name: "Meson ${{ matrix.name }}"
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Adds a 10-minute timeout to various multi-architecture and multi-compiler jobs to prevent indefinite execution and conserve CI resources.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a 10-minute limit to multi-architecture and compiler compatibility checks.
  * Helps prevent stalled validation jobs from running indefinitely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->