### PR TITLE
docs(doxygen): clean up warnings and improve API documentation structure

### DIFF
--- a/cmake/zxcDocs.cmake
+++ b/cmake/zxcDocs.cmake
@@ -6,8 +6,13 @@
 # Documentation (Doxygen).
 
 # Maintainer tooling: a generic target name an embedding project may own too.
+set(ZXC_DOXYGEN_MIN_VERSION 1.9.7)
 if(PROJECT_IS_TOP_LEVEL)
-    find_package(Doxygen)
+    find_package(Doxygen ${ZXC_DOXYGEN_MIN_VERSION})
+    if(NOT DOXYGEN_FOUND)
+        message(STATUS
+            "Doxygen >= ${ZXC_DOXYGEN_MIN_VERSION} not found - the 'doc' target is unavailable")
+    endif()
 endif()
 if(DOXYGEN_FOUND AND PROJECT_IS_TOP_LEVEL)
     # Generate the Doxyfile with the current project version

--- a/docs/Doxyfile.in
+++ b/docs/Doxyfile.in
@@ -35,6 +35,7 @@ OPTIMIZE_OUTPUT_VHDL   = NO
 OPTIMIZE_OUTPUT_SLICE  = NO
 EXTENSION_MAPPING      = 
 MARKDOWN_SUPPORT       = YES
+MARKDOWN_ID_STYLE      = GITHUB
 TOC_INCLUDE_HEADINGS   = 5
 AUTOLINK_SUPPORT       = YES
 BUILTIN_STL_SUPPORT    = NO
@@ -112,6 +113,7 @@ WARN_LOGFILE           =
 # Configuration options related to the input files
 #---------------------------------------------------------------------------
 INPUT                  = docs/mainpage.md \
+                         docs/EXAMPLES.md \
                          include \
                          src/lib
 INPUT_ENCODING         = UTF-8

--- a/docs/Doxyfile.in
+++ b/docs/Doxyfile.in
@@ -1,4 +1,4 @@
-# Doxyfile 1.9.1
+# Doxyfile 1.9.7
 
 #---------------------------------------------------------------------------
 # Project related configuration options

--- a/docs/Doxyfile.in
+++ b/docs/Doxyfile.in
@@ -111,7 +111,7 @@ WARN_LOGFILE           =
 #---------------------------------------------------------------------------
 # Configuration options related to the input files
 #---------------------------------------------------------------------------
-INPUT                  = README.md \
+INPUT                  = docs/mainpage.md \
                          include \
                          src/lib
 INPUT_ENCODING         = UTF-8
