### PR TITLE
docs: rename CRC to checksum in documentation and code comments

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -222,7 +222,7 @@ typedef enum {
     ZXC_ERROR_SRC_TOO_SMALL =  -3,  // input truncated
     ZXC_ERROR_BAD_MAGIC     =  -4,  // invalid magic word
     ZXC_ERROR_BAD_VERSION   =  -5,  // unsupported format version
-    ZXC_ERROR_BAD_HEADER    =  -6,  // corrupted header (CRC mismatch)
+    ZXC_ERROR_BAD_HEADER    =  -6,  // corrupted header (checksum mismatch)
     ZXC_ERROR_BAD_CHECKSUM  =  -7,  // checksum verification failed
     ZXC_ERROR_CORRUPT_DATA  =  -8,  // corrupted compressed data
     ZXC_ERROR_BAD_OFFSET    =  -9,  // invalid match offset

--- a/docs/FORMAT.md
+++ b/docs/FORMAT.md
@@ -24,7 +24,7 @@ It formalizes the current reference implementation of format version **8**.
 | Block #0             |
 |  - 8B Block Header   |
 |  - Block Payload     |
-|  - Optional 4B CRC32 |
+|  - Optional 4B Cksum |
 +----------------------+
 | Block #1             |
 |  ...                 |
@@ -48,7 +48,7 @@ Offset  Size  Field
 0x05    1     Chunk Size Code
 0x06    1     Flags
 0x07    7     Reserved (must be 0)
-0x0E    2     Header CRC16
+0x0E    2     Header Checksum
 ```
 
 ### 3.1 Field definitions
@@ -68,7 +68,7 @@ Offset  Size  Field
 - **Reserved / Dictionary ID**: 7 bytes.
   - When `HAS_DICTIONARY` is set: bytes `0x07..0x0A` contain a `dict_id` (`u32` LE), a 32-bit hash of the dictionary content. Bytes `0x0B..0x0D` remain zero.
   - When `HAS_DICTIONARY` is clear: all 7 bytes are zero.
-- **Header CRC16** (`u16`): computed with `zxc_hash16` on the 16-byte header where bytes `0x0E..0x0F` are zeroed.
+- **Header Checksum** (`u16`): computed with `zxc_hash16` on the 16-byte header where bytes `0x0E..0x0F` are zeroed.
 
 ---
 
@@ -82,7 +82,7 @@ Offset  Size  Field
 0x01    1     Block Flags
 0x02    1     Reserved
 0x03    4     Compressed Payload Size (comp_size)
-0x07    1     Header CRC8
+0x07    1     Header Checksum
 ```
 
 ### 4.1 Header semantics
@@ -96,7 +96,7 @@ Offset  Size  Field
 - **Block Flags**: currently not used by implementation (written as `0`).
 - **Reserved**: must be 0.
 - **comp_size**: payload size in bytes (does **not** include the optional trailing 4-byte block checksum).
-- **Header CRC8**: `zxc_hash8` over the 8-byte header with byte `0x07` forced to zero before hashing.
+- **Header Checksum**: `zxc_hash8` over the 8-byte header with byte `0x07` forced to zero before hashing.
 
 ### 4.2 Block physical layout
 
@@ -537,9 +537,9 @@ Offset  Size  Field
 
 ## 9. Decoder Validation Checklist (Practical)
 
-1. Validate file header magic/version/CRC16.
+1. Validate file header magic/version/checksum.
 2. Parse blocks sequentially:
-   - validate block header CRC8,
+   - validate block header checksum,
    - check block bounds using `comp_size`,
    - if enabled, verify trailing block checksum.
 3. Decode payload according to block type. For GLO/GHI:
@@ -580,13 +580,13 @@ encoding, layout, or the checksum algorithm — requires a **version bump**.
 
 - **Version compatibility**: a decoder accepts **only** the format version it implements and **MUST** reject any other version with `ZXC_ERROR_BAD_VERSION`. Because block-type numbering and payload formats may change between versions, a decoder **MUST NOT** attempt to interpret an archive whose version byte it does not recognise.
 - **Unknown block types**: a decoder **MUST reject** any block whose type is not defined for its format version (`ZXC_ERROR_BAD_BLOCK_TYPE`). The block-type set is fixed per version; introducing a new type is a version bump (decoders do **not** skip unknown blocks — silently advancing past untrusted, unrecognised data is unsafe).
-- **Reserved fields**: all reserved bytes and flag bits **MUST** be written as zero by encoders. The current decoder tolerates (ignores) non-zero reserved values — they are covered by the header CRC, so accidental corruption is still caught — but assigning a reserved field any meaning is a **version bump**, never a same-version extension.
+- **Reserved fields**: all reserved bytes and flag bits **MUST** be written as zero by encoders. The current decoder tolerates (ignores) non-zero reserved values — they are covered by the header checksum, so accidental corruption is still caught — but assigning a reserved field any meaning is a **version bump**, never a same-version extension.
 - **Defined-but-bounded fields**: where only specific values are defined (e.g. the checksum-algorithm id, currently `0` = RapidHash only), the decoder **rejects** out-of-range values (`ZXC_ERROR_BAD_HEADER`).
 
 ### 10.4 Minimum conforming decoder
 
 A minimal conforming decoder for version 8 **MUST** support:
-- File header parsing and CRC16 validation
+- File header parsing and checksum validation
 - **RAW** blocks (type 0) - passthrough copy.
 - **GLO** blocks (type 1) - full LZ decode with extras varint, including Huffman
   entropy sections (§5.2.1, PivCo layout) with code lengths up to 11 bits.
@@ -612,9 +612,9 @@ The recommended behavior for each class is specified below.
 |---|---|---|
 | **Bad magic** | File header, offset 0x00 | Reject immediately. Not a ZXC file. |
 | **Unsupported version** | File header, offset 0x04 | Reject immediately. Version not supported. |
-| **Header CRC16 mismatch** | File header, offset 0x0E | Reject. Header is corrupt or truncated. |
+| **File header checksum mismatch** | File header, offset 0x0E | Reject. Header is corrupt or truncated. |
 | **Invalid chunk size code** | File header, offset 0x05 | Reject. Code outside the valid range `[12..21]`. |
-| **Block header CRC8 mismatch** | Block header, offset 0x07 | Reject block. Stream is corrupt. |
+| **Block header checksum mismatch** | Block header, offset 0x07 | Reject block. Stream is corrupt. |
 | **Unknown block type** | Block header, offset 0x00 | Skip block using `comp_size` (see §10.3), or reject. |
 | **Block payload truncated** | During `fread` of `comp_size` bytes | Reject. Unexpected end of stream. |
 | **Block checksum mismatch** | Trailing 4-byte checksum | Reject block. Payload is corrupt. |
@@ -700,7 +700,7 @@ Offset  Size  Field
 0x06    2     Content size (u16 LE, max 65535)
 0x08    4     dict_id (u32 LE, binds content AND shared table, see below)
 0x0C    2     Reserved (0)
-0x0E    2     Header CRC16 (zxc_hash16, computed with bytes 0x0C-0x0F zeroed)
+0x0E    2     Header Checksum (zxc_hash16, computed with 0x0C-0x0F zeroed)
 0x10    N     Dictionary content (raw bytes)
 0x10+N  128   Shared literal Huffman table (256 × 4-bit packed code lengths,
               same layout as the § 5.2.1 code-length header; always present)
@@ -715,7 +715,7 @@ Offset  Size  Field
 - **dict_id**: `fold32(hash(table_128_bytes, seed = hash(content)))` —
   binds the exact (content, table) pair. Must match the `dict_id` stored in
   any ZXC file header that references this dictionary.
-- **Header CRC16**: `zxc_hash16` checksum of the 16-byte header with bytes `0x0C..0x0F` zeroed before hashing — same method as the ZXC file header.
+- **Header Checksum**: `zxc_hash16` checksum of the 16-byte header with bytes `0x0C..0x0F` zeroed before hashing — same method as the ZXC file header.
 - **Content**: raw bytes that prefill the LZ77 window. Not compressed.
 
 ### 12.5 Dictionary training
@@ -802,7 +802,7 @@ F5 2E B0 9C | 08 | 13 | 80 | 00 00 00 00 00 00 00 | 6E 5B
 - `13` -> chunk-size code 19 (exponent encoding: `2^19 = 524288` bytes, i.e. 512 KiB, the default).
 - `80` -> checksum enabled (`HAS_CHECKSUM=1`, algo id 0).
 - next 7 bytes are reserved zeros.
-- `6E 5B` -> header CRC16 (LE value `0x5B6E`).
+- `6E 5B` -> header checksum (LE value `0x5B6E`).
 
 #### B) Data Block #0 (RAW)
 
@@ -815,7 +815,7 @@ Block header at offset `0x10`:
 - type `00` = RAW.
 - flags `00`, reserved `00`.
 - `comp_size = 0x0000000A = 10` bytes.
-- header CRC8 = `0x69`.
+- header checksum = `0x69`.
 
 Payload at `0x18..0x21` (10 bytes):
 
@@ -841,7 +841,7 @@ FF | 00 | 00 | 00 00 00 00 | 02
 
 - type `FF` = EOF.
 - `comp_size = 0` (mandatory).
-- header CRC8 = `0x02`.
+- header checksum = `0x02`.
 
 #### D) File Footer (offset `0x2E`, 12 bytes)
 
@@ -909,7 +909,7 @@ FE | 00 | 00 | 04 00 00 00 | D2
 - `FE` -> type 254 = SEK (Seek Table).
 - flags `00`, reserved `00`.
 - `comp_size = 0x00000004 = 4` bytes (one entry x 4 bytes/entry).
-- header CRC8 = `0xD2`.
+- header checksum = `0xD2`.
 
 Seek table entry at `0x36`:
 
@@ -979,7 +979,7 @@ C7 D1 B0 9C | 01 | 00 | 05 00 | 23 58 DF 6F | 00 00 | 63 65
 - `05 00` -> content size (LE) = `5` bytes.
 - `23 58 DF 6F` -> `dict_id` (LE) = `0x6FDF5823`. Binds the **(content, table)** pair (see §12.4) and must match the `dict_id` stored in the file header of any `.zxc` archive compressed with this dictionary.
 - `00 00` -> reserved.
-- `63 65` -> header CRC16 (LE) = `0x6563`, computed over the 16-byte header with bytes `0x0C..0x0F` zeroed (same method as the ZXC file header — the CRC is the last 2 bytes of the header).
+- `63 65` -> header checksum (LE) = `0x6563`, computed over the 16-byte header with bytes `0x0C..0x0F` zeroed (same method as the ZXC file header — the checksum is the last 2 bytes of the header).
 
 #### B) Dictionary Content (offset `0x10`, 5 bytes)
 

--- a/docs/WHITEPAPER.md
+++ b/docs/WHITEPAPER.md
@@ -171,7 +171,7 @@ The file begins with a **16-byte** header that identifies the format and specifi
 ```
   Offset:  0               4       5       6       7                       14      16
            +---------------+-------+-------+-------+-----------------------+-------+
-           | Magic Word    | Ver   | Chunk | Flags | Reserved / Dict ID    | CRC   |
+           | Magic Word    | Ver   | Chunk | Flags | Reserved / Dict ID    | Cksum |
            | (4 bytes)     | (1B)  | (1B)  | (1B)  | (7 bytes)             | (2B)  |
            +---------------+-------+-------+-------+-----------------------+-------+
 ```
@@ -188,7 +188,7 @@ The file begins with a **16-byte** header that identifies the format and specifi
   - **Bits 4-5**: Reserved.
   - **Bits 0-3**: Checksum Algorithm ID (e.g., `0` = RapidHash).
 * **Reserved / Dictionary ID (7 bytes)**: Zero when `HAS_DICTIONARY` is clear. When `HAS_DICTIONARY` is set, bytes `0x07..0x0A` hold the `dict_id` (`u32` LE, a 32-bit hash of the dictionary content); the remaining bytes `0x0B..0x0D` stay zero.
-* **CRC (2 bytes)**: 16-bit Header Checksum. Calculated on the 16-byte header (with CRC bytes set to 0) using `zxc_hash16`.
+* **Checksum (2 bytes)**: 16-bit Header Checksum. Calculated on the 16-byte header (with the checksum bytes set to 0) using `zxc_hash16`.
 
 ### 5.2 Block Header Structure
 Each data block consists of an **8-byte** generic header that precedes the specific payload. This header allows the decoder to navigate the stream and identify the processing method required for the next chunk of data.
@@ -198,7 +198,7 @@ Each data block consists of an **8-byte** generic header that precedes the speci
 ```
   Offset:  0       1       2       3                       7       8
           +-------+-------+-------+-----------------------+-------+
-          | Type  | Flags | Rsrvd | Comp Size             | CRC   |
+          | Type  | Flags | Rsrvd | Comp Size             | Cksum |
           | (1B)  | (1B)  | (1B)  | (4 bytes)             | (1B)  |
           +-------+-------+-------+-----------------------+-------+
 
@@ -213,7 +213,7 @@ Each data block consists of an **8-byte** generic header that precedes the speci
 * **Flags**: Not used for now.
 * **Rsrvd**: Reserved for future use (must be 0).
 * **Comp Size**: Compressed payload size (excluding header and optional checksum).
-* **CRC**: 1-byte Header Checksum (located at the end of the header). Calculated on the 8-byte header (with CRC byte set to 0) using `zxc_hash8`.
+* **Checksum**: 1-byte Header Checksum (located at the end of the header). Calculated on the 8-byte header (with the checksum byte set to 0) using `zxc_hash8`.
 
 > **Note**: The decompressed size is not stored in the block header. For GLO/GHI blocks it falls out of decoding the sequences themselves; for RAW blocks it equals `Comp Size`.
 
@@ -404,7 +404,7 @@ The **EOF** block marks the end of the ZXC stream. It ensures that the decompres
 *   **Flags**:
     *   **Bit 7 (0x80)**: `has_checksum`. If set, implies the **Global Stream Checksum** in the footer is valid and should be verified.
 *   **Comp Size**: Unlike other blocks, these **MUST be set to 0**. The decoder enforces strict validation (`Type == EOF` AND `Comp Size == 0`) to prevent processing of malformed termination blocks.
-*   **CRC**: 1-byte Header Checksum (located at the end of the header). Calculated on the 8-byte header (with CRC byte set to 0) using `zxc_hash8`.
+*   **Checksum**: 1-byte Header Checksum (located at the end of the header). Calculated on the 8-byte header (with the checksum byte set to 0) using `zxc_hash8`.
 
 
 ### 5.6 File Footer
@@ -530,7 +530,7 @@ For workloads compressed in **small blocks** (4 KB–128 KB), a pre-trained dict
 
 *   **Two binding flavours**: the `dict_id` binds exactly what the encoder used. A **raw in-memory dictionary** (library API, content bytes only, no table) yields `dict_id = checksum(content)`; such archives never contain `enc_lit = 3` blocks. A **table-carrying dictionary** (the `.zxd` path) yields `dict_id = checksum(LE32(checksum(content)) || table)`, binding the exact (content, table) pair. There is no flag on the wire: the decoder simply computes the id for the pair it was given and matches it against the header.
 
-*   **`.zxd` file format**: A standalone dictionary file has a 16-byte header (magic `0x9CB0D1C7`, version, content size, `dict_id`, header CRC16) followed by the raw content bytes and the **128-byte shared Huffman table (always present)**. The `.zxd` extension is cosmetic — files are identified by their magic word, not their name.
+*   **`.zxd` file format**: A standalone dictionary file has a 16-byte header (magic `0x9CB0D1C7`, version, content size, `dict_id`, header checksum) followed by the raw content bytes and the **128-byte shared Huffman table (always present)**. The `.zxd` extension is cosmetic — files are identified by their magic word, not their name.
 
 *   **Training**: `zxc_train_dict()` analyzes a corpus of representative samples and selects the byte segments that maximize LZ77 match coverage, placing the most frequently matched segments at the **end** of the dictionary so they produce the shortest (most efficient) offsets in the virtual window. `zxc_train_dict_huf()` then compresses the same samples *with* the trained dictionary to histogram the **real post-LZ literals** (raw sample bytes are a poor proxy: LZ matches against the dictionary remove most repeated content first) and derives the shared table from that distribution. Training cost is bounded: past an 8 MiB budget, 4 KB sample slices are strided evenly across the corpus — a 256-symbol histogram converges long before, so even multi-hundred-MB corpora train in well under a second. Symbols unseen in training stay code-less by design: with `L = 8`, a code covering all 256 symbols would be forced by Kraft equality to the degenerate uniform 8-bit code; the encoder's per-block fallback handles uncovered bytes instead.
 

--- a/include/zxc_constants.h
+++ b/include/zxc_constants.h
@@ -99,7 +99,8 @@
  *
  * @{
  */
-/** @brief File header size: Magic(4) + Version(1) + Chunk(1) + Flags(1) + Reserved(7) + CRC(2). */
+/** @brief File header size: Magic(4) + Version(1) + Chunk(1) + Flags(1) + Reserved(7) +
+ * Checksum(2). */
 #define ZXC_FILE_HEADER_SIZE 16
 /** @brief File footer size: original_size(8) + global_checksum(4). */
 #define ZXC_FILE_FOOTER_SIZE 12

--- a/include/zxc_error.h
+++ b/include/zxc_error.h
@@ -47,7 +47,7 @@ typedef enum {
     /* Format/header errors */
     ZXC_ERROR_BAD_MAGIC = -4,    /**< Invalid magic word in file header. */
     ZXC_ERROR_BAD_VERSION = -5,  /**< Unsupported file format version. */
-    ZXC_ERROR_BAD_HEADER = -6,   /**< Corrupted or invalid header (CRC mismatch). */
+    ZXC_ERROR_BAD_HEADER = -6,   /**< Corrupted or invalid header (checksum mismatch). */
     ZXC_ERROR_BAD_CHECKSUM = -7, /**< Block or global checksum verification failed. */
 
     /* Data integrity errors */

--- a/src/lib/zxc_common.c
+++ b/src/lib/zxc_common.c
@@ -520,7 +520,7 @@ int zxc_cctx_attach_dict_huf(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRICT l
  * @brief Serialises a ZXC file header into @p dst.
  *
  * Layout (16 bytes): Magic (4) | Version (1) | Chunk (1) | Flags (1) |
- * Reserved (7) | CRC-16 (2).
+ * Reserved (7) | Checksum-16 (2).
  *
  * @param[out] dst          Destination buffer (>= @ref ZXC_FILE_HEADER_SIZE bytes).
  * @param[in]  dst_capacity Capacity of @p dst.
@@ -549,7 +549,7 @@ int zxc_write_file_header(uint8_t* RESTRICT dst, const size_t dst_capacity, cons
     ZXC_MEMSET(dst + 7, 0, 7);
     if (dict_id != 0) zxc_store_le32(dst + 7, dict_id);
 
-    // Bytes 14-15: CRC (16-bit)
+    // Bytes 14-15: checksum (16-bit)
     zxc_store_le16(dst + 14, 0);  // Zero out before hashing
     const uint16_t crc = zxc_hash16(dst);
     zxc_store_le16(dst + 14, crc);
@@ -560,7 +560,7 @@ int zxc_write_file_header(uint8_t* RESTRICT dst, const size_t dst_capacity, cons
 /**
  * @brief Parses and validates a ZXC file header from @p src.
  *
- * Checks the magic word, format version, and CRC-16.
+ * Checks the magic word, format version, and 16-bit checksum.
  *
  * @param[in]  src              Source buffer (>= @ref ZXC_FILE_HEADER_SIZE bytes).
  * @param[in]  src_size         Size of @p src.
@@ -580,11 +580,11 @@ int zxc_read_file_header(const uint8_t* RESTRICT src, const size_t src_size,
 
     uint8_t temp[ZXC_FILE_HEADER_SIZE];
     ZXC_MEMCPY(temp, src, ZXC_FILE_HEADER_SIZE);
-    // Zero out CRC bytes (14-15) before hash check
+    // Zero out checksum bytes (14-15) before hash check
     temp[14] = 0;
     temp[15] = 0;
-    // Header CRC16 (integrity), then the checksum-algorithm id in flags bits 0-3
-    // (only 0 = RapidHash is defined). CRC is checked first via short-circuit.
+    // Header checksum (integrity), then the checksum-algorithm id in flags bits 0-3
+    // (only 0 = RapidHash is defined). It is checked first via short-circuit.
     if (UNLIKELY(zxc_le16(src + 14) != zxc_hash16(temp) ||
                  (src[6] & 0x0FU) != ZXC_CHECKSUM_RAPIDHASH))
         return ZXC_ERROR_BAD_HEADER;
@@ -628,7 +628,7 @@ int zxc_write_block_header(uint8_t* RESTRICT dst, const size_t dst_capacity,
 /**
  * @brief Parses and validates a block header from @p src.
  *
- * Validates the 8-bit CRC embedded in the header.
+ * Validates the 8-bit checksum embedded in the header.
  *
  * @param[in]  src      Source buffer (>= @ref ZXC_BLOCK_HEADER_SIZE bytes).
  * @param[in]  src_size Size of @p src.

--- a/src/lib/zxc_dict.c
+++ b/src/lib/zxc_dict.c
@@ -53,7 +53,7 @@ uint32_t zxc_dict_id(const void* RESTRICT dict, const size_t dict_size,
 //    0x06  2  Content size (u16 LE)
 //    0x08  4  dict_id (u32 LE; covers content AND the Huffman table)
 //    0x0C  2  Reserved (0)
-//    0x0E  2  Header CRC16 (zxc_hash16, computed with bytes 0x0C-0x0F zeroed)
+//    0x0E  2  Header Checksum (zxc_hash16, computed with 0x0C-0x0F zeroed)
 //    0x10  N  Content bytes
 //    +N    128 Packed Huffman code lengths (always present)
 // -------------------------------------------------------------------------
@@ -117,7 +117,7 @@ int64_t zxc_dict_save(const void* RESTRICT content, const size_t content_size,
     dst[5] = 0; /* flags: reserved */
     zxc_store_le16(dst + 6, (uint16_t)content_size);
     zxc_store_le32(dst + 8, zxc_dict_id(content, content_size, (const uint8_t*)huf_lengths));
-    zxc_store_le32(dst + 12, 0); /* reserved (0x0C) + CRC16 (0x0E), zeroed before CRC */
+    zxc_store_le32(dst + 12, 0); /* reserved (0x0C) + checksum (0x0E), zeroed before hashing */
     const uint16_t crc = zxc_hash16(dst);
     zxc_store_le16(dst + 14, crc);
 
@@ -131,7 +131,7 @@ int64_t zxc_dict_save(const void* RESTRICT content, const size_t content_size,
  * @brief Parses a .zxd buffer, returning in-buffer views of content and table.
  *
  * Public API; full contract in @c zxc_dict.h. Validates magic, version, header
- * CRC and dict_id, then points the out-params into @p buf - no copy, so they
+ * checksum and dict_id, then points the out-params into @p buf - no copy, so they
  * stay valid only while @p buf does.
  *
  * @param[in]  buf               Serialized .zxd bytes.
@@ -162,7 +162,7 @@ int zxc_dict_load(const void* RESTRICT buf, const size_t buf_size,
 
     uint8_t temp[ZXC_DICT_HEADER_SIZE];
     ZXC_MEMCPY(temp, src, sizeof(temp));
-    zxc_store_le32(temp + 12, 0); /* reserved (0x0C) + CRC16 (0x0E), zeroed before CRC */
+    zxc_store_le32(temp + 12, 0); /* reserved (0x0C) + checksum (0x0E), zeroed before hashing */
     const uint16_t expected_crc = zxc_hash16(temp);
     if (UNLIKELY(zxc_le16(src + 14) != expected_crc)) return ZXC_ERROR_BAD_HEADER;
 

--- a/src/lib/zxc_internal.h
+++ b/src/lib/zxc_internal.h
@@ -407,7 +407,7 @@ extern "C" {
  *         histogram converges early, so past it slices are strided evenly instead. */
 #define ZXC_DICT_HUF_SAMPLE_BUDGET (8U << 20)
 
-/** @brief Block header size: Type(1)+Flags(1)+Reserved(1)+CRC(1)+CompSize(4). */
+/** @brief Block header size: Type(1)+Flags(1)+Reserved(1)+Checksum(1)+CompSize(4). */
 #define ZXC_BLOCK_HEADER_SIZE 8
 /** @brief Size of the per-block checksum field in bytes. */
 #define ZXC_BLOCK_CHECKSUM_SIZE 4

--- a/tests/format/README.md
+++ b/tests/format/README.md
@@ -41,13 +41,13 @@ For every file, `test_golden.c` walks the bytes and verifies, against
 
 - **File header (§3):** magic, version, chunk-size code, flags (incl.
   `HAS_CHECKSUM` / `HAS_DICTIONARY`), the reserved bytes — or the `dict_id` when
-  a dictionary is used — and the 16-bit header CRC (`zxc_hash16`).
+  a dictionary is used — and the 16-bit header checksum (`zxc_hash16`).
 - **Each block header (§4):** type, flags, reserved byte, `comp_size` bounds,
-  and the 8-bit header CRC (`zxc_hash8`).
+  and the 8-bit header checksum (`zxc_hash8`).
 - **Every payload type (§5):** RAW; GLO/GHI header + section descriptors
   (sizes must tile the payload); the Huffman literal section flag.
 - **EOF block (§5.4):** `comp_size == 0`.
-- **Optional SEK block (§5.5):** type, CRC8, `comp_size == n_blocks * 4`, and
+- **Optional SEK block (§5.5):** type, header checksum, `comp_size == n_blocks * 4`, and
   each entry equal to the physical size of its data block.
 - **Per-block checksum (§7.2):** recomputed (`zxc_checksum`) over the compressed
   payload and matched against the trailing 4 bytes.

--- a/tests/format/test_golden.c
+++ b/tests/format/test_golden.c
@@ -12,9 +12,9 @@
  * docs/FORMAT.md Sec 3-Sec 8:
  *
  *   - File header: magic, version, chunk-size code, flags, reserved bytes,
- *     and the 16-bit header CRC (zxc_hash16, Sec 3 / Sec 7.1).
+ *     and the 16-bit header checksum (zxc_hash16, Sec 3 / Sec 7.1).
  *   - Generic block container: type, flags, reserved, comp_size bounds and the
- *     8-bit header CRC (zxc_hash8, Sec 4 / Sec 7.1).
+ *     8-bit header checksum (zxc_hash8, Sec 4 / Sec 7.1).
  *   - Every block type in Sec 5: RAW, GLO and GHI (header + section descriptors,
  *     incl. the Huffman literal section), EOF (zero comp_size) and the optional
  *     SEK seek table. (Type 2 is reserved/removed.)
@@ -191,14 +191,14 @@ static int validate_structure(const char* ctx, const golden_case_t* gc, const ui
         for (int i = 7; i <= 13; i++) CHECK(buf[i] == 0, "header reserved byte 0x%02X nonzero", i);
     }
 
-    /* Sec 7.1 header CRC16: zxc_hash16 over the 16 header bytes with 0x0E..0x0F zeroed. */
+    /* Sec 7.1 file header checksum: zxc_hash16 over the 16 header bytes with 0x0E..0x0F zeroed. */
     {
         uint8_t tmp[ZXC_FILE_HEADER_SIZE];
         memcpy(tmp, buf, ZXC_FILE_HEADER_SIZE);
         tmp[14] = tmp[15] = 0;
         uint16_t want = zxc_hash16(tmp);
         uint16_t got = zxc_le16(buf + 14);
-        CHECK(got == want, "header CRC16 mismatch: got 0x%04X want 0x%04X", got, want);
+        CHECK(got == want, "file header checksum mismatch: got 0x%04X want 0x%04X", got, want);
     }
 
     /* ---- Block stream (Sec 4, Sec 5) ---- */
@@ -215,14 +215,14 @@ static int validate_structure(const char* ctx, const golden_case_t* gc, const ui
         uint8_t resv = bh[2];
         uint32_t comp = zxc_le32(bh + 3);
 
-        /* Sec 7.1 block header CRC8: zxc_hash8 over the 8 header bytes with 0x07 zeroed. */
+        /* Sec 7.1 block header checksum: zxc_hash8 over the 8 header bytes with 0x07 zeroed. */
         {
             uint8_t tmp[ZXC_BLOCK_HEADER_SIZE];
             memcpy(tmp, bh, ZXC_BLOCK_HEADER_SIZE);
             tmp[7] = 0;
             uint8_t want = zxc_hash8(tmp);
-            CHECK(bh[7] == want, "block CRC8 mismatch at %zu: got 0x%02X want 0x%02X", off, bh[7],
-                  want);
+            CHECK(bh[7] == want, "block header checksum mismatch at %zu: got 0x%02X want 0x%02X",
+                  off, bh[7], want);
         }
         CHECK(bflags == 0, "block flags nonzero (0x%02X) at %zu", bflags, off);
         CHECK(resv == 0, "block reserved nonzero (0x%02X) at %zu", resv, off);
@@ -280,7 +280,7 @@ static int validate_structure(const char* ctx, const golden_case_t* gc, const ui
         uint8_t tmp[ZXC_BLOCK_HEADER_SIZE];
         memcpy(tmp, sh, ZXC_BLOCK_HEADER_SIZE);
         tmp[7] = 0;
-        CHECK(sh[7] == zxc_hash8(tmp), "SEK header CRC8 mismatch at %zu", off);
+        CHECK(sh[7] == zxc_hash8(tmp), "SEK header checksum mismatch at %zu", off);
         CHECK(comp == (uint32_t)data_blocks * 4U, "SEK comp_size %u != n_blocks*4 (%d)", comp,
               data_blocks * 4);
         const uint8_t* entries = sh + ZXC_BLOCK_HEADER_SIZE;

--- a/tests/fuzz_dict.c
+++ b/tests/fuzz_dict.c
@@ -156,7 +156,7 @@ int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
     assert(zxc_dict_save(dict_buf, (size_t)dict_sz, huf, zxd_buf, zxd_bound) == (int64_t)zxd_sz);
 
     /* Flip one byte and re-load: must not crash. A surviving ZXC_OK can only
-     * come from a reserved-byte flip (offsets 12-13, zeroed before the CRC),
+     * come from a reserved-byte flip (offsets 12-13, zeroed before the checksum),
      * which cannot change the recovered content. */
     {
         const size_t pos = corrupt_pos % (size_t)zxd_sz;

--- a/tests/test_common.c
+++ b/tests/test_common.c
@@ -143,7 +143,7 @@ void fill_seek_data(uint8_t* buf, size_t size, uint8_t seed) {
 // Generic Round-Trip test function (Compress -> Decompress -> Compare)
 int test_round_trip(const char* test_name, const uint8_t* input, size_t size, int level,
                     int checksum_enabled) {
-    printf("=== TEST: %s (Sz: %zu, Lvl: %d, CRC: %s) ===\n", test_name, size, level,
+    printf("=== TEST: %s (Sz: %zu, Lvl: %d, Checksum: %s) ===\n", test_name, size, level,
            checksum_enabled ? "Enabled" : "Disabled");
 
     FILE* const f_in = tmpfile();

--- a/tests/test_format.c
+++ b/tests/test_format.c
@@ -720,7 +720,7 @@ int test_header_checksum() {
     uint8_t original_crc = header_buf[7];
     header_buf[7] = ~original_crc;  // Flip bits
     if (zxc_read_block_header(header_buf, ZXC_BLOCK_HEADER_SIZE, &bh_out) == 0) {
-        printf("  [FAIL] zxc_read_block_header should have failed on corrupted CRC\n");
+        printf("  [FAIL] zxc_read_block_header should have failed on corrupted checksum\n");
         return 0;
     }
     header_buf[7] = original_crc;  // Restore
@@ -847,7 +847,7 @@ int test_global_checksum_order() {
     return 1;
 }
 
-/* Builds a header with the given chunk-size code, fixes the CRC16, and returns
+/* Builds a header with the given chunk-size code, fixes the header checksum, and returns
  * zxc_read_file_header's verdict (block_size out via *bs). */
 static int chunk_code_verdict(uint8_t code, size_t* bs) {
     uint8_t hdr[ZXC_FILE_HEADER_SIZE];


### PR DESCRIPTION
Align internal terminology with the actual implementation by standardizing references from "CRC" to "checksum" across documentation, comments, and error messages.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Standardized terminology by referring to file and block integrity values as “checksums” instead of “CRCs.”
  * Clarified checksum descriptions, validation guidance, diagrams, error messages, and examples across format documentation.
  * Confirmed that checksum algorithms, sizes, locations, and calculated values remain unchanged.

* **Tests**
  * Updated test descriptions, status output, and validation messages to use consistent checksum terminology.
  * No validation behavior or checksum algorithms changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->