@@ -124,8 +124,7 @@ EXCLUDE_SYMLINKS       = NO
 EXCLUDE_PATTERNS       = */test/* \
                          */tests/* \
                          */build/* \
-                         */target/* \
-                         */src/lib/*.c
+                         */target/*
 EXCLUDE_SYMBOLS        = 
 EXAMPLE_PATH           = 
 EXAMPLE_PATTERNS       = *
@@ -135,7 +134,7 @@ INPUT_FILTER           =
 FILTER_PATTERNS        = 
 FILTER_SOURCE_FILES    = NO
 FILTER_SOURCE_PATTERNS = 
-USE_MDFILE_AS_MAINPAGE = README.md
+USE_MDFILE_AS_MAINPAGE = docs/mainpage.md
 
 #---------------------------------------------------------------------------
 # Configuration options related to source browsing
@@ -149,10 +148,6 @@ REFERENCES_LINK_SOURCE = YES
 SOURCE_TOOLTIPS        = YES
 USE_HTAGS              = NO
 VERBATIM_HEADERS       = YES
-CLANG_ASSISTED_PARSING = NO
-CLANG_ADD_INC_PATHS    = YES
-CLANG_OPTIONS          = 
-CLANG_DATABASE_PATH    = 
 
 #---------------------------------------------------------------------------
 # Configuration options related to the alphabetical class index
@@ -175,7 +170,6 @@ HTML_COLORSTYLE        = AUTO_LIGHT
 HTML_COLORSTYLE_HUE    = 220
 HTML_COLORSTYLE_SAT    = 100
 HTML_COLORSTYLE_GAMMA  = 80
-HTML_TIMESTAMP         = NO
 HTML_DYNAMIC_MENUS     = YES
 HTML_DYNAMIC_SECTIONS  = NO
 HTML_INDEX_NUM_ENTRIES = 100

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -701,10 +701,10 @@ For non-C languages, see the official bindings:
 
 | Language | Package | Install Command | Documentation |
 |----------|---------|-----------------|---------------|
-| **Rust** | [`crates.io`](https://crates.io/crates/zxc-compress) | `cargo add zxc-compress` | [README](../wrappers/rust/zxc/README.md) |
-| **Python**| [`PyPI`](https://pypi.org/project/zxc-compress) | `pip install zxc-compress` | [README](../wrappers/python/README.md) |
-| **Node.js**| [`npm`](https://www.npmjs.com/package/zxc-compress) | `npm install zxc-compress` | [README](../wrappers/nodejs/README.md) |
-| **Go** | `go get` | `go get github.com/hellobertrand/zxc/wrappers/go` | [README](../wrappers/go/README.md) |
+| **Rust** | [`crates.io`](https://crates.io/crates/zxc-compress) | `cargo add zxc-compress` | [README](https://github.com/hellobertrand/zxc/blob/main/wrappers/rust/zxc/README.md) |
+| **Python**| [`PyPI`](https://pypi.org/project/zxc-compress) | `pip install zxc-compress` | [README](https://github.com/hellobertrand/zxc/blob/main/wrappers/python/README.md) |
+| **Node.js**| [`npm`](https://www.npmjs.com/package/zxc-compress) | `npm install zxc-compress` | [README](https://github.com/hellobertrand/zxc/blob/main/wrappers/nodejs/README.md) |
+| **Go** | `go get` | `go get github.com/hellobertrand/zxc/wrappers/go` | [README](https://github.com/hellobertrand/zxc/blob/main/wrappers/go/README.md) |
 
 Community-maintained:
 - **Go**: https://github.com/meysam81/go-zxc

--- a/docs/FORMAT.md
+++ b/docs/FORMAT.md
@@ -54,11 +54,11 @@ Offset  Size  Field
 ### 3.1 Field definitions
 
 - **Magic Word** (`u32`): `0x9CB02EF5`.
-- **Format Version** (`u8`): `8`. Any other value is rejected (`ZXC_ERROR_BAD_VERSION`);
+- **Format Version** (`u8`): `8`. Any other value is rejected as an unsupported version;
 - **Chunk Size Code** (`u8`):
   - The value is an **exponent** in the range `[12, 21]`: `block_size = 2^code`.
     - `12` = 4 KB, `13` = 8 KB, ..., `19` = 512 KB (default), ..., `21` = 2 MB.
-  - All other values are rejected (`ZXC_ERROR_BAD_BLOCK_SIZE`).
+  - All other values are rejected as an invalid chunk size code.
   - Valid block sizes are powers of 2 in the range **4 KB – 2 MB**.
 - **Flags** (`u8`):
   - Bit 7 (`0x80`): `HAS_CHECKSUM`.
@@ -68,7 +68,7 @@ Offset  Size  Field
 - **Reserved / Dictionary ID**: 7 bytes.
   - When `HAS_DICTIONARY` is set: bytes `0x07..0x0A` contain a `dict_id` (`u32` LE), a 32-bit hash of the dictionary content. Bytes `0x0B..0x0D` remain zero.
   - When `HAS_DICTIONARY` is clear: all 7 bytes are zero.
-- **Header Checksum** (`u16`): computed with `zxc_hash16` on the 16-byte header where bytes `0x0E..0x0F` are zeroed.
+- **Header Checksum** (`u16`): the 16-bit header checksum of [7.1](#71-header-checksums), computed over the 16-byte header with bytes `0x0E..0x0F` zeroed.
 
 ---
 
@@ -96,7 +96,7 @@ Offset  Size  Field
 - **Block Flags**: currently not used by implementation (written as `0`).
 - **Reserved**: must be 0.
 - **comp_size**: payload size in bytes (does **not** include the optional trailing 4-byte block checksum).
-- **Header Checksum**: `zxc_hash8` over the 8-byte header with byte `0x07` forced to zero before hashing.
+- **Header Checksum**: the 8-bit header checksum of [7.1](#71-header-checksums), computed over the 8-byte header with byte `0x07` zeroed.
 
 ### 4.2 Block physical layout
 
@@ -125,7 +125,8 @@ No internal sub-header.
 
 ## 5.2 GLO block (`type=1`)
 
-General LZ-style format with separated streams.
+"General LZ, LOw throughput": LZ-style format with separated streams, trading
+decode throughput for ratio.
 
 ### GLO payload layout
 
@@ -237,11 +238,13 @@ and extras sections play the role of tokens/offsets/extras.
   - `n_sequences × 1` byte if `enc_off=1`, else `n_sequences × 2` bytes LE.
   - Values are **biased**: stored value = `actual_offset - 1`. Decoder adds `+ 1`.
   - This makes `offset == 0` impossible by construction (minimum decoded offset = 1).
-- **Extras stream**:
-  - Prefix-varint overflow values for token saturations:
-    - if `LL == 15`, read varint and add to LL
-    - if `ML == 15`, read varint and add to ML
-  - actual match length is `ML + 5` (minimum match = 5).
+- **Extras stream**: prefix-varint overflow values for token saturations, per
+  the rules below.
+
+Overflow rules:
+- if `LL == 15`, read varint from Extras and add it to LL.
+- if `ML == 15`, read varint from Extras and add it to ML.
+- otherwise decoded match length is `ML + 5` (minimum match = 5).
 
 ### 5.2.1 Huffman literal section
 
@@ -330,7 +333,7 @@ Decoder validation requirements:
   one symbol has `code_len = 1` and the Kraft sum is `2^10`.
 - Every node's run (bitmap or flat) must lie within the section payload.
 - A popcount that routes symbols to an absent child is a corruption error.
-- A failure on any of the above results in `ZXC_ERROR_CORRUPT_DATA`.
+- A failure on any of the above **MUST** be reported as a corrupt-data error.
 
 ### 5.2.2 Shared-table Huffman literal section
 
@@ -340,7 +343,7 @@ Decoder validation requirements:
 from the shared literal
 table carried by the `.zxd` dictionary (see § 12.4), validated once when the
 dictionary is attached (same rules as § 5.2.1). Decoders **MUST** reject
-`enc_lit=3` sections with `ZXC_ERROR_DICT_REQUIRED` when no dictionary table
+`enc_lit=3` sections when no dictionary table
 is attached. The archive's `dict_id` binds the (content, table) pair, so a
 matching table is guaranteed present whenever the dictionary check passed.
 
@@ -354,7 +357,8 @@ inline lengths header) over the token byte alphabet.
 
 ## 5.3 GHI block (`type=2`)
 
-High-throughput LZ format with packed 32-bit sequences.
+"General LZ, HIgh throughput": LZ format with packed 32-bit sequences, trading
+ratio for decode throughput.
 
 ### GHI payload layout
 
@@ -459,7 +463,12 @@ ZXC extras use a prefix-length varint.
 
 The length is encoded in unary form in the high bits of the first byte: the
 number of leading `1` bits, followed by a terminating `0`, indicates how
-many additional payload bytes follow. The scheme generalizes to N bytes
+many additional payload bytes follow. The total length is therefore known
+from the first byte alone, and every following byte carries eight payload
+bits. This differs from LEB128, which spends a continuation bit in each byte
+and reveals the length only as the value is scanned.
+
+The scheme generalizes to N bytes
 (`11110xxx` = 5, `111110xx` = 6, ...), but the current ZXC spec caps the
 encoding at 3 bytes because no legitimate value exceeds 21 bits (see below).
 
@@ -469,21 +478,38 @@ Encodings used:
 - `10xxxxxx` -> 2 bytes total (14 bits, value < 16384)
 - `110xxxxx` -> 3 bytes total (21 bits, value < 2 MiB)
 
-Payload bits from the following bytes are concatenated little-endian style
-(low bits first). Used by GLO/GHI to carry LL/ML overflows beyond
-token/sequence inline limits.
+The first byte's payload bits — those below its unary prefix — are the least
+significant bits of the value, and each following byte contributes the next
+eight bits up. Writing `b0`, `b1`, `b2` for the bytes in stream order, the
+accepted forms decode as:
+
+```
+1 byte:   value = b0
+2 bytes:  value = (b0 AND 0x3F) OR (b1 << 6)
+3 bytes:  value = (b0 AND 0x1F) OR (b1 << 5) OR (b2 << 13)
+```
+
+For example, the two bytes `AC 04` decode as the 2-byte form:
+`(0xAC AND 0x3F) OR (0x04 << 6)` = 44 + 256 = **300**. The three bytes
+`C3 35 0C` decode as the 3-byte form:
+`(0xC3 AND 0x1F) OR (0x35 << 5) OR (0x0C << 13)` = 3 + 1696 + 98304 =
+**100003**.
+
+Used by GLO/GHI to carry LL/ML overflows beyond token/sequence inline
+limits.
 
 **Value bound**: a varint encodes `(LL - MASK)` or `(ML - MASK)`.
-Since LL/ML are bounded by `ZXC_BLOCK_SIZE_MAX = 2 MiB` (2^21), every
-legitimate varint value is strictly less than 2^21 and therefore fits in
-**at most 3 bytes**.
+Since LL/ML are bounded by the largest block size a Chunk Size Code can
+select (2 MiB at code 21, see [3](#3-file-header-16-bytes)), every legitimate
+varint value is strictly less than 2^21 and therefore fits in **at most 3
+bytes**.
 
 Any prefix indicating a length >= 4 bytes (first byte `>= 0xE0`) is out of
 spec for this format version: encoders must never emit such a varint, and
 conforming decoders reject it as corrupt input. This caps the varint
 surface to the format-defined block size limit and neutralizes
 integer-overflow attacks in downstream bounds arithmetic. A future version
-of the format that raises `ZXC_BLOCK_SIZE_MAX` would also extend the
+of the format that raises the per-block size limit would also extend the
 accepted prefix lengths.
 
 ---
@@ -492,8 +518,39 @@ accepted prefix lengths.
 
 ## 7.1 Header checksums
 
-- File header: 16-bit (`zxc_hash16`).
-- Block header: 8-bit (`zxc_hash8`).
+The file header carries a 16-bit checksum at `0x0E..0x0F`; every block header
+carries an 8-bit checksum at `0x07`. Despite their historical name, both are
+xorshift hashes, not cyclic redundancy checks: the shift triple `(13, 7, 17)`
+is that of Marsaglia's `xorshift64`, used here to mix a seeded input rather
+than to generate a sequence.
+
+All arithmetic below is on unsigned 64-bit integers modulo 2^64, and all
+shifts are logical.
+
+The **8-bit block header checksum** takes the 8 header bytes as a single
+little-endian 64-bit integer `v`, with the checksum byte at `0x07` treated as
+zero:
+
+```
+h = v XOR 0x9E3779B97F4A7C15
+h = h XOR (h << 13)
+h = h XOR (h >> 7)
+h = h XOR (h << 17)
+checksum8 = ((h >> 32) XOR h) AND 0xFF
+```
+
+The **16-bit file header checksum** takes the 16 header bytes as two
+little-endian 64-bit integers, `v1` at `0x00` and `v2` at `0x08`, with the two
+checksum bytes at `0x0E..0x0F` treated as zero:
+
+```
+h = v1 XOR v2 XOR 0xD2D84A61D2D84A61
+h = h XOR (h << 13)
+h = h XOR (h >> 7)
+h = h XOR (h << 17)
+r  = ((h >> 32) XOR h) AND 0xFFFFFFFF
+checksum16 = ((r >> 16) XOR r) AND 0xFFFF
+```
 
 These protect metadata/navigation fields.
 
@@ -578,10 +635,10 @@ encoding, layout, or the checksum algorithm — requires a **version bump**.
 
 ### 10.3 Compatibility rules
 
-- **Version compatibility**: a decoder accepts **only** the format version it implements and **MUST** reject any other version with `ZXC_ERROR_BAD_VERSION`. Because block-type numbering and payload formats may change between versions, a decoder **MUST NOT** attempt to interpret an archive whose version byte it does not recognise.
-- **Unknown block types**: a decoder **MUST reject** any block whose type is not defined for its format version (`ZXC_ERROR_BAD_BLOCK_TYPE`). The block-type set is fixed per version; introducing a new type is a version bump (decoders do **not** skip unknown blocks — silently advancing past untrusted, unrecognised data is unsafe).
+- **Version compatibility**: a decoder accepts **only** the format version it implements and **MUST** reject any other version. Because block-type numbering and payload formats may change between versions, a decoder **MUST NOT** attempt to interpret an archive whose version byte it does not recognise.
+- **Unknown block types**: a decoder **MUST reject** any block whose type is not defined for its format version. The block-type set is fixed per version; introducing a new type is a version bump (decoders do **not** skip unknown blocks — silently advancing past untrusted, unrecognised data is unsafe).
 - **Reserved fields**: all reserved bytes and flag bits **MUST** be written as zero by encoders. The current decoder tolerates (ignores) non-zero reserved values — they are covered by the header checksum, so accidental corruption is still caught — but assigning a reserved field any meaning is a **version bump**, never a same-version extension.
-- **Defined-but-bounded fields**: where only specific values are defined (e.g. the checksum-algorithm id, currently `0` = RapidHash only), the decoder **rejects** out-of-range values (`ZXC_ERROR_BAD_HEADER`).
+- **Defined-but-bounded fields**: where only specific values are defined (e.g. the checksum-algorithm id, currently `0` = RapidHash only), the decoder **rejects** out-of-range values as a corrupt header.
 
 ### 10.4 Minimum conforming decoder
 
@@ -675,9 +732,9 @@ decompress any block independently.
 
 When `HAS_DICTIONARY` (flag bit 6) is set, the reserved bytes at offsets
 `0x07..0x0A` contain the `dict_id` (`u32` LE). A decoder **MUST**:
-1. Verify that a dictionary is provided (`ZXC_ERROR_DICT_REQUIRED` if not).
+1. Verify that a dictionary is provided; reject the archive if not.
 2. Verify that the dictionary id matches `header.dict_id`
-   (`ZXC_ERROR_DICT_MISMATCH` if not). For a raw in-memory dictionary without
+   ; reject on mismatch. For a raw in-memory dictionary without
    a shared table, the id is `zxc_dict_id(dict, dict_size, NULL)`. When a shared
    literal table is attached, the id also binds the table:
    `id = fold32(hash(table_128_bytes, seed = hash(content)))` (i.e. `zxc_dict_id(content, size, table)`).
@@ -700,7 +757,7 @@ Offset  Size  Field
 0x06    2     Content size (u16 LE, max 65535)
 0x08    4     dict_id (u32 LE, binds content AND shared table, see below)
 0x0C    2     Reserved (0)
-0x0E    2     Header Checksum (zxc_hash16, computed with 0x0C-0x0F zeroed)
+0x0E    2     Header Checksum (see 7.1, computed with 0x0C-0x0F zeroed)
 0x10    N     Dictionary content (raw bytes)
 0x10+N  128   Shared literal Huffman table (256 × 4-bit packed code lengths,
               same layout as the § 5.2.1 code-length header; always present)
@@ -708,14 +765,14 @@ Offset  Size  Field
 
 - **Magic Word**: `0x9CB0D1C7`. Allows immediate rejection of non-dictionary files.
 - **Version**: `1`. Decoders reject any other version with
-  `ZXC_ERROR_BAD_VERSION`.
+  an unsupported dictionary version.
 - **Flags**: bits `0..3` carry the checksum algorithm id (`0` = RapidHash-based folding), matching the ZXC file header flags; bits `4..7` are reserved (must be 0).
 - **Shared literal Huffman table**: code lengths for the `enc_lit=3` literal
   sections (§ 5.2.2), trained on the corpus' post-LZ literal distribution.
 - **dict_id**: `fold32(hash(table_128_bytes, seed = hash(content)))` —
   binds the exact (content, table) pair. Must match the `dict_id` stored in
   any ZXC file header that references this dictionary.
-- **Header Checksum**: `zxc_hash16` checksum of the 16-byte header with bytes `0x0C..0x0F` zeroed before hashing — same method as the ZXC file header.
+- **Header Checksum**: the 16-bit header checksum of [7.1](#71-header-checksums), computed over the 16-byte header with bytes `0x0C..0x0F` zeroed.
 - **Content**: raw bytes that prefill the LZ77 window. Not compressed.
 
 ### 12.5 Dictionary training
@@ -741,8 +798,8 @@ as follows:
 - On **decompression**, a dictionary is **not** auto-located: an archive that
   was compressed with a dictionary must be decompressed by passing that
   dictionary explicitly with `-D`. Without it, decompression fails with
-  `ZXC_ERROR_DICT_REQUIRED` (the `dict_id` in the header is still verified
-  against the supplied dictionary, yielding `ZXC_ERROR_DICT_MISMATCH` on a
+  a dictionary-required error (the `dict_id` in the header is still verified
+  against the supplied dictionary, yielding a dictionary-mismatch error on a
   mismatch).
 
 ---
@@ -953,7 +1010,7 @@ A minimal dictionary whose content is the 5 ASCII bytes `hello`. Total file size
 ### 15.1 Full hexdump
 
 ```text
-00000000: C7 D1 B0 9C 01 00 05 00 23 58 DF 6F 00 00 63 65
+00000000: C7 D1 B0 9C 01 00 05 00 34 07 FC 0C 00 00 2D 74
 00000010: 68 65 6C 6C 6F 00 00 00 00 00 00 00 00 00 00 00
 00000020: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
 00000030: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
@@ -970,16 +1027,16 @@ A minimal dictionary whose content is the 5 ASCII bytes `hello`. Total file size
 #### A) Dictionary Header (offset `0x00`, 16 bytes)
 
 ```text
-C7 D1 B0 9C | 01 | 00 | 05 00 | 23 58 DF 6F | 00 00 | 63 65
+C7 D1 B0 9C | 01 | 00 | 05 00 | 34 07 FC 0C | 00 00 | 2D 74
 ```
 
 - `C7 D1 B0 9C` -> magic word (LE) = `0x9CB0D1C7` (`.zxd` dictionary).
 - `01` -> dictionary format version 1.
 - `00` -> flags (bits 0..3 = checksum algorithm id `0` = RapidHash; bits 4..7 reserved).
 - `05 00` -> content size (LE) = `5` bytes.
-- `23 58 DF 6F` -> `dict_id` (LE) = `0x6FDF5823`. Binds the **(content, table)** pair (see §12.4) and must match the `dict_id` stored in the file header of any `.zxc` archive compressed with this dictionary.
+- `34 07 FC 0C` -> `dict_id` (LE) = `0x0CFC0734`. Binds the **(content, table)** pair (see §12.4) and must match the `dict_id` stored in the file header of any `.zxc` archive compressed with this dictionary.
 - `00 00` -> reserved.
-- `63 65` -> header checksum (LE) = `0x6563`, computed over the 16-byte header with bytes `0x0C..0x0F` zeroed (same method as the ZXC file header — the checksum is the last 2 bytes of the header).
+- `2D 74` -> header checksum (LE) = `0x742D`, computed over the 16-byte header with bytes `0x0C..0x0F` zeroed (same method as the ZXC file header — the checksum is the last 2 bytes of the header).
 
 #### B) Dictionary Content (offset `0x10`, 5 bytes)
 

--- a/docs/mainpage.md
+++ b/docs/mainpage.md
@@ -1,0 +1,31 @@
+# libzxc API Reference
+
+ZXC is a lossless data compression library built for high decompression
+throughput and random access. An archive is a sequence of independently
+decodable blocks, optionally indexed by a seek table, so any block can be
+decompressed without reading the blocks before it.
+
+This is the generated API reference. For the project overview, benchmarks and
+installation instructions see the
+[README](https://github.com/hellobertrand/zxc#readme); for the wire format see
+the [format specification](https://github.com/hellobertrand/zxc/blob/main/docs/FORMAT.md).
+
+## Choosing an API
+
+- \ref buffer_api — one-call compression of a whole buffer. Start here.
+- \ref context_api — reuse one context across many operations to avoid
+  repeated allocation.
+- \ref static_context_api — caller-provided workspace, no heap allocation.
+- \ref block_api — single blocks, without the archive header and footer.
+- \ref stream_api and \ref pstream — incremental pull and push streaming.
+- \ref seekable_api — random access to any block of a seekable archive.
+- \ref dictionary — pre-trained dictionaries for small, homogeneous payloads.
+
+## Reference
+
+- \ref error — error codes and their meaning.
+- \ref levels — compression levels.
+- \ref block_size — block-size codes and limits.
+- \ref file_format — on-disk format constants.
+- \ref library_info and \ref version — build and version queries.
+- \ref threading — thread-count limits.

--- a/docs/mainpage.md
+++ b/docs/mainpage.md
@@ -10,6 +10,9 @@ installation instructions see the
 [README](https://github.com/hellobertrand/zxc#readme); for the wire format see
 the [format specification](https://github.com/hellobertrand/zxc/blob/main/docs/FORMAT.md).
 
+Complete, runnable workflows for each of these APIs are collected in the
+[API Examples](EXAMPLES.md) page.
+
 ## Choosing an API
 
 - \ref buffer_api — one-call compression of a whole buffer. Start here.

--- a/src/lib/zxc_common.c
+++ b/src/lib/zxc_common.c
@@ -26,10 +26,6 @@
  * @brief Allocates memory aligned to the specified boundary.
  *
  * Uses `_aligned_malloc` on Windows and `posix_memalign` elsewhere.
- *
- * @param[in] size      Number of bytes to allocate.
- * @param[in] alignment Required alignment (must be a power of two).
- * @return Pointer to the allocated block, or @c NULL on failure.
  */
 void* zxc_aligned_malloc(const size_t size, const size_t alignment) {
 #if defined(_WIN32)
@@ -43,8 +39,6 @@ void* zxc_aligned_malloc(const size_t size, const size_t alignment) {
 
 /**
  * @brief Frees memory previously allocated by zxc_aligned_malloc().
- *
- * @param[in] ptr Pointer returned by zxc_aligned_malloc() (may be @c NULL).
  */
 void zxc_aligned_free(void* ptr) {
 #if defined(_WIN32)
@@ -109,31 +103,6 @@ typedef struct {
 } zxc_cctx_layout_t;
 
 /**
- * @brief Computes the single-allocation memory layout for a compression /
- *        decompression context.
- *
- * Walks the same partition order used by @ref zxc_cctx_init_in_workspace and
- * records each sub-buffer's offset plus the running @c total, so the sizing
- * query and the partitioning step share one source of truth and can never
- * disagree.
- *
- * Decompress (@p mode == 0) reserves @c work_buf, @c lit_buffer (both padded
- * for wild-copy overshoot) and the token / PivCo decode scratch buffers.
- * Compress (@p mode == 1) reserves the LZ match-finder
- * tables (hash positions, tags, chain), the sequence / extras / literal buffers
- * and - only at @c level >= ZXC_LEVEL_DENSITY - the optimal-parser scratch. A
- * @p dict_size > 0 appends the [dict | data] concat scratch in both modes.
- *
- * Every offset is cache-line aligned via @c ZXC_ALIGN_CL.
- *
- * @param[in] chunk_size  Block size in bytes.
- * @param[in] mode        1 = compression, 0 = decompression.
- * @param[in] level       Compression level (only consulted when @p mode == 1).
- * @param[in] dict_size   Dictionary prefill size; when > 0 the layout includes
- *                        the [dict | data] concat buffer.
- * @return Fully populated layout; @c .total is the required workspace size.
- */
-/**
  * @brief Worst-case sequence count for one block. Shared by the compressor's
  *        buffer sizing and the decoder's token scratch: the decode side must
  *        accept exactly what the compress side can emit, so both derive from
@@ -156,6 +125,34 @@ static void zxc_dctx_entropy_sizes(const size_t chunk_size, size_t* RESTRICT sz_
     *sz_pivco = chunk_size + ZXC_PIVCO_SCRATCH_PAD;
 }
 
+/**
+ * @brief Computes the single-allocation memory layout for a compression /
+ *        decompression context.
+ *
+ * Walks the same partition order used by @ref zxc_cctx_init_in_workspace and
+ * records each sub-buffer's offset plus the running @c total, so the sizing
+ * query and the partitioning step share one source of truth and can never
+ * disagree.
+ *
+ * Decompress (@p mode == 0) reserves @c work_buf, @c lit_buffer (both padded
+ * for wild-copy overshoot) and the token / PivCo decode scratch buffers.
+ * Compress (@p mode == 1) reserves the LZ match-finder
+ * tables (hash positions, tags, chain), the sequence / extras / literal buffers
+ * and - only at @c level >= ZXC_LEVEL_DENSITY - the optimal-parser scratch. A
+ * @p dict_size > 0 appends the [dict | data] concat scratch in both modes.
+ *
+ * Every offset is cache-line aligned via @c ZXC_ALIGN_CL.
+ *
+ * @param[in] chunk_size  Block size in bytes.
+ * @param[in] mode        1 = compression, 0 = decompression.
+ * @param[in] level       Compression level (only consulted when @p mode == 1).
+ * @param[in] dict_size   Dictionary prefill size; when > 0 the layout includes
+ *                        the [dict | data] concat buffer.
+ * @param[in] defer_entropy_scratch  When non-zero, the decode-side token
+ *                        and PivCo scratch are left out of the layout and
+ *                        allocated lazily on the first entropy section.
+ * @return Fully populated layout; @c .total is the required workspace size.
+ */
 static zxc_cctx_layout_t compute_cctx_layout(const size_t chunk_size, const int mode,
                                              const int level, const size_t dict_size,
                                              const int defer_entropy_scratch) {
@@ -258,12 +255,6 @@ static zxc_cctx_layout_t compute_cctx_layout(const size_t chunk_size, const int 
  * Public contract documented at the declaration in @c zxc_internal.h. Thin
  * wrapper that returns @c compute_cctx_layout(...).total, or 0 when
  * @p chunk_size is 0.
- *
- * @param[in] chunk_size  Block size in bytes.
- * @param[in] mode        1 = compression, 0 = decompression.
- * @param[in] level       Compression level (only consulted when @p mode == 1).
- * @param[in] dict_size   Dictionary prefill size; > 0 includes the concat buffer.
- * @return Workspace size in bytes, or 0 if @p chunk_size is 0.
  */
 size_t zxc_cctx_compute_workspace_size(const size_t chunk_size, const int mode, const int level,
                                        const size_t dict_size) {
@@ -279,16 +270,6 @@ size_t zxc_cctx_compute_workspace_size(const size_t chunk_size, const int mode, 
  * @ref compute_cctx_layout, rejects an undersized @p workspace, then carves the
  * sub-buffers out of it. @c ctx->memory_block stays NULL so @ref zxc_cctx_free
  * leaves the caller-owned workspace untouched.
- *
- * @param[out] ctx               Context to initialise.
- * @param[in]  workspace         Caller-allocated, cache-line-aligned buffer.
- * @param[in]  workspace_size    Capacity of @p workspace in bytes.
- * @param[in]  chunk_size        Block size in bytes.
- * @param[in]  mode              1 = compression, 0 = decompression.
- * @param[in]  level             Compression level (ignored when @p mode == 0).
- * @param[in]  checksum_enabled  Non-zero to enable checksum computation.
- * @param[in]  dict_size         Dictionary prefill size; > 0 carves the concat buffer.
- * @return @ref ZXC_OK, @ref ZXC_ERROR_NULL_INPUT, or @ref ZXC_ERROR_DST_TOO_SMALL.
  */
 int zxc_cctx_init_in_workspace(zxc_cctx_t* RESTRICT ctx, void* RESTRICT workspace,
                                const size_t workspace_size, const size_t chunk_size, const int mode,
@@ -361,19 +342,11 @@ int zxc_cctx_init_in_workspace(zxc_cctx_t* RESTRICT ctx, void* RESTRICT workspac
  * @brief Initialises a compression / decompression context, allocating the
  *        persistent buffer with @c ZXC_ALIGNED_MALLOC.
  *
- * Thin wrapper around @ref zxc_cctx_init_in_workspace: sizes the buffer via
+ * Thin wrapper around zxc_cctx_init_in_workspace(): sizes the buffer via
  * @ref zxc_cctx_compute_workspace_size, allocates it, then partitions it.
  * The pointer is stored in @c ctx->memory_block so @ref zxc_cctx_free can
  * release it.  The static-cctx public API (see @c zxc_buffer.h) bypasses
  * this wrapper and partitions a caller-supplied workspace directly.
- *
- * @param[out] ctx               Context to initialise.
- * @param[in]  chunk_size        Block size in bytes.
- * @param[in]  mode              1 = compression, 0 = decompression.
- * @param[in]  level             Compression level (ignored when @p mode == 0).
- * @param[in]  checksum_enabled  Non-zero to enable checksum computation.
- * @param[in]  dict_size         Dictionary prefill size.
- * @return @ref ZXC_OK on success, @ref ZXC_ERROR_MEMORY on allocation failure.
  */
 int zxc_cctx_init(zxc_cctx_t* RESTRICT ctx, const size_t chunk_size, const int mode,
                   const int level, const int checksum_enabled, const size_t dict_size) {
@@ -433,8 +406,6 @@ int zxc_cctx_alloc_entropy_scratch(zxc_cctx_t* ctx) {
  *
  * After this call every pointer inside @p ctx is @c NULL and the context
  * may be safely re-initialised with zxc_cctx_init().
- *
- * @param[in,out] ctx Context to tear down.
  */
 void zxc_cctx_free(zxc_cctx_t* ctx) {
     if (ctx->memory_block) {
@@ -521,15 +492,6 @@ int zxc_cctx_attach_dict_huf(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRICT l
  *
  * Layout (16 bytes): Magic (4) | Version (1) | Chunk (1) | Flags (1) |
  * Reserved (7) | Checksum-16 (2).
- *
- * @param[out] dst          Destination buffer (>= @ref ZXC_FILE_HEADER_SIZE bytes).
- * @param[in]  dst_capacity Capacity of @p dst.
- * @param[in]  chunk_size   Block size (stored as its log2 exponent).
- * @param[in]  has_checksum Non-zero to set the checksum flag.
- * @param[in]  dict_id      Dictionary id; when non-zero, sets the dictionary flag
- *                          and is stored in the header.
- * @return Number of bytes written (@ref ZXC_FILE_HEADER_SIZE) on success,
- *         or a negative @ref zxc_error_t code.
  */
 int zxc_write_file_header(uint8_t* RESTRICT dst, const size_t dst_capacity, const size_t chunk_size,
                           const int has_checksum, const uint32_t dict_id) {
@@ -561,15 +523,6 @@ int zxc_write_file_header(uint8_t* RESTRICT dst, const size_t dst_capacity, cons
  * @brief Parses and validates a ZXC file header from @p src.
  *
  * Checks the magic word, format version, and 16-bit checksum.
- *
- * @param[in]  src              Source buffer (>= @ref ZXC_FILE_HEADER_SIZE bytes).
- * @param[in]  src_size         Size of @p src.
- * @param[out] out_block_size   Receives the decoded block size (may be @c NULL).
- * @param[out] out_has_checksum Receives 1 if checksums are present, 0 otherwise
- *                              (may be @c NULL).
- * @param[out] out_dict_id      Receives the dictionary id, or 0 if none
- *                              (may be @c NULL).
- * @return @ref ZXC_OK on success, or a negative @ref zxc_error_t code.
  */
 int zxc_read_file_header(const uint8_t* RESTRICT src, const size_t src_size,
                          size_t* RESTRICT out_block_size, int* RESTRICT out_has_checksum,
@@ -604,12 +557,6 @@ int zxc_read_file_header(const uint8_t* RESTRICT src, const size_t src_size,
 
 /**
  * @brief Serialises a block header (8 bytes) into @p dst.
- *
- * @param[out] dst          Destination buffer (>= @ref ZXC_BLOCK_HEADER_SIZE bytes).
- * @param[in]  dst_capacity Capacity of @p dst.
- * @param[in]  bh           Populated block header descriptor.
- * @return Number of bytes written (@ref ZXC_BLOCK_HEADER_SIZE) on success,
- *         or a negative @ref zxc_error_t code.
  */
 int zxc_write_block_header(uint8_t* RESTRICT dst, const size_t dst_capacity,
                            const zxc_block_header_t* RESTRICT bh) {
@@ -629,11 +576,6 @@ int zxc_write_block_header(uint8_t* RESTRICT dst, const size_t dst_capacity,
  * @brief Parses and validates a block header from @p src.
  *
  * Validates the 8-bit checksum embedded in the header.
- *
- * @param[in]  src      Source buffer (>= @ref ZXC_BLOCK_HEADER_SIZE bytes).
- * @param[in]  src_size Size of @p src.
- * @param[out] bh       Receives the decoded block header fields.
- * @return @ref ZXC_OK on success, or a negative @ref zxc_error_t code.
  */
 int zxc_read_block_header(const uint8_t* RESTRICT src, const size_t src_size,
                           zxc_block_header_t* RESTRICT bh) {
@@ -655,14 +597,6 @@ int zxc_read_block_header(const uint8_t* RESTRICT src, const size_t src_size,
 
 /**
  * @brief Writes the 12-byte file footer (source size + global checksum).
- *
- * @param[out] dst              Destination buffer (>= @ref ZXC_FILE_FOOTER_SIZE bytes).
- * @param[in]  dst_capacity     Capacity of @p dst.
- * @param[in]  src_size         Original uncompressed size in bytes.
- * @param[in]  global_hash      Accumulated global checksum value.
- * @param[in]  checksum_enabled Non-zero to write the checksum; zero to zero-fill.
- * @return Number of bytes written (@ref ZXC_FILE_FOOTER_SIZE) on success,
- *         or a negative @ref zxc_error_t code.
  */
 int zxc_write_file_footer(uint8_t* RESTRICT dst, const size_t dst_capacity, const uint64_t src_size,
                           const uint32_t global_hash, const int checksum_enabled) {
@@ -730,13 +664,6 @@ static ZXC_ALWAYS_INLINE size_t zxc_glo_desc_size(const uint8_t enc_lit, const u
  * when level 7 Huffman-codes it. The decoder derives the rest - literals raw
  * size from @c n_literals, offsets from @c n_sequences and @c enc_off, extras
  * from the payload residue - so those cannot be forged inconsistently.
- *
- * @param[out] dst      Destination buffer.
- * @param[in]  rem      Remaining capacity of @p dst.
- * @param[in]  gh       Populated GLO header descriptor.
- * @param[in]  lit_comp Compressed size of the literal section.
- * @param[in]  tok_comp Compressed size of the token section.
- * @return Total bytes written on success, or a negative @ref zxc_error_t code.
  */
 int zxc_write_glo_header_and_desc(uint8_t* RESTRICT dst, const size_t rem,
                                   const zxc_gnr_header_t* RESTRICT gh, const uint32_t lit_comp,
@@ -762,13 +689,6 @@ int zxc_write_glo_header_and_desc(uint8_t* RESTRICT dst, const size_t rem,
 
 /**
  * @brief Parses a GLO block header and its section descriptors from @p src.
- *
- * @param[in]  src      Source buffer.
- * @param[in]  len      Size of @p src.
- * @param[out] gh       Receives the decoded GLO header.
- * @param[out] lit_comp Receives the literal section's compressed size.
- * @param[out] tok_comp Receives the token section's compressed size.
- * @return Bytes consumed (header + table), or a negative @ref zxc_error_t code.
  */
 int zxc_read_glo_header_and_desc(const uint8_t* RESTRICT src, const size_t len,
                                  zxc_gnr_header_t* RESTRICT gh, uint32_t* RESTRICT lit_comp,
@@ -801,11 +721,6 @@ int zxc_read_glo_header_and_desc(const uint8_t* RESTRICT src, const size_t len,
  * (`lit_comp == gh->n_literals`), its sequence stream is
  * `gh->n_sequences * 4` bytes wide, and its extras run from there to the
  * payload end.
- *
- * @param[out] dst Destination buffer.
- * @param[in]  rem Remaining capacity of @p dst.
- * @param[in]  gh  Populated GHI header descriptor.
- * @return Total bytes written on success, or a negative @ref zxc_error_t code.
  */
 int zxc_write_ghi_header(uint8_t* RESTRICT dst, const size_t rem,
                          const zxc_gnr_header_t* RESTRICT gh) {
@@ -817,11 +732,6 @@ int zxc_write_ghi_header(uint8_t* RESTRICT dst, const size_t rem,
 
 /**
  * @brief Parses a GHI block header from @p src.
- *
- * @param[in]  src Source buffer.
- * @param[in]  len Size of @p src.
- * @param[out] gh  Receives the decoded GHI header.
- * @return @ref ZXC_OK on success, or a negative @ref zxc_error_t code.
  */
 int zxc_read_ghi_header(const uint8_t* RESTRICT src, const size_t len,
                         zxc_gnr_header_t* RESTRICT gh) {
@@ -843,9 +753,6 @@ int zxc_read_ghi_header(const uint8_t* RESTRICT src, const size_t len,
  *
  * The block count is derived from @ref ZXC_BLOCK_SIZE_MIN (4 KB) to
  * guarantee the bound holds for all valid block sizes and seekable mode.
- *
- * @param[in] input_size Uncompressed input size in bytes.
- * @return Upper bound on compressed size, or 0 if @p input_size would overflow.
  */
 uint64_t zxc_compress_bound(const size_t input_size) {
     // Guard against uint64 overflow when summing per-block overhead
@@ -863,12 +770,6 @@ uint64_t zxc_compress_bound(const size_t input_size) {
 
 /**
  * @brief Returns the maximum compressed size for a single block (no file framing).
- *
- * @param[in] input_size Uncompressed block size in bytes
- *                       (must be <= @ref ZXC_BLOCK_SIZE_MAX).
- * @return Upper bound on compressed block size, or 0 if @p input_size is out
- *         of range for the Block API (i.e. exceeds ZXC_BLOCK_SIZE_MAX) or if
- *         the arithmetic would overflow.
  */
 uint64_t zxc_compress_block_bound(const size_t input_size) {
     // Mirrors the Block API contract: outside [1, ZXC_BLOCK_SIZE_MAX] the call
@@ -891,10 +792,6 @@ uint64_t zxc_compress_block_bound(const size_t input_size) {
  *
  * Returns 0 if @p uncompressed_size exceeds ZXC_BLOCK_SIZE_MAX (the Block API
  * limit), or if the arithmetic would overflow.
- *
- * @param[in] uncompressed_size  Exact decompressed size of the block.
- * @return Minimum @c dst_capacity in bytes, or 0 if @p uncompressed_size exceeds
- *         @c ZXC_BLOCK_SIZE_MAX.
  */
 uint64_t zxc_decompress_block_bound(const size_t uncompressed_size) {
     if (UNLIKELY(uncompressed_size > ZXC_BLOCK_SIZE_MAX)) return 0;
@@ -914,10 +811,6 @@ uint64_t zxc_decompress_block_bound(const size_t uncompressed_size) {
  * (@c opt_scratch, ~8.125 bytes per chunk_size byte) used by the optimal
  * parser and reused as transient package-merge scratch for the Huffman
  * code-length builder.
- *
- * @param[in] src_size  Input size; rounded up to a valid block size.
- * @param[in] level     Compression level (>= 6 includes the optimal-parser scratch).
- * @return Estimated context buffer size in bytes, or 0 if @p src_size is 0.
  */
 uint64_t zxc_estimate_cctx_size(const size_t src_size, const int level) {
     if (UNLIKELY(src_size == 0)) return 0;
@@ -931,10 +824,6 @@ uint64_t zxc_estimate_cctx_size(const size_t src_size, const int level) {
 
 /**
  * @brief Returns a human-readable string for the given error code.
- *
- * @param[in] code An error code from @ref zxc_error_t (or @ref ZXC_OK).
- * @return A static string such as @c "ZXC_OK" or @c "ZXC_ERROR_MEMORY".
- *         Returns @c "ZXC_UNKNOWN_ERROR" for unrecognised codes.
  */
 const char* zxc_error_name(const int code) {
     switch ((zxc_error_t)code) {

--- a/src/lib/zxc_compress.c
+++ b/src/lib/zxc_compress.c
@@ -2041,13 +2041,6 @@ static int zxc_encode_block_raw(const uint8_t* RESTRICT src, const size_t src_sz
  * block when the coded form would not shrink the data. When @c ctx->dict_size
  * is > 0, @p chunk is the [dict | block] concat and only the block tail counts
  * toward the expansion check. Appends the per-block checksum when enabled.
- *
- * @param[in,out] ctx     Compression context (level, dict_size, checksum, buffers).
- * @param[in]     chunk   Source bytes ([dict | block] when a dictionary is active).
- * @param[in]     src_sz  Length of @p chunk in bytes (includes any dict prefix).
- * @param[out]    dst     Destination block buffer.
- * @param[in]     dst_cap Capacity of @p dst in bytes.
- * @return Compressed block size in bytes on success, or a negative @ref zxc_error_t.
  */
 // cppcheck-suppress unusedFunction
 int zxc_compress_chunk_wrapper(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRICT chunk,

--- a/src/lib/zxc_decompress.c
+++ b/src/lib/zxc_decompress.c
@@ -272,7 +272,7 @@ static ZXC_ALWAYS_INLINE void zxc_decode_copy_overlap_run32(uint8_t* dst, const 
 /**
  * @brief Overlap copy for a run of period @p off (2..31) bounded by @c ml <= 32.
  *
- * Bounded length buys two things over @ref zxc_decode_copy_overlap_run32: the
+ * Bounded length buys two things over zxc_decode_copy_overlap_run32(): the
  * loop disappears, and the upper 16 bytes are skipped whenever @p ml allows -
  * which is most of the time, GLO matches averaging 7 to 11 bytes here.
  *
@@ -353,7 +353,7 @@ static ZXC_ALWAYS_INLINE void zxc_decode_copy_overlap_short(uint8_t* dst, const 
  * libc memset call on the typically short runs of the hot path. Like the other
  * run copiers it may **overshoot** up to 31 bytes past @p ml; the caller must
  * guarantee @ref ZXC_PAD_SIZE bytes of headroom. Falls back to
- * @ref ZXC_MEMSET on non-SIMD builds.
+ * `ZXC_MEMSET` on non-SIMD builds.
  *
  * @param[out] dst  Output cursor.
  * @param[in]  byte Byte value to replicate.
@@ -614,7 +614,7 @@ static ZXC_NOINLINE void zxc_decode_copy_match_exact(uint8_t* d_ptr, const uint8
  * @brief Decodes one GLO sequence of a 4x batch: extracts ll/ml, applies the
  *        varint extensions with their bounds checks, then emits via @p DECODE.
  *
- * Like @ref DECODE_MATCH_SAFE, references the call site's local names (e_ptr,
+ * Like `DECODE_MATCH_SAFE`, references the call site's local names (e_ptr,
  * e_end, l_ptr, l_end, d_ptr, d_end). @p RESERVE is the sum of the inline
  * (pre-varint) literal lengths of the batch's remaining sequences, so one
  * l_ptr bound covers the whole batch; @p N_REM counts the remaining
@@ -1699,13 +1699,6 @@ static ZXC_ALWAYS_INLINE int zxc_decompress_chunk_wrapper_body(
  *
  * Inlines the plain GLO/GHI decoders via @ref zxc_decompress_chunk_wrapper_body
  * with @c has_dict=0, so it carries no dict code and matches the dict-free build.
- *
- * @param[in,out] ctx     Decompression context.
- * @param[in]     src     Compressed block bytes.
- * @param[in]     src_sz  Size of @p src in bytes.
- * @param[out]    dst     Destination buffer for the decoded block.
- * @param[in]     dst_cap Capacity of @p dst in bytes.
- * @return Bytes written on success, or a negative @ref zxc_error_t.
  */
 // cppcheck-suppress unusedFunction
 int zxc_decompress_chunk_wrapper(const zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRICT src,

--- a/src/lib/zxc_dict.c
+++ b/src/lib/zxc_dict.c
@@ -25,12 +25,6 @@
  * Public API; see @c zxc_dict.h. One checksum over the content, chained with
  * the packed Huffman lengths so a single id covers both. Stored in the archive
  * header and re-checked on decode.
- *
- * @param[in] dict         Dictionary content bytes.
- * @param[in] dict_size    Content length in bytes.
- * @param[in] huf_lengths  Optional packed Huffman lengths (@c ZXC_HUF_TABLE_SIZE
- *                         bytes), or NULL to hash the content alone.
- * @return The 32-bit dictionary id, or 0 if @p dict is NULL or empty.
  */
 uint32_t zxc_dict_id(const void* RESTRICT dict, const size_t dict_size,
                      const void* RESTRICT huf_lengths) {
@@ -62,10 +56,6 @@ uint32_t zxc_dict_id(const void* RESTRICT dict, const size_t dict_size,
  * @brief Extracts the stored @c dict_id from a serialized .zxd buffer.
  *
  * Public API; see @c zxc_dict.h. Reads the header field without recomputing it.
- *
- * @param[in] buf       Serialized .zxd bytes.
- * @param[in] buf_size  Size of @p buf in bytes.
- * @return The stored dictionary id, or 0 if @p buf is too small or not a .zxd.
  */
 uint32_t zxc_dict_get_id(const void* buf, const size_t buf_size) {
     if (UNLIKELY(!buf || buf_size < ZXC_DICT_HEADER_SIZE)) return 0;
@@ -78,9 +68,6 @@ uint32_t zxc_dict_get_id(const void* buf, const size_t buf_size) {
  * @brief Worst-case .zxd byte size for a dictionary of @p content_size bytes.
  *
  * Public API; see @c zxc_dict.h. Sizes the buffer for @ref zxc_dict_save.
- *
- * @param[in] content_size  Dictionary content length in bytes.
- * @return Required buffer size: header + content + Huffman table.
  */
 size_t zxc_dict_save_bound(const size_t content_size) {
     return ZXC_DICT_HEADER_SIZE + content_size + ZXC_HUF_TABLE_SIZE;
@@ -91,15 +78,6 @@ size_t zxc_dict_save_bound(const size_t content_size) {
  *
  * Public API; full contract in @c zxc_dict.h. Header, then content, then packed
  * Huffman lengths - layout above.
- *
- * @param[in]  content       Dictionary content bytes.
- * @param[in]  content_size  Content length (<= @c ZXC_DICT_SIZE_MAX).
- * @param[in]  huf_lengths   Packed Huffman lengths (@c ZXC_HUF_TABLE_SIZE bytes).
- * @param[out] buf           Destination .zxd buffer.
- * @param[in]  buf_capacity  Capacity of @p buf (>= @ref zxc_dict_save_bound).
- * @return Bytes written on success, or a negative @ref zxc_error_t
- *         (@ref ZXC_ERROR_NULL_INPUT, @ref ZXC_ERROR_DICT_TOO_LARGE,
- *         @ref ZXC_ERROR_DST_TOO_SMALL).
  */
 int64_t zxc_dict_save(const void* RESTRICT content, const size_t content_size,
                       const void* RESTRICT huf_lengths, void* RESTRICT buf,
@@ -133,15 +111,6 @@ int64_t zxc_dict_save(const void* RESTRICT content, const size_t content_size,
  * Public API; full contract in @c zxc_dict.h. Validates magic, version, header
  * checksum and dict_id, then points the out-params into @p buf - no copy, so they
  * stay valid only while @p buf does.
- *
- * @param[in]  buf               Serialized .zxd bytes.
- * @param[in]  buf_size          Size of @p buf in bytes.
- * @param[out] content_out       Receives a pointer to the content bytes.
- * @param[out] content_size_out  Receives the content length.
- * @param[out] huf_out           Receives a pointer to the Huffman table (optional).
- * @param[out] dict_id_out       Receives the validated dict_id (optional).
- * @return @ref ZXC_OK, or a negative @ref zxc_error_t (bad magic / version /
- *         header / checksum, or too small).
  */
 int zxc_dict_load(const void* RESTRICT buf, const size_t buf_size,
                   const void** RESTRICT content_out, size_t* RESTRICT content_size_out,
@@ -186,11 +155,6 @@ int zxc_dict_load(const void* RESTRICT buf, const size_t buf_size,
  *
  * Public API; see @c zxc_dict.h. Locates the table on magic/version/size checks
  * alone, skipping @ref zxc_dict_load's full validation. Aliases @p buf.
- *
- * @param[in] buf       Serialized .zxd bytes.
- * @param[in] buf_size  Size of @p buf in bytes.
- * @return Pointer to the @c ZXC_HUF_TABLE_SIZE-byte table, or NULL if @p buf is
- *         too small or not a valid .zxd.
  */
 const void* zxc_dict_huf(const void* buf, const size_t buf_size) {
     if (UNLIKELY(!buf || buf_size < ZXC_DICT_HEADER_SIZE)) return NULL;
@@ -247,7 +211,7 @@ typedef struct {
  * @brief Restore the min-heap property at @p root over the range @p a[0..n).
  *
  * Sinks @p a[root] until both children are @c >= it, comparing on
- * @ref zxc_dict_seg_t::score. Iterative, so the stack stays O(1).
+ * `zxc_dict_seg_t::score`. Iterative, so the stack stays O(1).
  *
  * @param[in,out] a    Heap-ordered array; @p a[0..n) is treated as the heap.
  * @param[in]     root Index of the element to sift down. Must be @c < n.
@@ -267,7 +231,7 @@ static void zxc_dict_sift_down(zxc_dict_seg_t* RESTRICT a, size_t root, const si
 }
 
 /**
- * @brief Sort @p a[0..n) by @ref zxc_dict_seg_t::score in descending order.
+ * @brief Sort @p a[0..n) by `zxc_dict_seg_t::score` in descending order.
  *
  * In-place heapsort: a min-heap pushes the smallest scores to the tail, so the
  * array ends up descending, which is what the fill step wants. Not @c qsort:
@@ -298,13 +262,6 @@ static void zxc_dict_sort_segs_desc(zxc_dict_seg_t* RESTRICT a, const size_t n) 
  * Public API; full contract in @c zxc_dict.h, algorithm in the note above.
  * Picks are emitted in reverse so the highest-coverage bytes land at the dict's
  * end, where match offsets are smallest.
- *
- * @param[in]  samples        Array of @p n_samples sample buffers.
- * @param[in]  sample_sizes   Array of @p n_samples sample lengths.
- * @param[in]  n_samples      Number of samples.
- * @param[out] dict_buf       Destination for the trained content.
- * @param[in]  dict_capacity  Capacity of @p dict_buf (<= @c ZXC_DICT_SIZE_MAX).
- * @return Trained content length in bytes, or a negative @ref zxc_error_t.
  */
 int64_t zxc_train_dict(const void* const* RESTRICT samples, const size_t* RESTRICT sample_sizes,
                        const size_t n_samples, void* RESTRICT dict_buf,
@@ -478,14 +435,6 @@ int64_t zxc_train_dict(const void* const* RESTRICT samples, const size_t* RESTRI
  *
  * Public API; see @c zxc_dict.h and the algorithm note above. Slices are
  * sub-sampled to a fixed budget.
- *
- * @param[in]  samples          Array of @p n_samples sample buffers.
- * @param[in]  sample_sizes     Array of @p n_samples sample lengths.
- * @param[in]  n_samples        Number of samples.
- * @param[in]  dict             Trained dictionary content.
- * @param[in]  dict_size        Dictionary length (<= @c ZXC_DICT_SIZE_MAX).
- * @param[out] huf_lengths_out  Receives the @c ZXC_HUF_TABLE_SIZE packed lengths.
- * @return @ref ZXC_OK, or a negative @ref zxc_error_t.
  */
 int zxc_train_dict_huf(const void* const* RESTRICT samples, const size_t* RESTRICT sample_sizes,
                        const size_t n_samples, const void* RESTRICT dict, const size_t dict_size,
@@ -589,13 +538,6 @@ int zxc_train_dict_huf(const void* const* RESTRICT samples, const size_t* RESTRI
  * Public API; see @c zxc_dict.h. Trains the content (@ref zxc_train_dict), then
  * the shared table from that content (@ref zxc_train_dict_huf), then serializes
  * both (@ref zxc_dict_save). The two phases are a real data dependency.
- *
- * @param[in]  samples       Array of @p n_samples sample buffers.
- * @param[in]  sample_sizes  Array of @p n_samples sample lengths.
- * @param[in]  n_samples     Number of samples.
- * @param[out] zxd_buf       Destination .zxd buffer.
- * @param[in]  zxd_capacity  Capacity of @p zxd_buf in bytes.
- * @return Bytes written to @p zxd_buf, or a negative @ref zxc_error_t.
  */
 int64_t zxc_dict_train(const void* const* RESTRICT samples, const size_t* RESTRICT sample_sizes,
                        const size_t n_samples, void* RESTRICT zxd_buf, const size_t zxd_capacity) {

--- a/src/lib/zxc_dispatch.c
+++ b/src/lib/zxc_dispatch.c
@@ -468,13 +468,6 @@ static int zxc_compress_dispatch_init(zxc_cctx_t* RESTRICT ctx, const uint8_t* R
 
 /**
  * @brief Public decompression dispatcher (calls lazily-resolved implementation).
- *
- * @param[in,out] ctx    Decompression context.
- * @param[in]     src    Compressed input chunk (header + payload + optional checksum).
- * @param[in]     src_sz Size of @p src in bytes.
- * @param[out]    dst    Destination buffer for decompressed data.
- * @param[in]     dst_cap Capacity of @p dst.
- * @return Decompressed size in bytes, or a negative @ref zxc_error_t code.
  */
 int zxc_decompress_chunk_wrapper(const zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRICT src,
                                  const size_t src_sz, uint8_t* RESTRICT dst, const size_t dst_cap) {
@@ -520,13 +513,6 @@ static int zxc_decompress_chunk_wrapper_safe_public(const zxc_cctx_t* RESTRICT c
 
 /**
  * @brief Public compression dispatcher (calls lazily-resolved implementation).
- *
- * @param[in,out] ctx    Compression context.
- * @param[in]     src    Uncompressed input chunk.
- * @param[in]     src_sz Size of @p src in bytes.
- * @param[out]    dst    Destination buffer for compressed data.
- * @param[in]     dst_cap Capacity of @p dst.
- * @return Compressed size in bytes, or a negative @ref zxc_error_t code.
  */
 int zxc_compress_chunk_wrapper(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRICT src,
                                const size_t src_sz, uint8_t* RESTRICT dst, const size_t dst_cap) {
@@ -555,13 +541,8 @@ int zxc_compress_chunk_wrapper(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRICT
 /**
  * @brief Build length-limited per-symbol Huffman code lengths from frequencies.
  *
- * Un-suffixed entry forwarding to @ref zxc_huf_build_code_lengths_default; full
+ * Un-suffixed entry forwarding to `zxc_huf_build_code_lengths_default`; full
  * contract in @c zxc_internal.h.
- *
- * @param[in]  freq      Per-symbol frequency counts.
- * @param[out] code_len  Per-symbol code lengths.
- * @param[in]  scratch   Caller-provided build scratch buffer.
- * @return `ZXC_OK` on success, negative `zxc_error_t` on failure.
  */
 int zxc_huf_build_code_lengths(const uint32_t* RESTRICT freq, uint8_t* RESTRICT code_len,
                                void* RESTRICT scratch, const int max_code_len) {
@@ -610,11 +591,8 @@ size_t zxc_huf_calc_size_dict(const uint32_t* RESTRICT freq, const uint8_t* REST
 /**
  * @brief Pack per-symbol code lengths into the 128-byte nibble header.
  *
- * Un-suffixed entry forwarding to @ref zxc_huf_pack_lengths_default; full
+ * Un-suffixed entry forwarding to `zxc_huf_pack_lengths_default`; full
  * contract in @c zxc_internal.h.
- *
- * @param[in]  code_len  Per-symbol code lengths (one byte each).
- * @param[out] out       Destination 128-byte packed header.
  */
 void zxc_huf_pack_lengths(const uint8_t* RESTRICT code_len, uint8_t* RESTRICT out) {
     zxc_huf_pack_lengths_default(code_len, out);
@@ -623,12 +601,8 @@ void zxc_huf_pack_lengths(const uint8_t* RESTRICT code_len, uint8_t* RESTRICT ou
 /**
  * @brief Unpack and validate a 128-byte packed lengths header.
  *
- * Un-suffixed entry forwarding to @ref zxc_huf_unpack_lengths_default; full
+ * Un-suffixed entry forwarding to `zxc_huf_unpack_lengths_default`; full
  * contract in @c zxc_internal.h.
- *
- * @param[in]  in        128-byte packed lengths header.
- * @param[out] code_len  Destination per-symbol code lengths.
- * @return `ZXC_OK` on success, `ZXC_ERROR_CORRUPT_DATA` on invalid lengths.
  */
 int zxc_huf_unpack_lengths(const uint8_t* RESTRICT in, uint8_t* RESTRICT code_len) {
     return zxc_huf_unpack_lengths_default(in, code_len);
@@ -645,14 +619,6 @@ int zxc_huf_unpack_lengths(const uint8_t* RESTRICT in, uint8_t* RESTRICT code_le
  *
  * Manages context allocation internally, loops over blocks, writes the
  * file header / EOF block / footer, and accumulates the global checksum.
- *
- * @param[in]  src              Uncompressed input data.
- * @param[in]  src_size         Size of @p src in bytes.
- * @param[out] dst              Destination buffer (use zxc_compress_bound() to size).
- * @param[in]  dst_capacity     Capacity of @p dst.
- * @param[in]  opts             Compression options (level, block size, checksum,
- *                              dictionary, seekable, threads), or NULL for defaults.
- * @return Total compressed size in bytes, or a negative @ref zxc_error_t code.
  */
 // cppcheck-suppress unusedFunction
 int64_t zxc_compress(const void* RESTRICT src, const size_t src_size, void* RESTRICT dst,
@@ -829,14 +795,6 @@ static int64_t zxc_decompress_frame(const uint8_t* src, size_t src_size, uint8_t
  *
  * Validates the file header and footer, loops over compressed blocks,
  * and verifies the global checksum when enabled.
- *
- * @param[in]  src              Compressed input data.
- * @param[in]  src_size         Size of @p src in bytes.
- * @param[out] dst              Destination buffer for decompressed data.
- * @param[in]  dst_capacity     Capacity of @p dst.
- * @param[in]  opts             Decompression options (checksum verification,
- *                              dictionary, threads), or NULL for defaults.
- * @return Total decompressed size in bytes, or a negative @ref zxc_error_t code.
  */
 // cppcheck-suppress unusedFunction
 int64_t zxc_decompress(const void* RESTRICT src, const size_t src_size, void* RESTRICT dst,
@@ -1122,10 +1080,6 @@ static int zxc_inplace_probe(const uint8_t* comp, const size_t comp_size, uint64
  * close to the output boundary. Enforcing a minimum bound via src_size + floor maintains the
  * required separation regardless of archive padding. For authentic archives, this adjustment grows
  * the bound by at most 16 bytes and guarantees it never shrinks.
- *
- * @param[in] src      Compressed archive (only header + footer are read).
- * @param[in] src_size Size of the archive in bytes.
- * @return Required buffer size in bytes, or 0 if @p src is not a valid archive.
  */
 // cppcheck-suppress unusedFunction
 size_t zxc_decompress_inplace_bound(const void* src, const size_t src_size) {
@@ -1156,17 +1110,6 @@ size_t zxc_decompress_inplace_bound(const void* src, const size_t src_size) {
  * the read cursor, so a single allocation replaces the usual input+output pair.
  * Dictionary archives are supported (they decode through the context's own
  * bounce buffer, which does not alias @p buffer).
- *
- * @param[in,out] buffer           Single work buffer holding the flush-right
- *                                 archive; receives the decompressed output.
- * @param[in]     buffer_capacity  Total size of @p buffer in bytes.
- * @param[in]     comp_size        Size of the compressed archive in bytes.
- * @param[in]     opts             Decompression options, or NULL for defaults.
- * @return Decompressed size in bytes, or a negative @ref zxc_error_t code:
- *         @ref ZXC_ERROR_DST_TOO_SMALL if the buffer is short of either margin,
- *         otherwise the @ref zxc_inplace_probe verdict
- *         (@ref ZXC_ERROR_BAD_MAGIC, @ref ZXC_ERROR_BAD_HEADER,
- *         @ref ZXC_ERROR_CORRUPT_DATA).
  */
 // cppcheck-suppress unusedFunction
 int64_t zxc_decompress_inplace(void* buffer, const size_t buffer_capacity, const size_t comp_size,
@@ -1193,12 +1136,8 @@ int64_t zxc_decompress_inplace(void* buffer, const size_t buffer_capacity, const
  * @brief Reads the decompressed size from a ZXC-compressed buffer.
  *
  * The size sits in the file footer (last @ref ZXC_FILE_FOOTER_SIZE bytes) and is
- * untrusted, so it goes through @ref zxc_footer_dsize_plausible: a forged size
+ * untrusted, so it goes through zxc_footer_dsize_plausible(): a forged size
  * returns 0, and callers sizing an allocation from it inherit the check.
- *
- * @param[in] src      Compressed data.
- * @param[in] src_size Size of @p src in bytes.
- * @return Original uncompressed size, or 0 on error or an implausible footer.
  */
 uint64_t zxc_get_decompressed_size(const void* src, const size_t src_size) {
     if (UNLIKELY(src_size < ZXC_FILE_HEADER_SIZE + ZXC_FILE_FOOTER_SIZE)) return 0;
@@ -1224,11 +1163,6 @@ uint64_t zxc_get_decompressed_size(const void* src, const size_t src_size) {
  *
  * Public API; see @c zxc_buffer.h. Validates the magic, then returns the
  * header's @c dict_id field when the dictionary flag is set. Does not decompress.
- *
- * @param[in] src       Start of the compressed archive (>= @c ZXC_FILE_HEADER_SIZE).
- * @param[in] src_size  Size of @p src in bytes.
- * @return The dictionary id, or 0 if @p src is invalid or the archive uses no
- *         dictionary.
  */
 // cppcheck-suppress unusedFunction
 uint32_t zxc_get_dict_id(const void* src, const size_t src_size) {
@@ -1303,8 +1237,6 @@ zxc_cctx* zxc_create_cctx(const zxc_compress_opts_t* opts) {
  * Public API; see @c zxc_buffer.h. Frees the inner buffers and the handle.
  * NULL-safe. For a static (caller-workspace) context this is a no-op, since the
  * caller owns the workspace.
- *
- * @param[in] cctx  Context from @ref zxc_create_cctx (may be NULL).
  */
 void zxc_free_cctx(zxc_cctx* cctx) {
     if (UNLIKELY(!cctx)) return;
@@ -1322,15 +1254,6 @@ void zxc_free_cctx(zxc_cctx* cctx) {
  * the context's sticky defaults, re-initialises the inner buffers only when the
  * block size changes (level / checksum update in place), then writes the file
  * header, the compressed blocks, the EOF block and the footer.
- *
- * @param[in,out] cctx          Reusable compression context.
- * @param[in]     src           Source bytes.
- * @param[in]     src_size      Number of source bytes (must be > 0).
- * @param[out]    dst           Destination buffer for the archive.
- * @param[in]     dst_capacity  Capacity of @p dst in bytes.
- * @param[in]     opts          Per-call option overrides, or NULL for the
- *                              context defaults.
- * @return Archive size in bytes on success, or a negative @ref zxc_error_t.
  */
 int64_t zxc_compress_cctx(zxc_cctx* cctx, const void* RESTRICT src, const size_t src_size,
                           void* RESTRICT dst, const size_t dst_capacity,
@@ -1464,8 +1387,6 @@ zxc_dctx* zxc_create_dctx(void) {
  *
  * Public API; see @c zxc_buffer.h. Frees the inner buffers and the handle.
  * NULL-safe; a no-op for a static (caller-workspace) context.
- *
- * @param[in] dctx  Context from @ref zxc_create_dctx (may be NULL).
  */
 void zxc_free_dctx(zxc_dctx* dctx) {
     if (UNLIKELY(!dctx)) return;
@@ -1484,14 +1405,6 @@ void zxc_free_dctx(zxc_dctx* dctx) {
  * dict call left a prefix), then decodes each block - straight into @p dst when
  * the tail padding fits, otherwise through a bounce buffer - and verifies the
  * footer size and optional checksum.
- *
- * @param[in,out] dctx          Reusable decompression context.
- * @param[in]     src           Compressed archive bytes.
- * @param[in]     src_size      Archive size (>= @c ZXC_FILE_HEADER_SIZE).
- * @param[out]    dst           Destination for the decompressed output.
- * @param[in]     dst_capacity  Capacity of @p dst in bytes.
- * @param[in]     opts          Per-call options (e.g. checksum), or NULL.
- * @return Decompressed size in bytes on success, or a negative @ref zxc_error_t.
  */
 int64_t zxc_decompress_dctx(zxc_dctx* dctx, const void* RESTRICT src, const size_t src_size,
                             void* RESTRICT dst, const size_t dst_capacity,
@@ -1615,14 +1528,6 @@ int64_t zxc_decompress_dctx(zxc_dctx* dctx, const void* RESTRICT src, const size
  * effective block size changes, or when a per-call level raise into the
  * optimal-parser tier requires the opt_scratch region; static contexts
  * reject both cases instead (the workspace cannot grow).
- *
- * @param[in,out] cctx          Reusable compression context.
- * @param[in]     src           Source block bytes.
- * @param[in]     src_size      Source length (0 < @p src_size <= @c ZXC_BLOCK_SIZE_MAX).
- * @param[out]    dst           Destination buffer for the block payload.
- * @param[in]     dst_capacity  Capacity of @p dst in bytes.
- * @param[in]     opts          Per-call options (level, dict, ...), or NULL.
- * @return Block payload size in bytes on success, or a negative @ref zxc_error_t.
  */
 int64_t zxc_compress_block(zxc_cctx* cctx, const void* RESTRICT src, const size_t src_size,
                            void* RESTRICT dst, const size_t dst_capacity,
@@ -1714,14 +1619,6 @@ int64_t zxc_compress_block(zxc_cctx* cctx, const void* RESTRICT src, const size_
  * With a dictionary in @p opts the decode runs through the [dict | decode]
  * bounce buffer; otherwise it goes straight into @p dst when the tail padding
  * fits, or via @c work_buf when it doesn't.
- *
- * @param[in,out] dctx          Reusable decompression context.
- * @param[in]     src           Compressed block bytes.
- * @param[in]     src_size      Source length (>= @c ZXC_BLOCK_HEADER_SIZE).
- * @param[out]    dst           Destination for the decoded payload.
- * @param[in]     dst_capacity  Capacity of @p dst in bytes.
- * @param[in]     opts          Per-call options (dict, checksum), or NULL.
- * @return Decoded payload size in bytes on success, or a negative @ref zxc_error_t.
  */
 int64_t zxc_decompress_block(zxc_dctx* dctx, const void* RESTRICT src, const size_t src_size,
                              void* RESTRICT dst, const size_t dst_capacity,
@@ -1801,14 +1698,6 @@ int64_t zxc_decompress_block(zxc_dctx* dctx, const void* RESTRICT src, const siz
  * use the strict safe decoder (no bounce buffer, no +ZXC_DECOMPRESS_TAIL_PAD).
  *
  * Public API; full contract in @c zxc_buffer.h.
- *
- * @param[in,out] dctx          Reusable decompression context.
- * @param[in]     src           Compressed block bytes.
- * @param[in]     src_size      Source length (>= @c ZXC_BLOCK_HEADER_SIZE).
- * @param[out]    dst           Destination for the decoded payload.
- * @param[in]     dst_capacity  Exact uncompressed size (<= @c ZXC_BLOCK_SIZE_MAX).
- * @param[in]     opts          Per-call options (dict, checksum), or NULL.
- * @return Decoded payload size in bytes on success, or a negative @ref zxc_error_t.
  */
 int64_t zxc_decompress_block_safe(zxc_dctx* dctx, const void* RESTRICT src, const size_t src_size,
                                   void* RESTRICT dst, const size_t dst_capacity,
@@ -1877,10 +1766,6 @@ int64_t zxc_decompress_block_safe(zxc_dctx* dctx, const void* RESTRICT src, cons
  * Public API; see @c zxc_buffer.h. Sum of the cache-line-aligned handle header
  * and the persistent buffer that @ref zxc_init_static_cctx carves for the given
  * @p block_size / @p level. Performs no allocation.
- *
- * @param[in] block_size  Block size the context will be pinned to.
- * @param[in] level       Compression level.
- * @return Required workspace size in bytes, or 0 if the parameters are invalid.
  */
 size_t zxc_static_cctx_workspace_size(const size_t block_size, const int level) {
     if (UNLIKELY(!zxc_validate_block_size(block_size))) return 0;
@@ -1928,9 +1813,6 @@ zxc_cctx* zxc_init_static_cctx(void* RESTRICT workspace, const size_t workspace_
  * Public API; see @c zxc_buffer.h. Sum of the cache-line-aligned handle header
  * and the persistent buffer that @ref zxc_init_static_dctx carves for the given
  * @p block_size. Performs no allocation.
- *
- * @param[in] block_size  Block size the context will be pinned to.
- * @return Required workspace size in bytes, or 0 if @p block_size is invalid.
  */
 size_t zxc_static_dctx_workspace_size(const size_t block_size) {
     if (UNLIKELY(!zxc_validate_block_size(block_size))) return 0;

--- a/src/lib/zxc_driver.c
+++ b/src/lib/zxc_driver.c
@@ -1026,11 +1026,6 @@ static int64_t zxc_stream_engine_run(FILE* f_in, FILE* f_out, const int n_thread
  * level, block size, checksums, seekable, dictionary) with their defaults, then
  * drives @ref zxc_stream_engine_run in compression mode with the
  * compress chunk processor.
- *
- * @param[in]  f_in   Input stream (must be non-NULL).
- * @param[out] f_out  Output stream (NULL performs a dry run / size estimate).
- * @param[in]  opts   Compression options, or NULL for all defaults.
- * @return Total bytes written on success, or a negative @ref zxc_error_t.
  */
 int64_t zxc_stream_compress(FILE* f_in, FILE* f_out, const zxc_compress_opts_t* opts) {
     if (UNLIKELY(!f_in)) return ZXC_ERROR_NULL_INPUT;
@@ -1062,11 +1057,6 @@ int64_t zxc_stream_compress(FILE* f_in, FILE* f_out, const zxc_compress_opts_t* 
  * checksums, dictionary), then drives @ref zxc_stream_engine_run in
  * decompression mode with the decompress chunk processor. The block size and
  * level are recovered from the archive header, not from @p opts.
- *
- * @param[in]  f_in   Input (compressed) stream (must be non-NULL).
- * @param[out] f_out  Output (decompressed) stream.
- * @param[in]  opts   Decompression options, or NULL for all defaults.
- * @return Total bytes written on success, or a negative @ref zxc_error_t.
  */
 int64_t zxc_stream_decompress(FILE* f_in, FILE* f_out, const zxc_decompress_opts_t* opts) {
     if (UNLIKELY(!f_in)) return ZXC_ERROR_NULL_INPUT;
@@ -1090,11 +1080,6 @@ int64_t zxc_stream_decompress(FILE* f_in, FILE* f_out, const zxc_decompress_opts
  * Public API; see @c zxc_stream.h. Validates the file magic, reads the 64-bit
  * decompressed-size field from the footer, and restores the caller's original
  * stream position before returning. Does not decompress any data.
- *
- * @param[in] f_in  Compressed stream (must be non-NULL and seekable).
- * @return Decompressed size in bytes, or a negative @ref zxc_error_t
- *         (@ref ZXC_ERROR_BAD_MAGIC, @ref ZXC_ERROR_SRC_TOO_SMALL,
- *         @ref ZXC_ERROR_IO).
  */
 int64_t zxc_stream_get_decompressed_size(FILE* f_in) {
     if (UNLIKELY(!f_in)) return ZXC_ERROR_NULL_INPUT;
@@ -1153,7 +1138,7 @@ typedef struct {
  * Win32 implementation: a positioned @c ReadFile via @c OVERLAPPED, so
  * concurrent worker threads never race on a shared file cursor.
  *
- * @param[in]  vctx    @ref zxc_stdio_ctx_t carrying the file handle.
+ * @param[in]  vctx    `zxc_stdio_ctx_t` carrying the file handle.
  * @param[out] dst     Destination buffer (at least @p len bytes).
  * @param[in]  len     Number of bytes to read.
  * @param[in]  offset  Absolute byte offset to read from.
@@ -1185,7 +1170,7 @@ typedef struct {
  * POSIX implementation: a single @c pread, which carries its own offset and so
  * is safe to call concurrently from multiple worker threads on one descriptor.
  *
- * @param[in]  vctx    @ref zxc_stdio_ctx_t carrying the file descriptor.
+ * @param[in]  vctx    `zxc_stdio_ctx_t` carrying the file descriptor.
  * @param[out] dst     Destination buffer (at least @p len bytes).
  * @param[in]  len     Number of bytes to read.
  * @param[in]  offset  Absolute byte offset to read from.
@@ -1207,10 +1192,6 @@ static int64_t zxc_stdio_read_at(void* vctx, void* dst, size_t len, uint64_t off
  * delegates to @ref zxc_seekable_open_reader. The reader context is heap-owned
  * and handed to the returned handle via @ref zxc_seekable_attach_owned_ctx, so
  * @ref zxc_seekable_free releases it.
- *
- * @param[in] f  Open, seekable file handle.
- * @return A handle to release with @ref zxc_seekable_free, or NULL on bad input,
- *         an I/O error, or a missing / malformed seek table.
  */
 zxc_seekable* zxc_seekable_open_file(FILE* f) {
     if (UNLIKELY(!f)) return NULL;

--- a/src/lib/zxc_huffman.c
+++ b/src/lib/zxc_huffman.c
@@ -159,15 +159,6 @@ static void pm_leaves_sort(pm_leaf_t* RESTRICT leaves, const int n) {
  * Symbols with `freq[i] == 0` get `code_len[i] == 0`; every other symbol
  * receives a length in `[1, ZXC_HUF_MAX_CODE_LEN_ULTRA]`. The single-present-symbol
  * case is handled as a degenerate code of length 1.
- *
- * @param[in]  freq     Frequency table indexed by symbol (0..255).
- * @param[out] code_len Output code-length array, written in full.
- * @param[in]  scratch  Optional scratch of `ZXC_HUF_BUILD_SCRATCH_SIZE` bytes
- *                      (carved into items / counts / stack regions). If
- *                      `NULL`, the function allocates its own working memory
- *                      for the duration of the call.
- * @return `ZXC_OK` on success, `ZXC_ERROR_MEMORY` or `ZXC_ERROR_CORRUPT_DATA`
- *         on failure.
  */
 int zxc_huf_build_code_lengths(const uint32_t* RESTRICT freq, uint8_t* RESTRICT code_len,
                                void* RESTRICT scratch, const int max_code_len) {

--- a/src/lib/zxc_internal.h
+++ b/src/lib/zxc_internal.h
@@ -1904,13 +1904,13 @@ int zxc_decompress_chunk_wrapper_dict(const zxc_cctx_t* RESTRICT ctx, const uint
  * pointer, same one-time CPU detection on the first call.
  *
  * @param[in,out] ctx     Compression context: configuration and working buffers.
- * @param[in]     chunk   Raw data to compress.
- * @param[in]     src_sz  Size of @p chunk in bytes.
+ * @param[in]     src     Raw data to compress.
+ * @param[in]     src_sz  Size of @p src in bytes.
  * @param[out]    dst     Destination buffer.
  * @param[in]     dst_cap Capacity of @p dst.
  * @return Bytes written (> 0), or a negative @ref zxc_error_t.
  */
-int zxc_compress_chunk_wrapper(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRICT chunk,
+int zxc_compress_chunk_wrapper(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRICT src,
                                const size_t src_sz, uint8_t* RESTRICT dst, const size_t dst_cap);
 
 // ---------------------------------------------------------------------------

--- a/src/lib/zxc_pstream.c
+++ b/src/lib/zxc_pstream.c
@@ -261,10 +261,6 @@ static int cs_drain_pending(zxc_cstream* cs, zxc_outbuf_t* out) {
  * returns @c NULL rather than silently dropping them.  Pre-sizes the
  * @c pending buffer so that the file header / footer paths never need a
  * realloc.
- *
- * @param[in] opts Compression options, or @c NULL for full defaults.
- * @return New stream owned by the caller, or @c NULL on allocation
- *         failure / invalid option values (including dictionary options).
  */
 zxc_cstream* zxc_cstream_create(const zxc_compress_opts_t* opts) {
     zxc_cstream* cs = (zxc_cstream*)ZXC_CALLOC(1, sizeof(*cs));
@@ -337,7 +333,7 @@ static int cs_stage_file_header(zxc_cstream* cs) {
  * @brief Stages the 8-byte EOF block into the @c pending buffer.
  *
  * The EOF block is a regular block header with @c block_type set to
- * @ref ZXC_BLOCK_EOF and @c comp_size = 0; it carries no payload.
+ * `ZXC_BLOCK_EOF` and @c comp_size = 0; it carries no payload.
  *
  * @param[in,out] cs Compression stream.
  * @return @ref ZXC_OK on success, negative @ref zxc_error_t on failure.
@@ -401,9 +397,6 @@ void zxc_cstream_free(zxc_cstream* cs) {
 
 /**
  * @brief Returns the suggested input chunk size (configured block size).
- *
- * @param[in] cs Compression stream.
- * @return Block size in bytes, or 0 if @p cs is @c NULL.
  */
 size_t zxc_cstream_in_size(const zxc_cstream* cs) { return cs ? cs->block_size : 0; }
 
@@ -413,9 +406,6 @@ size_t zxc_cstream_in_size(const zxc_cstream* cs) { return cs ? cs->block_size :
  * Sized to hold one full compressed block plus framing overhead, i.e.
  * @ref zxc_compress_block_bound applied to the configured block size.
  * Falls back to @c block_size when the bound overflows @c size_t.
- *
- * @param[in] cs Compression stream.
- * @return Suggested output buffer capacity in bytes, or 0 if @p cs is @c NULL.
  */
 size_t zxc_cstream_out_size(const zxc_cstream* cs) {
     if (UNLIKELY(!cs)) return 0;  // LCOV_EXCL_LINE
@@ -435,13 +425,6 @@ size_t zxc_cstream_out_size(const zxc_cstream* cs) {
  * The terminal states (@c CS_DRAIN_LAST, @c CS_DRAIN_EOF, @c CS_DRAIN_FOOTER,
  * @c CS_DONE, @c CS_ERRORED) are owned by @ref zxc_cstream_end; reaching
  * them here yields @ref ZXC_ERROR_NULL_INPUT.
- *
- * @param[in,out] cs  Compression stream.
- * @param[in,out] out Caller output buffer.
- * @param[in,out] in  Caller input buffer.
- * @return @c 0 if @p in fully consumed and nothing pending,
- *         @c >0 number of bytes still pending (drain @p out then call again),
- *         @c <0 a @ref zxc_error_t code.
  */
 int64_t zxc_cstream_compress(zxc_cstream* cs, zxc_outbuf_t* out, zxc_inbuf_t* in) {
     if (UNLIKELY(!cs || !out || !in || in->pos > in->size || out->pos > out->size ||
@@ -515,12 +498,6 @@ int64_t zxc_cstream_compress(zxc_cstream* cs, zxc_outbuf_t* out, zxc_inbuf_t* in
  * -> @c CS_DONE).  Reentrant: when @p out fills mid-drain, returns the
  * number of bytes still pending and resumes from where it left off on the
  * next call.  See the public contract in @ref zxc_cstream_end.
- *
- * @param[in,out] cs  Compression stream.
- * @param[in,out] out Caller output buffer.
- * @return @c 0 once finalisation is complete (stream is now in DONE state),
- *         @c >0 number of bytes still pending (drain and call again),
- *         @c <0 a @ref zxc_error_t code.
  */
 int64_t zxc_cstream_end(zxc_cstream* cs, zxc_outbuf_t* out) {
     if (UNLIKELY(!cs || !out || cs->state == CS_DONE)) return ZXC_ERROR_NULL_INPUT;
@@ -812,9 +789,6 @@ static int ds_pull_payload(zxc_dstream* ds, zxc_inbuf_t* in) {
  * to the @c FILE*-based pipeline).  @c block_size, @c file_has_checksum,
  * and the @c payload / @c decoded buffers are filled in lazily once the
  * file header is parsed.
- *
- * @param[in] opts Decompression options, or @c NULL for full defaults.
- * @return New stream owned by the caller, or @c NULL on allocation failure.
  */
 zxc_dstream* zxc_dstream_create(const zxc_decompress_opts_t* opts) {
     zxc_dstream* ds = (zxc_dstream*)ZXC_CALLOC(1, sizeof(*ds));
@@ -836,8 +810,6 @@ zxc_dstream* zxc_dstream_create(const zxc_decompress_opts_t* opts) {
  * @brief Releases a decompression stream and all internal buffers.
  *
  * Safe to call with @c NULL.
- *
- * @param[in,out] ds Stream returned by @ref zxc_dstream_create.
  */
 void zxc_dstream_free(zxc_dstream* ds) {
     if (UNLIKELY(!ds)) return;  // LCOV_EXCL_LINE
@@ -849,9 +821,6 @@ void zxc_dstream_free(zxc_dstream* ds) {
 
 /**
  * @brief Returns 1 iff the stream has reached @c DS_DONE.
- *
- * @param[in] ds Decompression stream.
- * @return @c 1 if DONE, @c 0 otherwise (including errored).
  */
 int zxc_dstream_finished(const zxc_dstream* ds) { return (ds && ds->state == DS_DONE) ? 1 : 0; }
 
@@ -861,9 +830,6 @@ int zxc_dstream_finished(const zxc_dstream* ds) { return (ds && ds->state == DS_
  * Before the file header is parsed the call returns
  * @ref ZXC_BLOCK_SIZE_DEFAULT; afterwards it returns the maximal compressed
  * block size derived from the negotiated @c block_size.
- *
- * @param[in] ds Decompression stream.
- * @return Suggested input buffer capacity in bytes, or 0 if @p ds is @c NULL.
  */
 size_t zxc_dstream_in_size(const zxc_dstream* ds) {
     if (UNLIKELY(!ds)) return 0;  // LCOV_EXCL_LINE
@@ -877,9 +843,6 @@ size_t zxc_dstream_in_size(const zxc_dstream* ds) {
  *
  * Equals the negotiated @c block_size; before the file header is parsed,
  * returns @ref ZXC_BLOCK_SIZE_DEFAULT.
- *
- * @param[in] ds Decompression stream.
- * @return Suggested output buffer capacity in bytes, or 0 if @p ds is @c NULL.
  */
 size_t zxc_dstream_out_size(const zxc_dstream* ds) {
     if (UNLIKELY(!ds)) return 0;  // LCOV_EXCL_LINE
@@ -1035,13 +998,6 @@ static int ds_handle_need_block_header(zxc_dstream* ds, zxc_inbuf_t* in) {
  * @par Errors
  * On any negative return the stream becomes errored (sticky); subsequent
  * calls keep returning the same code until @ref zxc_dstream_free.
- *
- * @param[in,out] ds  Decompression stream.
- * @param[in,out] out Caller output buffer.
- * @param[in,out] in  Caller input buffer.
- * @return @c >0 number of decompressed bytes written into @p out this call,
- *         @c 0 stream complete (DONE) or no progress possible,
- *         @c <0 a @ref zxc_error_t code.
  */
 int64_t zxc_dstream_decompress(zxc_dstream* ds, zxc_outbuf_t* out, zxc_inbuf_t* in) {
     if (UNLIKELY(!ds || !out || !in || in->pos > in->size || out->pos > out->size ||

--- a/src/lib/zxc_seekable.c
+++ b/src/lib/zxc_seekable.c
@@ -165,9 +165,6 @@ static int zxc_seek_get_num_procs(void) {
  * Public API (declared in @c zxc_seekable.h): one block header plus
  * @p num_blocks fixed-size entries. Use it to size the destination buffer
  * before @ref zxc_write_seek_table.
- *
- * @param[in] num_blocks  Number of block entries the table will hold.
- * @return Total table size in bytes (block header + entries).
  */
 size_t zxc_seek_table_size(const uint32_t num_blocks) {
     return ZXC_BLOCK_HEADER_SIZE + (size_t)num_blocks * ZXC_SEEK_ENTRY_SIZE;
@@ -178,14 +175,6 @@ size_t zxc_seek_table_size(const uint32_t num_blocks) {
  *
  * Public API; full contract in @c zxc_seekable.h. Emits the standard ZXC block
  * header followed by one little-endian @c u32 compressed-size entry per block.
- *
- * @param[out] dst           Destination buffer.
- * @param[in]  dst_capacity  Capacity of @p dst in bytes.
- * @param[in]  comp_sizes    Array of @p num_blocks compressed block sizes.
- * @param[in]  num_blocks    Number of blocks (and entries) to write.
- * @return Bytes written on success, or a negative @ref zxc_error_t
- *         (@ref ZXC_ERROR_OVERFLOW, @ref ZXC_ERROR_DST_TOO_SMALL,
- *         @ref ZXC_ERROR_NULL_INPUT).
  */
 int64_t zxc_write_seek_table(uint8_t* dst, const size_t dst_capacity, const uint32_t* comp_sizes,
                              const uint32_t num_blocks) {
@@ -400,11 +389,6 @@ static zxc_seekable* zxc_seekable_parse(const uint8_t* data, const size_t data_s
  *
  * Public API; see @c zxc_seekable.h. Thin guard around
  * @ref zxc_seekable_parse, which detects and validates the trailing seek table.
- *
- * @param[in] src       Pointer to the whole compressed archive.
- * @param[in] src_size  Archive size in bytes.
- * @return A handle to release with @ref zxc_seekable_free, or NULL on bad input
- *         or a missing / malformed seek table.
  */
 zxc_seekable* zxc_seekable_open(const void* src, const size_t src_size) {
     if (UNLIKELY(!src || src_size == 0)) return NULL;
@@ -422,10 +406,6 @@ zxc_seekable* zxc_seekable_open(const void* src, const size_t src_size) {
  * validates the SEK block, and builds the per-block compressed-offset prefix
  * sums. Unlike @ref zxc_seekable_open the archive is never mapped whole; only
  * the metadata is read up front.
- *
- * @param[in] r  Reader descriptor (@c read_at and @c size must be set).
- * @return A handle to release with @ref zxc_seekable_free, or NULL on bad input,
- *         a short read, or a malformed seek table.
  */
 zxc_seekable* zxc_seekable_open_reader(const zxc_reader_t* r) {
     if (UNLIKELY(!r || !r->read_at || r->size == 0)) return NULL;
@@ -555,15 +535,11 @@ zxc_seekable* zxc_seekable_open_reader(const zxc_reader_t* r) {
 
 /**
  * @brief Number of blocks in the archive.
- * @param[in] s  Seekable handle (may be NULL).
- * @return Block count, or 0 if @p s is NULL.
  */
 uint32_t zxc_seekable_get_num_blocks(const zxc_seekable* s) { return s ? s->num_blocks : 0; }
 
 /**
  * @brief Total decompressed size of the archive.
- * @param[in] s  Seekable handle (may be NULL).
- * @return Decompressed size in bytes, or 0 if @p s is NULL.
  */
 uint64_t zxc_seekable_get_decompressed_size(const zxc_seekable* s) {
     return s ? s->total_decomp : 0;
@@ -571,10 +547,6 @@ uint64_t zxc_seekable_get_decompressed_size(const zxc_seekable* s) {
 
 /**
  * @brief Compressed byte size of a given block.
- * @param[in] s          Seekable handle (may be NULL).
- * @param[in] block_idx  Zero-based block index.
- * @return Compressed size in bytes, or 0 if @p s is NULL or @p block_idx is
- *         out of range.
  */
 uint32_t zxc_seekable_get_block_comp_size(const zxc_seekable* s, const uint32_t block_idx) {
     if (UNLIKELY(!s || block_idx >= s->num_blocks)) return 0;
@@ -586,11 +558,6 @@ uint32_t zxc_seekable_get_block_comp_size(const zxc_seekable* s, const uint32_t 
  *
  * Every block decompresses to @c block_size except the last, which holds the
  * remainder of @c total_decomp.
- *
- * @param[in] s          Seekable handle (may be NULL).
- * @param[in] block_idx  Zero-based block index.
- * @return Decompressed size in bytes, or 0 if @p s is NULL or @p block_idx is
- *         out of range.
  */
 uint32_t zxc_seekable_get_block_decomp_size(const zxc_seekable* s, const uint32_t block_idx) {
     if (UNLIKELY(!s || block_idx >= s->num_blocks)) return 0;
@@ -684,13 +651,6 @@ static int zxc_seek_read_block(const zxc_seekable* s, const uint32_t block_idx, 
  * lazily-initialised, dictionary-aware context, and copies out only the
  * requested sub-range. Single-threaded; see @ref zxc_seekable_decompress_range_mt
  * for the parallel variant.
- *
- * @param[in,out] s             Seekable handle (carries the reusable context).
- * @param[out]    dst           Destination buffer.
- * @param[in]     dst_capacity  Capacity of @p dst (must be >= @p len).
- * @param[in]     offset        Absolute decompressed start offset.
- * @param[in]     len           Number of decompressed bytes to produce.
- * @return @p len on success, or a negative @ref zxc_error_t.
  */
 int64_t zxc_seekable_decompress_range(zxc_seekable* s, void* dst, const size_t dst_capacity,
                                       const uint64_t offset, const size_t len) {
@@ -896,7 +856,7 @@ static void zxc_seek_mt_fail_stripe(zxc_seek_mt_stripe_t* st, const int code) {
  * Each job's outcome goes into its @c result (read by the main thread after
  * join); on error the worker abandons the rest of its stripe.
  *
- * @param[in,out] arg  Pointer to this worker's @ref zxc_seek_mt_stripe_t.
+ * @param[in,out] arg  Pointer to this worker's `zxc_seek_mt_stripe_t`.
  * @return Always NULL (result codes are reported via the jobs).
  */
 static void* zxc_seek_mt_worker(void* arg) {
@@ -987,14 +947,6 @@ static void* zxc_seek_mt_worker(void* arg) {
  * block (each with its own thread-local context and read buffer) and runs them
  * fork-join in waves of up to @p n_threads. Falls back to the single-threaded
  * path for trivial spans. @p n_threads == 0 auto-detects the core count.
- *
- * @param[in,out] s             Seekable handle (read-only during the parallel phase).
- * @param[out]    dst           Destination buffer.
- * @param[in]     dst_capacity  Capacity of @p dst (must be >= @p len).
- * @param[in]     offset        Absolute decompressed start offset.
- * @param[in]     len           Number of decompressed bytes to produce.
- * @param[in]     n_threads     Worker thread count; 0 = auto-detect.
- * @return @p len on success, or the first negative @ref zxc_error_t observed.
  */
 int64_t zxc_seekable_decompress_range_mt(zxc_seekable* s, void* dst, const size_t dst_capacity,
                                          const uint64_t offset, const size_t len, int n_threads) {
@@ -1113,8 +1065,6 @@ int64_t zxc_seekable_decompress_range_mt(zxc_seekable* s, void* dst, const size_
  * Public API; see @c zxc_seekable.h. Tears down the reusable context, the seek
  * arrays (comp sizes / offsets), the owned dictionary copy and any attached
  * reader context. NULL-safe.
- *
- * @param[in] s  Seekable handle to release (may be NULL).
  */
 void zxc_seekable_free(zxc_seekable* s) {
     if (UNLIKELY(!s)) return;
@@ -1133,13 +1083,6 @@ void zxc_seekable_free(zxc_seekable* s) {
  * the file header, then takes an owned copy of @p dict (and the optional shared
  * literal Huffman table @p dict_huf). Drops any context already built so the
  * [dict | decode] bounce buffer is re-carved on the next decompress.
- *
- * @param[in,out] s          Seekable handle.
- * @param[in]     dict       Dictionary bytes.
- * @param[in]     dict_size  Dictionary length (<= @c ZXC_DICT_SIZE_MAX).
- * @param[in]     dict_huf   Optional shared literal Huffman table, or NULL.
- * @return @ref ZXC_OK, or a negative @ref zxc_error_t
- *         (@ref ZXC_ERROR_DICT_TOO_LARGE, @ref ZXC_ERROR_DICT_MISMATCH, ...).
  */
 int zxc_seekable_set_dict(zxc_seekable* s, const void* dict, const size_t dict_size,
                           const void* dict_huf) {
@@ -1180,9 +1123,6 @@ int zxc_seekable_set_dict(zxc_seekable* s, const void* dict, const size_t dict_s
  * @c ZXC_FREE when @ref zxc_seekable_free runs. Used by
  * @ref zxc_seekable_open_file so its allocated reader state outlives the open
  * call. NULL-safe on @p s.
- *
- * @param[in,out] s    Seekable handle (may be NULL).
- * @param[in]     ctx  Heap pointer to hand over; freed by @ref zxc_seekable_free.
  */
 void zxc_seekable_attach_owned_ctx(zxc_seekable* s, void* ctx) {
     if (s) s->owned_reader_ctx = ctx;

--- a/wrappers/python/README.md
+++ b/wrappers/python/README.md
@@ -18,3 +18,110 @@ cd zxc/wrappers/python
 python -m venv .venv
 source .venv/bin/activate 
 pip install .
+```
+
+## Quick Start
+
+```python
+import zxc
+
+data = b"hello zxc" * 1000
+
+blob = zxc.compress(data)                 # level, checksum and dict are optional
+assert zxc.decompress(blob) == data
+```
+
+`compress()` and `decompress()` accept any object supporting the buffer
+protocol - `bytes`, `bytearray`, `memoryview`, NumPy arrays - and release the
+GIL, so Python threads run them in true parallel.
+
+## Compression Levels
+
+```python
+zxc.compress(data, level=zxc.LEVEL_FASTEST)   # fastest, largest output
+zxc.compress(data, level=zxc.LEVEL_DEFAULT)   # the default
+zxc.compress(data, level=zxc.LEVEL_ULTRA)     # smallest output, slowest
+```
+
+`LEVEL_FAST`, `LEVEL_BALANCED`, `LEVEL_COMPACT` and `LEVEL_DENSITY` sit between
+them. `min_level()`, `max_level()` and `default_level()` return the bounds at
+runtime.
+
+## Streaming Files
+
+`stream_compress()` and `stream_decompress()` work on objects exposing a real
+file descriptor via `fileno()`, so in-memory streams such as `io.BytesIO` are
+not accepted. Both return the number of bytes written and take `n_threads=0` to
+mean "one per available core".
+
+```python
+with open("input.bin", "rb") as src, open("output.zxc", "wb") as dst:
+    written = zxc.stream_compress(src, dst, level=zxc.LEVEL_DEFAULT)
+
+with open("output.zxc", "rb") as src, open("restored.bin", "wb") as dst:
+    zxc.stream_decompress(src, dst)
+```
+
+For in-memory streams, use the push-based `CStream` / `DStream` instead:
+
+```python
+with zxc.CStream(level=zxc.LEVEL_DEFAULT) as cs:
+    out = cs.compress(chunk) + cs.end()
+```
+
+## File Objects
+
+`ZxcReader` and `ZxcWriter` are `io.RawIOBase` adapters, so they compose with
+`io.BufferedReader` and the rest of the `io` stack:
+
+```python
+with open("output.zxc", "wb") as f, zxc.ZxcWriter(f) as w:
+    w.write(data)
+
+with open("output.zxc", "rb") as f, zxc.ZxcReader(f) as r:
+    restored = r.read()
+```
+
+`detect_zxc(data)` reports whether a buffer starts with a ZXC file header.
+
+## Random Access
+
+A seekable archive can be decompressed block by block, without reading what
+comes before:
+
+```python
+blob = ...  # produced with stream_compress(..., seekable=True)
+
+with zxc.Seekable(blob) as s:
+    print(s.num_blocks, s.decompressed_size)
+    middle = s.decompress_range(offset=1 << 20, length=4096)
+```
+
+## Pre-Trained Dictionaries
+
+Dictionaries lift the ratio on many small, similar payloads. The same
+dictionary is required at both ends:
+
+```python
+d = zxc.Dictionary.train(samples)          # samples: list[bytes]
+blob = zxc.compress(data, dict=d.content, dict_huf=d.huf)
+back = zxc.decompress(blob, dict=d.content, dict_huf=d.huf)
+
+open("corpus.zxd", "wb").write(d.save())   # persist
+d2 = zxc.Dictionary.load(open("corpus.zxd", "rb").read())
+```
+
+`get_dict_id(archive)` returns the dictionary id an archive was built with, so
+you can pick the right one before decompressing.
+
+## Testing
+
+```bash
+cd zxc/wrappers/python
+pip install pytest
+pytest tests/ -v
+```
+
+## License
+
+BSD-3-Clause - see [LICENSE](../../LICENSE).

--- a/wrappers/python/README.md
+++ b/wrappers/python/README.md
@@ -51,8 +51,8 @@ runtime.
 
 `stream_compress()` and `stream_decompress()` work on objects exposing a real
 file descriptor via `fileno()`, so in-memory streams such as `io.BytesIO` are
-not accepted. Both return the number of bytes written and take `n_threads=0` to
-mean "one per available core".
+not accepted. Both return the number of bytes written and take `n_threads=0`
+to mean the default, auto-detected thread count.
 
 ```python
 with open("input.bin", "rb") as src, open("output.zxc", "wb") as dst:
@@ -82,7 +82,10 @@ with open("output.zxc", "rb") as f, zxc.ZxcReader(f) as r:
     restored = r.read()
 ```
 
-`detect_zxc(data)` reports whether a buffer starts with a ZXC file header.
+`detect_zxc(data)` checks only the 4-byte magic word at the start of the
+buffer. It does not validate the rest of the header, the footer, or the
+archive contents, so a truncated or corrupt archive still passes - treat it as
+content-type sniffing, not as a validity check.
 
 ## Random Access
 
@@ -107,8 +110,11 @@ d = zxc.Dictionary.train(samples)          # samples: list[bytes]
 blob = zxc.compress(data, dict=d.content, dict_huf=d.huf)
 back = zxc.decompress(blob, dict=d.content, dict_huf=d.huf)
 
-open("corpus.zxd", "wb").write(d.save())   # persist
-d2 = zxc.Dictionary.load(open("corpus.zxd", "rb").read())
+with open("corpus.zxd", "wb") as f:        # persist
+    f.write(d.save())
+
+with open("corpus.zxd", "rb") as f:
+    d2 = zxc.Dictionary.load(f.read())
 ```
 
 `get_dict_id(archive)` returns the dictionary id an archive was built with, so


### PR DESCRIPTION
Address Doxygen warnings by removing unused configuration options and consolidating documentation. Introduce a dedicated main page to provide a structured overview of the library API and usage patterns, and prune redundant Doxygen parameter documentation from function definitions to reduce noise.

Signed-off-by: Bertrand Lebonnois <5901952+hellobertrand@users.noreply.github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an API reference landing page with links to project documentation and runnable examples.
  * Improved generated API documentation formatting, navigation, and cross-references.
  * Updated Rust, Python, Node.js, and Go binding links.
  * Expanded Python documentation with installation, usage, streaming, random access, dictionaries, testing, and licensing guidance.
  * Clarified compression input descriptions and centralized parameter and return-value contracts.
  * Updated documentation generation to require Doxygen 1.9.7 or newer, with clearer availability messaging.
* **Refactor**
  * Reorganized documentation without changing runtime behavior or public APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->