### PR TITLE
refactor(lib): Improve code and enhances robustness

### DIFF
--- a/src/lib/zxc_common.c
+++ b/src/lib/zxc_common.c
@@ -206,11 +206,11 @@ static zxc_cctx_layout_t compute_cctx_layout(const size_t chunk_size, const int 
         // so sized to the larger demand. Keep in sync with zxc_estimate_cctx_size()
         // and its consumer in zxc_compress.c.
         if (level >= ZXC_LEVEL_DENSITY) {
-            const size_t sz_dp = ZXC_ALIGN_CL((chunk_size + 1) * sizeof(uint32_t));
-            const size_t sz_pl = ZXC_ALIGN_CL((chunk_size + 1) * sizeof(uint16_t));
-            const size_t sz_po = ZXC_ALIGN_CL((chunk_size + 1) * sizeof(uint16_t));
-            const size_t n_bm_words = ZXC_BITMAP_WORDS(chunk_size + 1);
-            const size_t sz_bm = ZXC_ALIGN_CL(n_bm_words * sizeof(uint64_t));
+            size_t sz_dp;
+            size_t sz_pl;
+            size_t sz_po;
+            size_t sz_bm;
+            zxc_opt_dp_sizes(chunk_size, &sz_dp, &sz_pl, &sz_po, &sz_bm);
             const size_t dp_needed = sz_dp + sz_pl + sz_po + sz_bm;
             layout.sz_opt =
                 (dp_needed > ZXC_HUF_BUILD_SCRATCH_SIZE) ? dp_needed : ZXC_HUF_BUILD_SCRATCH_SIZE;

--- a/src/lib/zxc_common.c
+++ b/src/lib/zxc_common.c
@@ -539,7 +539,7 @@ int zxc_read_file_header(const uint8_t* RESTRICT src, const size_t src_size,
     // Header checksum (integrity), then the checksum-algorithm id in flags bits 0-3
     // (only 0 = RapidHash is defined). It is checked first via short-circuit.
     if (UNLIKELY(zxc_le16(src + 14) != zxc_hash16(temp) ||
-                 (src[6] & 0x0FU) != ZXC_CHECKSUM_RAPIDHASH))
+                 (src[6] & ZXC_FILE_CHECKSUM_ALGO_MASK) != ZXC_CHECKSUM_RAPIDHASH))
         return ZXC_ERROR_BAD_HEADER;
 
     if (out_block_size) {

--- a/src/lib/zxc_compress.c
+++ b/src/lib/zxc_compress.c
@@ -1177,6 +1177,8 @@ static void zxc_lz_seed_dict(const uint8_t* RESTRICT src, const size_t dict_size
 static int zxc_encode_block_glo(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRICT src,
                                 const size_t src_sz, uint8_t* RESTRICT dst, size_t dst_cap,
                                 size_t* RESTRICT out_sz) {
+    if (UNLIKELY(dst_cap < ZXC_BLOCK_HEADER_SIZE)) return ZXC_ERROR_DST_TOO_SMALL;
+
     const int level = ctx->compression_level;
     const size_t dict_sz = ctx->dict_size;
 
@@ -1850,6 +1852,8 @@ parse_done:;
 static int zxc_encode_block_ghi(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRICT src,
                                 const size_t src_sz, uint8_t* RESTRICT dst, const size_t dst_cap,
                                 size_t* RESTRICT const out_sz) {
+    if (UNLIKELY(dst_cap < ZXC_BLOCK_HEADER_SIZE)) return ZXC_ERROR_DST_TOO_SMALL;
+
     const int level = ctx->compression_level;
     const size_t dict_sz = ctx->dict_size;
 

--- a/src/lib/zxc_compress.c
+++ b/src/lib/zxc_compress.c
@@ -894,8 +894,7 @@ static int zxc_lz77_optimal_parse_glo(zxc_cctx_t* RESTRICT ctx, const uint8_t* R
     const uint8_t* const search_limit = src + search_limit_pos;
 
     // DP arrays carved from ctx->opt_scratch, one allocation reused across
-    // blocks, each sub-buffer cache-line padded. Keep `needed` in sync with
-    // zxc_estimate_cctx_size().
+    // blocks, each sub-buffer cache-line padded.
     //
     //   dp             : (chunk+1) x u32: min cost to reach position p.
     //   parent_len     : (chunk+1) x u16: 0 = literal, >= MIN_MATCH = match.
@@ -907,20 +906,12 @@ static int zxc_lz77_optimal_parse_glo(zxc_cctx_t* RESTRICT ctx, const uint8_t* R
     // The same buffer doubles as package-merge scratch for the code-length
     // builder: that scratch is live before the DP and after the parse is read
     // out, never during, so capacity is just the larger of the two.
-    const size_t chunk = ctx->chunk_size;
-    const size_t sz_dp = ZXC_ALIGN_CL((chunk + 1) * sizeof(uint32_t));
-    const size_t sz_pl = ZXC_ALIGN_CL((chunk + 1) * sizeof(uint16_t));
-    const size_t sz_po = ZXC_ALIGN_CL((chunk + 1) * sizeof(uint16_t));
-    const size_t n_bm_words = ZXC_BITMAP_WORDS(chunk + 1);
-    const size_t sz_bm = ZXC_ALIGN_CL(n_bm_words * sizeof(uint64_t));
-    const size_t dp_needed = sz_dp + sz_pl + sz_po + sz_bm;
-    const size_t needed =
-        (dp_needed > ZXC_HUF_BUILD_SCRATCH_SIZE) ? dp_needed : ZXC_HUF_BUILD_SCRATCH_SIZE;
-
-    // zxc_cctx_init pre-allocates opt_scratch inside ctx->memory_block at
-    // level >= ZXC_LEVEL_DENSITY. The formula above must stay byte-for-byte in
-    // sync with it and with zxc_estimate_cctx_size().
-    (void)needed;
+    size_t sz_dp;
+    size_t sz_pl;
+    size_t sz_po;
+    size_t sz_bm;
+    zxc_opt_dp_sizes(ctx->chunk_size, &sz_dp, &sz_pl, &sz_po, &sz_bm);
+    const size_t n_bm_words = ZXC_BITMAP_WORDS(ctx->chunk_size + 1);
 
     // Per-block literal cost (sample only block data, not dict prefix):
     const uint32_t lit_cost = zxc_opt_estimate_lit_bits(src_base, block_sz, ctx->opt_scratch);

--- a/src/lib/zxc_compress.c
+++ b/src/lib/zxc_compress.c
@@ -52,6 +52,27 @@ static ZXC_ALWAYS_INLINE uint32_t zxc_hash_func(const uint64_t val, const int us
     }
 }
 
+// One tag per hash slot: rejects a mismatching head without touching the
+// referenced data.
+static ZXC_ALWAYS_INLINE uint8_t zxc_hash_tag(const uint32_t val4) {
+    return (uint8_t)(val4 ^ (val4 >> 16));
+}
+
+// Slots carry the epoch above offset_mask, so an entry left from an earlier
+// block reads as 0 (no match) and the table never needs clearing.
+static ZXC_ALWAYS_INLINE uint32_t zxc_epoch_pos(const uint32_t head, const uint32_t offset_mask,
+                                                const uint32_t epoch_mark) {
+    return ((head & ~offset_mask) == epoch_mark) ? (head & offset_mask) : 0;
+}
+
+// Chain link cur_pos -> prev_idx. Branchless: a missing predecessor, or one
+// beyond the window, gives 0, which the walk reads as end of chain.
+static ZXC_ALWAYS_INLINE uint16_t zxc_chain_delta(const uint32_t cur_pos, const uint32_t prev_idx) {
+    const uint32_t dist = cur_pos - prev_idx;
+    const uint32_t valid = -((int32_t)((prev_idx != 0) & (dist < ZXC_LZ_WINDOW_SIZE)));
+    return (uint16_t)(dist & valid);
+}
+
 // SSE2 selected, not merely available: guards the two helpers below.
 #if defined(ZXC_USE_SSE2) && !(defined(ZXC_USE_AVX512) && defined(__AVX512VL__)) && \
     !defined(ZXC_USE_AVX2) && !defined(ZXC_USE_NEON64) && !defined(ZXC_USE_NEON32)
@@ -141,6 +162,32 @@ static ZXC_ALWAYS_INLINE size_t zxc_write_varint(uint8_t* RESTRICT dst, const ui
     return 3;
 }
 
+// A token field saturates at `mask`; the excess goes to the extras stream as a
+// varint. Returns 0 if it does not fit one.
+static ZXC_ALWAYS_INLINE int zxc_emit_extra(uint8_t* RESTRICT extras, size_t* RESTRICT used,
+                                            const uint32_t val, const uint32_t mask) {
+    if (LIKELY(val < mask)) return 1;
+    const size_t n = zxc_write_varint(extras + *used, val - mask);
+    if (UNLIKELY(n == 0)) return 0;
+    *used += n;
+    return 1;
+}
+
+// One 32-byte wild copy covers the common short run. Within 32 bytes of iend it
+// would read past the block, so the tail takes an exact copy.
+static ZXC_ALWAYS_INLINE void zxc_flush_literals(uint8_t* literals, size_t* lit_c,
+                                                 const uint8_t* anchor, const uint32_t ll,
+                                                 const uint8_t* iend) {
+    if (LIKELY(anchor + ZXC_PAD_SIZE <= iend)) {
+        zxc_copy32(literals + *lit_c, anchor);
+        if (UNLIKELY(ll > ZXC_PAD_SIZE))
+            ZXC_MEMCPY(literals + *lit_c + ZXC_PAD_SIZE, anchor + ZXC_PAD_SIZE, ll - ZXC_PAD_SIZE);
+    } else {
+        ZXC_MEMCPY(literals + *lit_c, anchor, ll);
+    }
+    *lit_c += ll;
+}
+
 /**
  * @brief Structure representing a match found during compression.
  *
@@ -196,7 +243,7 @@ static ZXC_ALWAYS_INLINE zxc_match_t zxc_lz77_find_best_match(
     uint32_t h = zxc_hash_func(cur_val8, use_hash5);
 
     // 8-bit tag: XOR fold of first 4 bytes for fast rejection
-    const uint8_t cur_tag = (uint8_t)(cur_val ^ (cur_val >> 16));
+    const uint8_t cur_tag = zxc_hash_tag(cur_val);
 
     const uint32_t cur_pos = (uint32_t)(ip - src);
 
@@ -206,8 +253,7 @@ static ZXC_ALWAYS_INLINE zxc_match_t zxc_lz77_find_best_match(
     if (level <= ZXC_LEVEL_FAST && stored_tag != cur_tag) {
         match_idx = 0;
     } else {
-        const uint32_t raw_head = hash_table[h];
-        match_idx = ((raw_head & ~offset_mask) == epoch_mark) ? (raw_head & offset_mask) : 0;
+        match_idx = zxc_epoch_pos(hash_table[h], offset_mask, epoch_mark);
     }
 
     // skip_head still drives the chain walk on level >= 3 (advances past the
@@ -219,10 +265,7 @@ static ZXC_ALWAYS_INLINE zxc_match_t zxc_lz77_find_best_match(
     hash_table[h] = epoch_mark | cur_pos;
     hash_tags[h] = cur_tag;
 
-    // Branchless chain table update
-    const uint32_t dist = cur_pos - match_idx;
-    const uint32_t valid_mask = -((int32_t)((match_idx != 0) & (dist < ZXC_LZ_WINDOW_SIZE)));
-    chain_table[cur_pos & ZXC_LZ_WINDOW_MASK] = (uint16_t)(dist & valid_mask);
+    chain_table[cur_pos & ZXC_LZ_WINDOW_MASK] = zxc_chain_delta(cur_pos, match_idx);
 
     int attempts = p.search_depth;
 
@@ -460,9 +503,8 @@ _finalize_match:
         const uint32_t h2 = zxc_hash_func(next_val8, use_hash5);
         const uint8_t next_stored_tag = hash_tags[h2];
         const uint32_t next_head = hash_table[h2];
-        uint32_t next_idx =
-            (next_head & ~offset_mask) == epoch_mark ? (next_head & offset_mask) : 0;
-        const uint8_t next_tag = (uint8_t)(next_val ^ (next_val >> 16));
+        uint32_t next_idx = zxc_epoch_pos(next_head, offset_mask, epoch_mark);
+        const uint8_t next_tag = zxc_hash_tag(next_val);
         const int skip_lazy_head = (next_idx > 0 && next_stored_tag != next_tag);
         uint32_t max_lazy2 = 0;
         int lazy_att = p.lazy_attempts;
@@ -508,8 +550,8 @@ _finalize_match:
             const uint32_t h3 = zxc_hash_func(val3_8, use_hash5);
             const uint8_t tag3 = hash_tags[h3];
             const uint32_t head3 = hash_table[h3];
-            uint32_t idx3 = (head3 & ~offset_mask) == epoch_mark ? (head3 & offset_mask) : 0;
-            const uint8_t cur_tag3 = (uint8_t)(val3 ^ (val3 >> 16));
+            uint32_t idx3 = zxc_epoch_pos(head3, offset_mask, epoch_mark);
+            const uint8_t cur_tag3 = zxc_hash_tag(val3);
             const int skip_head3 = (idx3 > 0 && tag3 != cur_tag3);
 
             int is_first3 = 1;
@@ -1017,16 +1059,9 @@ static int zxc_lz77_optimal_parse_glo(zxc_cctx_t* RESTRICT ctx, const uint8_t* R
             buf_offsets[seq_c] = off_biased;
             if (off_biased > max_offset) max_offset = off_biased;
 
-            if (UNLIKELY(ll >= ZXC_TOKEN_LL_MASK)) {
-                const size_t n = zxc_write_varint(buf_extras + extras_sz, ll - ZXC_TOKEN_LL_MASK);
-                if (UNLIKELY(n == 0)) return ZXC_ERROR_OVERFLOW;
-                extras_sz += n;
-            }
-            if (UNLIKELY(ml >= ZXC_TOKEN_ML_MASK)) {
-                const size_t n = zxc_write_varint(buf_extras + extras_sz, ml - ZXC_TOKEN_ML_MASK);
-                if (UNLIKELY(n == 0)) return ZXC_ERROR_OVERFLOW;
-                extras_sz += n;
-            }
+            if (UNLIKELY(!zxc_emit_extra(buf_extras, &extras_sz, ll, ZXC_TOKEN_LL_MASK) ||
+                         !zxc_emit_extra(buf_extras, &extras_sz, ml, ZXC_TOKEN_ML_MASK)))
+                return ZXC_ERROR_OVERFLOW;
 
             seq_c++;
             lit_start = pos;
@@ -1080,28 +1115,20 @@ static void zxc_lz_seed_dict(const uint8_t* RESTRICT src, const size_t dict_size
         const uint64_t val8 = zxc_le64(src + i);
         const uint32_t h = zxc_hash_func(val8, use_hash5);
         const uint32_t cur_pos = (uint32_t)i;
-        const uint8_t tag = (uint8_t)((uint32_t)val8 ^ ((uint32_t)val8 >> 16));
 
         hash_table[h] = epoch_mark | cur_pos;
-        hash_tags[h] = tag;
+        hash_tags[h] = zxc_hash_tag((uint32_t)val8);
         chain_table[cur_pos & ZXC_LZ_WINDOW_MASK] = 0;
     }
     for (size_t i = half; i < limit; i++) {
         const uint64_t val8 = zxc_le64(src + i);
         const uint32_t h = zxc_hash_func(val8, use_hash5);
         const uint32_t cur_pos = (uint32_t)i;
-        const uint8_t tag = (uint8_t)((uint32_t)val8 ^ ((uint32_t)val8 >> 16));
-
-        const uint32_t raw_head = hash_table[h];
-        const uint32_t prev_idx =
-            ((raw_head & ~offset_mask) == epoch_mark) ? (raw_head & offset_mask) : 0;
+        const uint32_t prev_idx = zxc_epoch_pos(hash_table[h], offset_mask, epoch_mark);
 
         hash_table[h] = epoch_mark | cur_pos;
-        hash_tags[h] = tag;
-
-        const uint32_t dist = cur_pos - prev_idx;
-        const uint32_t valid = -((int32_t)((prev_idx != 0) & (dist < ZXC_LZ_WINDOW_SIZE)));
-        chain_table[cur_pos & ZXC_LZ_WINDOW_MASK] = (uint16_t)(dist & valid);
+        hash_tags[h] = zxc_hash_tag((uint32_t)val8);
+        chain_table[cur_pos & ZXC_LZ_WINDOW_MASK] = zxc_chain_delta(cur_pos, prev_idx);
     }
 }
 
@@ -1204,18 +1231,7 @@ static int zxc_encode_block_glo(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRIC
             const uint32_t ml = m.len - ZXC_LZ_MIN_MATCH_LEN;
             const uint32_t off = (uint32_t)(ip - m.ref);
 
-            if (ll > 0) {
-                if (LIKELY(anchor + ZXC_PAD_SIZE <= iend)) {
-                    zxc_copy32(literals + lit_c, anchor);
-                    if (UNLIKELY(ll > ZXC_PAD_SIZE)) {
-                        ZXC_MEMCPY(literals + lit_c + ZXC_PAD_SIZE, anchor + ZXC_PAD_SIZE,
-                                   ll - ZXC_PAD_SIZE);
-                    }
-                } else {
-                    ZXC_MEMCPY(literals + lit_c, anchor, ll);
-                }
-                lit_c += ll;
-            }
+            if (ll > 0) zxc_flush_literals(literals, &lit_c, anchor, ll, iend);
 
             const uint8_t ll_code = (ll >= ZXC_TOKEN_LL_MASK) ? ZXC_TOKEN_LL_MASK : (uint8_t)ll;
             const uint8_t ml_code = (ml >= ZXC_TOKEN_ML_MASK) ? ZXC_TOKEN_ML_MASK : (uint8_t)ml;
@@ -1224,16 +1240,9 @@ static int zxc_encode_block_glo(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRIC
             if ((off - ZXC_LZ_OFFSET_BIAS) > max_offset)
                 max_offset = (uint16_t)(off - ZXC_LZ_OFFSET_BIAS);
 
-            if (ll >= ZXC_TOKEN_LL_MASK) {
-                const size_t n = zxc_write_varint(buf_extras + extras_sz, ll - ZXC_TOKEN_LL_MASK);
-                if (UNLIKELY(n == 0)) return ZXC_ERROR_OVERFLOW;
-                extras_sz += n;
-            }
-            if (ml >= ZXC_TOKEN_ML_MASK) {
-                const size_t n = zxc_write_varint(buf_extras + extras_sz, ml - ZXC_TOKEN_ML_MASK);
-                if (UNLIKELY(n == 0)) return ZXC_ERROR_OVERFLOW;
-                extras_sz += n;
-            }
+            if (UNLIKELY(!zxc_emit_extra(buf_extras, &extras_sz, ll, ZXC_TOKEN_LL_MASK) ||
+                         !zxc_emit_extra(buf_extras, &extras_sz, ml, ZXC_TOKEN_ML_MASK)))
+                return ZXC_ERROR_OVERFLOW;
 
             seq_c++;
 
@@ -1244,15 +1253,11 @@ static int zxc_encode_block_glo(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRIC
                     const uint64_t val_u8 = zxc_le64(match_end - 2);
                     const uint32_t val_u = (uint32_t)val_u8;
                     const uint32_t h_u = zxc_hash_func(val_u8, 1);
-                    const uint32_t prev_head = hash_table[h_u];
                     const uint32_t prev_idx =
-                        (prev_head & ~offset_mask) == epoch_mark ? (prev_head & offset_mask) : 0;
+                        zxc_epoch_pos(hash_table[h_u], offset_mask, epoch_mark);
                     hash_table[h_u] = epoch_mark | pos_u;
-                    hash_tags[h_u] = (uint8_t)(val_u ^ (val_u >> 16));
-                    chain_table[pos_u & ZXC_LZ_WINDOW_MASK] =
-                        (prev_idx > 0 && (pos_u - prev_idx) < ZXC_LZ_WINDOW_SIZE)
-                            ? (uint16_t)(pos_u - prev_idx)
-                            : 0;
+                    hash_tags[h_u] = zxc_hash_tag(val_u);
+                    chain_table[pos_u & ZXC_LZ_WINDOW_MASK] = zxc_chain_delta(pos_u, prev_idx);
                 }
             }
 
@@ -1889,18 +1894,7 @@ static int zxc_encode_block_ghi(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRIC
             const uint32_t ml = m.len - ZXC_LZ_MIN_MATCH_LEN;
             const uint32_t off = (uint32_t)(ip - m.ref);
 
-            if (ll > 0) {
-                if (LIKELY(anchor + ZXC_PAD_SIZE <= iend)) {
-                    zxc_copy32(literals + lit_c, anchor);
-                    if (UNLIKELY(ll > ZXC_PAD_SIZE)) {
-                        ZXC_MEMCPY(literals + lit_c + ZXC_PAD_SIZE, anchor + ZXC_PAD_SIZE,
-                                   ll - ZXC_PAD_SIZE);
-                    }
-                } else {
-                    ZXC_MEMCPY(literals + lit_c, anchor, ll);
-                }
-                lit_c += ll;
-            }
+            if (ll > 0) zxc_flush_literals(literals, &lit_c, anchor, ll, iend);
 
             const uint32_t ll_write = (ll >= ZXC_SEQ_LL_MASK) ? 255U : ll;
             const uint32_t ml_write = (ml >= ZXC_SEQ_ML_MASK) ? 255U : ml;
@@ -1910,16 +1904,9 @@ static int zxc_encode_block_ghi(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRIC
             buf_sequences[seq_c] = seq_val;
             seq_c++;
 
-            if (ll >= ZXC_SEQ_LL_MASK) {
-                const size_t n = zxc_write_varint(buf_extras + extras_c, ll - ZXC_SEQ_LL_MASK);
-                if (UNLIKELY(n == 0)) return ZXC_ERROR_OVERFLOW;
-                extras_c += n;
-            }
-            if (ml >= ZXC_SEQ_ML_MASK) {
-                const size_t n = zxc_write_varint(buf_extras + extras_c, ml - ZXC_SEQ_ML_MASK);
-                if (UNLIKELY(n == 0)) return ZXC_ERROR_OVERFLOW;
-                extras_c += n;
-            }
+            if (UNLIKELY(!zxc_emit_extra(buf_extras, &extras_c, ll, ZXC_SEQ_LL_MASK) ||
+                         !zxc_emit_extra(buf_extras, &extras_c, ml, ZXC_SEQ_ML_MASK)))
+                return ZXC_ERROR_OVERFLOW;
 
             ip += m.len;
             anchor = ip;

--- a/src/lib/zxc_compress.c
+++ b/src/lib/zxc_compress.c
@@ -52,21 +52,33 @@ static ZXC_ALWAYS_INLINE uint32_t zxc_hash_func(const uint64_t val, const int us
     }
 }
 
-// One tag per hash slot: rejects a mismatching head without touching the
-// referenced data.
+/**
+ * @brief 8-bit rejection tag: XOR fold of the first four bytes at a position.
+ *
+ * One tag per hash slot, so a mismatching head is rejected without touching the
+ * referenced data.
+ */
 static ZXC_ALWAYS_INLINE uint8_t zxc_hash_tag(const uint32_t val4) {
     return (uint8_t)(val4 ^ (val4 >> 16));
 }
 
-// Slots carry the epoch above offset_mask, so an entry left from an earlier
-// block reads as 0 (no match) and the table never needs clearing.
+/**
+ * @brief Decodes a hash-table slot into a block position, 0 if it is stale.
+ *
+ * Slots carry the epoch above @c offset_mask, so an entry left from an earlier
+ * block reads as "no match" and the table never needs clearing.
+ */
 static ZXC_ALWAYS_INLINE uint32_t zxc_epoch_pos(const uint32_t head, const uint32_t offset_mask,
                                                 const uint32_t epoch_mark) {
     return ((head & ~offset_mask) == epoch_mark) ? (head & offset_mask) : 0;
 }
 
-// Chain link cur_pos -> prev_idx. Branchless: a missing predecessor, or one
-// beyond the window, gives 0, which the walk reads as end of chain.
+/**
+ * @brief Chain link from a position back to the one the hash slot held.
+ *
+ * Branchless: a missing predecessor, or one beyond the window, gives 0, which
+ * the chain walk reads as end of chain.
+ */
 static ZXC_ALWAYS_INLINE uint16_t zxc_chain_delta(const uint32_t cur_pos, const uint32_t prev_idx) {
     const uint32_t dist = cur_pos - prev_idx;
     const uint32_t valid = -((int32_t)((prev_idx != 0) & (dist < ZXC_LZ_WINDOW_SIZE)));
@@ -162,8 +174,12 @@ static ZXC_ALWAYS_INLINE size_t zxc_write_varint(uint8_t* RESTRICT dst, const ui
     return 3;
 }
 
-// A token field saturates at `mask`; the excess goes to the extras stream as a
-// varint. Returns 0 if it does not fit one.
+/**
+ * @brief Appends a saturated token field's excess to the extras stream.
+ *
+ * A field holds values below its mask; a larger one stores the mask in the
+ * token and the excess here as a varint. Returns 0 if it does not fit one.
+ */
 static ZXC_ALWAYS_INLINE int zxc_emit_extra(uint8_t* RESTRICT extras, size_t* RESTRICT used,
                                             const uint32_t val, const uint32_t mask) {
     if (LIKELY(val < mask)) return 1;
@@ -173,8 +189,12 @@ static ZXC_ALWAYS_INLINE int zxc_emit_extra(uint8_t* RESTRICT extras, size_t* RE
     return 1;
 }
 
-// One 32-byte wild copy covers the common short run. Within 32 bytes of iend it
-// would read past the block, so the tail takes an exact copy.
+/**
+ * @brief Stages a run of literals into the literal stream.
+ *
+ * One 32-byte wild copy covers the common short run. Within 32 bytes of the
+ * block end that copy would read past it, so the tail takes an exact copy.
+ */
 static ZXC_ALWAYS_INLINE void zxc_flush_literals(uint8_t* literals, size_t* lit_c,
                                                  const uint8_t* anchor, const uint32_t ll,
                                                  const uint8_t* iend) {

--- a/src/lib/zxc_compress.c
+++ b/src/lib/zxc_compress.c
@@ -2039,6 +2039,8 @@ static int zxc_encode_block_raw(const uint8_t* RESTRICT src, const size_t src_sz
 // cppcheck-suppress unusedFunction
 int zxc_compress_chunk_wrapper(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRICT chunk,
                                const size_t src_sz, uint8_t* RESTRICT dst, const size_t dst_cap) {
+    if (UNLIKELY(dst_cap < ZXC_BLOCK_HEADER_SIZE)) return ZXC_ERROR_DST_TOO_SMALL;
+
     const size_t dict_sz = ctx->dict_size;
     const size_t block_sz = src_sz - dict_sz;
     const uint8_t* block_data = chunk + dict_sz;

--- a/src/lib/zxc_compress.c
+++ b/src/lib/zxc_compress.c
@@ -85,6 +85,55 @@ static ZXC_ALWAYS_INLINE uint16_t zxc_chain_delta(const uint32_t cur_pos, const 
     return (uint16_t)(dist & valid);
 }
 
+/**
+ * @brief Pair-equality mask for the RLE lookahead: element i is set when
+ *        p[i] == p[i+1].
+ *
+ * The only thing that differs between vector widths; the scan that consumes it
+ * is written once. @c ZXC_RLE_WIN is the bytes examined per step and
+ * @c ZXC_RLE_BPB the mask bits each byte occupies (4 on NEON, which has no
+ * byte-movemask). 32-bit NEON has no cheap equivalent and keeps its own scan.
+ */
+#if defined(ZXC_USE_AVX512)
+#define ZXC_RLE_WIN 64
+#define ZXC_RLE_BPB 1
+#define ZXC_RLE_CTZ(x) zxc_ctz64(x)
+typedef uint64_t zxc_rle_mask_t;
+static ZXC_ALWAYS_INLINE zxc_rle_mask_t zxc_rle_pair_mask(const uint8_t* p) {
+    return (uint64_t)_mm512_cmpeq_epi8_mask(_mm512_loadu_si512((const void*)p),
+                                            _mm512_loadu_si512((const void*)(p + 1)));
+}
+#elif defined(ZXC_USE_AVX2)
+#define ZXC_RLE_WIN 32
+#define ZXC_RLE_BPB 1
+#define ZXC_RLE_CTZ(x) zxc_ctz32(x)
+typedef uint32_t zxc_rle_mask_t;
+static ZXC_ALWAYS_INLINE zxc_rle_mask_t zxc_rle_pair_mask(const uint8_t* p) {
+    const __m256i v0 = _mm256_loadu_si256((const __m256i*)p);
+    const __m256i v1 = _mm256_loadu_si256((const __m256i*)(p + 1));
+    return (uint32_t)_mm256_movemask_epi8(_mm256_cmpeq_epi8(v0, v1));
+}
+#elif defined(ZXC_USE_SSE2)
+#define ZXC_RLE_WIN 16
+#define ZXC_RLE_BPB 1
+#define ZXC_RLE_CTZ(x) zxc_ctz32(x)
+typedef uint32_t zxc_rle_mask_t;
+static ZXC_ALWAYS_INLINE zxc_rle_mask_t zxc_rle_pair_mask(const uint8_t* p) {
+    const __m128i v0 = _mm_loadu_si128((const __m128i*)p);
+    const __m128i v1 = _mm_loadu_si128((const __m128i*)(p + 1));
+    return (uint32_t)_mm_movemask_epi8(_mm_cmpeq_epi8(v0, v1));
+}
+#elif defined(ZXC_USE_NEON64)
+#define ZXC_RLE_WIN 16
+#define ZXC_RLE_BPB 4
+#define ZXC_RLE_CTZ(x) zxc_ctz64(x)
+typedef uint64_t zxc_rle_mask_t;
+static ZXC_ALWAYS_INLINE zxc_rle_mask_t zxc_rle_pair_mask(const uint8_t* p) {
+    const uint8x16_t eq = vceqq_u8(vld1q_u8(p), vld1q_u8(p + 1));
+    return vget_lane_u64(vreinterpret_u64_u8(vshrn_n_u16(vreinterpretq_u16_u8(eq), 4)), 0);
+}
+#endif
+
 // SSE2 selected, not merely available: guards the two helpers below.
 #if defined(ZXC_USE_SSE2) && !(defined(ZXC_USE_AVX512) && defined(__AVX512VL__)) && \
     !defined(ZXC_USE_AVX2) && !defined(ZXC_USE_NEON64) && !defined(ZXC_USE_NEON32)
@@ -1410,93 +1459,24 @@ parse_done:;
                 // Literal run: scan ahead with fast SIMD lookahead
                 const uint8_t* lit_start = run_start;
 
-#if defined(ZXC_USE_AVX512)
-                while (p <= p_end_4 - 64) {
-                    const __m512i v0 = _mm512_loadu_si512((const void*)p);
-                    const __m512i v1 = _mm512_loadu_si512((const void*)(p + 1));
-                    const uint64_t m = (uint64_t)_mm512_cmpeq_epi8_mask(v0, v1);
-                    const uint64_t mask = m & (m >> 1) & (m >> 2);
+#if defined(ZXC_RLE_WIN)
+                while (p <= p_end_4 - ZXC_RLE_WIN) {
+                    const zxc_rle_mask_t m = zxc_rle_pair_mask(p);
+                    const zxc_rle_mask_t mask = m & (m >> ZXC_RLE_BPB) & (m >> (2 * ZXC_RLE_BPB));
                     if (LIKELY(mask == 0)) {
-                        p += 62;
+                        p += ZXC_RLE_WIN - 2;
                         continue;
                     }
-                    const unsigned rpos = (unsigned)zxc_ctz64(mask);
-                    const unsigned rpairs = (unsigned)zxc_ctz64(~(m >> rpos));
-                    if (UNLIKELY(rpos + rpairs >= 64)) {
+                    const unsigned rpos = (unsigned)(ZXC_RLE_CTZ(mask) / ZXC_RLE_BPB);
+                    const unsigned rpairs =
+                        (unsigned)(ZXC_RLE_CTZ(~(m >> (rpos * ZXC_RLE_BPB))) / ZXC_RLE_BPB);
+                    if (UNLIKELY(rpos + rpairs >= ZXC_RLE_WIN)) {
                         p += rpos;
                         goto _lit_done; /* run may extend past the window */
                     }
                     const size_t seg = (size_t)(p + rpos - lit_start);
                     rle_size += seg + ((seg + 127) >> 7);
-                    rle_size += 2; /* run in [4,63]: full_chunks=0, rem>=4 */
-                    p += rpos + rpairs + 1;
-                    lit_start = p;
-                }
-#elif defined(ZXC_USE_AVX2)
-                while (p <= p_end_4 - 32) {
-                    __m256i v0 = _mm256_loadu_si256((const __m256i*)p);
-                    __m256i v1 = _mm256_loadu_si256((const __m256i*)(p + 1));
-                    const uint32_t m = (uint32_t)_mm256_movemask_epi8(_mm256_cmpeq_epi8(v0, v1));
-                    const uint32_t mask = m & (m >> 1) & (m >> 2);
-                    if (LIKELY(mask == 0)) {
-                        p += 30;
-                        continue;
-                    }
-                    const unsigned rpos = zxc_ctz32(mask);
-                    const unsigned rpairs = zxc_ctz32(~(m >> rpos));
-                    if (UNLIKELY(rpos + rpairs >= 32)) {
-                        p += rpos;
-                        goto _lit_done; /* run may extend past the window */
-                    }
-                    const size_t seg = (size_t)(p + rpos - lit_start);
-                    rle_size += seg + ((seg + 127) >> 7);
-                    rle_size += 2; /* run in [4,31]: full_chunks=0, rem>=4 */
-                    p += rpos + rpairs + 1;
-                    lit_start = p;
-                }
-#elif defined(ZXC_USE_SSE2)
-                while (p <= p_end_4 - 16) {
-                    __m128i v0 = _mm_loadu_si128((const __m128i*)p);
-                    __m128i v1 = _mm_loadu_si128((const __m128i*)(p + 1));
-                    const uint32_t m = (uint32_t)_mm_movemask_epi8(_mm_cmpeq_epi8(v0, v1));
-                    const uint32_t mask = m & (m >> 1) & (m >> 2);
-                    if (LIKELY(mask == 0)) {
-                        p += 14;
-                        continue;
-                    }
-                    const unsigned rpos = zxc_ctz32(mask);
-                    const unsigned rpairs = zxc_ctz32(~(m >> rpos));
-                    if (UNLIKELY(rpos + rpairs >= 16)) {
-                        p += rpos;
-                        goto _lit_done; /* run may extend past the window */
-                    }
-                    const size_t seg = (size_t)(p + rpos - lit_start);
-                    rle_size += seg + ((seg + 127) >> 7);
-                    rle_size += 2; /* run in [4,16]: full_chunks=0, rem>=4 */
-                    p += rpos + rpairs + 1;
-                    lit_start = p;
-                }
-#elif defined(ZXC_USE_NEON64)
-                while (p <= p_end_4 - 16) {
-                    uint8x16_t v0 = vld1q_u8(p);
-                    uint8x16_t v1 = vld1q_u8(p + 1);
-                    const uint8x16_t eq = vceqq_u8(v0, v1);
-                    const uint64_t m = vget_lane_u64(
-                        vreinterpret_u64_u8(vshrn_n_u16(vreinterpretq_u16_u8(eq), 4)), 0);
-                    const uint64_t mask = m & (m >> 4) & (m >> 8);
-                    if (LIKELY(mask == 0)) {
-                        p += 14;
-                        continue;
-                    }
-                    const unsigned rpos = (unsigned)(zxc_ctz64(mask) >> 2);
-                    const unsigned rpairs = (unsigned)(zxc_ctz64(~(m >> (rpos * 4))) >> 2);
-                    if (UNLIKELY(rpos + rpairs >= 16)) {
-                        p += rpos;
-                        goto _lit_done; /* run may extend past the window */
-                    }
-                    const size_t seg = (size_t)(p + rpos - lit_start);
-                    rle_size += seg + ((seg + 127) >> 7);
-                    rle_size += 2; /* run in [4,16]: full_chunks=0, rem>=4 */
+                    rle_size += 2; /* run fits one chunk: full_chunks=0, rem>=4 */
                     p += rpos + rpairs + 1;
                     lit_start = p;
                 }

--- a/src/lib/zxc_compress.c
+++ b/src/lib/zxc_compress.c
@@ -1516,11 +1516,7 @@ parse_done:;
                     if (UNLIKELY(p[0] == p[1] && p[1] == p[2] && p[2] == p[3])) break;
                     p++;
                 }
-                while (p < p_end) {
-                    if (UNLIKELY(p + 3 < p_end && p[0] == p[1] && p[1] == p[2] && p[2] == p[3]))
-                        break;
-                    p++;
-                }
+                if (p >= p_end_4) p = p_end;
 
 #if defined(ZXC_USE_AVX512) || defined(ZXC_USE_AVX2) || defined(ZXC_USE_NEON64) || \
     defined(ZXC_USE_NEON32) || defined(ZXC_USE_SSE2)
@@ -1968,9 +1964,7 @@ static int zxc_encode_block_ghi(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRIC
 
     ZXC_MEMCPY(p_curr, literals, lit_c);
     p_curr += lit_c;
-    rem -= sz_lit;
 
-    if (UNLIKELY(rem < sz_seq)) return ZXC_ERROR_DST_TOO_SMALL;
     // Write sequences in little-endian order
 #ifdef ZXC_BIG_ENDIAN
     for (uint32_t i = 0; i < seq_c; i++) {

--- a/src/lib/zxc_decompress.c
+++ b/src/lib/zxc_decompress.c
@@ -347,6 +347,32 @@ static ZXC_ALWAYS_INLINE void zxc_decode_copy_overlap_short(uint8_t* dst, const 
 }
 
 /**
+ * @brief Writes a run in 32-byte wild stores, for the fill, literal and match copiers.
+ *
+ * Emits one 32-byte unit, then one more per remaining 32 bytes of @p len. The
+ * last unit goes out whole, so the run may **overshoot** up to 31 bytes past
+ * @p len: every caller owes @ref ZXC_PAD_SIZE bytes of writable headroom.
+ *
+ * @param len     Run length in bytes (>= 1).
+ * @param emit    Statement writing the 32-byte unit at the current cursors.
+ * @param advance Statement moving those cursors on by 32 bytes.
+ */
+#define ZXC_WILD_RUN32(len, emit, advance) \
+    do {                                   \
+        emit;                              \
+        if (UNLIKELY((len) > 32)) {        \
+            advance;                       \
+            size_t _rem = (len) - 32;      \
+            while (_rem > 32) {            \
+                emit;                      \
+                advance;                   \
+                _rem -= 32;                \
+            }                              \
+            emit;                          \
+        }                                  \
+    } while (0)
+
+/**
  * @brief Fills an @p ml-byte single-byte run (LZ offset == 1) with wild stores.
  *
  * Splats @p byte into a vector register and emits 32-byte chunks, avoiding a
@@ -364,49 +390,18 @@ static ZXC_ALWAYS_INLINE void zxc_decode_fill_run(uint8_t* dst, const uint8_t by
                                                   const uint64_t ml) {
 #if defined(ZXC_USE_AVX2) || defined(ZXC_USE_AVX512)
     const __m256i v = _mm256_set1_epi8((char)byte);
-    _mm256_storeu_si256((__m256i*)dst, v);
-    if (UNLIKELY(ml > 32)) {
-        uint8_t* out = dst + 32;
-        size_t rem = ml - 32;
-        while (rem > 32) {
-            _mm256_storeu_si256((__m256i*)out, v);
-            out += 32;
-            rem -= 32;
-        }
-        _mm256_storeu_si256((__m256i*)out, v);
-    }
+    uint8_t* out = dst;
+    ZXC_WILD_RUN32(ml, _mm256_storeu_si256((__m256i*)out, v), out += 32);
 #elif defined(ZXC_USE_SSE2)
     const __m128i v = _mm_set1_epi8((char)byte);
-    _mm_storeu_si128((__m128i*)dst, v);
-    _mm_storeu_si128((__m128i*)(dst + 16), v);
-    if (UNLIKELY(ml > 32)) {
-        uint8_t* out = dst + 32;
-        size_t rem = ml - 32;
-        while (rem > 32) {
-            _mm_storeu_si128((__m128i*)out, v);
-            _mm_storeu_si128((__m128i*)(out + 16), v);
-            out += 32;
-            rem -= 32;
-        }
-        _mm_storeu_si128((__m128i*)out, v);
-        _mm_storeu_si128((__m128i*)(out + 16), v);
-    }
+    uint8_t* out = dst;
+    ZXC_WILD_RUN32(ml,
+                   (_mm_storeu_si128((__m128i*)out, v), _mm_storeu_si128((__m128i*)(out + 16), v)),
+                   out += 32);
 #elif defined(ZXC_USE_NEON64) || defined(ZXC_USE_NEON32)
     const uint8x16_t v = vdupq_n_u8(byte);
-    vst1q_u8(dst, v);
-    vst1q_u8(dst + 16, v);
-    if (UNLIKELY(ml > 32)) {
-        uint8_t* out = dst + 32;
-        size_t rem = ml - 32;
-        while (rem > 32) {
-            vst1q_u8(out, v);
-            vst1q_u8(out + 16, v);
-            out += 32;
-            rem -= 32;
-        }
-        vst1q_u8(out, v);
-        vst1q_u8(out + 16, v);
-    }
+    uint8_t* out = dst;
+    ZXC_WILD_RUN32(ml, (vst1q_u8(out, v), vst1q_u8(out + 16, v)), out += 32);
 #else
     ZXC_MEMSET(dst, byte, ml);
 #endif
@@ -437,19 +432,7 @@ static ZXC_ALWAYS_INLINE void zxc_decode_fill_run(uint8_t* dst, const uint8_t by
 static ZXC_ALWAYS_INLINE void zxc_decode_copy_literals(uint8_t* RESTRICT dst,
                                                        const uint8_t* RESTRICT src,
                                                        const uint64_t ll) {
-    zxc_copy32(dst, src);
-    if (UNLIKELY(ll > 32)) {
-        dst += 32;
-        src += 32;
-        size_t rem = ll - 32;
-        while (rem > 32) {
-            zxc_copy32(dst, src);
-            dst += 32;
-            src += 32;
-            rem -= 32;
-        }
-        zxc_copy32(dst, src);
-    }
+    ZXC_WILD_RUN32(ll, zxc_copy32(dst, src), (dst += 32, src += 32));
 }
 
 /**
@@ -479,25 +462,17 @@ static ZXC_ALWAYS_INLINE void zxc_decode_copy_match(uint8_t* RESTRICT d_ptr, con
                                                     const uint64_t ml) {
     const uint8_t* match_src = d_ptr - off;
     if (LIKELY(off >= 32)) {
-        zxc_copy32(d_ptr, match_src);
-        if (UNLIKELY(ml > 32)) {
-            uint8_t* out = d_ptr + 32;
-            const uint8_t* ref = match_src + 32;
-            size_t rem = ml - 32;
-            while (rem > 32) {
-                zxc_copy32(out, ref);
-                out += 32;
-                ref += 32;
-                rem -= 32;
-            }
-            zxc_copy32(out, ref);
-        }
+        uint8_t* out = d_ptr;
+        const uint8_t* ref = match_src;
+        ZXC_WILD_RUN32(ml, zxc_copy32(out, ref), (out += 32, ref += 32));
     } else if (off == 1) {
         zxc_decode_fill_run(d_ptr, match_src[0], ml);
     } else {
         zxc_decode_copy_overlap_run32(d_ptr, off, ml);
     }
 }
+
+#undef ZXC_WILD_RUN32
 
 /**
  * @brief Match copy for a length that cannot exceed 32 bytes.

--- a/src/lib/zxc_decompress.c
+++ b/src/lib/zxc_decompress.c
@@ -817,6 +817,26 @@ static ZXC_NOINLINE int zxc_decode_block_glo_entropy_safe(const zxc_cctx_t* REST
                                                           size_t dst_capacity);
 
 /**
+ * @brief Flushes the literals the sequence loop did not consume, then reports
+ *        the decoded size.
+ *
+ * Both block decoders end this way: a stream that stops before its literals are
+ * exhausted still owes the remainder to the output.
+ */
+static ZXC_ALWAYS_INLINE int zxc_decode_trailing_literals(uint8_t* d_ptr, const uint8_t* d_end,
+                                                          const uint8_t* l_ptr,
+                                                          const uint8_t* l_end,
+                                                          const uint8_t* dst) {
+    if (UNLIKELY(l_ptr > l_end)) return ZXC_ERROR_CORRUPT_DATA;
+    if (UNLIKELY(d_ptr > d_end)) return ZXC_ERROR_OVERFLOW;
+
+    const size_t remaining_literals = (size_t)(l_end - l_ptr);
+    if (UNLIKELY(remaining_literals > (size_t)(d_end - d_ptr))) return ZXC_ERROR_OVERFLOW;
+    ZXC_MEMCPY(d_ptr, l_ptr, remaining_literals);
+    return (int)(d_ptr + remaining_literals - dst);
+}
+
+/**
  * @brief Unified GLO (General Low) block decoder body, shared by the fast,
  *        safe, dictionary and entropy-token variants.
  *
@@ -879,7 +899,6 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(const zxc_cctx_t* RESTRIC
     // --- Literal Stream Setup ---
     const uint8_t* l_ptr;
     const uint8_t* l_end;
-    uint8_t* rle_buf = NULL;
 
     size_t lit_stream_size = lit_comp;
     // Decoded size of an encoded literal section (RAW ignores it).
@@ -913,8 +932,8 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(const zxc_cctx_t* RESTRIC
             // zxc_cctx_init (mode == 0).
             if (UNLIKELY(ctx->lit_buffer_cap < alloc_size)) return ZXC_ERROR_CORRUPT_DATA;
 
-            rle_buf = ctx->lit_buffer;
-            if (UNLIKELY(!rle_buf || lit_stream_size > (size_t)(src + src_size - p_curr)))
+            uint8_t* const rle_buf = ctx->lit_buffer;
+            if (UNLIKELY(lit_stream_size > (size_t)(src + src_size - p_curr)))
                 return ZXC_ERROR_CORRUPT_DATA;
 
             const uint8_t* r_ptr = p_curr;
@@ -1196,16 +1215,7 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(const zxc_cctx_t* RESTRIC
     }
 
     // --- Trailing Literals ---
-    // Copy remaining literals from source stream (literal exhaustion)
-    if (UNLIKELY(l_ptr > l_end)) return ZXC_ERROR_CORRUPT_DATA;
-    if (UNLIKELY(d_ptr > d_end)) return ZXC_ERROR_OVERFLOW;
-
-    const size_t remaining_literals = (size_t)(l_end - l_ptr);
-    if (UNLIKELY(remaining_literals > (size_t)(d_end - d_ptr))) return ZXC_ERROR_OVERFLOW;
-    ZXC_MEMCPY(d_ptr, l_ptr, remaining_literals);
-    d_ptr += remaining_literals;
-
-    return (int)(d_ptr - dst);
+    return zxc_decode_trailing_literals(d_ptr, d_end, l_ptr, l_end, dst);
 }
 
 /**
@@ -1456,16 +1466,7 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(const zxc_cctx_t* RESTRIC
     }
 
     // --- Trailing Literals ---
-    // Copy remaining literals from source stream (literal exhaustion)
-    if (UNLIKELY(l_ptr > l_end)) return ZXC_ERROR_CORRUPT_DATA;
-    if (UNLIKELY(d_ptr > d_end)) return ZXC_ERROR_OVERFLOW;
-
-    const size_t remaining_literals = (size_t)(l_end - l_ptr);
-    if (UNLIKELY(remaining_literals > (size_t)(d_end - d_ptr))) return ZXC_ERROR_OVERFLOW;
-    ZXC_MEMCPY(d_ptr, l_ptr, remaining_literals);
-    d_ptr += remaining_literals;
-
-    return (int)(d_ptr - dst);
+    return zxc_decode_trailing_literals(d_ptr, d_end, l_ptr, l_end, dst);
 }
 
 /**
@@ -1501,13 +1502,6 @@ static ZXC_NOINLINE int zxc_decode_block_glo_entropy_safe(const zxc_cctx_t* REST
  *
  * Wrapper over @ref zxc_decode_block_glo_impl with @c safe=0, @c has_dict=0, so
  * the no-dict chunk wrapper inlines it exactly like the dict-free build.
- *
- * @param[in,out] ctx          Decompression context.
- * @param[in]     src          Compressed GLO block payload.
- * @param[in]     src_size     Size of @p src in bytes.
- * @param[out]    dst          Destination buffer.
- * @param[in]     dst_capacity Capacity of @p dst in bytes.
- * @return Bytes written on success, or a negative @ref zxc_error_t.
  */
 static int zxc_decode_block_glo(const zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRICT src,
                                 const size_t src_size, uint8_t* RESTRICT dst,
@@ -1519,13 +1513,6 @@ static int zxc_decode_block_glo(const zxc_cctx_t* RESTRICT ctx, const uint8_t* R
  * @brief Decode a no-dict GHI block (plain, inlinable path).
  *
  * Wrapper over @ref zxc_decode_block_ghi_impl with @c safe=0, @c has_dict=0.
- *
- * @param[in,out] ctx          Decompression context.
- * @param[in]     src          Compressed GHI block payload.
- * @param[in]     src_size     Size of @p src in bytes.
- * @param[out]    dst          Destination buffer.
- * @param[in]     dst_capacity Capacity of @p dst in bytes.
- * @return Bytes written on success, or a negative @ref zxc_error_t.
  */
 static int zxc_decode_block_ghi(const zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRICT src,
                                 const size_t src_size, uint8_t* RESTRICT dst,
@@ -1539,13 +1526,6 @@ static int zxc_decode_block_ghi(const zxc_cctx_t* RESTRICT ctx, const uint8_t* R
  * Wrapper over @ref zxc_decode_block_glo_impl with @c safe=0, @c has_dict=1.
  * NOINLINE: only reached on the cold dict path (@ref zxc_decompress_chunk_wrapper_dict),
  * so it never loads into I-cache on a no-dict stream.
- *
- * @param[in,out] ctx          Decompression context (dict prefix in its buffer).
- * @param[in]     src          Compressed GLO block payload.
- * @param[in]     src_size     Size of @p src in bytes.
- * @param[out]    dst          Destination buffer.
- * @param[in]     dst_capacity Capacity of @p dst in bytes.
- * @return Bytes written on success, or a negative @ref zxc_error_t.
  */
 static ZXC_NOINLINE int zxc_decode_block_glo_dict(const zxc_cctx_t* RESTRICT ctx,
                                                   const uint8_t* RESTRICT src,
@@ -1559,13 +1539,6 @@ static ZXC_NOINLINE int zxc_decode_block_glo_dict(const zxc_cctx_t* RESTRICT ctx
  *
  * Wrapper over @ref zxc_decode_block_ghi_impl with @c safe=0, @c has_dict=1
  * (NOINLINE; see @ref zxc_decode_block_glo_dict).
- *
- * @param[in,out] ctx          Decompression context (dict prefix in its buffer).
- * @param[in]     src          Compressed GHI block payload.
- * @param[in]     src_size     Size of @p src in bytes.
- * @param[out]    dst          Destination buffer.
- * @param[in]     dst_capacity Capacity of @p dst in bytes.
- * @return Bytes written on success, or a negative @ref zxc_error_t.
  */
 static ZXC_NOINLINE int zxc_decode_block_ghi_dict(const zxc_cctx_t* RESTRICT ctx,
                                                   const uint8_t* RESTRICT src,
@@ -1580,13 +1553,6 @@ static ZXC_NOINLINE int zxc_decode_block_ghi_dict(const zxc_cctx_t* RESTRICT ctx
  * Wrapper over @ref zxc_decode_block_glo_impl with @c safe=1, @c has_dict=0.
  * The safe path never carries a dict (block_safe routes dict inputs to the
  * bounce path), so @c has_dict=0 folds the dead dict handling.
- *
- * @param[in,out] ctx          Decompression context.
- * @param[in]     src          Compressed GLO block payload.
- * @param[in]     src_size     Size of @p src in bytes.
- * @param[out]    dst          Destination buffer (capacity == exact decoded size).
- * @param[in]     dst_capacity Capacity of @p dst in bytes.
- * @return Bytes written on success, or a negative @ref zxc_error_t.
  */
 static ZXC_NOINLINE int zxc_decode_block_glo_safe(const zxc_cctx_t* RESTRICT ctx,
                                                   const uint8_t* RESTRICT src,
@@ -1601,13 +1567,6 @@ static ZXC_NOINLINE int zxc_decode_block_glo_safe(const zxc_cctx_t* RESTRICT ctx
  * Wrapper over @ref zxc_decode_block_ghi_impl with @c safe=1, @c has_dict=0
  * (the strict-tail safe path never carries a dict; see
  * @ref zxc_decode_block_glo_safe).
- *
- * @param[in,out] ctx          Decompression context.
- * @param[in]     src          Compressed GHI block payload.
- * @param[in]     src_size     Size of @p src in bytes.
- * @param[out]    dst          Destination buffer (capacity == exact decoded size).
- * @param[in]     dst_capacity Capacity of @p dst in bytes.
- * @return Bytes written on success, or a negative @ref zxc_error_t.
  */
 static ZXC_NOINLINE int zxc_decode_block_ghi_safe(const zxc_cctx_t* RESTRICT ctx,
                                                   const uint8_t* RESTRICT src,

--- a/src/lib/zxc_decompress.c
+++ b/src/lib/zxc_decompress.c
@@ -553,13 +553,13 @@ static ZXC_ALWAYS_INLINE void zxc_decode_copy_match_glo(uint8_t* RESTRICT d_ptr,
  * multiple of @p off, the result is byte-identical to the naive per-byte
  * copy, in O(log(ml/off)) calls instead of O(ml) iterations.
  *
- * @param[in,out] d_ptr     Output cursor (match source is @c d_ptr-off).
- * @param[in]     match_src Match source, equal to @c d_ptr-off.
- * @param[in]     off       Back-reference distance, @c >= 1.
- * @param[in]     ml        Match length in bytes.
+ * @param[in,out] d_ptr Output cursor; the match source is @c d_ptr-off.
+ * @param[in]     off   Back-reference distance, @c >= 1.
+ * @param[in]     ml    Match length in bytes.
  */
-static ZXC_NOINLINE void zxc_decode_copy_match_exact(uint8_t* d_ptr, const uint8_t* match_src,
-                                                     const size_t off, const size_t ml) {
+static ZXC_NOINLINE void zxc_decode_copy_match_exact(uint8_t* d_ptr, const size_t off,
+                                                     const size_t ml) {
+    const uint8_t* const match_src = d_ptr - off;
     if (off >= ml) {
         ZXC_MEMCPY(d_ptr, match_src, ml);
     } else if (ml < 16) {
@@ -1207,9 +1207,7 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(const zxc_cctx_t* RESTRIC
         d_ptr += ll;
 
         if (UNLIKELY((size_t)(d_ptr - d_floor) < offset)) return ZXC_ERROR_BAD_OFFSET;
-        const uint8_t* match_src = d_ptr - offset;
-
-        zxc_decode_copy_match_exact(d_ptr, match_src, offset, ml);
+        zxc_decode_copy_match_exact(d_ptr, offset, ml);
         d_ptr += ml;
         n_seq--;
     }
@@ -1354,9 +1352,7 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(const zxc_cctx_t* RESTRIC
 
             if (UNLIKELY(d_ptr + ml > d_end)) return ZXC_ERROR_OVERFLOW;
             if (UNLIKELY((size_t)(d_ptr - d_floor) < offset)) return ZXC_ERROR_BAD_OFFSET;
-            const uint8_t* match_src = d_ptr - offset;
-
-            zxc_decode_copy_match_exact(d_ptr, match_src, offset, ml);
+            zxc_decode_copy_match_exact(d_ptr, offset, ml);
             d_ptr += ml;
         } else {
             zxc_decode_copy_literals(d_ptr, l_ptr, ll);
@@ -1458,9 +1454,7 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(const zxc_cctx_t* RESTRIC
         d_ptr += ll;
 
         if (UNLIKELY((size_t)(d_ptr - d_floor) < offset)) return ZXC_ERROR_BAD_OFFSET;
-        const uint8_t* match_src = d_ptr - offset;
-
-        zxc_decode_copy_match_exact(d_ptr, match_src, offset, ml);
+        zxc_decode_copy_match_exact(d_ptr, offset, ml);
         d_ptr += ml;
         n_seq--;
     }

--- a/src/lib/zxc_decompress.c
+++ b/src/lib/zxc_decompress.c
@@ -933,7 +933,7 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(const zxc_cctx_t* RESTRIC
             if (UNLIKELY(ctx->lit_buffer_cap < alloc_size)) return ZXC_ERROR_CORRUPT_DATA;
 
             uint8_t* const rle_buf = ctx->lit_buffer;
-            if (UNLIKELY(lit_stream_size > (size_t)(src + src_size - p_curr)))
+            if (UNLIKELY(!rle_buf || lit_stream_size > (size_t)(src + src_size - p_curr)))
                 return ZXC_ERROR_CORRUPT_DATA;
 
             const uint8_t* r_ptr = p_curr;

--- a/src/lib/zxc_decompress.c
+++ b/src/lib/zxc_decompress.c
@@ -347,32 +347,6 @@ static ZXC_ALWAYS_INLINE void zxc_decode_copy_overlap_short(uint8_t* dst, const 
 }
 
 /**
- * @brief Writes a run in 32-byte wild stores, for the fill, literal and match copiers.
- *
- * Emits one 32-byte unit, then one more per remaining 32 bytes of @p len. The
- * last unit goes out whole, so the run may **overshoot** up to 31 bytes past
- * @p len: every caller owes @ref ZXC_PAD_SIZE bytes of writable headroom.
- *
- * @param len     Run length in bytes (>= 1).
- * @param emit    Statement writing the 32-byte unit at the current cursors.
- * @param advance Statement moving those cursors on by 32 bytes.
- */
-#define ZXC_WILD_RUN32(len, emit, advance) \
-    do {                                   \
-        emit;                              \
-        if (UNLIKELY((len) > 32)) {        \
-            advance;                       \
-            size_t _rem = (len) - 32;      \
-            while (_rem > 32) {            \
-                emit;                      \
-                advance;                   \
-                _rem -= 32;                \
-            }                              \
-            emit;                          \
-        }                                  \
-    } while (0)
-
-/**
  * @brief Fills an @p ml-byte single-byte run (LZ offset == 1) with wild stores.
  *
  * Splats @p byte into a vector register and emits 32-byte chunks, avoiding a
@@ -390,18 +364,49 @@ static ZXC_ALWAYS_INLINE void zxc_decode_fill_run(uint8_t* dst, const uint8_t by
                                                   const uint64_t ml) {
 #if defined(ZXC_USE_AVX2) || defined(ZXC_USE_AVX512)
     const __m256i v = _mm256_set1_epi8((char)byte);
-    uint8_t* out = dst;
-    ZXC_WILD_RUN32(ml, _mm256_storeu_si256((__m256i*)out, v), out += 32);
+    _mm256_storeu_si256((__m256i*)dst, v);
+    if (UNLIKELY(ml > 32)) {
+        uint8_t* out = dst + 32;
+        size_t rem = ml - 32;
+        while (rem > 32) {
+            _mm256_storeu_si256((__m256i*)out, v);
+            out += 32;
+            rem -= 32;
+        }
+        _mm256_storeu_si256((__m256i*)out, v);
+    }
 #elif defined(ZXC_USE_SSE2)
     const __m128i v = _mm_set1_epi8((char)byte);
-    uint8_t* out = dst;
-    ZXC_WILD_RUN32(ml,
-                   (_mm_storeu_si128((__m128i*)out, v), _mm_storeu_si128((__m128i*)(out + 16), v)),
-                   out += 32);
+    _mm_storeu_si128((__m128i*)dst, v);
+    _mm_storeu_si128((__m128i*)(dst + 16), v);
+    if (UNLIKELY(ml > 32)) {
+        uint8_t* out = dst + 32;
+        size_t rem = ml - 32;
+        while (rem > 32) {
+            _mm_storeu_si128((__m128i*)out, v);
+            _mm_storeu_si128((__m128i*)(out + 16), v);
+            out += 32;
+            rem -= 32;
+        }
+        _mm_storeu_si128((__m128i*)out, v);
+        _mm_storeu_si128((__m128i*)(out + 16), v);
+    }
 #elif defined(ZXC_USE_NEON64) || defined(ZXC_USE_NEON32)
     const uint8x16_t v = vdupq_n_u8(byte);
-    uint8_t* out = dst;
-    ZXC_WILD_RUN32(ml, (vst1q_u8(out, v), vst1q_u8(out + 16, v)), out += 32);
+    vst1q_u8(dst, v);
+    vst1q_u8(dst + 16, v);
+    if (UNLIKELY(ml > 32)) {
+        uint8_t* out = dst + 32;
+        size_t rem = ml - 32;
+        while (rem > 32) {
+            vst1q_u8(out, v);
+            vst1q_u8(out + 16, v);
+            out += 32;
+            rem -= 32;
+        }
+        vst1q_u8(out, v);
+        vst1q_u8(out + 16, v);
+    }
 #else
     ZXC_MEMSET(dst, byte, ml);
 #endif
@@ -432,7 +437,19 @@ static ZXC_ALWAYS_INLINE void zxc_decode_fill_run(uint8_t* dst, const uint8_t by
 static ZXC_ALWAYS_INLINE void zxc_decode_copy_literals(uint8_t* RESTRICT dst,
                                                        const uint8_t* RESTRICT src,
                                                        const uint64_t ll) {
-    ZXC_WILD_RUN32(ll, zxc_copy32(dst, src), (dst += 32, src += 32));
+    zxc_copy32(dst, src);
+    if (UNLIKELY(ll > 32)) {
+        dst += 32;
+        src += 32;
+        size_t rem = ll - 32;
+        while (rem > 32) {
+            zxc_copy32(dst, src);
+            dst += 32;
+            src += 32;
+            rem -= 32;
+        }
+        zxc_copy32(dst, src);
+    }
 }
 
 /**
@@ -462,17 +479,25 @@ static ZXC_ALWAYS_INLINE void zxc_decode_copy_match(uint8_t* RESTRICT d_ptr, con
                                                     const uint64_t ml) {
     const uint8_t* match_src = d_ptr - off;
     if (LIKELY(off >= 32)) {
-        uint8_t* out = d_ptr;
-        const uint8_t* ref = match_src;
-        ZXC_WILD_RUN32(ml, zxc_copy32(out, ref), (out += 32, ref += 32));
+        zxc_copy32(d_ptr, match_src);
+        if (UNLIKELY(ml > 32)) {
+            uint8_t* out = d_ptr + 32;
+            const uint8_t* ref = match_src + 32;
+            size_t rem = ml - 32;
+            while (rem > 32) {
+                zxc_copy32(out, ref);
+                out += 32;
+                ref += 32;
+                rem -= 32;
+            }
+            zxc_copy32(out, ref);
+        }
     } else if (off == 1) {
         zxc_decode_fill_run(d_ptr, match_src[0], ml);
     } else {
         zxc_decode_copy_overlap_run32(d_ptr, off, ml);
     }
 }
-
-#undef ZXC_WILD_RUN32
 
 /**
  * @brief Match copy for a length that cannot exceed 32 bytes.
@@ -528,13 +553,13 @@ static ZXC_ALWAYS_INLINE void zxc_decode_copy_match_glo(uint8_t* RESTRICT d_ptr,
  * multiple of @p off, the result is byte-identical to the naive per-byte
  * copy, in O(log(ml/off)) calls instead of O(ml) iterations.
  *
- * @param[in,out] d_ptr Output cursor; the match source is @c d_ptr-off.
- * @param[in]     off   Back-reference distance, @c >= 1.
- * @param[in]     ml    Match length in bytes.
+ * @param[in,out] d_ptr     Output cursor (match source is @c d_ptr-off).
+ * @param[in]     match_src Match source, equal to @c d_ptr-off.
+ * @param[in]     off       Back-reference distance, @c >= 1.
+ * @param[in]     ml        Match length in bytes.
  */
-static ZXC_NOINLINE void zxc_decode_copy_match_exact(uint8_t* d_ptr, const size_t off,
-                                                     const size_t ml) {
-    const uint8_t* const match_src = d_ptr - off;
+static ZXC_NOINLINE void zxc_decode_copy_match_exact(uint8_t* d_ptr, const uint8_t* match_src,
+                                                     const size_t off, const size_t ml) {
     if (off >= ml) {
         ZXC_MEMCPY(d_ptr, match_src, ml);
     } else if (ml < 16) {
@@ -792,26 +817,6 @@ static ZXC_NOINLINE int zxc_decode_block_glo_entropy_safe(const zxc_cctx_t* REST
                                                           size_t dst_capacity);
 
 /**
- * @brief Flushes the literals the sequence loop did not consume, then reports
- *        the decoded size.
- *
- * Both block decoders end this way: a stream that stops before its literals are
- * exhausted still owes the remainder to the output.
- */
-static ZXC_ALWAYS_INLINE int zxc_decode_trailing_literals(uint8_t* d_ptr, const uint8_t* d_end,
-                                                          const uint8_t* l_ptr,
-                                                          const uint8_t* l_end,
-                                                          const uint8_t* dst) {
-    if (UNLIKELY(l_ptr > l_end)) return ZXC_ERROR_CORRUPT_DATA;
-    if (UNLIKELY(d_ptr > d_end)) return ZXC_ERROR_OVERFLOW;
-
-    const size_t remaining_literals = (size_t)(l_end - l_ptr);
-    if (UNLIKELY(remaining_literals > (size_t)(d_end - d_ptr))) return ZXC_ERROR_OVERFLOW;
-    ZXC_MEMCPY(d_ptr, l_ptr, remaining_literals);
-    return (int)(d_ptr + remaining_literals - dst);
-}
-
-/**
  * @brief Unified GLO (General Low) block decoder body, shared by the fast,
  *        safe, dictionary and entropy-token variants.
  *
@@ -874,6 +879,7 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(const zxc_cctx_t* RESTRIC
     // --- Literal Stream Setup ---
     const uint8_t* l_ptr;
     const uint8_t* l_end;
+    uint8_t* rle_buf = NULL;
 
     size_t lit_stream_size = lit_comp;
     // Decoded size of an encoded literal section (RAW ignores it).
@@ -907,7 +913,7 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(const zxc_cctx_t* RESTRIC
             // zxc_cctx_init (mode == 0).
             if (UNLIKELY(ctx->lit_buffer_cap < alloc_size)) return ZXC_ERROR_CORRUPT_DATA;
 
-            uint8_t* const rle_buf = ctx->lit_buffer;
+            rle_buf = ctx->lit_buffer;
             if (UNLIKELY(!rle_buf || lit_stream_size > (size_t)(src + src_size - p_curr)))
                 return ZXC_ERROR_CORRUPT_DATA;
 
@@ -1182,13 +1188,24 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(const zxc_cctx_t* RESTRIC
         d_ptr += ll;
 
         if (UNLIKELY((size_t)(d_ptr - d_floor) < offset)) return ZXC_ERROR_BAD_OFFSET;
-        zxc_decode_copy_match_exact(d_ptr, offset, ml);
+        const uint8_t* match_src = d_ptr - offset;
+
+        zxc_decode_copy_match_exact(d_ptr, match_src, offset, ml);
         d_ptr += ml;
         n_seq--;
     }
 
     // --- Trailing Literals ---
-    return zxc_decode_trailing_literals(d_ptr, d_end, l_ptr, l_end, dst);
+    // Copy remaining literals from source stream (literal exhaustion)
+    if (UNLIKELY(l_ptr > l_end)) return ZXC_ERROR_CORRUPT_DATA;
+    if (UNLIKELY(d_ptr > d_end)) return ZXC_ERROR_OVERFLOW;
+
+    const size_t remaining_literals = (size_t)(l_end - l_ptr);
+    if (UNLIKELY(remaining_literals > (size_t)(d_end - d_ptr))) return ZXC_ERROR_OVERFLOW;
+    ZXC_MEMCPY(d_ptr, l_ptr, remaining_literals);
+    d_ptr += remaining_literals;
+
+    return (int)(d_ptr - dst);
 }
 
 /**
@@ -1327,7 +1344,9 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(const zxc_cctx_t* RESTRIC
 
             if (UNLIKELY(d_ptr + ml > d_end)) return ZXC_ERROR_OVERFLOW;
             if (UNLIKELY((size_t)(d_ptr - d_floor) < offset)) return ZXC_ERROR_BAD_OFFSET;
-            zxc_decode_copy_match_exact(d_ptr, offset, ml);
+            const uint8_t* match_src = d_ptr - offset;
+
+            zxc_decode_copy_match_exact(d_ptr, match_src, offset, ml);
             d_ptr += ml;
         } else {
             zxc_decode_copy_literals(d_ptr, l_ptr, ll);
@@ -1429,13 +1448,24 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(const zxc_cctx_t* RESTRIC
         d_ptr += ll;
 
         if (UNLIKELY((size_t)(d_ptr - d_floor) < offset)) return ZXC_ERROR_BAD_OFFSET;
-        zxc_decode_copy_match_exact(d_ptr, offset, ml);
+        const uint8_t* match_src = d_ptr - offset;
+
+        zxc_decode_copy_match_exact(d_ptr, match_src, offset, ml);
         d_ptr += ml;
         n_seq--;
     }
 
     // --- Trailing Literals ---
-    return zxc_decode_trailing_literals(d_ptr, d_end, l_ptr, l_end, dst);
+    // Copy remaining literals from source stream (literal exhaustion)
+    if (UNLIKELY(l_ptr > l_end)) return ZXC_ERROR_CORRUPT_DATA;
+    if (UNLIKELY(d_ptr > d_end)) return ZXC_ERROR_OVERFLOW;
+
+    const size_t remaining_literals = (size_t)(l_end - l_ptr);
+    if (UNLIKELY(remaining_literals > (size_t)(d_end - d_ptr))) return ZXC_ERROR_OVERFLOW;
+    ZXC_MEMCPY(d_ptr, l_ptr, remaining_literals);
+    d_ptr += remaining_literals;
+
+    return (int)(d_ptr - dst);
 }
 
 /**
@@ -1471,6 +1501,13 @@ static ZXC_NOINLINE int zxc_decode_block_glo_entropy_safe(const zxc_cctx_t* REST
  *
  * Wrapper over @ref zxc_decode_block_glo_impl with @c safe=0, @c has_dict=0, so
  * the no-dict chunk wrapper inlines it exactly like the dict-free build.
+ *
+ * @param[in,out] ctx          Decompression context.
+ * @param[in]     src          Compressed GLO block payload.
+ * @param[in]     src_size     Size of @p src in bytes.
+ * @param[out]    dst          Destination buffer.
+ * @param[in]     dst_capacity Capacity of @p dst in bytes.
+ * @return Bytes written on success, or a negative @ref zxc_error_t.
  */
 static int zxc_decode_block_glo(const zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRICT src,
                                 const size_t src_size, uint8_t* RESTRICT dst,
@@ -1482,6 +1519,13 @@ static int zxc_decode_block_glo(const zxc_cctx_t* RESTRICT ctx, const uint8_t* R
  * @brief Decode a no-dict GHI block (plain, inlinable path).
  *
  * Wrapper over @ref zxc_decode_block_ghi_impl with @c safe=0, @c has_dict=0.
+ *
+ * @param[in,out] ctx          Decompression context.
+ * @param[in]     src          Compressed GHI block payload.
+ * @param[in]     src_size     Size of @p src in bytes.
+ * @param[out]    dst          Destination buffer.
+ * @param[in]     dst_capacity Capacity of @p dst in bytes.
+ * @return Bytes written on success, or a negative @ref zxc_error_t.
  */
 static int zxc_decode_block_ghi(const zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRICT src,
                                 const size_t src_size, uint8_t* RESTRICT dst,
@@ -1495,6 +1539,13 @@ static int zxc_decode_block_ghi(const zxc_cctx_t* RESTRICT ctx, const uint8_t* R
  * Wrapper over @ref zxc_decode_block_glo_impl with @c safe=0, @c has_dict=1.
  * NOINLINE: only reached on the cold dict path (@ref zxc_decompress_chunk_wrapper_dict),
  * so it never loads into I-cache on a no-dict stream.
+ *
+ * @param[in,out] ctx          Decompression context (dict prefix in its buffer).
+ * @param[in]     src          Compressed GLO block payload.
+ * @param[in]     src_size     Size of @p src in bytes.
+ * @param[out]    dst          Destination buffer.
+ * @param[in]     dst_capacity Capacity of @p dst in bytes.
+ * @return Bytes written on success, or a negative @ref zxc_error_t.
  */
 static ZXC_NOINLINE int zxc_decode_block_glo_dict(const zxc_cctx_t* RESTRICT ctx,
                                                   const uint8_t* RESTRICT src,
@@ -1508,6 +1559,13 @@ static ZXC_NOINLINE int zxc_decode_block_glo_dict(const zxc_cctx_t* RESTRICT ctx
  *
  * Wrapper over @ref zxc_decode_block_ghi_impl with @c safe=0, @c has_dict=1
  * (NOINLINE; see @ref zxc_decode_block_glo_dict).
+ *
+ * @param[in,out] ctx          Decompression context (dict prefix in its buffer).
+ * @param[in]     src          Compressed GHI block payload.
+ * @param[in]     src_size     Size of @p src in bytes.
+ * @param[out]    dst          Destination buffer.
+ * @param[in]     dst_capacity Capacity of @p dst in bytes.
+ * @return Bytes written on success, or a negative @ref zxc_error_t.
  */
 static ZXC_NOINLINE int zxc_decode_block_ghi_dict(const zxc_cctx_t* RESTRICT ctx,
                                                   const uint8_t* RESTRICT src,
@@ -1522,6 +1580,13 @@ static ZXC_NOINLINE int zxc_decode_block_ghi_dict(const zxc_cctx_t* RESTRICT ctx
  * Wrapper over @ref zxc_decode_block_glo_impl with @c safe=1, @c has_dict=0.
  * The safe path never carries a dict (block_safe routes dict inputs to the
  * bounce path), so @c has_dict=0 folds the dead dict handling.
+ *
+ * @param[in,out] ctx          Decompression context.
+ * @param[in]     src          Compressed GLO block payload.
+ * @param[in]     src_size     Size of @p src in bytes.
+ * @param[out]    dst          Destination buffer (capacity == exact decoded size).
+ * @param[in]     dst_capacity Capacity of @p dst in bytes.
+ * @return Bytes written on success, or a negative @ref zxc_error_t.
  */
 static ZXC_NOINLINE int zxc_decode_block_glo_safe(const zxc_cctx_t* RESTRICT ctx,
                                                   const uint8_t* RESTRICT src,
@@ -1536,6 +1601,13 @@ static ZXC_NOINLINE int zxc_decode_block_glo_safe(const zxc_cctx_t* RESTRICT ctx
  * Wrapper over @ref zxc_decode_block_ghi_impl with @c safe=1, @c has_dict=0
  * (the strict-tail safe path never carries a dict; see
  * @ref zxc_decode_block_glo_safe).
+ *
+ * @param[in,out] ctx          Decompression context.
+ * @param[in]     src          Compressed GHI block payload.
+ * @param[in]     src_size     Size of @p src in bytes.
+ * @param[out]    dst          Destination buffer (capacity == exact decoded size).
+ * @param[in]     dst_capacity Capacity of @p dst in bytes.
+ * @return Bytes written on success, or a negative @ref zxc_error_t.
  */
 static ZXC_NOINLINE int zxc_decode_block_ghi_safe(const zxc_cctx_t* RESTRICT ctx,
                                                   const uint8_t* RESTRICT src,

--- a/src/lib/zxc_dict.c
+++ b/src/lib/zxc_dict.c
@@ -286,14 +286,13 @@ int64_t zxc_train_dict(const void* const* RESTRICT samples, const size_t* RESTRI
     }
 
     // Step 2: count k-gram frequencies
-    uint16_t* freq = (uint16_t*)ZXC_MALLOC(ZXC_DICT_HASH_SIZE * sizeof(uint16_t));
+    uint16_t* freq = (uint16_t*)ZXC_CALLOC(ZXC_DICT_HASH_SIZE, sizeof(uint16_t));
     if (UNLIKELY(!freq)) {
         // LCOV_EXCL_START
         ZXC_FREE(corpus);
         return ZXC_ERROR_MEMORY;
         // LCOV_EXCL_STOP
     }
-    ZXC_MEMSET(freq, 0, ZXC_DICT_HASH_SIZE * sizeof(uint16_t));
 
     // Sample positions rather than count them all: a full count saturates the
     // 16-bit counters, the extension test then never stops and segments balloon

--- a/src/lib/zxc_dict.c
+++ b/src/lib/zxc_dict.c
@@ -275,6 +275,9 @@ int64_t zxc_train_dict(const void* const* RESTRICT samples, const size_t* RESTRI
     for (size_t i = 0; i < n_samples; i++) corpus_size += sample_sizes[i];
     if (UNLIKELY(corpus_size < ZXC_DICT_KGRAM_LEN)) return ZXC_ERROR_SRC_TOO_SMALL;
 
+    int64_t rc;
+    uint16_t* freq = NULL;
+    zxc_dict_seg_t* segs = NULL;
     uint8_t* corpus = (uint8_t*)ZXC_MALLOC(corpus_size);
     if (UNLIKELY(!corpus)) return ZXC_ERROR_MEMORY;
     {
@@ -286,12 +289,10 @@ int64_t zxc_train_dict(const void* const* RESTRICT samples, const size_t* RESTRI
     }
 
     // Step 2: count k-gram frequencies
-    uint16_t* freq = (uint16_t*)ZXC_CALLOC(ZXC_DICT_HASH_SIZE, sizeof(uint16_t));
+    freq = (uint16_t*)ZXC_CALLOC(ZXC_DICT_HASH_SIZE, sizeof(uint16_t));
     if (UNLIKELY(!freq)) {
-        // LCOV_EXCL_START
-        ZXC_FREE(corpus);
-        return ZXC_ERROR_MEMORY;
-        // LCOV_EXCL_STOP
+        rc = ZXC_ERROR_MEMORY;  // LCOV_EXCL_LINE
+        goto done;              // LCOV_EXCL_LINE
     }
 
     // Sample positions rather than count them all: a full count saturates the
@@ -313,13 +314,10 @@ int64_t zxc_train_dict(const void* const* RESTRICT samples, const size_t* RESTRI
     size_t stride = ZXC_DICT_KGRAM_LEN;
     if (seg_alloc > 0 && corpus_size / seg_alloc > stride) stride = corpus_size / seg_alloc;
 
-    zxc_dict_seg_t* segs = (zxc_dict_seg_t*)ZXC_MALLOC(seg_alloc * sizeof(zxc_dict_seg_t));
+    segs = (zxc_dict_seg_t*)ZXC_MALLOC(seg_alloc * sizeof(zxc_dict_seg_t));
     if (UNLIKELY(!segs)) {
-        // LCOV_EXCL_START
-        ZXC_FREE(freq);
-        ZXC_FREE(corpus);
-        return ZXC_ERROR_MEMORY;
-        // LCOV_EXCL_STOP
+        rc = ZXC_ERROR_MEMORY;  // LCOV_EXCL_LINE
+        goto done;              // LCOV_EXCL_LINE
     }
 
     size_t n_segs = 0;
@@ -349,10 +347,8 @@ int64_t zxc_train_dict(const void* const* RESTRICT samples, const size_t* RESTRI
         // No frequent patterns. Use tail of corpus as dict.
         const size_t copy = (corpus_size < dict_capacity) ? corpus_size : dict_capacity;
         ZXC_MEMCPY(dict_buf, corpus + corpus_size - copy, copy);
-        ZXC_FREE(freq);
-        ZXC_FREE(segs);
-        ZXC_FREE(corpus);
-        return (int64_t)copy;
+        rc = (int64_t)copy;
+        goto done;
     }
 
     // Step 4: pick greedily in descending coverage, zeroing each pick's k-grams
@@ -390,7 +386,9 @@ int64_t zxc_train_dict(const void* const* RESTRICT samples, const size_t* RESTRI
         total += copy;
     }
 
+    // Released early: the emit loop below only needs the picks.
     ZXC_FREE(freq);
+    freq = NULL;
 
     // Step 5: emit in reverse so the highest-coverage segment lands at the END
     // of the dict. The dict sits just before the data, so bytes near its end
@@ -411,9 +409,13 @@ int64_t zxc_train_dict(const void* const* RESTRICT samples, const size_t* RESTRI
         filled = tail;
     }
 
+    rc = (int64_t)filled;
+
+done:
     ZXC_FREE(segs);
+    ZXC_FREE(freq);
     ZXC_FREE(corpus);
-    return (int64_t)filled;
+    return rc;
 }
 
 // -------------------------------------------------------------------------

--- a/src/lib/zxc_dispatch.c
+++ b/src/lib/zxc_dispatch.c
@@ -434,6 +434,9 @@ int zxc_compress_chunk_wrapper(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRICT
     return func(ctx, src, src_sz, dst, dst_cap);
 }
 
+#undef ZXC_DISPATCH_STORE
+#undef ZXC_DISPATCH_LOAD
+
 // ============================================================================
 // HUFFMAN TRAMPOLINES
 // ============================================================================

--- a/src/lib/zxc_dispatch.c
+++ b/src/lib/zxc_dispatch.c
@@ -291,11 +291,72 @@ static ZXC_ATOMIC zxc_decompress_func_t zxc_decompress_safe_ptr = (zxc_decompres
 /** @brief Lazily-resolved pointer to the best compression variant. */
 static ZXC_ATOMIC zxc_compress_func_t zxc_compress_ptr = (zxc_compress_func_t)0;
 
+// Publication of a resolved pointer, and the matching acquire load. One pair of
+// definitions instead of an #if around every access.
+#if ZXC_USE_C11_ATOMICS
+#define ZXC_DISPATCH_STORE(ptr, val) atomic_store_explicit(&(ptr), (val), memory_order_release)
+#define ZXC_DISPATCH_LOAD(ptr) atomic_load_explicit(&(ptr), memory_order_acquire)
+#else
+#define ZXC_DISPATCH_STORE(ptr, val) ((ptr) = (val))
+#define ZXC_DISPATCH_LOAD(ptr) (ptr)
+#endif
+
+/**
+ * @struct zxc_variant_set_t
+ * @brief The four chunk entry points of one ISA variant, resolved together.
+ *
+ * The three lazy initialisers below differ only in which of these they publish,
+ * so the per-architecture selection ladder lives in one place: adding an ISA
+ * tier is one line here instead of three ladders to keep in step.
+ */
+typedef struct {
+    zxc_decompress_func_t decompress;
+    zxc_decompress_func_t decompress_dict;
+    zxc_decompress_func_t decompress_safe;
+    zxc_compress_func_t compress;
+} zxc_variant_set_t;
+
+/** @brief Returns the variant set of suffix @p sfx from the enclosing function. */
+#define ZXC_RETURN_VARIANT_SET(sfx)                                                    \
+    do {                                                                               \
+        const zxc_variant_set_t v_ = {                                                 \
+            zxc_decompress_chunk_wrapper##sfx, zxc_decompress_chunk_wrapper_dict##sfx, \
+            zxc_decompress_chunk_wrapper_safe##sfx, zxc_compress_chunk_wrapper##sfx};  \
+        return v_;                                                                     \
+    } while (0)
+
+/**
+ * @brief Detects the CPU tier and returns the matching variant set.
+ *
+ * @return The best available variants, or the `_default` (baseline) set when no
+ *         ISA extension applies or the build is single-variant.
+ */
+// LCOV_EXCL_START
+static zxc_variant_set_t zxc_select_variants(void) {
+    const zxc_cpu_feature_t cpu = zxc_detect_cpu_features();
+    (void)cpu;
+
+#ifndef ZXC_ONLY_DEFAULT
+#if defined(__x86_64__) || defined(_M_X64)
+    if (cpu == ZXC_CPU_AVX512) ZXC_RETURN_VARIANT_SET(_avx512);
+    if (cpu == ZXC_CPU_AVX2) ZXC_RETURN_VARIANT_SET(_avx2);
+#elif defined(__arm__) || defined(_M_ARM)
+    // 32-bit ARM: the only arch with a real runtime NEON probe (getauxval).
+    // cppcheck-suppress knownConditionTrueFalse
+    if (cpu == ZXC_CPU_NEON) ZXC_RETURN_VARIANT_SET(_neon32);
+#endif
+#endif
+    ZXC_RETURN_VARIANT_SET(_default);
+}
+// LCOV_EXCL_STOP
+
+#undef ZXC_RETURN_VARIANT_SET
+
 /**
  * @brief First-call initialiser for the decompression dispatcher.
  *
- * Detects CPU features, selects the best implementation, stores the
- * pointer atomically, then tail-calls into it.
+ * Publishes both decompression pointers (plain and dict), then tail-calls the
+ * one this context needs.
  *
  * @param[in]  ctx      Decompression context (its @c dict_size picks the dict variant).
  * @param[in]  src      Compressed input chunk.
@@ -309,61 +370,17 @@ static ZXC_ATOMIC zxc_compress_func_t zxc_compress_ptr = (zxc_compress_func_t)0;
 static int zxc_decompress_dispatch_init(const zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRICT src,
                                         const size_t src_sz, uint8_t* RESTRICT dst,
                                         const size_t dst_cap) {
-    const zxc_cpu_feature_t cpu = zxc_detect_cpu_features();
-    zxc_decompress_func_t zxc_decompress_ptr_local = NULL;
-    zxc_decompress_func_t zxc_decompress_dict_ptr_local = NULL;
-
-#ifndef ZXC_ONLY_DEFAULT
-#if defined(__x86_64__) || defined(_M_X64)
-    if (cpu == ZXC_CPU_AVX512) {
-        zxc_decompress_ptr_local = zxc_decompress_chunk_wrapper_avx512;
-        zxc_decompress_dict_ptr_local = zxc_decompress_chunk_wrapper_dict_avx512;
-    } else if (cpu == ZXC_CPU_AVX2) {
-        zxc_decompress_ptr_local = zxc_decompress_chunk_wrapper_avx2;
-        zxc_decompress_dict_ptr_local = zxc_decompress_chunk_wrapper_dict_avx2;
-    } else {
-        zxc_decompress_ptr_local = zxc_decompress_chunk_wrapper_default;
-        zxc_decompress_dict_ptr_local = zxc_decompress_chunk_wrapper_dict_default;
-    }
-#elif defined(__arm__) || defined(_M_ARM)
-    // 32-bit ARM: the only arch with a real runtime NEON probe (getauxval).
-    // cppcheck-suppress knownConditionTrueFalse
-    if (cpu == ZXC_CPU_NEON) {
-        zxc_decompress_ptr_local = zxc_decompress_chunk_wrapper_neon32;
-        zxc_decompress_dict_ptr_local = zxc_decompress_chunk_wrapper_dict_neon32;
-    } else {
-        zxc_decompress_ptr_local = zxc_decompress_chunk_wrapper_default;
-        zxc_decompress_dict_ptr_local = zxc_decompress_chunk_wrapper_dict_default;
-    }
-#else
-    (void)cpu;
-    zxc_decompress_ptr_local = zxc_decompress_chunk_wrapper_default;
-    zxc_decompress_dict_ptr_local = zxc_decompress_chunk_wrapper_dict_default;
-#endif
-#else
-    (void)cpu;
-    zxc_decompress_ptr_local = zxc_decompress_chunk_wrapper_default;
-    zxc_decompress_dict_ptr_local = zxc_decompress_chunk_wrapper_dict_default;
-#endif
-
-#if ZXC_USE_C11_ATOMICS
-    atomic_store_explicit(&zxc_decompress_ptr, zxc_decompress_ptr_local, memory_order_release);
-    atomic_store_explicit(&zxc_decompress_dict_ptr, zxc_decompress_dict_ptr_local,
-                          memory_order_release);
-#else
-    zxc_decompress_ptr = zxc_decompress_ptr_local;
-    zxc_decompress_dict_ptr = zxc_decompress_dict_ptr_local;
-#endif
-    return (ctx->dict_size ? zxc_decompress_dict_ptr_local : zxc_decompress_ptr_local)(
-        ctx, src, src_sz, dst, dst_cap);
+    const zxc_variant_set_t v = zxc_select_variants();
+    ZXC_DISPATCH_STORE(zxc_decompress_ptr, v.decompress);
+    ZXC_DISPATCH_STORE(zxc_decompress_dict_ptr, v.decompress_dict);
+    return (ctx->dict_size ? v.decompress_dict : v.decompress)(ctx, src, src_sz, dst, dst_cap);
 }
-// LCOV_EXCL_STOP
 
 /**
  * @brief First-call initialiser for the safe-decompression dispatcher.
  *
- * Mirrors @ref zxc_decompress_dispatch_init but selects the `_safe_*`
- * decoder variants used by @ref zxc_decompress_block_safe.
+ * Mirrors @ref zxc_decompress_dispatch_init but publishes the `_safe_*` decoder
+ * used by @ref zxc_decompress_block_safe.
  *
  * @param[in]  ctx      Decompression context.
  * @param[in]  src      Compressed input chunk.
@@ -373,51 +390,16 @@ static int zxc_decompress_dispatch_init(const zxc_cctx_t* RESTRICT ctx, const ui
  * @return Result of the selected variant: decompressed size, or negative
  *         @ref zxc_error_t.
  */
-// LCOV_EXCL_START
 static int zxc_decompress_safe_dispatch_init(const zxc_cctx_t* RESTRICT ctx,
                                              const uint8_t* RESTRICT src, const size_t src_sz,
                                              uint8_t* RESTRICT dst, const size_t dst_cap) {
-    const zxc_cpu_feature_t cpu = zxc_detect_cpu_features();
-    zxc_decompress_func_t zxc_decompress_safe_ptr_local = NULL;
-
-#ifndef ZXC_ONLY_DEFAULT
-#if defined(__x86_64__) || defined(_M_X64)
-    if (cpu == ZXC_CPU_AVX512)
-        zxc_decompress_safe_ptr_local = zxc_decompress_chunk_wrapper_safe_avx512;
-    else if (cpu == ZXC_CPU_AVX2)
-        zxc_decompress_safe_ptr_local = zxc_decompress_chunk_wrapper_safe_avx2;
-    else
-        zxc_decompress_safe_ptr_local = zxc_decompress_chunk_wrapper_safe_default;
-#elif defined(__arm__) || defined(_M_ARM)
-    // cppcheck-suppress knownConditionTrueFalse
-    if (cpu == ZXC_CPU_NEON)
-        zxc_decompress_safe_ptr_local = zxc_decompress_chunk_wrapper_safe_neon32;
-    else
-        zxc_decompress_safe_ptr_local = zxc_decompress_chunk_wrapper_safe_default;
-#else
-    (void)cpu;
-    zxc_decompress_safe_ptr_local = zxc_decompress_chunk_wrapper_safe_default;
-#endif
-#else
-    (void)cpu;
-    zxc_decompress_safe_ptr_local = zxc_decompress_chunk_wrapper_safe_default;
-#endif
-
-#if ZXC_USE_C11_ATOMICS
-    atomic_store_explicit(&zxc_decompress_safe_ptr, zxc_decompress_safe_ptr_local,
-                          memory_order_release);
-#else
-    zxc_decompress_safe_ptr = zxc_decompress_safe_ptr_local;
-#endif
-    return zxc_decompress_safe_ptr_local(ctx, src, src_sz, dst, dst_cap);
+    const zxc_variant_set_t v = zxc_select_variants();
+    ZXC_DISPATCH_STORE(zxc_decompress_safe_ptr, v.decompress_safe);
+    return v.decompress_safe(ctx, src, src_sz, dst, dst_cap);
 }
-// LCOV_EXCL_STOP
 
 /**
  * @brief First-call initialiser for the compression dispatcher.
- *
- * Detects CPU features, selects the best implementation, stores the
- * pointer atomically, then tail-calls into it.
  *
  * @param[in,out] ctx      Compression context.
  * @param[in]     src      Uncompressed input chunk.
@@ -427,42 +409,12 @@ static int zxc_decompress_safe_dispatch_init(const zxc_cctx_t* RESTRICT ctx,
  * @return Result of the selected variant: compressed size, or negative
  *         @ref zxc_error_t.
  */
-// LCOV_EXCL_START
 static int zxc_compress_dispatch_init(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRICT src,
                                       const size_t src_sz, uint8_t* RESTRICT dst,
                                       const size_t dst_cap) {
-    const zxc_cpu_feature_t cpu = zxc_detect_cpu_features();
-    zxc_compress_func_t zxc_compress_ptr_local = NULL;
-
-#ifndef ZXC_ONLY_DEFAULT
-#if defined(__x86_64__) || defined(_M_X64)
-    if (cpu == ZXC_CPU_AVX512)
-        zxc_compress_ptr_local = zxc_compress_chunk_wrapper_avx512;
-    else if (cpu == ZXC_CPU_AVX2)
-        zxc_compress_ptr_local = zxc_compress_chunk_wrapper_avx2;
-    else
-        zxc_compress_ptr_local = zxc_compress_chunk_wrapper_default;
-#elif defined(__arm__) || defined(_M_ARM)
-    // cppcheck-suppress knownConditionTrueFalse
-    if (cpu == ZXC_CPU_NEON)
-        zxc_compress_ptr_local = zxc_compress_chunk_wrapper_neon32;
-    else
-        zxc_compress_ptr_local = zxc_compress_chunk_wrapper_default;
-#else
-    (void)cpu;
-    zxc_compress_ptr_local = zxc_compress_chunk_wrapper_default;
-#endif
-#else
-    (void)cpu;
-    zxc_compress_ptr_local = zxc_compress_chunk_wrapper_default;
-#endif
-
-#if ZXC_USE_C11_ATOMICS
-    atomic_store_explicit(&zxc_compress_ptr, zxc_compress_ptr_local, memory_order_release);
-#else
-    zxc_compress_ptr = zxc_compress_ptr_local;
-#endif
-    return zxc_compress_ptr_local(ctx, src, src_sz, dst, dst_cap);
+    const zxc_variant_set_t v = zxc_select_variants();
+    ZXC_DISPATCH_STORE(zxc_compress_ptr, v.compress);
+    return v.compress(ctx, src, src_sz, dst, dst_cap);
 }
 // LCOV_EXCL_STOP
 
@@ -474,13 +426,8 @@ int zxc_decompress_chunk_wrapper(const zxc_cctx_t* RESTRICT ctx, const uint8_t* 
     // dict_size is constant for a stream; this per-block branch (outside the decode
     // loop) routes to the dict variant only when a dictionary is active, so the
     // no-dict path runs the dict-free chunk wrapper (identical codegen to main).
-#if ZXC_USE_C11_ATOMICS
-    const zxc_decompress_func_t func = atomic_load_explicit(
-        ctx->dict_size ? &zxc_decompress_dict_ptr : &zxc_decompress_ptr, memory_order_acquire);
-#else
-    const zxc_decompress_func_t func =
-        ctx->dict_size ? zxc_decompress_dict_ptr : zxc_decompress_ptr;
-#endif
+    const zxc_decompress_func_t func = ctx->dict_size ? ZXC_DISPATCH_LOAD(zxc_decompress_dict_ptr)
+                                                      : ZXC_DISPATCH_LOAD(zxc_decompress_ptr);
     if (UNLIKELY(!func)) return zxc_decompress_dispatch_init(ctx, src, src_sz, dst, dst_cap);
     return func(ctx, src, src_sz, dst, dst_cap);
 }
@@ -501,12 +448,7 @@ static int zxc_decompress_chunk_wrapper_safe_public(const zxc_cctx_t* RESTRICT c
                                                     const uint8_t* RESTRICT src,
                                                     const size_t src_sz, uint8_t* RESTRICT dst,
                                                     const size_t dst_cap) {
-#if ZXC_USE_C11_ATOMICS
-    const zxc_decompress_func_t func =
-        atomic_load_explicit(&zxc_decompress_safe_ptr, memory_order_acquire);
-#else
-    const zxc_decompress_func_t func = zxc_decompress_safe_ptr;
-#endif
+    const zxc_decompress_func_t func = ZXC_DISPATCH_LOAD(zxc_decompress_safe_ptr);
     if (UNLIKELY(!func)) return zxc_decompress_safe_dispatch_init(ctx, src, src_sz, dst, dst_cap);
     return func(ctx, src, src_sz, dst, dst_cap);
 }
@@ -516,11 +458,7 @@ static int zxc_decompress_chunk_wrapper_safe_public(const zxc_cctx_t* RESTRICT c
  */
 int zxc_compress_chunk_wrapper(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRICT src,
                                const size_t src_sz, uint8_t* RESTRICT dst, const size_t dst_cap) {
-#if ZXC_USE_C11_ATOMICS
-    const zxc_compress_func_t func = atomic_load_explicit(&zxc_compress_ptr, memory_order_acquire);
-#else
-    const zxc_compress_func_t func = zxc_compress_ptr;
-#endif
+    const zxc_compress_func_t func = ZXC_DISPATCH_LOAD(zxc_compress_ptr);
     if (UNLIKELY(!func)) return zxc_compress_dispatch_init(ctx, src, src_sz, dst, dst_cap);
     return func(ctx, src, src_sz, dst, dst_cap);
 }
@@ -627,12 +565,11 @@ int64_t zxc_compress(const void* RESTRICT src, const size_t src_size, void* REST
 
     const int checksum_enabled = opts ? opts->checksum_enabled : 0;
     const int seekable = opts ? opts->seekable : 0;
-    const int level = zxc_level_clamp((opts && opts->level > 0) ? opts->level : ZXC_LEVEL_DEFAULT);
-    const size_t block_size =
-        (opts && opts->block_size > 0) ? opts->block_size : ZXC_BLOCK_SIZE_DEFAULT;
+    const int level = ZXC_OPTS_LEVEL(opts, ZXC_LEVEL_DEFAULT);
+    const size_t block_size = ZXC_OPTS_BLOCK_SIZE(opts, ZXC_BLOCK_SIZE_DEFAULT);
     const uint8_t* dict = opts ? (const uint8_t*)opts->dict : NULL;
-    const size_t dict_size = (opts && opts->dict) ? opts->dict_size : 0;
-    const uint8_t* dict_huf = (opts && opts->dict) ? (const uint8_t*)opts->dict_huf : NULL;
+    const size_t dict_size = ZXC_OPTS_DICT_SIZE(opts);
+    const uint8_t* dict_huf = ZXC_OPTS_DICT_HUF(opts);
 
     if (UNLIKELY(dict_size > ZXC_DICT_SIZE_MAX)) return ZXC_ERROR_DICT_TOO_LARGE;
     if (UNLIKELY(!zxc_validate_block_size(block_size))) return ZXC_ERROR_BAD_BLOCK_SIZE;
@@ -817,8 +754,8 @@ static int64_t zxc_decompress_frame(const uint8_t* src, const size_t src_size, u
                                     const size_t dst_capacity, const zxc_decompress_opts_t* opts) {
     const int checksum_enabled = opts ? opts->checksum_enabled : 0;
     const uint8_t* dict = opts ? (const uint8_t*)opts->dict : NULL;
-    const size_t dict_size = (opts && opts->dict) ? opts->dict_size : 0;
-    const uint8_t* dict_huf = (opts && opts->dict) ? (const uint8_t*)opts->dict_huf : NULL;
+    const size_t dict_size = ZXC_OPTS_DICT_SIZE(opts);
+    const uint8_t* dict_huf = ZXC_OPTS_DICT_HUF(opts);
 
     const uint8_t* ip = src;
     const uint8_t* ip_end = ip + src_size;
@@ -1206,10 +1143,8 @@ zxc_cctx* zxc_create_cctx(const zxc_compress_opts_t* opts) {
     if (UNLIKELY(!cctx)) return NULL;  // LCOV_EXCL_LINE
 
     // Resolve and store sticky defaults.
-    cctx->stored_level =
-        zxc_level_clamp((opts && opts->level > 0) ? opts->level : ZXC_LEVEL_DEFAULT);
-    cctx->stored_block_size =
-        (opts && opts->block_size > 0) ? opts->block_size : ZXC_BLOCK_SIZE_DEFAULT;
+    cctx->stored_level = ZXC_OPTS_LEVEL(opts, ZXC_LEVEL_DEFAULT);
+    cctx->stored_block_size = ZXC_OPTS_BLOCK_SIZE(opts, ZXC_BLOCK_SIZE_DEFAULT);
     cctx->stored_checksum = opts ? opts->checksum_enabled : 0;
 
     if (opts) {
@@ -1259,9 +1194,8 @@ int64_t zxc_compress_cctx(zxc_cctx* cctx, const void* RESTRICT src, const size_t
     if (UNLIKELY(!src || !dst || src_size == 0 || dst_capacity == 0)) return ZXC_ERROR_NULL_INPUT;
 
     const int checksum_enabled = opts ? opts->checksum_enabled : cctx->stored_checksum;
-    const int level = zxc_level_clamp((opts && opts->level > 0) ? opts->level : cctx->stored_level);
-    const size_t block_size =
-        (opts && opts->block_size > 0) ? opts->block_size : cctx->stored_block_size;
+    const int level = ZXC_OPTS_LEVEL(opts, cctx->stored_level);
+    const size_t block_size = ZXC_OPTS_BLOCK_SIZE(opts, cctx->stored_block_size);
 
     if (UNLIKELY(!zxc_validate_block_size(block_size))) return ZXC_ERROR_BAD_BLOCK_SIZE;
 
@@ -1538,16 +1472,15 @@ int64_t zxc_compress_block(zxc_cctx* cctx, const void* RESTRICT src, const size_
     if (UNLIKELY(src_size > ZXC_BLOCK_SIZE_MAX)) return ZXC_ERROR_BAD_BLOCK_SIZE;
 
     const int checksum_enabled = opts ? opts->checksum_enabled : cctx->stored_checksum;
-    const int level = zxc_level_clamp((opts && opts->level > 0) ? opts->level : cctx->stored_level);
+    const int level = ZXC_OPTS_LEVEL(opts, cctx->stored_level);
     // For block API, block_size == src_size (the caller compresses one block at a time).
-    const size_t block_size =
-        (opts && opts->block_size > 0) ? opts->block_size : cctx->stored_block_size;
+    const size_t block_size = ZXC_OPTS_BLOCK_SIZE(opts, cctx->stored_block_size);
     const size_t min_bs = zxc_block_size_ceil(src_size);
 
     // Always ensure internal buffers can hold src_size.
     // When a dictionary is active, offset_bits must accommodate dict + block.
     const uint8_t* b_dict = opts ? (const uint8_t*)opts->dict : NULL;
-    const size_t b_dict_size = (opts && opts->dict) ? opts->dict_size : 0;
+    const size_t b_dict_size = ZXC_OPTS_DICT_SIZE(opts);
     const size_t base_block_size = (block_size > min_bs) ? block_size : min_bs;
     const size_t effective_block_size =
         b_dict_size > 0 ? zxc_block_size_ceil(b_dict_size + base_block_size) : base_block_size;
@@ -1632,7 +1565,7 @@ int64_t zxc_decompress_block(zxc_dctx* dctx, const void* RESTRICT src, const siz
     const int checksum_enabled = opts ? opts->checksum_enabled : 0;
 
     const uint8_t* dict = opts ? (const uint8_t*)opts->dict : NULL;
-    const size_t dict_size = (opts && opts->dict) ? opts->dict_size : 0;
+    const size_t dict_size = ZXC_OPTS_DICT_SIZE(opts);
 
     // Derive the block_size from dst_capacity (callers know the original size)
     const size_t block_size = zxc_block_size_ceil(dst_capacity);

--- a/src/lib/zxc_dispatch.c
+++ b/src/lib/zxc_dispatch.c
@@ -1049,12 +1049,11 @@ static uint64_t zxc_inplace_margin(const uint64_t dsize, const size_t chunk_size
  */
 static int zxc_inplace_probe(const uint8_t* comp, const size_t comp_size, uint64_t* dsize,
                              uint64_t* margin, uint64_t* floor) {
-    if (UNLIKELY(zxc_le32(comp) != ZXC_MAGIC_WORD)) return ZXC_ERROR_BAD_MAGIC;
     size_t chunk_size = 0;
     int has_cs = 0;
-    uint32_t did = 0;
-    if (UNLIKELY(zxc_read_file_header(comp, comp_size, &chunk_size, &has_cs, &did) != ZXC_OK))
-        return ZXC_ERROR_BAD_HEADER;
+
+    const int hr = zxc_read_file_header(comp, comp_size, &chunk_size, &has_cs, NULL);
+    if (UNLIKELY(hr != ZXC_OK)) return (hr == ZXC_ERROR_BAD_MAGIC) ? hr : ZXC_ERROR_BAD_HEADER;
 
     const uint64_t d = zxc_le64(comp + comp_size - ZXC_FILE_FOOTER_SIZE);
     if (UNLIKELY(!zxc_footer_dsize_plausible(d, chunk_size, comp_size)))
@@ -1143,12 +1142,10 @@ uint64_t zxc_get_decompressed_size(const void* src, const size_t src_size) {
     if (UNLIKELY(src_size < ZXC_FILE_HEADER_SIZE + ZXC_FILE_FOOTER_SIZE)) return 0;
 
     const uint8_t* const p = (const uint8_t*)src;
-    if (UNLIKELY(zxc_le32(p) != ZXC_MAGIC_WORD)) return 0;
-
     size_t chunk_size = 0;
     int has_cs = 0;
-    uint32_t did = 0;
-    if (UNLIKELY(zxc_read_file_header(p, src_size, &chunk_size, &has_cs, &did) != ZXC_OK)) return 0;
+
+    if (UNLIKELY(zxc_read_file_header(p, src_size, &chunk_size, &has_cs, NULL) != ZXC_OK)) return 0;
 
     const uint8_t* const footer = p + src_size - ZXC_FILE_FOOTER_SIZE;
     const uint64_t dsize = zxc_le64(footer);

--- a/src/lib/zxc_dispatch.c
+++ b/src/lib/zxc_dispatch.c
@@ -328,8 +328,8 @@ typedef struct {
 /**
  * @brief Detects the CPU tier and returns the matching variant set.
  *
- * @return The best available variants, or the `_default` (baseline) set when no
- *         ISA extension applies or the build is single-variant.
+ * Falls back to the `_default` (baseline) set when no ISA extension applies or
+ * the build is single-variant.
  */
 // LCOV_EXCL_START
 static zxc_variant_set_t zxc_select_variants(void) {
@@ -355,16 +355,8 @@ static zxc_variant_set_t zxc_select_variants(void) {
 /**
  * @brief First-call initialiser for the decompression dispatcher.
  *
- * Publishes both decompression pointers (plain and dict), then tail-calls the
- * one this context needs.
- *
- * @param[in]  ctx      Decompression context (its @c dict_size picks the dict variant).
- * @param[in]  src      Compressed input chunk.
- * @param[in]  src_sz   Size of @p src in bytes.
- * @param[out] dst      Destination buffer for decompressed data.
- * @param[in]  dst_cap  Capacity of @p dst in bytes.
- * @return Result of the selected variant: decompressed size, or negative
- *         @ref zxc_error_t.
+ * Publishes both decompression pointers, then tail-calls the one this context
+ * needs (its @c dict_size picks the dict variant).
  */
 // LCOV_EXCL_START
 static int zxc_decompress_dispatch_init(const zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRICT src,
@@ -377,18 +369,7 @@ static int zxc_decompress_dispatch_init(const zxc_cctx_t* RESTRICT ctx, const ui
 }
 
 /**
- * @brief First-call initialiser for the safe-decompression dispatcher.
- *
- * Mirrors @ref zxc_decompress_dispatch_init but publishes the `_safe_*` decoder
- * used by @ref zxc_decompress_block_safe.
- *
- * @param[in]  ctx      Decompression context.
- * @param[in]  src      Compressed input chunk.
- * @param[in]  src_sz   Size of @p src in bytes.
- * @param[out] dst      Destination buffer (strict: exact uncompressed size).
- * @param[in]  dst_cap  Capacity of @p dst in bytes.
- * @return Result of the selected variant: decompressed size, or negative
- *         @ref zxc_error_t.
+ * @brief Same, for the `_safe_*` decoder used by @ref zxc_decompress_block_safe.
  */
 static int zxc_decompress_safe_dispatch_init(const zxc_cctx_t* RESTRICT ctx,
                                              const uint8_t* RESTRICT src, const size_t src_sz,
@@ -398,17 +379,7 @@ static int zxc_decompress_safe_dispatch_init(const zxc_cctx_t* RESTRICT ctx,
     return v.decompress_safe(ctx, src, src_sz, dst, dst_cap);
 }
 
-/**
- * @brief First-call initialiser for the compression dispatcher.
- *
- * @param[in,out] ctx      Compression context.
- * @param[in]     src      Uncompressed input chunk.
- * @param[in]     src_sz   Size of @p src in bytes.
- * @param[out]    dst      Destination buffer for the compressed chunk.
- * @param[in]     dst_cap  Capacity of @p dst in bytes.
- * @return Result of the selected variant: compressed size, or negative
- *         @ref zxc_error_t.
- */
+/** @brief Same, for the compressor. */
 static int zxc_compress_dispatch_init(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRICT src,
                                       const size_t src_sz, uint8_t* RESTRICT dst,
                                       const size_t dst_cap) {

--- a/src/lib/zxc_driver.c
+++ b/src/lib/zxc_driver.c
@@ -563,13 +563,13 @@ static int zxc_stream_read_loop(zxc_stream_ctx_t* ctx, FILE* f_in, const int mod
 
                 const int has_crc = ctx->file_has_checksum;
                 const size_t checksum_sz = (has_crc ? ZXC_BLOCK_CHECKSUM_SIZE : 0);
-                const size_t body_total = bh.comp_size + checksum_sz;
-                const size_t total_len = ZXC_BLOCK_HEADER_SIZE + body_total;
-
-                if (UNLIKELY(total_len > job->in_cap)) {
+                const uint64_t total_len =
+                    (uint64_t)bh.comp_size + checksum_sz + ZXC_BLOCK_HEADER_SIZE;
+                if (UNLIKELY(total_len > (uint64_t)job->in_cap)) {
                     ctx->io_error = 1;
                     break;
                 }
+                const size_t body_total = (size_t)bh.comp_size + checksum_sz;
 
                 ZXC_MEMCPY(job->in_buf, bh_buf, ZXC_BLOCK_HEADER_SIZE);
 
@@ -652,7 +652,7 @@ static void zxc_stream_finish_compress(zxc_stream_ctx_t* ctx, writer_args_t* w, 
 /**
  * @brief Consumes and validates the trailer of a decompressed stream.
  */
-static void zxc_stream_finish_decompress(zxc_stream_ctx_t* ctx, writer_args_t* w, FILE* f_in,
+static void zxc_stream_finish_decompress(zxc_stream_ctx_t* ctx, const writer_args_t* w, FILE* f_in,
                                          const uint32_t d_global_hash, const int checksum_enabled) {
     // After the EOF block, the stream may contain:
     //   (a) [FOOTER 12B]                  - no seekable table

--- a/src/lib/zxc_driver.c
+++ b/src/lib/zxc_driver.c
@@ -483,20 +483,12 @@ static void* zxc_async_writer(void* arg) {
 }
 
 /**
- * @brief Tears the engine down after a setup failure, then reports @p code.
+ * @brief Tears the engine down after a setup failure and reports the error.
  *
- * Stops and joins the @p started workers (if any), destroys the ring's
- * synchronisation objects and releases every allocation made so far. Every
- * failure point in the setup sequence returns through here, so the destruction
- * order lives in one place instead of being pasted per exit.
- *
- * @param[in,out] ctx        Engine context whose primitives were initialised.
- * @param[in]     workers    Worker handle array (may be NULL).
- * @param[in]     started    Number of workers actually spawned.
- * @param[in]     mem_block  Ring-buffer allocation (may be NULL).
- * @param[in]     seek_comp  Seek-table accumulator (may be NULL).
- * @param[in]     code       Negative @ref zxc_error_t to return.
- * @return @p code.
+ * Stops and joins whatever workers were started, destroys the ring's
+ * synchronisation objects and releases every allocation made so far. Each
+ * failure point returns through here, so the destruction order lives in one
+ * place; all pointers may be NULL.
  */
 // LCOV_EXCL_START
 static int64_t zxc_stream_engine_fail(zxc_stream_ctx_t* ctx, pthread_t* workers, const int started,

--- a/src/lib/zxc_driver.c
+++ b/src/lib/zxc_driver.c
@@ -550,8 +550,11 @@ static int zxc_stream_read_loop(zxc_stream_ctx_t* ctx, FILE* f_in, const int mod
 
                 if (bh.block_type == ZXC_BLOCK_EOF) {
                     if (UNLIKELY(bh.comp_size != 0)) {
+                        // LCOV_EXCL_START
                         ctx->io_error = 1;
+                        read_eof = 1;
                         goto _job_prepared;
+                        // LCOV_EXCL_STOP
                     }
                     read_eof = 1;
                     read_sz = 0;
@@ -618,7 +621,7 @@ static void zxc_stream_finish_compress(zxc_stream_ctx_t* ctx, writer_args_t* w, 
     zxc_write_block_header(eof_buf, ZXC_BLOCK_HEADER_SIZE, &eof_bh);
     if (UNLIKELY(f_out &&
                  fwrite(eof_buf, 1, ZXC_BLOCK_HEADER_SIZE, f_out) != ZXC_BLOCK_HEADER_SIZE))
-        ctx->io_error = 1;
+        ctx->io_error = 1;  // LCOV_EXCL_LINE
     else
         w->total_bytes += ZXC_BLOCK_HEADER_SIZE;
 
@@ -677,14 +680,14 @@ static void zxc_stream_finish_decompress(zxc_stream_ctx_t* ctx, writer_args_t* w
             // Read full 12-byte footer
             if (!ctx->io_error &&
                 UNLIKELY(fread(footer, 1, ZXC_FILE_FOOTER_SIZE, f_in) != ZXC_FILE_FOOTER_SIZE))
-                ctx->io_error = 1;
+                ctx->io_error = 1;  // LCOV_EXCL_LINE
         } else {
             // peek_buf contains the first 8 bytes of the 12-byte footer.
             // Read the remaining 4 bytes and assemble.
             ZXC_MEMCPY(footer, peek_buf, ZXC_BLOCK_HEADER_SIZE);
             const size_t tail = ZXC_FILE_FOOTER_SIZE - ZXC_BLOCK_HEADER_SIZE; /* 4 */
             if (UNLIKELY(fread(footer + ZXC_BLOCK_HEADER_SIZE, 1, tail, f_in) != tail))
-                ctx->io_error = 1;
+                ctx->io_error = 1;  // LCOV_EXCL_LINE
         }
     }
 
@@ -855,16 +858,16 @@ static int64_t zxc_stream_engine_run(FILE* f_in, FILE* f_out, const int n_thread
 
     pthread_t* const workers = ZXC_MALLOC((size_t)num_workers * sizeof(pthread_t));
     if (UNLIKELY(!workers))
-        return zxc_stream_engine_fail(&ctx, NULL, 0, mem_block, NULL,
-                                      ZXC_ERROR_MEMORY);  // LCOV_EXCL_LINE
+        return zxc_stream_engine_fail(&ctx, NULL, 0, mem_block, NULL,  // LCOV_EXCL_LINE
+                                      ZXC_ERROR_MEMORY);               // LCOV_EXCL_LINE
     int started_workers = 0;
     for (int i = 0; i < num_workers; i++) {
         if (UNLIKELY(pthread_create(&workers[i], NULL, zxc_stream_worker, &ctx) != 0)) break;
         started_workers++;
     }
     if (UNLIKELY(started_workers == 0))
-        return zxc_stream_engine_fail(&ctx, workers, 0, mem_block, NULL,
-                                      ZXC_ERROR_MEMORY);  // LCOV_EXCL_LINE
+        return zxc_stream_engine_fail(&ctx, workers, 0, mem_block, NULL,  // LCOV_EXCL_LINE
+                                      ZXC_ERROR_MEMORY);                  // LCOV_EXCL_LINE
 
     writer_args_t w_args = {&ctx, f_out, 0, 0, 0, NULL, 0, 0};
 
@@ -873,8 +876,10 @@ static int64_t zxc_stream_engine_run(FILE* f_in, FILE* f_out, const int n_thread
         w_args.seek_cap = 64;
         w_args.seek_comp = (uint32_t*)ZXC_MALLOC(w_args.seek_cap * sizeof(uint32_t));
         if (UNLIKELY(!w_args.seek_comp))
-            return zxc_stream_engine_fail(&ctx, workers, started_workers, mem_block, NULL,
-                                          ZXC_ERROR_MEMORY);  // LCOV_EXCL_LINE
+            return zxc_stream_engine_fail(&ctx, workers, started_workers,  // LCOV_EXCL_LINE
+                                          mem_block,                       // LCOV_EXCL_LINE
+                                          NULL,                            // LCOV_EXCL_LINE
+                                          ZXC_ERROR_MEMORY);               // LCOV_EXCL_LINE
     }
 
     if (mode == 1 && f_out) {
@@ -888,8 +893,9 @@ static int64_t zxc_stream_engine_run(FILE* f_in, FILE* f_out, const int n_thread
     }
     pthread_t writer_th;
     if (UNLIKELY(pthread_create(&writer_th, NULL, zxc_async_writer, &w_args) != 0))
-        return zxc_stream_engine_fail(&ctx, workers, started_workers, mem_block, w_args.seek_comp,
-                                      ZXC_ERROR_MEMORY);  // LCOV_EXCL_LINE
+        return zxc_stream_engine_fail(&ctx, workers, started_workers, mem_block,  // LCOV_EXCL_LINE
+                                      w_args.seek_comp,                           // LCOV_EXCL_LINE
+                                      ZXC_ERROR_MEMORY);                          // LCOV_EXCL_LINE
 
     uint64_t total_src_bytes = 0;
     const int read_idx =

--- a/src/lib/zxc_driver.c
+++ b/src/lib/zxc_driver.c
@@ -701,14 +701,10 @@ static int64_t zxc_stream_engine_run(FILE* f_in, FILE* f_out, const int n_thread
     const size_t alloc_out = (raw_alloc_out + ZXC_ALIGNMENT_MASK) & ~ZXC_ALIGNMENT_MASK;
 
     const size_t per_job_sz = sizeof(zxc_stream_job_t) + sizeof(int) + alloc_in + alloc_out;
-    const size_t alloc_size = ctx.ring_size * per_job_sz;
-    uint8_t* const mem_block = ZXC_ALIGNED_MALLOC(alloc_size, ZXC_CACHE_LINE_SIZE);
-    if (UNLIKELY(!mem_block || per_job_sz > SIZE_MAX / ctx.ring_size)) {
-        // LCOV_EXCL_START
-        ZXC_ALIGNED_FREE(mem_block);
-        return ZXC_ERROR_MEMORY;
-        // LCOV_EXCL_STOP
-    }
+    if (UNLIKELY(per_job_sz > SIZE_MAX / ctx.ring_size)) return ZXC_ERROR_MEMORY;  // LCOV_EXCL_LINE
+
+    uint8_t* const mem_block = ZXC_ALIGNED_MALLOC(ctx.ring_size * per_job_sz, ZXC_CACHE_LINE_SIZE);
+    if (UNLIKELY(!mem_block)) return ZXC_ERROR_MEMORY;  // LCOV_EXCL_LINE
 
     uint8_t* ptr = mem_block;
     ctx.jobs = (zxc_stream_job_t*)ptr;

--- a/src/lib/zxc_driver.c
+++ b/src/lib/zxc_driver.c
@@ -512,6 +512,199 @@ static int64_t zxc_stream_engine_fail(zxc_stream_ctx_t* ctx, pthread_t* workers,
 // LCOV_EXCL_STOP
 
 /**
+ * @brief Reads the input and feeds the ring until the stream ends.
+ *
+ * Returns the ring index the terminator job goes to.
+ */
+static int zxc_stream_read_loop(zxc_stream_ctx_t* ctx, FILE* f_in, const int mode,
+                                const size_t chunk_sz, uint64_t* total_src_bytes,
+                                uint32_t* d_global_hash) {
+    int read_idx = 0;
+    int read_eof = 0;
+
+    while (!read_eof && !ctx->io_error) {
+        zxc_stream_job_t* const job = &ctx->jobs[read_idx];
+        pthread_mutex_lock(&ctx->lock);
+        while (job->status != JOB_STATUS_FREE && !ctx->io_error)
+            pthread_cond_wait(&ctx->cond_reader, &ctx->lock);
+        pthread_mutex_unlock(&ctx->lock);
+
+        if (UNLIKELY(ctx->io_error)) break;
+
+        size_t read_sz = 0;
+        if (mode == 1) {
+            read_sz = fread(job->in_buf, 1, chunk_sz, f_in);
+            *total_src_bytes += read_sz;
+            if (UNLIKELY(read_sz == 0)) read_eof = 1;
+        } else {
+            uint8_t bh_buf[ZXC_BLOCK_HEADER_SIZE];
+            size_t h_read = fread(bh_buf, 1, ZXC_BLOCK_HEADER_SIZE, f_in);
+            if (UNLIKELY(h_read < ZXC_BLOCK_HEADER_SIZE)) {
+                read_eof = 1;
+            } else {
+                zxc_block_header_t bh;
+                if (UNLIKELY(zxc_read_block_header(bh_buf, ZXC_BLOCK_HEADER_SIZE, &bh) != ZXC_OK)) {
+                    read_eof = 1;
+                    goto _job_prepared;
+                }
+
+                if (bh.block_type == ZXC_BLOCK_EOF) {
+                    if (UNLIKELY(bh.comp_size != 0)) {
+                        ctx->io_error = 1;
+                        goto _job_prepared;
+                    }
+                    read_eof = 1;
+                    read_sz = 0;
+                    goto _job_prepared;
+                }
+
+                const int has_crc = ctx->file_has_checksum;
+                const size_t checksum_sz = (has_crc ? ZXC_BLOCK_CHECKSUM_SIZE : 0);
+                const size_t body_total = bh.comp_size + checksum_sz;
+                const size_t total_len = ZXC_BLOCK_HEADER_SIZE + body_total;
+
+                if (UNLIKELY(total_len > job->in_cap)) {
+                    ctx->io_error = 1;
+                    break;
+                }
+
+                ZXC_MEMCPY(job->in_buf, bh_buf, ZXC_BLOCK_HEADER_SIZE);
+
+                // Single fread for body + checksum (reduces syscalls)
+                const size_t body_read =
+                    fread(job->in_buf + ZXC_BLOCK_HEADER_SIZE, 1, body_total, f_in);
+
+                if (UNLIKELY(body_read != body_total)) {
+                    ctx->io_error = 1;
+                    break;
+                } else if (has_crc) {
+                    // Update Global Hash for Decompression
+                    const uint32_t b_crc =
+                        zxc_le32(job->in_buf + ZXC_BLOCK_HEADER_SIZE + bh.comp_size);
+                    *d_global_hash = zxc_hash_combine_rotate(*d_global_hash, b_crc);
+                }
+                read_sz = ZXC_BLOCK_HEADER_SIZE + body_read;
+            }
+        }
+    _job_prepared:
+        if (UNLIKELY(read_eof && read_sz == 0)) break;
+
+        job->in_sz = read_sz;
+        pthread_mutex_lock(&ctx->lock);
+        job->status = JOB_STATUS_FILLED;
+        ctx->worker_queue[ctx->wq_head] = read_idx;
+        ctx->wq_head = (ctx->wq_head + 1) % ctx->ring_size;
+        ctx->wq_count++;
+        read_idx = (read_idx + 1) % ctx->ring_size;
+        pthread_cond_signal(&ctx->cond_worker);
+        pthread_mutex_unlock(&ctx->lock);
+
+        if (UNLIKELY(read_sz < chunk_sz && mode == 1)) read_eof = 1;
+    }
+    return read_idx;
+}
+
+/**
+ * @brief Closes a compressed stream: EOF block, optional seek table, footer.
+ *
+ * Runs once the writer thread has drained, so it appends straight to the file.
+ */
+static void zxc_stream_finish_compress(zxc_stream_ctx_t* ctx, writer_args_t* w, FILE* f_out,
+                                       const uint64_t total_src_bytes, const int checksum_enabled) {
+    // EOF block
+    uint8_t eof_buf[ZXC_BLOCK_HEADER_SIZE];
+    const zxc_block_header_t eof_bh = {
+        .block_type = ZXC_BLOCK_EOF, .block_flags = 0, .reserved = 0, .comp_size = 0};
+    zxc_write_block_header(eof_buf, ZXC_BLOCK_HEADER_SIZE, &eof_bh);
+    if (UNLIKELY(f_out &&
+                 fwrite(eof_buf, 1, ZXC_BLOCK_HEADER_SIZE, f_out) != ZXC_BLOCK_HEADER_SIZE))
+        ctx->io_error = 1;
+    else
+        w->total_bytes += ZXC_BLOCK_HEADER_SIZE;
+
+    // Seekable: write SEK block between EOF and footer
+    if (!ctx->io_error && w->seek_comp && w->seek_count > 0) {
+        const size_t st_size = zxc_seek_table_size(w->seek_count);
+        uint8_t* const st_buf = (uint8_t*)ZXC_MALLOC(st_size);
+        if (st_buf) {
+            const int64_t st_val =
+                zxc_write_seek_table(st_buf, st_size, w->seek_comp, w->seek_count);
+            if (st_val > 0 && f_out && fwrite(st_buf, 1, (size_t)st_val, f_out) == (size_t)st_val)
+                w->total_bytes += st_val;
+            ZXC_FREE(st_buf);
+        }
+    }
+
+    // Footer
+    uint8_t footer_buf[ZXC_FILE_FOOTER_SIZE];
+    zxc_write_file_footer(footer_buf, ZXC_FILE_FOOTER_SIZE, total_src_bytes, w->global_hash,
+                          checksum_enabled);
+    if (UNLIKELY(f_out &&
+                 fwrite(footer_buf, 1, ZXC_FILE_FOOTER_SIZE, f_out) != ZXC_FILE_FOOTER_SIZE))
+        ctx->io_error = 1;
+    else
+        w->total_bytes += ZXC_FILE_FOOTER_SIZE;
+}
+
+/**
+ * @brief Consumes and validates the trailer of a decompressed stream.
+ */
+static void zxc_stream_finish_decompress(zxc_stream_ctx_t* ctx, writer_args_t* w, FILE* f_in,
+                                         const uint32_t d_global_hash, const int checksum_enabled) {
+    // After the EOF block, the stream may contain:
+    //   (a) [FOOTER 12B]                  - no seekable table
+    //   (b) [SEK header 8B] [payload] [FOOTER 12B] - seekable archive
+    uint8_t peek_buf[ZXC_BLOCK_HEADER_SIZE];
+    uint8_t footer[ZXC_FILE_FOOTER_SIZE];
+
+    if (UNLIKELY(fread(peek_buf, 1, ZXC_BLOCK_HEADER_SIZE, f_in) != ZXC_BLOCK_HEADER_SIZE)) {
+        ctx->io_error = 1;
+    } else {
+        zxc_block_header_t peek_bh;
+        const int is_sek =
+            (zxc_read_block_header(peek_buf, ZXC_BLOCK_HEADER_SIZE, &peek_bh) == ZXC_OK &&
+             peek_bh.block_type == ZXC_BLOCK_SEK);
+
+        if (is_sek) {
+            // Drain the SEK payload (read + discard)
+            size_t remaining = (size_t)peek_bh.comp_size;
+            uint8_t discard[512];
+            while (remaining > 0 && !ctx->io_error) {
+                const size_t chunk = remaining < sizeof(discard) ? remaining : sizeof(discard);
+                if (UNLIKELY(fread(discard, 1, chunk, f_in) != chunk)) ctx->io_error = 1;
+                remaining -= chunk;
+            }
+            // Read full 12-byte footer
+            if (!ctx->io_error &&
+                UNLIKELY(fread(footer, 1, ZXC_FILE_FOOTER_SIZE, f_in) != ZXC_FILE_FOOTER_SIZE))
+                ctx->io_error = 1;
+        } else {
+            // peek_buf contains the first 8 bytes of the 12-byte footer.
+            // Read the remaining 4 bytes and assemble.
+            ZXC_MEMCPY(footer, peek_buf, ZXC_BLOCK_HEADER_SIZE);
+            const size_t tail = ZXC_FILE_FOOTER_SIZE - ZXC_BLOCK_HEADER_SIZE; /* 4 */
+            if (UNLIKELY(fread(footer + ZXC_BLOCK_HEADER_SIZE, 1, tail, f_in) != tail))
+                ctx->io_error = 1;
+        }
+    }
+
+    // Verify Footer Content: Source Size and Global Checksum
+    if (!ctx->io_error) {
+        const int size_ok = (zxc_le64(footer) == (uint64_t)w->total_bytes);
+        int valid = size_ok;
+        if (valid && checksum_enabled && ctx->file_has_checksum)
+            valid = (zxc_le32(footer + sizeof(uint64_t)) == d_global_hash);
+        if (UNLIKELY(!valid)) {
+            // A footer that disagrees with what we produced is corruption,
+            // not an I/O fault; tell the two apart for the caller.
+            if (!ctx->fail_code)
+                ctx->fail_code = size_ok ? ZXC_ERROR_BAD_CHECKSUM : ZXC_ERROR_CORRUPT_DATA;
+            ctx->io_error = 1;
+        }
+    }
+}
+
+/**
  * @brief Orchestrates the multithreaded streaming compression or decompression
  * engine.
  *
@@ -698,90 +891,9 @@ static int64_t zxc_stream_engine_run(FILE* f_in, FILE* f_out, const int n_thread
         return zxc_stream_engine_fail(&ctx, workers, started_workers, mem_block, w_args.seek_comp,
                                       ZXC_ERROR_MEMORY);  // LCOV_EXCL_LINE
 
-    int read_idx = 0;
-    int read_eof = 0;
     uint64_t total_src_bytes = 0;
-
-    // Reader Loop: Reads from file, prepares jobs, pushes to worker queue.
-    while (!read_eof && !ctx.io_error) {
-        zxc_stream_job_t* const job = &ctx.jobs[read_idx];
-        pthread_mutex_lock(&ctx.lock);
-        while (job->status != JOB_STATUS_FREE && !ctx.io_error)
-            pthread_cond_wait(&ctx.cond_reader, &ctx.lock);
-        pthread_mutex_unlock(&ctx.lock);
-
-        if (UNLIKELY(ctx.io_error)) break;
-
-        size_t read_sz = 0;
-        if (mode == 1) {
-            read_sz = fread(job->in_buf, 1, runtime_chunk_sz, f_in);
-            total_src_bytes += read_sz;
-            if (UNLIKELY(read_sz == 0)) read_eof = 1;
-        } else {
-            uint8_t bh_buf[ZXC_BLOCK_HEADER_SIZE];
-            size_t h_read = fread(bh_buf, 1, ZXC_BLOCK_HEADER_SIZE, f_in);
-            if (UNLIKELY(h_read < ZXC_BLOCK_HEADER_SIZE)) {
-                read_eof = 1;
-            } else {
-                zxc_block_header_t bh;
-                if (UNLIKELY(zxc_read_block_header(bh_buf, ZXC_BLOCK_HEADER_SIZE, &bh) != ZXC_OK)) {
-                    read_eof = 1;
-                    goto _job_prepared;
-                }
-
-                if (bh.block_type == ZXC_BLOCK_EOF) {
-                    if (UNLIKELY(bh.comp_size != 0)) {
-                        ctx.io_error = 1;
-                        goto _job_prepared;
-                    }
-                    read_eof = 1;
-                    read_sz = 0;
-                    goto _job_prepared;
-                }
-
-                const int has_crc = ctx.file_has_checksum;
-                const size_t checksum_sz = (has_crc ? ZXC_BLOCK_CHECKSUM_SIZE : 0);
-                const size_t body_total = bh.comp_size + checksum_sz;
-                const size_t total_len = ZXC_BLOCK_HEADER_SIZE + body_total;
-
-                if (UNLIKELY(total_len > job->in_cap)) {
-                    ctx.io_error = 1;
-                    break;
-                }
-
-                ZXC_MEMCPY(job->in_buf, bh_buf, ZXC_BLOCK_HEADER_SIZE);
-
-                // Single fread for body + checksum (reduces syscalls)
-                const size_t body_read =
-                    fread(job->in_buf + ZXC_BLOCK_HEADER_SIZE, 1, body_total, f_in);
-
-                if (UNLIKELY(body_read != body_total)) {
-                    ctx.io_error = 1;
-                    break;
-                } else if (has_crc) {
-                    // Update Global Hash for Decompression
-                    const uint32_t b_crc =
-                        zxc_le32(job->in_buf + ZXC_BLOCK_HEADER_SIZE + bh.comp_size);
-                    d_global_hash = zxc_hash_combine_rotate(d_global_hash, b_crc);
-                }
-                read_sz = ZXC_BLOCK_HEADER_SIZE + body_read;
-            }
-        }
-    _job_prepared:
-        if (UNLIKELY(read_eof && read_sz == 0)) break;
-
-        job->in_sz = read_sz;
-        pthread_mutex_lock(&ctx.lock);
-        job->status = JOB_STATUS_FILLED;
-        ctx.worker_queue[ctx.wq_head] = read_idx;
-        ctx.wq_head = (ctx.wq_head + 1) % ctx.ring_size;
-        ctx.wq_count++;
-        read_idx = (read_idx + 1) % ctx.ring_size;
-        pthread_cond_signal(&ctx.cond_worker);
-        pthread_mutex_unlock(&ctx.lock);
-
-        if (UNLIKELY(read_sz < runtime_chunk_sz && mode == 1)) read_eof = 1;
-    }
+    const int read_idx =
+        zxc_stream_read_loop(&ctx, f_in, mode, runtime_chunk_sz, &total_src_bytes, &d_global_hash);
 
     zxc_stream_job_t* const end_job = &ctx.jobs[read_idx];
     pthread_mutex_lock(&ctx.lock);
@@ -804,95 +916,10 @@ static int64_t zxc_stream_engine_run(FILE* f_in, FILE* f_out, const int n_thread
     pthread_cond_destroy(&ctx.cond_reader);
     pthread_mutex_destroy(&ctx.lock);
 
-    // Write EOF Block + optional Seek Table + Footer if compression and no error
-    if (mode == 1 && !ctx.io_error && w_args.total_bytes >= 0) {
-        // EOF block
-        uint8_t eof_buf[ZXC_BLOCK_HEADER_SIZE];
-        const zxc_block_header_t eof_bh = {
-            .block_type = ZXC_BLOCK_EOF, .block_flags = 0, .reserved = 0, .comp_size = 0};
-        zxc_write_block_header(eof_buf, ZXC_BLOCK_HEADER_SIZE, &eof_bh);
-        if (UNLIKELY(f_out &&
-                     fwrite(eof_buf, 1, ZXC_BLOCK_HEADER_SIZE, f_out) != ZXC_BLOCK_HEADER_SIZE))
-            ctx.io_error = 1;
-        else
-            w_args.total_bytes += ZXC_BLOCK_HEADER_SIZE;
-
-        // Seekable: write SEK block between EOF and footer
-        if (!ctx.io_error && w_args.seek_comp && w_args.seek_count > 0) {
-            const size_t st_size = zxc_seek_table_size(w_args.seek_count);
-            uint8_t* const st_buf = (uint8_t*)ZXC_MALLOC(st_size);
-            if (st_buf) {
-                const int64_t st_val =
-                    zxc_write_seek_table(st_buf, st_size, w_args.seek_comp, w_args.seek_count);
-                if (st_val > 0 && f_out &&
-                    fwrite(st_buf, 1, (size_t)st_val, f_out) == (size_t)st_val)
-                    w_args.total_bytes += st_val;
-                ZXC_FREE(st_buf);
-            }
-        }
-
-        // Footer
-        uint8_t footer_buf[ZXC_FILE_FOOTER_SIZE];
-        zxc_write_file_footer(footer_buf, ZXC_FILE_FOOTER_SIZE, total_src_bytes, w_args.global_hash,
-                              checksum_enabled);
-        if (UNLIKELY(f_out &&
-                     fwrite(footer_buf, 1, ZXC_FILE_FOOTER_SIZE, f_out) != ZXC_FILE_FOOTER_SIZE))
-            ctx.io_error = 1;
-        else
-            w_args.total_bytes += ZXC_FILE_FOOTER_SIZE;
-    } else if (mode == 0 && !ctx.io_error) {
-        // After the EOF block, the stream may contain:
-        //   (a) [FOOTER 12B]                  - no seekable table
-        //   (b) [SEK header 8B] [payload] [FOOTER 12B] - seekable archive
-        uint8_t peek_buf[ZXC_BLOCK_HEADER_SIZE];
-        uint8_t footer[ZXC_FILE_FOOTER_SIZE];
-
-        if (UNLIKELY(fread(peek_buf, 1, ZXC_BLOCK_HEADER_SIZE, f_in) != ZXC_BLOCK_HEADER_SIZE)) {
-            ctx.io_error = 1;
-        } else {
-            zxc_block_header_t peek_bh;
-            const int is_sek =
-                (zxc_read_block_header(peek_buf, ZXC_BLOCK_HEADER_SIZE, &peek_bh) == ZXC_OK &&
-                 peek_bh.block_type == ZXC_BLOCK_SEK);
-
-            if (is_sek) {
-                // Drain the SEK payload (read + discard)
-                size_t remaining = (size_t)peek_bh.comp_size;
-                uint8_t discard[512];
-                while (remaining > 0 && !ctx.io_error) {
-                    const size_t chunk = remaining < sizeof(discard) ? remaining : sizeof(discard);
-                    if (UNLIKELY(fread(discard, 1, chunk, f_in) != chunk)) ctx.io_error = 1;
-                    remaining -= chunk;
-                }
-                // Read full 12-byte footer
-                if (!ctx.io_error &&
-                    UNLIKELY(fread(footer, 1, ZXC_FILE_FOOTER_SIZE, f_in) != ZXC_FILE_FOOTER_SIZE))
-                    ctx.io_error = 1;
-            } else {
-                // peek_buf contains the first 8 bytes of the 12-byte footer.
-                // Read the remaining 4 bytes and assemble.
-                ZXC_MEMCPY(footer, peek_buf, ZXC_BLOCK_HEADER_SIZE);
-                const size_t tail = ZXC_FILE_FOOTER_SIZE - ZXC_BLOCK_HEADER_SIZE; /* 4 */
-                if (UNLIKELY(fread(footer + ZXC_BLOCK_HEADER_SIZE, 1, tail, f_in) != tail))
-                    ctx.io_error = 1;
-            }
-        }
-
-        // Verify Footer Content: Source Size and Global Checksum
-        if (!ctx.io_error) {
-            const int size_ok = (zxc_le64(footer) == (uint64_t)w_args.total_bytes);
-            int valid = size_ok;
-            if (valid && checksum_enabled && ctx.file_has_checksum)
-                valid = (zxc_le32(footer + sizeof(uint64_t)) == d_global_hash);
-            if (UNLIKELY(!valid)) {
-                // A footer that disagrees with what we produced is corruption,
-                // not an I/O fault; tell the two apart for the caller.
-                if (!ctx.fail_code)
-                    ctx.fail_code = size_ok ? ZXC_ERROR_BAD_CHECKSUM : ZXC_ERROR_CORRUPT_DATA;
-                ctx.io_error = 1;
-            }
-        }
-    }
+    if (mode == 1 && !ctx.io_error && w_args.total_bytes >= 0)
+        zxc_stream_finish_compress(&ctx, &w_args, f_out, total_src_bytes, checksum_enabled);
+    else if (mode == 0 && !ctx.io_error)
+        zxc_stream_finish_decompress(&ctx, &w_args, f_in, d_global_hash, checksum_enabled);
 
     ZXC_FREE(w_args.seek_comp);
     ZXC_FREE(workers);

--- a/src/lib/zxc_driver.c
+++ b/src/lib/zxc_driver.c
@@ -544,6 +544,8 @@ static int zxc_stream_read_loop(zxc_stream_ctx_t* ctx, FILE* f_in, const int mod
             } else {
                 zxc_block_header_t bh;
                 if (UNLIKELY(zxc_read_block_header(bh_buf, ZXC_BLOCK_HEADER_SIZE, &bh) != ZXC_OK)) {
+                    ctx->io_error = 1;
+                    if (!ctx->fail_code) ctx->fail_code = ZXC_ERROR_CORRUPT_DATA;
                     read_eof = 1;
                     goto _job_prepared;
                 }
@@ -629,10 +631,16 @@ static void zxc_stream_finish_compress(zxc_stream_ctx_t* ctx, writer_args_t* w, 
     if (!ctx->io_error && w->seek_comp && w->seek_count > 0) {
         const size_t st_size = zxc_seek_table_size(w->seek_count);
         uint8_t* const st_buf = (uint8_t*)ZXC_MALLOC(st_size);
-        if (st_buf) {
+        if (UNLIKELY(!st_buf)) {
+            ctx->io_error = 1;                                       // LCOV_EXCL_LINE
+            if (!ctx->fail_code) ctx->fail_code = ZXC_ERROR_MEMORY;  // LCOV_EXCL_LINE
+        } else {
             const int64_t st_val =
                 zxc_write_seek_table(st_buf, st_size, w->seek_comp, w->seek_count);
-            if (st_val > 0 && f_out && fwrite(st_buf, 1, (size_t)st_val, f_out) == (size_t)st_val)
+            if (UNLIKELY(st_val <= 0 ||
+                         (f_out && fwrite(st_buf, 1, (size_t)st_val, f_out) != (size_t)st_val)))
+                ctx->io_error = 1;  // LCOV_EXCL_LINE
+            else
                 w->total_bytes += st_val;
             ZXC_FREE(st_buf);
         }
@@ -882,13 +890,14 @@ static int64_t zxc_stream_engine_run(FILE* f_in, FILE* f_out, const int n_thread
                                           ZXC_ERROR_MEMORY);               // LCOV_EXCL_LINE
     }
 
-    if (mode == 1 && f_out) {
-        uint8_t h[ZXC_FILE_HEADER_SIZE];
-        zxc_write_file_header(h, ZXC_FILE_HEADER_SIZE, runtime_chunk_sz, checksum_enabled,
-                              (dict && dict_size) ? zxc_dict_id(dict, dict_size, dict_huf) : 0);
-        if (UNLIKELY(fwrite(h, 1, ZXC_FILE_HEADER_SIZE, f_out) != ZXC_FILE_HEADER_SIZE))
-            ctx.io_error = 1;
-
+    if (mode == 1) {
+        if (f_out) {
+            uint8_t h[ZXC_FILE_HEADER_SIZE];
+            zxc_write_file_header(h, ZXC_FILE_HEADER_SIZE, runtime_chunk_sz, checksum_enabled,
+                                  (dict && dict_size) ? zxc_dict_id(dict, dict_size, dict_huf) : 0);
+            if (UNLIKELY(fwrite(h, 1, ZXC_FILE_HEADER_SIZE, f_out) != ZXC_FILE_HEADER_SIZE))
+                ctx.io_error = 1;
+        }
         w_args.total_bytes = ZXC_FILE_HEADER_SIZE;
     }
     pthread_t writer_th;

--- a/src/lib/zxc_driver.c
+++ b/src/lib/zxc_driver.c
@@ -37,124 +37,22 @@
 #include "../../include/zxc_seekable.h"
 #include "../../include/zxc_stream.h"
 #include "zxc_internal.h"
+#include "zxc_threads.h"
 
 // ============================================================================
-// WINDOWS THREADING EMULATION
+// PLATFORM SHIMS
 // ============================================================================
-// Maps POSIX pthread calls to the Windows Native API, so one threading logic
-// compiles on Linux/macOS and Windows.
+// Threading comes from zxc_threads.h (POSIX names everywhere, Win32 underneath);
+// only the file-positioning names are remapped here, next to their users.
 #if defined(_WIN32)
 #include <io.h> /* _get_osfhandle, _fileno (used by zxc_seekable_open_file) */
 #include <malloc.h>
-#include <process.h>
 #include <sys/types.h>
 #include <windows.h>
 
 // Map POSIX file positioning functions to Windows equivalents
 #define fseeko _fseeki64
 #define ftello _ftelli64
-
-/**
- * @brief Returns the logical-processor count (backs the @c sysconf shim below).
- * @return Number of processors reported by @c GetSystemInfo.
- */
-static int zxc_get_num_procs(void) {
-    SYSTEM_INFO sysinfo;
-    GetSystemInfo(&sysinfo);
-    return sysinfo.dwNumberOfProcessors;
-}
-
-typedef CRITICAL_SECTION pthread_mutex_t;
-typedef CONDITION_VARIABLE pthread_cond_t;
-typedef HANDLE pthread_t;
-
-#define pthread_mutex_init(m, a) InitializeCriticalSection(m)
-#define pthread_mutex_destroy(m) DeleteCriticalSection(m)
-#define pthread_mutex_lock(m) EnterCriticalSection(m)
-#define pthread_mutex_unlock(m) LeaveCriticalSection(m)
-
-#define pthread_cond_init(c, a) InitializeConditionVariable(c)
-#define pthread_cond_destroy(c) (void)(0)
-#define pthread_cond_wait(c, m) SleepConditionVariableCS(c, m, INFINITE)
-#define pthread_cond_signal(c) WakeConditionVariable(c)
-#define pthread_cond_broadcast(c) WakeAllConditionVariable(c)
-
-/**
- * @brief Trampoline payload bridging the POSIX @c void*(*)(void*) worker
- *        signature to the @c _beginthreadex entry point.
- *
- * Heap-allocated by the @c pthread_create shim and freed by
- * @ref zxc_win_thread_entry once the captured worker has started.
- */
-typedef struct {
-    void* (*func)(void*); /* worker to invoke */
-    void* arg;            /* argument forwarded to @c func */
-} zxc_win_thread_arg_t;
-
-/**
- * @brief @c _beginthreadex entry point: unpacks the trampoline payload, frees
- *        it, then runs the captured POSIX-style worker.
- *
- * @param[in] p  Heap @ref zxc_win_thread_arg_t handed over by the creator;
- *               ownership transfers to this function.
- * @return Always 0 (the worker's @c void* result is discarded, as on POSIX).
- */
-static unsigned __stdcall zxc_win_thread_entry(void* p) {
-    zxc_win_thread_arg_t* a = (zxc_win_thread_arg_t*)p;
-    void* (*f)(void*) = a->func;
-    void* arg = a->arg;
-    ZXC_FREE(a);
-    f(arg);
-    return 0;
-}
-
-/**
- * @brief @c pthread_create shim: spawns @p start_routine(@p arg) via
- *        @c _beginthreadex, matching the POSIX prototype.
- *
- * @param[out] thread        Receives the thread handle on success.
- * @param[in]  attr          Unused (POSIX attribute object); ignored.
- * @param[in]  start_routine Worker to run on the new thread.
- * @param[in]  arg           Opaque argument forwarded to @p start_routine.
- * @return 0 on success, @ref ZXC_ERROR_MEMORY on allocation or spawn failure.
- */
-static int pthread_create(pthread_t* thread, const void* attr, void* (*start_routine)(void*),
-                          void* arg) {
-    (void)attr;
-    zxc_win_thread_arg_t* wrapper = ZXC_MALLOC(sizeof(zxc_win_thread_arg_t));
-    if (UNLIKELY(!wrapper)) return ZXC_ERROR_MEMORY;
-    wrapper->func = start_routine;
-    wrapper->arg = arg;
-    uintptr_t handle = _beginthreadex(NULL, 0, zxc_win_thread_entry, wrapper, 0, NULL);
-    if (UNLIKELY(handle == 0)) {
-        ZXC_FREE(wrapper);
-        return ZXC_ERROR_MEMORY;
-    }
-    *thread = (HANDLE)handle;
-    return 0;
-}
-
-/**
- * @brief @c pthread_join shim: blocks until @p thread finishes, then closes its
- *        handle.
- *
- * @param[in] thread  Handle from a successful @c pthread_create.
- * @param[in] retval  Unused (POSIX exit-value out-param); ignored.
- * @return Always 0.
- */
-static int pthread_join(pthread_t thread, void** retval) {
-    (void)retval;
-    WaitForSingleObject(thread, INFINITE);
-    CloseHandle(thread);
-    return 0;
-}
-
-#define sysconf(x) zxc_get_num_procs()
-#define _SC_NPROCESSORS_ONLN 0
-
-#else
-#include <pthread.h>
-#include <unistd.h>
 #endif
 
 // ============================================================================
@@ -585,6 +483,43 @@ static void* zxc_async_writer(void* arg) {
 }
 
 /**
+ * @brief Tears the engine down after a setup failure, then reports @p code.
+ *
+ * Stops and joins the @p started workers (if any), destroys the ring's
+ * synchronisation objects and releases every allocation made so far. Every
+ * failure point in the setup sequence returns through here, so the destruction
+ * order lives in one place instead of being pasted per exit.
+ *
+ * @param[in,out] ctx        Engine context whose primitives were initialised.
+ * @param[in]     workers    Worker handle array (may be NULL).
+ * @param[in]     started    Number of workers actually spawned.
+ * @param[in]     mem_block  Ring-buffer allocation (may be NULL).
+ * @param[in]     seek_comp  Seek-table accumulator (may be NULL).
+ * @param[in]     code       Negative @ref zxc_error_t to return.
+ * @return @p code.
+ */
+// LCOV_EXCL_START
+static int64_t zxc_stream_engine_fail(zxc_stream_ctx_t* ctx, pthread_t* workers, const int started,
+                                      uint8_t* mem_block, uint32_t* seek_comp, const int64_t code) {
+    if (started > 0) {
+        pthread_mutex_lock(&ctx->lock);
+        ctx->shutdown_workers = 1;
+        pthread_cond_broadcast(&ctx->cond_worker);
+        pthread_mutex_unlock(&ctx->lock);
+        for (int i = 0; i < started; i++) pthread_join(workers[i], NULL);
+    }
+    pthread_cond_destroy(&ctx->cond_writer);
+    pthread_cond_destroy(&ctx->cond_worker);
+    pthread_cond_destroy(&ctx->cond_reader);
+    pthread_mutex_destroy(&ctx->lock);
+    ZXC_FREE(workers);
+    ZXC_FREE(seek_comp);
+    ZXC_ALIGNED_FREE(mem_block);
+    return code;
+}
+// LCOV_EXCL_STOP
+
+/**
  * @brief Orchestrates the multithreaded streaming compression or decompression
  * engine.
  *
@@ -669,7 +604,7 @@ static int64_t zxc_stream_engine_run(FILE* f_in, FILE* f_out, const int n_thread
         }
     }
 
-    int num_threads = (n_threads > 0) ? n_threads : (int)sysconf(_SC_NPROCESSORS_ONLN);
+    int num_threads = (n_threads > 0) ? n_threads : zxc_num_procs();
     if (num_threads > ZXC_MAX_THREADS) num_threads = ZXC_MAX_THREADS;
     // Reserve 1 thread for Writer/Reader overhead if possible
     const int num_workers = (num_threads > 1) ? num_threads - 1 : 1;
@@ -734,28 +669,17 @@ static int64_t zxc_stream_engine_run(FILE* f_in, FILE* f_out, const int n_thread
     pthread_cond_init(&ctx.cond_writer, NULL);
 
     pthread_t* const workers = ZXC_MALLOC((size_t)num_workers * sizeof(pthread_t));
-    if (UNLIKELY(!workers)) {
-        // LCOV_EXCL_START
-        ZXC_ALIGNED_FREE(mem_block);
-        return ZXC_ERROR_MEMORY;
-        // LCOV_EXCL_STOP
-    }
+    if (UNLIKELY(!workers))
+        return zxc_stream_engine_fail(&ctx, NULL, 0, mem_block, NULL,
+                                      ZXC_ERROR_MEMORY);  // LCOV_EXCL_LINE
     int started_workers = 0;
     for (int i = 0; i < num_workers; i++) {
         if (UNLIKELY(pthread_create(&workers[i], NULL, zxc_stream_worker, &ctx) != 0)) break;
         started_workers++;
     }
-    if (UNLIKELY(started_workers == 0)) {
-        // LCOV_EXCL_START
-        pthread_cond_destroy(&ctx.cond_writer);
-        pthread_cond_destroy(&ctx.cond_worker);
-        pthread_cond_destroy(&ctx.cond_reader);
-        pthread_mutex_destroy(&ctx.lock);
-        ZXC_FREE(workers);
-        ZXC_ALIGNED_FREE(mem_block);
-        return ZXC_ERROR_MEMORY;
-        // LCOV_EXCL_STOP
-    }
+    if (UNLIKELY(started_workers == 0))
+        return zxc_stream_engine_fail(&ctx, workers, 0, mem_block, NULL,
+                                      ZXC_ERROR_MEMORY);  // LCOV_EXCL_LINE
 
     writer_args_t w_args = {&ctx, f_out, 0, 0, 0, NULL, 0, 0};
 
@@ -763,22 +687,9 @@ static int64_t zxc_stream_engine_run(FILE* f_in, FILE* f_out, const int n_thread
     if (mode == 1 && seekable) {
         w_args.seek_cap = 64;
         w_args.seek_comp = (uint32_t*)ZXC_MALLOC(w_args.seek_cap * sizeof(uint32_t));
-        // LCOV_EXCL_START
-        if (UNLIKELY(!w_args.seek_comp)) {
-            pthread_mutex_lock(&ctx.lock);
-            ctx.shutdown_workers = 1;
-            pthread_cond_broadcast(&ctx.cond_worker);
-            pthread_mutex_unlock(&ctx.lock);
-            for (int i = 0; i < started_workers; i++) pthread_join(workers[i], NULL);
-            pthread_cond_destroy(&ctx.cond_writer);
-            pthread_cond_destroy(&ctx.cond_worker);
-            pthread_cond_destroy(&ctx.cond_reader);
-            pthread_mutex_destroy(&ctx.lock);
-            ZXC_FREE(workers);
-            ZXC_ALIGNED_FREE(mem_block);
-            return ZXC_ERROR_MEMORY;
-        }
-        // LCOV_EXCL_STOP
+        if (UNLIKELY(!w_args.seek_comp))
+            return zxc_stream_engine_fail(&ctx, workers, started_workers, mem_block, NULL,
+                                          ZXC_ERROR_MEMORY);  // LCOV_EXCL_LINE
     }
 
     if (mode == 1 && f_out) {
@@ -791,22 +702,9 @@ static int64_t zxc_stream_engine_run(FILE* f_in, FILE* f_out, const int n_thread
         w_args.total_bytes = ZXC_FILE_HEADER_SIZE;
     }
     pthread_t writer_th;
-    if (UNLIKELY(pthread_create(&writer_th, NULL, zxc_async_writer, &w_args) != 0)) {
-        // LCOV_EXCL_START
-        pthread_mutex_lock(&ctx.lock);
-        ctx.shutdown_workers = 1;
-        pthread_cond_broadcast(&ctx.cond_worker);
-        pthread_mutex_unlock(&ctx.lock);
-        for (int i = 0; i < started_workers; i++) pthread_join(workers[i], NULL);
-        pthread_cond_destroy(&ctx.cond_writer);
-        pthread_cond_destroy(&ctx.cond_worker);
-        pthread_cond_destroy(&ctx.cond_reader);
-        pthread_mutex_destroy(&ctx.lock);
-        ZXC_FREE(workers);
-        ZXC_ALIGNED_FREE(mem_block);
-        return ZXC_ERROR_MEMORY;
-        // LCOV_EXCL_STOP
-    }
+    if (UNLIKELY(pthread_create(&writer_th, NULL, zxc_async_writer, &w_args) != 0))
+        return zxc_stream_engine_fail(&ctx, workers, started_workers, mem_block, w_args.seek_comp,
+                                      ZXC_ERROR_MEMORY);  // LCOV_EXCL_LINE
 
     int read_idx = 0;
     int read_eof = 0;
@@ -1029,18 +927,17 @@ int64_t zxc_stream_compress(FILE* f_in, FILE* f_out, const zxc_compress_opts_t* 
     const int n_threads = opts ? opts->n_threads : 0;
     const int checksum_enabled = opts ? opts->checksum_enabled : 0;
     const int seekable = opts ? opts->seekable : 0;
-    const int level = (opts && opts->level > 0) ? opts->level : ZXC_LEVEL_DEFAULT;
-    const size_t block_size =
-        (opts && opts->block_size > 0) ? opts->block_size : ZXC_BLOCK_SIZE_DEFAULT;
+    const int level = ZXC_OPTS_LEVEL(opts, ZXC_LEVEL_DEFAULT);
+    const size_t block_size = ZXC_OPTS_BLOCK_SIZE(opts, ZXC_BLOCK_SIZE_DEFAULT);
     const uint8_t* dict = opts ? (const uint8_t*)opts->dict : NULL;
-    const size_t dict_size = (opts && opts->dict) ? opts->dict_size : 0;
+    const size_t dict_size = ZXC_OPTS_DICT_SIZE(opts);
     zxc_progress_callback_t cb = opts ? opts->progress_cb : NULL;
     void* ud = opts ? opts->user_data : NULL;
 
     if (UNLIKELY(!zxc_validate_block_size(block_size))) return ZXC_ERROR_BAD_BLOCK_SIZE;
     if (UNLIKELY(dict_size > ZXC_DICT_SIZE_MAX)) return ZXC_ERROR_DICT_TOO_LARGE;
 
-    const uint8_t* dict_huf = (opts && opts->dict) ? (const uint8_t*)opts->dict_huf : NULL;
+    const uint8_t* dict_huf = ZXC_OPTS_DICT_HUF(opts);
     return zxc_stream_engine_run(f_in, f_out, n_threads, 1, level, block_size, checksum_enabled,
                                  seekable, zxc_compress_chunk_wrapper, cb, ud, dict, dict_size,
                                  dict_huf);
@@ -1060,11 +957,11 @@ int64_t zxc_stream_decompress(FILE* f_in, FILE* f_out, const zxc_decompress_opts
     const int n_threads = opts ? opts->n_threads : 0;
     const int checksum_enabled = opts ? opts->checksum_enabled : 0;
     const uint8_t* dict = opts ? (const uint8_t*)opts->dict : NULL;
-    const size_t dict_size = (opts && opts->dict) ? opts->dict_size : 0;
+    const size_t dict_size = ZXC_OPTS_DICT_SIZE(opts);
     zxc_progress_callback_t cb = opts ? opts->progress_cb : NULL;
     void* ud = opts ? opts->user_data : NULL;
 
-    const uint8_t* dict_huf = (opts && opts->dict) ? (const uint8_t*)opts->dict_huf : NULL;
+    const uint8_t* dict_huf = ZXC_OPTS_DICT_HUF(opts);
     return zxc_stream_engine_run(f_in, f_out, n_threads, 0, 0, 0, checksum_enabled, 0,
                                  (zxc_chunk_processor_t)zxc_decompress_chunk_wrapper, cb, ud, dict,
                                  dict_size, dict_huf);

--- a/src/lib/zxc_huffman.c
+++ b/src/lib/zxc_huffman.c
@@ -1375,9 +1375,6 @@ int zxc_huf_encode_section_dict(const uint8_t* RESTRICT literals, const size_t n
                                  0);
 }
 
-// ISA-independent cold dict setup: emit once in the primary variant, not in
-// every per-ISA copy (dead weight). zxc_pivco_tree_build stays per-variant.
-#if defined(ZXC_VARIANT_PRIMARY)
 /**
  * @brief Flags the children of every leaf-pair parent.
  *
@@ -1433,6 +1430,9 @@ static ZXC_ALWAYS_INLINE void zxc_pivco_build_c2s(const zxc_pivco_tree_t* RESTRI
         stk_l[sp] = (uint8_t)(cl + 1);
     }
 }
+
+// ISA-independent cold dict setup
+#if defined(ZXC_VARIANT_PRIMARY)
 
 /**
  * @brief Precompute the topology-derived decoder tables for @p t.

--- a/src/lib/zxc_huffman.c
+++ b/src/lib/zxc_huffman.c
@@ -2397,6 +2397,8 @@ static int zxc_pivco_decode_core(const uint8_t* RESTRICT payload, const size_t p
                 }
                 zxc_pivco_unpack_flat(buf_d + seq_off[nid], c, D, bit_ptr[nid], c2s);
             } else {
+                if (UNLIKELY(nd->child[0] < 0)) return ZXC_ERROR_CORRUPT_DATA;
+
                 const zxc_pivco_node_t* const l = &t->nd[nd->child[0]];
                 if (nd->child[1] >= 0 && l->sym >= 0 && t->nd[nd->child[1]].sym >= 0) {
                     zxc_pivco_emit_leaf_pair(buf_d + seq_off[nid], c, (uint8_t)l->sym,

--- a/src/lib/zxc_huffman.c
+++ b/src/lib/zxc_huffman.c
@@ -2397,16 +2397,15 @@ static int zxc_pivco_decode_core(const uint8_t* RESTRICT payload, const size_t p
                 }
                 zxc_pivco_unpack_flat(buf_d + seq_off[nid], c, D, bit_ptr[nid], c2s);
             } else {
-                const int ch0 = nd->child[0];
-                const int ch1 = nd->child[1];
-                if (ch0 >= 0 && ch1 >= 0 && t->nd[ch0].sym >= 0 && t->nd[ch1].sym >= 0) {
-                    zxc_pivco_emit_leaf_pair(buf_d + seq_off[nid], c, (uint8_t)t->nd[ch0].sym,
-                                             (uint8_t)t->nd[ch1].sym, bit_ptr[nid]);
+                const zxc_pivco_node_t* const l = &t->nd[nd->child[0]];
+                if (nd->child[1] >= 0 && l->sym >= 0 && t->nd[nd->child[1]].sym >= 0) {
+                    zxc_pivco_emit_leaf_pair(buf_d + seq_off[nid], c, (uint8_t)l->sym,
+                                             (uint8_t)t->nd[nd->child[1]].sym, bit_ptr[nid]);
                     continue;
                 }
-                const uint32_t nl = ch0 >= 0 ? count[ch0] : 0;
-                const uint32_t src_off = ch0 >= 0 ? seq_off[ch0] : seq_off[nd->child[1]];
-                zxc_pivco_merge(buf_d + seq_off[nid], buf_c + src_off, nl, c - nl, bit_ptr[nid]);
+                const uint32_t nl = count[nd->child[0]];
+                zxc_pivco_merge(buf_d + seq_off[nid], buf_c + seq_off[nd->child[0]], nl, c - nl,
+                                bit_ptr[nid]);
             }
         }
     }

--- a/src/lib/zxc_huffman.c
+++ b/src/lib/zxc_huffman.c
@@ -1481,9 +1481,9 @@ int zxc_huf_dict_tree_build(const uint8_t* RESTRICT packed_lengths, zxc_pivco_tr
 /**
  * @brief Advances the merge cursors past one fixed-width step.
  *
- * Every fixed-width arm below closes the same way: the step took @c pc bytes
- * from the right child and the rest from the left. Operates on the enclosing
- * loop's @c lp, @c rp and @c i.
+ * Every fixed-width arm closes the same way: the step took @c pc bytes from the
+ * right child and the rest from the left. Operates on the enclosing loop's
+ * @c lp, @c rp and @c i, and expands @c pc twice, so pass a named value.
  */
 #define ZXC_PIVCO_MERGE_STEP(w, pc) \
     do {                            \
@@ -1523,7 +1523,8 @@ static ZXC_ALWAYS_INLINE void zxc_pivco_merge(uint8_t* RESTRICT out, const uint8
         const uint8x8_t ia = vld1_u8(zxc_pivco_idxa_u8[b0]);
         const uint8x8_t ib = vld1_u8(zxc_pivco_idxb_pre[pc0][b1]);
         vst1q_u8(out + i, vqtbl2q_u8(tb, vcombine_u8(ia, ib)));
-        ZXC_PIVCO_MERGE_STEP(16, pc0 + zxc_pivco_popcnt32(b1));
+        const int pc = pc0 + zxc_pivco_popcnt32(b1);
+        ZXC_PIVCO_MERGE_STEP(16, pc);
     }
 #else /* x86 tiers */
 #if defined(ZXC_USE_AVX512) && defined(__AVX512VBMI2__)
@@ -1540,7 +1541,8 @@ static ZXC_ALWAYS_INLINE void zxc_pivco_merge(uint8_t* RESTRICT out, const uint8
         const __m512i outv =
             _mm512_mask_expandloadu_epi8(vl, (__mmask64)ctrl, (const void*)(R + rp));
         _mm512_storeu_si512((void*)(out + i), outv);
-        ZXC_PIVCO_MERGE_STEP(64, zxc_pivco_popcnt64(ctrl));
+        const int pc = zxc_pivco_popcnt64(ctrl);
+        ZXC_PIVCO_MERGE_STEP(64, pc);
     }
 #endif
 #if defined(ZXC_USE_AVX512) || defined(ZXC_USE_AVX2) || \
@@ -1629,7 +1631,8 @@ static ZXC_ALWAYS_INLINE void zxc_pivco_merge(uint8_t* RESTRICT out, const uint8
         const __m128i sell = _mm_shuffle_epi8(vl, _mm_add_epi8(ix, _mm_set1_epi8(0x70)));
         const __m128i selr = _mm_shuffle_epi8(vr, _mm_sub_epi8(ix, _mm_set1_epi8(16)));
         _mm_storeu_si128((__m128i*)(void*)(out + i), _mm_or_si128(sell, selr));
-        ZXC_PIVCO_MERGE_STEP(16, pc0 + zxc_pivco_popcnt32(b1));
+        const int pc = pc0 + zxc_pivco_popcnt32(b1);
+        ZXC_PIVCO_MERGE_STEP(16, pc);
     }
 #elif defined(ZXC_USE_NEON32)
     // 8 outputs per step: four-register VTBL over {L[0..7], -, R[0..7], -}. The
@@ -1643,7 +1646,8 @@ static ZXC_ALWAYS_INLINE void zxc_pivco_merge(uint8_t* RESTRICT out, const uint8
         tb.val[2] = vld1_u8(R + rp);
         tb.val[3] = vdup_n_u8(0);
         vst1_u8(out + i, vtbl4_u8(tb, vld1_u8(zxc_pivco_idxa_u8[b])));
-        ZXC_PIVCO_MERGE_STEP(8, zxc_pivco_popcnt32(b));
+        const int pc = zxc_pivco_popcnt32(b);
+        ZXC_PIVCO_MERGE_STEP(8, pc);
     }
 #endif
 #endif /* x86 tiers */
@@ -1658,9 +1662,7 @@ static ZXC_ALWAYS_INLINE void zxc_pivco_merge(uint8_t* RESTRICT out, const uint8
         const uint8_t* ix = zxc_pivco_idxa_u8[b];
         for (int j = 0; j < 8; j++) out[i + (size_t)j] = comb[ix[j]];
         const int pc = zxc_pivco_popcnt32(b);
-        rp += (size_t)pc;
-        lp += (size_t)(8 - pc);
-        i += 8;
+        ZXC_PIVCO_MERGE_STEP(8, pc);
     }
     while (i < n) {
         const int bit = (bits[i >> 3] >> (i & 7)) & 1;

--- a/src/lib/zxc_huffman.c
+++ b/src/lib/zxc_huffman.c
@@ -1378,6 +1378,54 @@ int zxc_huf_encode_section_dict(const uint8_t* RESTRICT literals, const size_t n
 // ISA-independent cold dict setup: emit once in the primary variant, not in
 // every per-ISA copy (dead weight). zxc_pivco_tree_build stays per-variant.
 #if defined(ZXC_VARIANT_PRIMARY)
+// A parent whose two children are both leaves emits their runs from its own
+// bits (XOR-blend), so the children are never reconstructed: flag them.
+static ZXC_ALWAYS_INLINE void zxc_pivco_mark_leaf_pairs(const zxc_pivco_tree_t* RESTRICT t,
+                                                        uint8_t* RESTRICT skip) {
+    ZXC_MEMSET(skip, 0, ZXC_PIVCO_MAX_NODES);
+    for (int i = 0; i < t->n_nodes; i++) {
+        const zxc_pivco_node_t* nd = &t->nd[t->bfs[i]];
+        if (nd->sym >= 0) continue;
+        const int ch0 = nd->child[0];
+        const int ch1 = nd->child[1];
+        if (ch0 >= 0 && ch1 >= 0 && t->nd[ch0].sym >= 0 && t->nd[ch1].sym >= 0) {
+            skip[ch0] = 1;
+            skip[ch1] = 1;
+        }
+    }
+}
+
+// Code -> symbol table of the flat subtree at nid: complete of depth D, so its
+// 2^D codes index c2s directly. Built at attach for a dict tree, per block else.
+static ZXC_ALWAYS_INLINE void zxc_pivco_build_c2s(const zxc_pivco_tree_t* RESTRICT t, const int nid,
+                                                  uint8_t* RESTRICT c2s) {
+    int16_t stk_n[ZXC_HUF_MAX_CODE_LEN_ULTRA + 1];
+    uint16_t stk_p[ZXC_HUF_MAX_CODE_LEN_ULTRA + 1];
+    uint8_t stk_l[ZXC_HUF_MAX_CODE_LEN_ULTRA + 1];
+    int sp = 0;
+    stk_n[0] = (int16_t)nid;
+    stk_p[0] = 0;
+    stk_l[0] = 0;
+    while (sp >= 0) {
+        const int cn = stk_n[sp];
+        const uint32_t cp = stk_p[sp];
+        const int cl = stk_l[sp];
+        sp--;
+        if (t->nd[cn].sym >= 0) {
+            c2s[cp] = (uint8_t)t->nd[cn].sym;
+            continue;
+        }
+        sp++;
+        stk_n[sp] = t->nd[cn].child[0];
+        stk_p[sp] = (uint16_t)cp;
+        stk_l[sp] = (uint8_t)(cl + 1);
+        sp++;
+        stk_n[sp] = t->nd[cn].child[1];
+        stk_p[sp] = (uint16_t)(cp | (1U << cl));
+        stk_l[sp] = (uint8_t)(cl + 1);
+    }
+}
+
 /**
  * @brief Precompute the topology-derived decoder tables for @p t.
  *
@@ -1389,17 +1437,7 @@ int zxc_huf_encode_section_dict(const uint8_t* RESTRICT literals, const size_t n
  */
 static void zxc_pivco_decode_aux_build(const zxc_pivco_tree_t* RESTRICT t,
                                        zxc_pivco_decode_aux_t* RESTRICT aux) {
-    ZXC_MEMSET(aux->skip, 0, sizeof(aux->skip));
-    for (int i = 0; i < t->n_nodes; i++) {
-        const zxc_pivco_node_t* nd = &t->nd[t->bfs[i]];
-        if (nd->sym >= 0) continue;
-        const int ch0 = nd->child[0];
-        const int ch1 = nd->child[1];
-        if (ch0 >= 0 && ch1 >= 0 && t->nd[ch0].sym >= 0 && t->nd[ch1].sym >= 0) {
-            aux->skip[ch0] = 1;
-            aux->skip[ch1] = 1;
-        }
-    }
+    zxc_pivco_mark_leaf_pairs(t, aux->skip);
 
     // Flat subtrees have disjoint leaves, so the concatenated tables fit in
     // ZXC_HUF_NUM_SYMBOLS pool entries (see zxc_pivco_decode_aux_t).
@@ -1408,33 +1446,8 @@ static void zxc_pivco_decode_aux_build(const zxc_pivco_tree_t* RESTRICT t,
         const int nid = t->bfs[i];
         if (t->covered[nid] || !t->flat_d[nid]) continue;
         aux->c2s_off[nid] = (uint16_t)pool_off;
-        uint8_t* const c2s = aux->c2s_pool + pool_off;
+        zxc_pivco_build_c2s(t, nid, aux->c2s_pool + pool_off);
         pool_off += 1U << t->flat_d[nid];
-        int16_t stk_n[ZXC_HUF_MAX_CODE_LEN_ULTRA + 1];
-        uint16_t stk_p[ZXC_HUF_MAX_CODE_LEN_ULTRA + 1];
-        uint8_t stk_l[ZXC_HUF_MAX_CODE_LEN_ULTRA + 1];
-        int sp = 0;
-        stk_n[0] = (int16_t)nid;
-        stk_p[0] = 0;
-        stk_l[0] = 0;
-        while (sp >= 0) {
-            const int cn = stk_n[sp];
-            const uint32_t cp = stk_p[sp];
-            const int cl = stk_l[sp];
-            sp--;
-            if (t->nd[cn].sym >= 0) {
-                c2s[cp] = (uint8_t)t->nd[cn].sym;
-                continue;
-            }
-            sp++;
-            stk_n[sp] = t->nd[cn].child[0];
-            stk_p[sp] = (uint16_t)cp;
-            stk_l[sp] = (uint8_t)(cl + 1);
-            sp++;
-            stk_n[sp] = t->nd[cn].child[1];
-            stk_p[sp] = (uint16_t)(cp | (1U << cl));
-            stk_l[sp] = (uint8_t)(cl + 1);
-        }
     }
 }
 
@@ -1456,6 +1469,15 @@ int zxc_huf_dict_tree_build(const uint8_t* RESTRICT packed_lengths, zxc_pivco_tr
     return ZXC_OK;
 }
 #endif /* ZXC_VARIANT_PRIMARY */
+
+// Cursor advance closing every fixed-width arm below: the step took pc bytes
+// from the right child, w - pc from the left. Uses the caller's lp, rp and i.
+#define ZXC_PIVCO_MERGE_STEP(w, pc) \
+    do {                            \
+        rp += (size_t)(pc);         \
+        lp += (size_t)((w) - (pc)); \
+        i += (w);                   \
+    } while (0)
 
 /**
  * @brief Merge two adjacent child sequences under control bits.
@@ -1488,10 +1510,7 @@ static ZXC_ALWAYS_INLINE void zxc_pivco_merge(uint8_t* RESTRICT out, const uint8
         const uint8x8_t ia = vld1_u8(zxc_pivco_idxa_u8[b0]);
         const uint8x8_t ib = vld1_u8(zxc_pivco_idxb_pre[pc0][b1]);
         vst1q_u8(out + i, vqtbl2q_u8(tb, vcombine_u8(ia, ib)));
-        const int pc = pc0 + zxc_pivco_popcnt32(b1);
-        rp += (size_t)pc;
-        lp += (size_t)(16 - pc);
-        i += 16;
+        ZXC_PIVCO_MERGE_STEP(16, pc0 + zxc_pivco_popcnt32(b1));
     }
 #else /* x86 tiers */
 #if defined(ZXC_USE_AVX512) && defined(__AVX512VBMI2__)
@@ -1508,10 +1527,7 @@ static ZXC_ALWAYS_INLINE void zxc_pivco_merge(uint8_t* RESTRICT out, const uint8
         const __m512i outv =
             _mm512_mask_expandloadu_epi8(vl, (__mmask64)ctrl, (const void*)(R + rp));
         _mm512_storeu_si512((void*)(out + i), outv);
-        const int pc = zxc_pivco_popcnt64(ctrl);
-        rp += (size_t)pc;
-        lp += (size_t)(64 - pc);
-        i += 64;
+        ZXC_PIVCO_MERGE_STEP(64, zxc_pivco_popcnt64(ctrl));
     }
 #endif
 #if defined(ZXC_USE_AVX512) || defined(ZXC_USE_AVX2) || \
@@ -1600,10 +1616,7 @@ static ZXC_ALWAYS_INLINE void zxc_pivco_merge(uint8_t* RESTRICT out, const uint8
         const __m128i sell = _mm_shuffle_epi8(vl, _mm_add_epi8(ix, _mm_set1_epi8(0x70)));
         const __m128i selr = _mm_shuffle_epi8(vr, _mm_sub_epi8(ix, _mm_set1_epi8(16)));
         _mm_storeu_si128((__m128i*)(void*)(out + i), _mm_or_si128(sell, selr));
-        const int pc = pc0 + zxc_pivco_popcnt32(b1);
-        rp += (size_t)pc;
-        lp += (size_t)(16 - pc);
-        i += 16;
+        ZXC_PIVCO_MERGE_STEP(16, pc0 + zxc_pivco_popcnt32(b1));
     }
 #elif defined(ZXC_USE_NEON32)
     // 8 outputs per step: four-register VTBL over {L[0..7], -, R[0..7], -}. The
@@ -1617,10 +1630,7 @@ static ZXC_ALWAYS_INLINE void zxc_pivco_merge(uint8_t* RESTRICT out, const uint8
         tb.val[2] = vld1_u8(R + rp);
         tb.val[3] = vdup_n_u8(0);
         vst1_u8(out + i, vtbl4_u8(tb, vld1_u8(zxc_pivco_idxa_u8[b])));
-        const int pc = zxc_pivco_popcnt32(b);
-        rp += (size_t)pc;
-        lp += (size_t)(8 - pc);
-        i += 8;
+        ZXC_PIVCO_MERGE_STEP(8, zxc_pivco_popcnt32(b));
     }
 #endif
 #endif /* x86 tiers */
@@ -1644,6 +1654,8 @@ static ZXC_ALWAYS_INLINE void zxc_pivco_merge(uint8_t* RESTRICT out, const uint8
         out[i++] = bit ? R[rp++] : L[lp++];
     }
 }
+
+#undef ZXC_PIVCO_MERGE_STEP
 
 /**
  * @brief Decode a flat subtree's packed D-bit code run into symbols.
@@ -2339,17 +2351,7 @@ static int zxc_pivco_decode_core(const uint8_t* RESTRICT payload, const size_t p
     if (aux) {
         skip = aux->skip;
     } else {
-        ZXC_MEMSET(skip_local, 0, sizeof(skip_local));
-        for (int i = 0; i < t->n_nodes; i++) {
-            const zxc_pivco_node_t* nd = &t->nd[t->bfs[i]];
-            if (nd->sym >= 0) continue;
-            const int ch0 = nd->child[0];
-            const int ch1 = nd->child[1];
-            if (ch0 >= 0 && ch1 >= 0 && t->nd[ch0].sym >= 0 && t->nd[ch1].sym >= 0) {
-                skip_local[ch0] = 1;
-                skip_local[ch1] = 1;
-            }
-        }
+        zxc_pivco_mark_leaf_pairs(t, skip_local);
         skip = skip_local;
     }
 
@@ -2375,31 +2377,7 @@ static int zxc_pivco_decode_core(const uint8_t* RESTRICT payload, const size_t p
                 if (aux) {
                     c2s = aux->c2s_pool + aux->c2s_off[nid];
                 } else {
-                    int16_t stk_n[ZXC_HUF_MAX_CODE_LEN_ULTRA + 1];
-                    uint16_t stk_p[ZXC_HUF_MAX_CODE_LEN_ULTRA + 1];
-                    uint8_t stk_l[ZXC_HUF_MAX_CODE_LEN_ULTRA + 1];
-                    int sp = 0;
-                    stk_n[0] = (int16_t)nid;
-                    stk_p[0] = 0;
-                    stk_l[0] = 0;
-                    while (sp >= 0) {
-                        const int cn = stk_n[sp];
-                        const uint32_t cp = stk_p[sp];
-                        const int cl = stk_l[sp];
-                        sp--;
-                        if (t->nd[cn].sym >= 0) {
-                            c2s_local[cp] = (uint8_t)t->nd[cn].sym;
-                            continue;
-                        }
-                        sp++;
-                        stk_n[sp] = t->nd[cn].child[0];
-                        stk_p[sp] = (uint16_t)cp;
-                        stk_l[sp] = (uint8_t)(cl + 1);
-                        sp++;
-                        stk_n[sp] = t->nd[cn].child[1];
-                        stk_p[sp] = (uint16_t)(cp | (1U << cl));
-                        stk_l[sp] = (uint8_t)(cl + 1);
-                    }
+                    zxc_pivco_build_c2s(t, nid, c2s_local);
                     c2s = c2s_local;
                 }
                 zxc_pivco_unpack_flat(buf_d + seq_off[nid], c, D, bit_ptr[nid], c2s);

--- a/src/lib/zxc_huffman.c
+++ b/src/lib/zxc_huffman.c
@@ -1378,8 +1378,12 @@ int zxc_huf_encode_section_dict(const uint8_t* RESTRICT literals, const size_t n
 // ISA-independent cold dict setup: emit once in the primary variant, not in
 // every per-ISA copy (dead weight). zxc_pivco_tree_build stays per-variant.
 #if defined(ZXC_VARIANT_PRIMARY)
-// A parent whose two children are both leaves emits their runs from its own
-// bits (XOR-blend), so the children are never reconstructed: flag them.
+/**
+ * @brief Flags the children of every leaf-pair parent.
+ *
+ * A parent whose two children are both leaves emits their runs from its own
+ * bits (XOR-blend), so those children are never reconstructed.
+ */
 static ZXC_ALWAYS_INLINE void zxc_pivco_mark_leaf_pairs(const zxc_pivco_tree_t* RESTRICT t,
                                                         uint8_t* RESTRICT skip) {
     ZXC_MEMSET(skip, 0, ZXC_PIVCO_MAX_NODES);
@@ -1395,8 +1399,12 @@ static ZXC_ALWAYS_INLINE void zxc_pivco_mark_leaf_pairs(const zxc_pivco_tree_t* 
     }
 }
 
-// Code -> symbol table of the flat subtree at nid: complete of depth D, so its
-// 2^D codes index c2s directly. Built at attach for a dict tree, per block else.
+/**
+ * @brief Builds the code-to-symbol table of a flat subtree.
+ *
+ * The subtree is complete of depth D, so its 2^D codes index the table
+ * directly. Built once at attach for a dictionary tree, per block otherwise.
+ */
 static ZXC_ALWAYS_INLINE void zxc_pivco_build_c2s(const zxc_pivco_tree_t* RESTRICT t, const int nid,
                                                   uint8_t* RESTRICT c2s) {
     int16_t stk_n[ZXC_HUF_MAX_CODE_LEN_ULTRA + 1];
@@ -1470,8 +1478,13 @@ int zxc_huf_dict_tree_build(const uint8_t* RESTRICT packed_lengths, zxc_pivco_tr
 }
 #endif /* ZXC_VARIANT_PRIMARY */
 
-// Cursor advance closing every fixed-width arm below: the step took pc bytes
-// from the right child, w - pc from the left. Uses the caller's lp, rp and i.
+/**
+ * @brief Advances the merge cursors past one fixed-width step.
+ *
+ * Every fixed-width arm below closes the same way: the step took @c pc bytes
+ * from the right child and the rest from the left. Operates on the enclosing
+ * loop's @c lp, @c rp and @c i.
+ */
 #define ZXC_PIVCO_MERGE_STEP(w, pc) \
     do {                            \
         rp += (size_t)(pc);         \

--- a/src/lib/zxc_internal.h
+++ b/src/lib/zxc_internal.h
@@ -829,6 +829,24 @@ static inline int zxc_level_clamp(const int level) {
     return (level > ZXC_LEVEL_ULTRA) ? ZXC_LEVEL_ULTRA : level;
 }
 
+/** @name Option-block accessors
+ *  @brief Read one field of a (possibly NULL) public options struct, applying
+ *         that field's convention. Macros rather than functions because the
+ *         compression and decompression option structs share these fields
+ *         without sharing a type.
+ *
+ *  @c dict_size and @c dict_huf are gated on @c dict itself: a caller that
+ *  leaves @c dict NULL has no dictionary, whatever the sibling fields hold.
+ *  @c level and @c block_size follow the documented "0 means default"
+ *  convention, and a level is clamped to the highest one the encoder implements.
+ *  @{
+ */
+#define ZXC_OPTS_DICT_SIZE(o) (((o) && (o)->dict) ? (o)->dict_size : (size_t)0)
+#define ZXC_OPTS_DICT_HUF(o) (((o) && (o)->dict) ? (const uint8_t*)(o)->dict_huf : NULL)
+#define ZXC_OPTS_LEVEL(o, dflt) zxc_level_clamp(((o) && (o)->level > 0) ? (o)->level : (dflt))
+#define ZXC_OPTS_BLOCK_SIZE(o, dflt) (((o) && (o)->block_size > 0) ? (o)->block_size : (dflt))
+/** @} */
+
 /** @brief Encoder Huffman code-length cap for a compression @p level: levels below
  *         ::ZXC_LEVEL_ULTRA use ::ZXC_HUF_MAX_CODE_LEN_DENSITY, ::ZXC_LEVEL_ULTRA uses
  *         the full ::ZXC_HUF_MAX_CODE_LEN_ULTRA ceiling (denser codes, slower decode).

--- a/src/lib/zxc_internal.h
+++ b/src/lib/zxc_internal.h
@@ -161,12 +161,6 @@ extern "C" {
  */
 #define ZXC_PREFETCH_READ(ptr) __builtin_prefetch((const void*)(ptr), 0, 3)
 
-/** @def ZXC_PREFETCH_WRITE
- * @brief Prefetch data for writing.
- * @param ptr Pointer to data to prefetch.
- */
-#define ZXC_PREFETCH_WRITE(ptr) __builtin_prefetch((const void*)(ptr), 1, 3)
-
 /** @def ZXC_MEMCPY
  * @brief Optimized memory copy using compiler built-in.
  */
@@ -206,10 +200,8 @@ extern "C" {
 #if defined(_M_IX86) || defined(_M_X64) || defined(_M_AMD64)
 #include <xmmintrin.h>
 #define ZXC_PREFETCH_READ(ptr) _mm_prefetch((const char*)(ptr), _MM_HINT_T0)
-#define ZXC_PREFETCH_WRITE(ptr) _mm_prefetch((const char*)(ptr), _MM_HINT_T0)
 #else
 #define ZXC_PREFETCH_READ(ptr) __prefetch((const void*)(ptr))
-#define ZXC_PREFETCH_WRITE(ptr) __prefetch((const void*)(ptr))
 #endif
 #define LIKELY(x) (x)
 #define UNLIKELY(x) (x)
@@ -241,7 +233,6 @@ extern "C" {
 #define UNLIKELY(x) (x)
 #define RESTRICT
 #define ZXC_PREFETCH_READ(ptr)
-#define ZXC_PREFETCH_WRITE(ptr)
 #define ZXC_MEMCPY(dst, src, n) memcpy(dst, src, n)
 #define ZXC_MEMSET(dst, val, n) memset(dst, val, n)
 
@@ -425,9 +416,6 @@ extern "C" {
  *  zxc_compress_bound().
  */
 #define ZXC_BLOCK_FORMAT_OVERHEAD 68
-
-/** @brief Widest GLO section descriptors: literal and token compressed sizes. */
-#define ZXC_GLO_MAX_DESC_SIZE (2 * sizeof(uint32_t))
 
 /** @brief Checksum algorithm id for RapidHash (default, sole implementation). */
 #define ZXC_CHECKSUM_RAPIDHASH 0
@@ -1472,7 +1460,7 @@ static ZXC_ALWAYS_INLINE uint32_t zxc_hash_combine_rotate(const uint32_t hash,
  * @brief Writes a GLO sub-header followed by its section descriptors.
  *
  * They hold only the two sizes the header cannot imply, and are 0, 4 or 8 bytes
- * wide accordingly (@ref ZXC_GLO_MAX_DESC_SIZE).
+ * wide accordingly.
  *
  * @param[out] dst      Pointer to the destination buffer.
  * @param[in]  rem      The remaining space in the destination buffer.

--- a/src/lib/zxc_internal.h
+++ b/src/lib/zxc_internal.h
@@ -829,23 +829,19 @@ static inline int zxc_level_clamp(const int level) {
     return (level > ZXC_LEVEL_ULTRA) ? ZXC_LEVEL_ULTRA : level;
 }
 
-/** @name Option-block accessors
- *  @brief Read one field of a (possibly NULL) public options struct, applying
- *         that field's convention. Macros rather than functions because the
- *         compression and decompression option structs share these fields
- *         without sharing a type.
+/** @brief Dictionary length from a (possibly NULL) options struct.
  *
- *  @c dict_size and @c dict_huf are gated on @c dict itself: a caller that
- *  leaves @c dict NULL has no dictionary, whatever the sibling fields hold.
- *  @c level and @c block_size follow the documented "0 means default"
- *  convention, and a level is clamped to the highest one the encoder implements.
- *  @{
- */
+ *  Gated on @c dict itself: no dictionary pointer means no dictionary, whatever
+ *  the sibling fields hold. Macros rather than functions because the compression
+ *  and decompression option structs carry these fields without sharing a type. */
 #define ZXC_OPTS_DICT_SIZE(o) (((o) && (o)->dict) ? (o)->dict_size : (size_t)0)
+/** @brief Shared literal Huffman table, gated on @c dict the same way. */
 #define ZXC_OPTS_DICT_HUF(o) (((o) && (o)->dict) ? (const uint8_t*)(o)->dict_huf : NULL)
+/** @brief Compression level, 0 meaning the default, clamped to the highest level
+ *         the encoder implements. */
 #define ZXC_OPTS_LEVEL(o, dflt) zxc_level_clamp(((o) && (o)->level > 0) ? (o)->level : (dflt))
+/** @brief Block size, 0 meaning the default. */
 #define ZXC_OPTS_BLOCK_SIZE(o, dflt) (((o) && (o)->block_size > 0) ? (o)->block_size : (dflt))
-/** @} */
 
 /** @brief Encoder Huffman code-length cap for a compression @p level: levels below
  *         ::ZXC_LEVEL_ULTRA use ::ZXC_HUF_MAX_CODE_LEN_DENSITY, ::ZXC_LEVEL_ULTRA uses

--- a/src/lib/zxc_internal.h
+++ b/src/lib/zxc_internal.h
@@ -886,6 +886,21 @@ typedef struct {
      (size_t)ZXC_HUF_MAX_CODE_LEN_ULTRA * (size_t)ZXC_HUF_PM_LEVEL_BOUND * \
          sizeof(zxc_huf_pm_frame_t))
 
+/**
+ * @brief The four DP partitions the optimal parser carves out of opt_scratch.
+ *
+ * One definition shared by compute_cctx_layout(), which reserves the region,
+ * and zxc_lz77_optimal_parse_glo(), which carves it: the two cannot drift.
+ */
+static ZXC_ALWAYS_INLINE void zxc_opt_dp_sizes(const size_t chunk_size, size_t* RESTRICT sz_dp,
+                                               size_t* RESTRICT sz_pl, size_t* RESTRICT sz_po,
+                                               size_t* RESTRICT sz_bm) {
+    *sz_dp = ZXC_ALIGN_CL((chunk_size + 1) * sizeof(uint32_t));
+    *sz_pl = ZXC_ALIGN_CL((chunk_size + 1) * sizeof(uint16_t));
+    *sz_po = ZXC_ALIGN_CL((chunk_size + 1) * sizeof(uint16_t));
+    *sz_bm = ZXC_ALIGN_CL(ZXC_BITMAP_WORDS(chunk_size + 1) * sizeof(uint64_t));
+}
+
 /** @name Block Size Helpers
  *  @brief Runtime helpers for variable block sizes.
  *  @{ */

--- a/src/lib/zxc_pstream.c
+++ b/src/lib/zxc_pstream.c
@@ -276,9 +276,8 @@ zxc_cstream* zxc_cstream_create(const zxc_compress_opts_t* opts) {
         return NULL;
     }
 
-    if (cs->opts.level == 0) cs->opts.level = ZXC_LEVEL_DEFAULT;
-    cs->opts.level = zxc_level_clamp(cs->opts.level);
-    if (cs->opts.block_size == 0) cs->opts.block_size = ZXC_BLOCK_SIZE_DEFAULT;
+    cs->opts.level = ZXC_OPTS_LEVEL(&cs->opts, ZXC_LEVEL_DEFAULT);
+    cs->opts.block_size = ZXC_OPTS_BLOCK_SIZE(&cs->opts, ZXC_BLOCK_SIZE_DEFAULT);
     // n_threads is ignored on this single-threaded path.
     cs->opts.n_threads = 0;
     cs->opts.progress_cb = NULL;

--- a/src/lib/zxc_pstream.c
+++ b/src/lib/zxc_pstream.c
@@ -224,26 +224,40 @@ static int cs_compress_one_block(zxc_cstream* cs) {
 }
 
 /**
- * @brief Drains staged output bytes into the caller's output buffer.
+ * @brief Copies [@p pos, @p len) of @p src into @p out, as far as it fits.
  *
- * Copies as many bytes as possible from
- * @c cs->pending[pending_pos..pending_len) into
- * @c out->dst[pos..size), advancing both cursors.
+ * The single output pump: both the compressor's pending staging buffer and the
+ * decompressor's decoded block drain through it, so the cursor bookkeeping is
+ * written once.
  *
- * @param[in,out] cs  Compression stream.
- * @param[in,out] out Caller output buffer.
- * @return Non-zero once the @c pending buffer has been fully drained
- *         (@c pending_pos == @c pending_len), zero otherwise.
+ * @param[in,out] out  Caller output buffer; @c pos is advanced.
+ * @param[in]     src  Source buffer.
+ * @param[in,out] pos  Read cursor into @p src; advanced by the copied count.
+ * @param[in]     len  Total valid bytes in @p src.
+ * @return Number of bytes copied.
+ */
+static size_t zxc_outbuf_push(zxc_outbuf_t* out, const uint8_t* RESTRICT src, size_t* RESTRICT pos,
+                              const size_t len) {
+    const size_t avail_out = out->size - out->pos;
+    const size_t avail_src = len - *pos;
+    const size_t n = avail_out < avail_src ? avail_out : avail_src;
+    if (n) {
+        ZXC_MEMCPY((uint8_t*)out->dst + out->pos, src + *pos, n);
+        out->pos += n;
+        *pos += n;
+    }
+    return n;
+}
+
+/**
+ * @brief Flushes as much of the pending staging buffer as @p out can take.
+ *
+ * @param[in,out] cs   Compression stream.
+ * @param[in,out] out  Caller output buffer; @c pos is advanced.
+ * @return 1 once @c pending is fully drained, 0 if bytes remain.
  */
 static int cs_drain_pending(zxc_cstream* cs, zxc_outbuf_t* out) {
-    const size_t avail_out = out->size - out->pos;
-    const size_t avail_pen = cs->pending_len - cs->pending_pos;
-    const size_t n = avail_out < avail_pen ? avail_out : avail_pen;
-    if (n) {
-        ZXC_MEMCPY((uint8_t*)out->dst + out->pos, cs->pending + cs->pending_pos, n);
-        out->pos += n;
-        cs->pending_pos += n;
-    }
+    zxc_outbuf_push(out, cs->pending, &cs->pending_pos, cs->pending_len);
     return cs->pending_pos == cs->pending_len;
 }
 
@@ -736,49 +750,29 @@ static int ds_set_error(zxc_dstream* ds, const int code) {
 }
 
 /**
- * @brief Pulls up to @c (scratch_need - scratch_used) bytes from @p in.
+ * @brief Copies from @p in into @p dst until it holds @p need bytes.
  *
- * Used to accumulate fixed-size frames (file header, block header, footer,
- * EOF tail peek) into the inline @c scratch buffer.
+ * The single input pump: the fixed-size frame accumulator (file header, block
+ * header, footer, EOF tail peek) and the variable-size block payload differ
+ * only in which buffer they fill.
  *
- * @param[in,out] ds Decompression stream.
- * @param[in,out] in Caller input buffer; @c pos is advanced.
- * @return @c 1 once @c scratch holds exactly @c scratch_need bytes,
- *         @c 0 otherwise (need more input).
+ * @param[out]    dst   Destination buffer, at least @p need bytes.
+ * @param[in,out] used  Bytes already accumulated; advanced by the copied count.
+ * @param[in]     need  Target byte count.
+ * @param[in,out] in    Caller input buffer; @c pos is advanced.
+ * @return 1 once @p dst holds exactly @p need bytes, 0 if more input is needed.
  */
-static int ds_pull_scratch(zxc_dstream* ds, zxc_inbuf_t* in) {
-    const size_t want = ds->scratch_need - ds->scratch_used;
+static int ds_pull(uint8_t* RESTRICT dst, size_t* RESTRICT used, const size_t need,
+                   zxc_inbuf_t* in) {
+    const size_t want = need - *used;
     const size_t avail = in->size - in->pos;
     const size_t n = want < avail ? want : avail;
     if (n) {
-        ZXC_MEMCPY(ds->scratch + ds->scratch_used, (const uint8_t*)in->src + in->pos, n);
+        ZXC_MEMCPY(dst + *used, (const uint8_t*)in->src + in->pos, n);
         in->pos += n;
-        ds->scratch_used += n;
+        *used += n;
     }
-    return ds->scratch_used == ds->scratch_need;
-}
-
-/**
- * @brief Same as @ref ds_pull_scratch but pulls into the heap @c payload buffer.
- *
- * Used to accumulate the variable-size compressed block payload
- * (header + comp_size [+ checksum]).
- *
- * @param[in,out] ds Decompression stream.
- * @param[in,out] in Caller input buffer; @c pos is advanced.
- * @return @c 1 once @c payload holds exactly @c payload_need bytes,
- *         @c 0 otherwise (need more input).
- */
-static int ds_pull_payload(zxc_dstream* ds, zxc_inbuf_t* in) {
-    const size_t want = ds->payload_need - ds->payload_used;
-    const size_t avail = in->size - in->pos;
-    const size_t n = want < avail ? want : avail;
-    if (n) {
-        ZXC_MEMCPY(ds->payload + ds->payload_used, (const uint8_t*)in->src + in->pos, n);
-        in->pos += n;
-        ds->payload_used += n;
-    }
-    return ds->payload_used == ds->payload_need;
+    return *used == need;
 }
 
 /**
@@ -850,28 +844,17 @@ size_t zxc_dstream_out_size(const zxc_dstream* ds) {
 }
 
 /**
- * @brief Drains @c ds->decoded[decoded_pos..decoded_size) into @p out.
+ * @brief Flushes as much of the decoded block as @p out can take.
  *
- * Updates @c ds->total_out by the number of bytes copied and, when
- * @p produced is non-NULL, accumulates the same count into @c *produced
- * (used by the outer state machine to compute the per-call return value).
- *
- * @param[in,out] ds       Decompression stream.
- * @param[in,out] out      Caller output buffer.
- * @param[in,out] produced Optional running count of bytes produced this call.
- * @return @c 1 once @c decoded is fully drained, @c 0 otherwise.
+ * @param[in,out] ds        Decompression stream; @c total_out is advanced.
+ * @param[in,out] out       Caller output buffer; @c pos is advanced.
+ * @param[in,out] produced  Optional running total to add the copied count to.
+ * @return 1 once the decoded block is fully drained, 0 if bytes remain.
  */
 static int ds_drain_decoded(zxc_dstream* ds, zxc_outbuf_t* out, size_t* produced) {
-    const size_t avail_out = out->size - out->pos;
-    const size_t avail_dec = ds->decoded_size - ds->decoded_pos;
-    const size_t n = avail_out < avail_dec ? avail_out : avail_dec;
-    if (n) {
-        ZXC_MEMCPY((uint8_t*)out->dst + out->pos, ds->decoded + ds->decoded_pos, n);
-        out->pos += n;
-        ds->decoded_pos += n;
-        ds->total_out += n;
-        if (produced) *produced += n;
-    }
+    const size_t n = zxc_outbuf_push(out, ds->decoded, &ds->decoded_pos, ds->decoded_size);
+    ds->total_out += n;
+    if (produced) *produced += n;
     return ds->decoded_pos == ds->decoded_size;
 }
 
@@ -892,7 +875,7 @@ static int ds_drain_decoded(zxc_dstream* ds, zxc_outbuf_t* out, size_t* produced
  *         negative @ref zxc_error_t on validation/allocation failure.
  */
 static int ds_handle_need_file_header(zxc_dstream* ds, zxc_inbuf_t* in) {
-    if (!ds_pull_scratch(ds, in)) return 1;
+    if (!ds_pull(ds->scratch, &ds->scratch_used, ds->scratch_need, in)) return 1;
 
     size_t bs = 0;
     int has_csum = 0;
@@ -944,7 +927,7 @@ static int ds_handle_need_file_header(zxc_dstream* ds, zxc_inbuf_t* in) {
  *         negative @ref zxc_error_t on validation/allocation failure.
  */
 static int ds_handle_need_block_header(zxc_dstream* ds, zxc_inbuf_t* in) {
-    if (!ds_pull_scratch(ds, in)) return 1;
+    if (!ds_pull(ds->scratch, &ds->scratch_used, ds->scratch_need, in)) return 1;
 
     const int rc = zxc_read_block_header(ds->scratch, ds->scratch_used, &ds->cur_bh);
     if (UNLIKELY(rc != ZXC_OK)) return ds_set_error(ds, rc);  // LCOV_EXCL_LINE
@@ -1026,7 +1009,8 @@ int64_t zxc_dstream_decompress(zxc_dstream* ds, zxc_outbuf_t* out, zxc_inbuf_t* 
             }
 
             case DS_NEED_BLOCK_PAYLOAD: {
-                if (!ds_pull_payload(ds, in)) return (int64_t)produced;
+                if (!ds_pull(ds->payload, &ds->payload_used, ds->payload_need, in))
+                    return (int64_t)produced;
                 ds->state = DS_DECODE_BLOCK;
                 break;
             }
@@ -1076,7 +1060,8 @@ int64_t zxc_dstream_decompress(zxc_dstream* ds, zxc_outbuf_t* out, zxc_inbuf_t* 
             }
 
             case DS_PEEK_TAIL: {
-                if (!ds_pull_scratch(ds, in)) return (int64_t)produced;
+                if (!ds_pull(ds->scratch, &ds->scratch_used, ds->scratch_need, in))
+                    return (int64_t)produced;
                 // Try to interpret as a block header (SEK).
                 zxc_block_header_t peek;
                 const int sek_rc = zxc_read_block_header(ds->scratch, ds->scratch_used, &peek);
@@ -1106,7 +1091,8 @@ int64_t zxc_dstream_decompress(zxc_dstream* ds, zxc_outbuf_t* out, zxc_inbuf_t* 
 
             case DS_NEED_FOOTER_REST:
             case DS_NEED_FOOTER_FULL: {
-                if (!ds_pull_scratch(ds, in)) return (int64_t)produced;
+                if (!ds_pull(ds->scratch, &ds->scratch_used, ds->scratch_need, in))
+                    return (int64_t)produced;
                 ds->state = DS_VALIDATE_FOOTER;
                 break;
             }

--- a/src/lib/zxc_pstream.c
+++ b/src/lib/zxc_pstream.c
@@ -224,17 +224,10 @@ static int cs_compress_one_block(zxc_cstream* cs) {
 }
 
 /**
- * @brief Copies [@p pos, @p len) of @p src into @p out, as far as it fits.
+ * @brief Copies what fits of a staged buffer into the caller's output.
  *
- * The single output pump: both the compressor's pending staging buffer and the
- * decompressor's decoded block drain through it, so the cursor bookkeeping is
- * written once.
- *
- * @param[in,out] out  Caller output buffer; @c pos is advanced.
- * @param[in]     src  Source buffer.
- * @param[in,out] pos  Read cursor into @p src; advanced by the copied count.
- * @param[in]     len  Total valid bytes in @p src.
- * @return Number of bytes copied.
+ * The single output pump: the compressor's pending buffer and the
+ * decompressor's decoded block both drain through it. Returns the byte count.
  */
 static size_t zxc_outbuf_push(zxc_outbuf_t* out, const uint8_t* RESTRICT src, size_t* RESTRICT pos,
                               const size_t len) {
@@ -249,13 +242,7 @@ static size_t zxc_outbuf_push(zxc_outbuf_t* out, const uint8_t* RESTRICT src, si
     return n;
 }
 
-/**
- * @brief Flushes as much of the pending staging buffer as @p out can take.
- *
- * @param[in,out] cs   Compression stream.
- * @param[in,out] out  Caller output buffer; @c pos is advanced.
- * @return 1 once @c pending is fully drained, 0 if bytes remain.
- */
+/** @brief Flushes the pending staging buffer; 1 once fully drained. */
 static int cs_drain_pending(zxc_cstream* cs, zxc_outbuf_t* out) {
     zxc_outbuf_push(out, cs->pending, &cs->pending_pos, cs->pending_len);
     return cs->pending_pos == cs->pending_len;
@@ -750,17 +737,11 @@ static int ds_set_error(zxc_dstream* ds, const int code) {
 }
 
 /**
- * @brief Copies from @p in into @p dst until it holds @p need bytes.
+ * @brief Accumulates caller input into a buffer until it holds the wanted size.
  *
- * The single input pump: the fixed-size frame accumulator (file header, block
- * header, footer, EOF tail peek) and the variable-size block payload differ
- * only in which buffer they fill.
- *
- * @param[out]    dst   Destination buffer, at least @p need bytes.
- * @param[in,out] used  Bytes already accumulated; advanced by the copied count.
- * @param[in]     need  Target byte count.
- * @param[in,out] in    Caller input buffer; @c pos is advanced.
- * @return 1 once @p dst holds exactly @p need bytes, 0 if more input is needed.
+ * The single input pump: the fixed-size frame accumulator (headers, footer, EOF
+ * peek) and the variable-size block payload differ only in the buffer they
+ * fill. Returns 1 once the target size is reached, 0 if more input is needed.
  */
 static int ds_pull(uint8_t* RESTRICT dst, size_t* RESTRICT used, const size_t need,
                    zxc_inbuf_t* in) {
@@ -843,14 +824,7 @@ size_t zxc_dstream_out_size(const zxc_dstream* ds) {
     return ds->block_size == 0 ? ZXC_BLOCK_SIZE_DEFAULT : ds->block_size;
 }
 
-/**
- * @brief Flushes as much of the decoded block as @p out can take.
- *
- * @param[in,out] ds        Decompression stream; @c total_out is advanced.
- * @param[in,out] out       Caller output buffer; @c pos is advanced.
- * @param[in,out] produced  Optional running total to add the copied count to.
- * @return 1 once the decoded block is fully drained, 0 if bytes remain.
- */
+/** @brief Flushes the decoded block; 1 once fully drained. `produced` is optional. */
 static int ds_drain_decoded(zxc_dstream* ds, zxc_outbuf_t* out, size_t* produced) {
     const size_t n = zxc_outbuf_push(out, ds->decoded, &ds->decoded_pos, ds->decoded_size);
     ds->total_out += n;

--- a/src/lib/zxc_seekable.c
+++ b/src/lib/zxc_seekable.c
@@ -208,10 +208,10 @@ static zxc_seekable* zxc_seekable_parse(const zxc_seek_source_t* src) {
 
     // Step 4: locate and validate the seek block. Two headers of margin, not one:
     // the tail read below spans the EOF block, so tail_total could wrap on 32 bits.
-    const uint64_t entries_total_64 = (uint64_t)num_blocks * ZXC_SEEK_ENTRY_SIZE;
-    if (UNLIKELY(entries_total_64 > SIZE_MAX - 2 * ZXC_BLOCK_HEADER_SIZE)) return NULL;
+    const uint64_t entries_total = num_blocks_64 * ZXC_SEEK_ENTRY_SIZE;
+    if (UNLIKELY(entries_total > SIZE_MAX - 2 * ZXC_BLOCK_HEADER_SIZE)) return NULL;
 
-    const size_t seek_block_total = ZXC_BLOCK_HEADER_SIZE + (size_t)entries_total_64;
+    const size_t seek_block_total = ZXC_BLOCK_HEADER_SIZE + (size_t)entries_total;
     if (UNLIKELY((uint64_t)seek_block_total + ZXC_FILE_FOOTER_SIZE > src->size)) return NULL;
 
     const uint64_t seek_off = src->size - ZXC_FILE_FOOTER_SIZE - (uint64_t)seek_block_total;
@@ -241,7 +241,7 @@ static zxc_seekable* zxc_seekable_parse(const zxc_seek_source_t* src) {
 
     zxc_block_header_t bh;
     if (UNLIKELY(zxc_read_block_header(seek_blk, seek_block_total, &bh) != ZXC_OK ||
-                 bh.block_type != ZXC_BLOCK_SEK || bh.comp_size != (uint32_t)entries_total_64))
+                 bh.block_type != ZXC_BLOCK_SEK || bh.comp_size != (uint32_t)entries_total))
         goto fail;
 
     // Step 5: allocate the handle and parse the entries

--- a/src/lib/zxc_seekable.c
+++ b/src/lib/zxc_seekable.c
@@ -240,8 +240,11 @@ static zxc_seekable* zxc_seekable_parse(const zxc_seek_source_t* src) {
     const uint8_t* const seek_blk = tail_view + ZXC_BLOCK_HEADER_SIZE;
 
     zxc_block_header_t bh;
+    // The SEK header stores the table size in a 32-bit field, so reject any larger value before
+    // reading it.
+    if (UNLIKELY(entries_total > UINT32_MAX)) goto fail;
     if (UNLIKELY(zxc_read_block_header(seek_blk, seek_block_total, &bh) != ZXC_OK ||
-                 bh.block_type != ZXC_BLOCK_SEK || bh.comp_size != (uint32_t)entries_total))
+                 bh.block_type != ZXC_BLOCK_SEK || bh.comp_size != entries_total))
         goto fail;
 
     // Step 5: allocate the handle and parse the entries

--- a/src/lib/zxc_seekable.c
+++ b/src/lib/zxc_seekable.c
@@ -202,7 +202,7 @@ static zxc_seekable* zxc_seekable_parse(const zxc_seek_source_t* src) {
     if (UNLIKELY(total_decomp == 0)) return NULL;
 
     // Step 3: derive num_blocks = ceil(total_decomp / block_size)
-    const uint64_t num_blocks_64 = (total_decomp + block_size - 1) / block_size;
+    const uint64_t num_blocks_64 = total_decomp / block_size + (total_decomp % block_size != 0);
     if (UNLIKELY(num_blocks_64 > UINT32_MAX)) return NULL;
     const uint32_t num_blocks = (uint32_t)num_blocks_64;
 

--- a/src/lib/zxc_seekable.c
+++ b/src/lib/zxc_seekable.c
@@ -225,15 +225,15 @@ static zxc_seekable* zxc_seekable_parse(const zxc_seek_source_t* src) {
     const uint64_t tail_off = seek_off - ZXC_BLOCK_HEADER_SIZE;
 
     uint8_t* tail = NULL;
-    const uint8_t* tail_view = src->data ? src->data + tail_off : NULL;
+    const uint8_t* tail_view;
     zxc_seekable* s = NULL;
-    if (!tail_view) {
+    if (src->data) {
+        tail_view = src->data + tail_off;
+    } else {
         tail = (uint8_t*)ZXC_MALLOC(tail_total);
         if (UNLIKELY(!tail)) return NULL;  // LCOV_EXCL_LINE
         if (UNLIKELY(!zxc_seek_source_read(src, tail, tail_total, tail_off))) goto fail;
         tail_view = tail;
-    } else if (UNLIKELY(tail_off + tail_total > src->size)) {
-        return NULL;  // LCOV_EXCL_LINE
     }
 
     const uint8_t* const eof_hdr = tail_view;

--- a/src/lib/zxc_seekable.c
+++ b/src/lib/zxc_seekable.c
@@ -611,8 +611,8 @@ static uint32_t zxc_seek_decomp_size(const uint32_t block_size, const uint64_t t
 /**
  * @brief Reads a compressed block into @p buf from the memory buffer or reader.
  *
- * Single-threaded path: copies from @c s->src in buffer mode, otherwise calls
- * @c s->reader.read_at (which also backs the FILE* variant).
+ * Copies from @c s->src in buffer mode, otherwise calls @c s->reader.read_at
+ * (which also backs the FILE* variant).
  *
  * @param[in]  s          Seekable handle.
  * @param[in]  block_idx  Zero-based block index to read.
@@ -765,42 +765,6 @@ typedef struct {
 } zxc_seek_mt_job_t;
 
 /**
- * @brief Thread-safe block read backing the multi-threaded path.
- *
- * Like @ref zxc_seek_read_block but safe to call concurrently: buffer mode uses
- * @c memcpy on const data, reader mode relies on a positioned (pread-style)
- * callback that carries its own offset.
- *
- * @param[in]  s          Seekable handle (read-only).
- * @param[in]  block_idx  Zero-based block index to read.
- * @param[out] buf        Destination buffer.
- * @param[in]  buf_cap    Capacity of @p buf in bytes.
- * @return The block's compressed byte count on success, or a negative
- *         @ref zxc_error_t.
- */
-static int zxc_seek_read_block_mt(const zxc_seekable* s, const uint32_t block_idx, uint8_t* buf,
-                                  const size_t buf_cap) {
-    const uint64_t off = s->comp_offsets[block_idx];
-    const uint32_t csz = s->comp_sizes[block_idx];
-    if (UNLIKELY(csz > buf_cap)) return ZXC_ERROR_DST_TOO_SMALL;
-
-    if (s->src) {
-        // Buffer mode - memcpy is inherently thread-safe on const data
-        if (UNLIKELY(off + csz > s->src_size)) return ZXC_ERROR_SRC_TOO_SMALL;
-        ZXC_MEMCPY(buf, s->src + off, csz);
-    } else if (s->reader.read_at) {
-        // Reader callback - caller-supplied read_at must be thread-safe.
-        // The FILE* variant (zxc_seekable_file.c) installs a pread-backed
-        // callback that is naturally thread-safe.
-        const int64_t r = s->reader.read_at(s->reader.ctx, buf, csz, off);
-        if (UNLIKELY(r != (int64_t)csz)) return (r < 0) ? (int)r : ZXC_ERROR_IO;
-    } else {
-        return ZXC_ERROR_NULL_INPUT;  // LCOV_EXCL_LINE
-    }
-    return (int)csz;
-}
-
-/**
  * @struct zxc_seek_mt_stripe_t
  * @brief Per-thread stripe descriptor for multi-threaded decompression.
  *
@@ -904,7 +868,7 @@ static void* zxc_seek_mt_worker(void* arg) {
         zxc_seek_mt_job_t* const job = &jobs[i];
 
         const int read_res =
-            zxc_seek_read_block_mt(s, job->block_idx, read_buf, max_csz + ZXC_PAD_SIZE);
+            zxc_seek_read_block(s, job->block_idx, read_buf, max_csz + ZXC_PAD_SIZE);
         if (UNLIKELY(read_res < 0)) {
             // LCOV_EXCL_START
             job->result = read_res;

--- a/src/lib/zxc_seekable.c
+++ b/src/lib/zxc_seekable.c
@@ -101,6 +101,7 @@ struct zxc_seekable_s {
     uint32_t* comp_sizes;   /* array[num_blocks] */
     uint64_t* comp_offsets; /* prefix-sum: byte offset in compressed file per block */
     uint64_t total_decomp;  /* total decompressed size (from footer) */
+    uint32_t max_comp_size; /* largest entry of comp_sizes, from the same walk */
 
     // File header info - block_size is always a power of 2 in [4KB, 2MB],
     // fits in 21 bits.
@@ -108,9 +109,13 @@ struct zxc_seekable_s {
     int file_has_checksums;
     uint32_t expected_dict_id; /* dict_id from the file header; 0 = no dictionary */
 
-    // Reusable decompression context (single-threaded path only)
+    // Reusable decompression context and compressed-block scratch. Both belong
+    // to the single-threaded path, which is already not reentrant per handle;
+    // the multi-threaded path gives each worker its own.
     zxc_cctx_t dctx;
     int dctx_initialized;
+    uint8_t* read_buf;
+    size_t read_buf_cap;
 
     // Dictionary (owned copy, freed in zxc_seekable_free).
     uint8_t* dict;
@@ -259,6 +264,7 @@ static zxc_seekable* zxc_seekable_parse(const zxc_seek_source_t* src) {
             // Reject entries below minimum (block header) or larger than the file
             if (UNLIKELY(s->comp_sizes[i] < ZXC_BLOCK_HEADER_SIZE || s->comp_sizes[i] > src->size))
                 goto fail;
+            if (s->comp_sizes[i] > s->max_comp_size) s->max_comp_size = s->comp_sizes[i];
             s->comp_offsets[i] = comp_acc;
             comp_acc += s->comp_sizes[i];
             // Reject if cumulative offset exceeds file size (inconsistent table)
@@ -473,23 +479,21 @@ int64_t zxc_seekable_decompress_range(zxc_seekable* s, void* dst, const size_t d
     uint8_t* out = (uint8_t*)dst;
     size_t remaining = len;
 
-    // Allocate read buffer for compressed blocks
-    size_t max_comp = 0;
-    for (uint32_t bi = blk_start; bi <= blk_end; bi++) {
-        if (s->comp_sizes[bi] > max_comp) max_comp = s->comp_sizes[bi];
+    // Compressed-block scratch, sized once for the largest block of the archive
+    // and kept on the handle: a range read is often one of many.
+    const size_t read_cap = (size_t)s->max_comp_size + ZXC_PAD_SIZE;
+    if (s->read_buf_cap < read_cap) {
+        uint8_t* const nb = (uint8_t*)ZXC_REALLOC(s->read_buf, read_cap);
+        if (UNLIKELY(!nb)) return ZXC_ERROR_MEMORY;  // LCOV_EXCL_LINE
+        s->read_buf = nb;
+        s->read_buf_cap = read_cap;
     }
-    uint8_t* const read_buf = (uint8_t*)ZXC_MALLOC(max_comp + ZXC_PAD_SIZE);
-    if (UNLIKELY(!read_buf)) return ZXC_ERROR_MEMORY;  // LCOV_EXCL_LINE
+    uint8_t* const read_buf = s->read_buf;
 
     for (uint32_t bi = blk_start; bi <= blk_end; bi++) {
         // Read compressed block data
-        const int read_res = zxc_seek_read_block(s, bi, read_buf, max_comp + ZXC_PAD_SIZE);
-        if (UNLIKELY(read_res < 0)) {
-            // LCOV_EXCL_START
-            ZXC_FREE(read_buf);
-            return read_res;
-            // LCOV_EXCL_STOP
-        }
+        const int read_res = zxc_seek_read_block(s, bi, read_buf, read_cap);
+        if (UNLIKELY(read_res < 0)) return read_res;  // LCOV_EXCL_LINE
 
         // Decompress the block: when a dictionary is active, decode into the
         // cctx-owned dict_buffer (which has dict content prepended) so that
@@ -498,22 +502,12 @@ int64_t zxc_seekable_decompress_range(zxc_seekable* s, void* dst, const size_t d
             s->dctx.dict_buffer ? s->dctx.dict_buffer + s->dict_size : s->dctx.work_buf;
         const int dec_res =
             zxc_decompress_chunk_wrapper(&s->dctx, read_buf, (size_t)read_res, dec_dst, work_sz);
-        if (UNLIKELY(dec_res < 0)) {
-            // LCOV_EXCL_START
-            ZXC_FREE(read_buf);
-            return dec_res;
-            // LCOV_EXCL_STOP
-        }
+        if (UNLIKELY(dec_res < 0)) return dec_res;  // LCOV_EXCL_LINE
 
         // Calculate which portion of this block's decompressed data we need
         const uint64_t blk_decomp_start = zxc_seek_decomp_offset(s->block_size, bi);
         const size_t skip = (offset > blk_decomp_start) ? (size_t)(offset - blk_decomp_start) : 0;
-        if (UNLIKELY((size_t)dec_res < skip)) {
-            // LCOV_EXCL_START
-            ZXC_FREE(read_buf);
-            return ZXC_ERROR_CORRUPT_DATA;
-            // LCOV_EXCL_STOP
-        }
+        if (UNLIKELY((size_t)dec_res < skip)) return ZXC_ERROR_CORRUPT_DATA;  // LCOV_EXCL_LINE
         const size_t avail = (size_t)dec_res - skip;
         const size_t copy = (avail < remaining) ? avail : remaining;
 
@@ -522,7 +516,6 @@ int64_t zxc_seekable_decompress_range(zxc_seekable* s, void* dst, const size_t d
         remaining -= copy;
     }
 
-    ZXC_FREE(read_buf);
     return (int64_t)len;
 }
 
@@ -631,12 +624,9 @@ static void* zxc_seek_mt_worker(void* arg) {
     uint8_t* const dict_work = dctx.dict_buffer;
     if (dict_work) ZXC_MEMCPY(dict_work, s->dict, s->dict_size);
 
-    // Read buffer sized for the largest compressed block of the stripe.
-    size_t max_csz = 0;
-    for (uint32_t i = st->first; i < st->num_jobs; i += st->stride) {
-        const uint32_t csz = s->comp_sizes[jobs[i].block_idx];
-        if (csz > max_csz) max_csz = csz;
-    }
+    // One read buffer per worker (they cannot share), sized from the archive-wide
+    // maximum recorded at parse time rather than by rescanning the stripe.
+    const size_t max_csz = (size_t)s->max_comp_size;
     uint8_t* const read_buf = (uint8_t*)ZXC_MALLOC(max_csz + ZXC_PAD_SIZE);
     if (UNLIKELY(!read_buf)) {
         // LCOV_EXCL_START
@@ -815,6 +805,7 @@ void zxc_seekable_free(zxc_seekable* s) {
     if (UNLIKELY(!s)) return;
     if (s->dctx_initialized) zxc_cctx_free(&s->dctx);
     ZXC_FREE(s->dict);
+    ZXC_FREE(s->read_buf);
     ZXC_FREE(s->comp_sizes);
     ZXC_FREE(s->comp_offsets);
     ZXC_FREE(s->owned_reader_ctx);

--- a/src/lib/zxc_seekable.c
+++ b/src/lib/zxc_seekable.c
@@ -32,128 +32,7 @@
 #include "../../include/zxc_dict.h"
 #include "../../include/zxc_error.h"
 #include "zxc_internal.h"
-
-// =========================================================================
-// Platform Threading Layer
-// =========================================================================
-
-// LCOV_EXCL_START - Windows platform layer, not reachable on POSIX CI
-#if defined(_WIN32)
-#include <process.h> /* _beginthreadex */
-#include <windows.h>
-
-// Map POSIX threading primitives to Windows equivalents
-typedef HANDLE zxc_thread_t;
-
-/**
- * @brief Trampoline payload bridging the POSIX-style @c void*(*)(void*) worker
- *        signature to the Win32 @c _beginthreadex entry point.
- *
- * Heap-allocated by @ref zxc_seek_thread_create and freed by
- * @ref zxc_seek_thread_entry once the captured callback has started.
- */
-typedef struct {
-    void* (*func)(void*); /* worker to invoke */
-    void* arg;            /* argument forwarded to @c func */
-} zxc_seek_thread_arg_t;
-
-/**
- * @brief @c _beginthreadex entry point: unpacks the trampoline payload, frees
- *        it, then runs the captured POSIX-style worker.
- *
- * @param[in] p  Heap @ref zxc_seek_thread_arg_t handed over by the creator;
- *               ownership transfers to this function.
- * @return Always 0 (the worker's @c void* result is discarded, matching the
- *         POSIX path which also ignores it).
- */
-static unsigned __stdcall zxc_seek_thread_entry(void* p) {
-    zxc_seek_thread_arg_t* a = (zxc_seek_thread_arg_t*)p;
-    void* (*f)(void*) = a->func;
-    void* arg = a->arg;
-    ZXC_FREE(a);
-    f(arg);
-    return 0;
-}
-
-/**
- * @brief Spawns a thread running @p fn(@p arg), abstracting @c _beginthreadex.
- *
- * Allocates a @ref zxc_seek_thread_arg_t trampoline so the Win32 entry-point
- * signature can carry a POSIX-style worker; the trampoline is freed by the
- * thread itself (or here, on a launch failure).
- *
- * @param[out] t    Receives the created thread handle on success.
- * @param[in]  fn   Worker to run on the new thread.
- * @param[in]  arg  Opaque argument forwarded to @p fn.
- * @return 0 on success, @ref ZXC_ERROR_MEMORY on allocation or spawn failure.
- */
-static int zxc_seek_thread_create(zxc_thread_t* t, void* (*fn)(void*), void* arg) {
-    zxc_seek_thread_arg_t* wrapper = ZXC_MALLOC(sizeof(zxc_seek_thread_arg_t));
-    if (UNLIKELY(!wrapper)) return ZXC_ERROR_MEMORY;
-    wrapper->func = fn;
-    wrapper->arg = arg;
-    uintptr_t handle = _beginthreadex(NULL, 0, zxc_seek_thread_entry, wrapper, 0, NULL);
-    if (UNLIKELY(handle == 0)) {
-        ZXC_FREE(wrapper);
-        return ZXC_ERROR_MEMORY;
-    }
-    *t = (HANDLE)handle;
-    return 0;
-}
-
-/**
- * @brief Blocks until thread @p t finishes, then releases its handle.
- * @param[in] t  Handle from a successful @ref zxc_seek_thread_create.
- */
-static void zxc_seek_thread_join(zxc_thread_t t) {
-    WaitForSingleObject(t, INFINITE);
-    CloseHandle(t);
-}
-
-/**
- * @brief Returns the number of logical processors reported by the OS.
- * @return Online processor count (always >= 1 in practice).
- */
-static int zxc_seek_get_num_procs(void) {
-    SYSTEM_INFO si;
-    GetSystemInfo(&si);
-    return (int)si.dwNumberOfProcessors;
-}
-// LCOV_EXCL_STOP
-
-#else /* POSIX */
-#include <pthread.h>
-#include <unistd.h>
-
-typedef pthread_t zxc_thread_t;
-
-/**
- * @brief Spawns a thread running @p fn(@p arg) via @c pthread_create.
- * @param[out] t    Receives the created thread handle on success.
- * @param[in]  fn   Worker to run on the new thread.
- * @param[in]  arg  Opaque argument forwarded to @p fn.
- * @return 0 on success, @ref ZXC_ERROR_MEMORY if the thread cannot be created.
- */
-static int zxc_seek_thread_create(zxc_thread_t* t, void* (*fn)(void*), void* arg) {
-    return pthread_create(t, NULL, fn, arg) == 0 ? 0 : ZXC_ERROR_MEMORY;
-}
-
-/**
- * @brief Blocks until thread @p t finishes (its @c void* result is discarded).
- * @param[in] t  Handle from a successful @ref zxc_seek_thread_create.
- */
-static void zxc_seek_thread_join(zxc_thread_t t) { pthread_join(t, NULL); }
-
-/**
- * @brief Returns the number of online logical processors.
- * @return @c _SC_NPROCESSORS_ONLN, clamped to a minimum of 1 if the query fails.
- */
-static int zxc_seek_get_num_procs(void) {
-    const long n = sysconf(_SC_NPROCESSORS_ONLN);
-    return (n > 0) ? (int)n : 1;
-}
-
-#endif /* _WIN32 */
+#include "zxc_threads.h"
 
 // =========================================================================
 // Seek Table Writer
@@ -242,40 +121,81 @@ struct zxc_seekable_s {
 };
 
 /**
- * @brief Parses the seek table from raw bytes at the end of the archive.
+ * @struct zxc_seek_source_t
+ * @brief Where the archive bytes come from during parsing.
+ *
+ * The two public entry points differ only in this: @ref zxc_seekable_open holds
+ * the whole archive in memory, @ref zxc_seekable_open_reader reaches it through
+ * a positioned callback. Everything after the first read is common, so the
+ * parser below takes a source instead of being written twice.
+ */
+typedef struct {
+    const uint8_t* data;     /* in-memory archive, NULL in callback mode */
+    const zxc_reader_t* rdr; /* callback mode, NULL in buffer mode */
+    uint64_t size;           /* archive size, both modes */
+} zxc_seek_source_t;
+
+/**
+ * @brief Reads @p len bytes at @p off from the archive, whatever backs it.
+ *
+ * @param[in]  src  Archive source.
+ * @param[out] dst  Destination buffer of at least @p len bytes.
+ * @param[in]  len  Byte count to read.
+ * @param[in]  off  Absolute offset in the archive.
+ * @return 1 on success, 0 if the range falls outside the archive or the
+ *         caller-supplied reader came up short.
+ */
+static int zxc_seek_source_read(const zxc_seek_source_t* src, void* dst, const size_t len,
+                                const uint64_t off) {
+    if (UNLIKELY(off > src->size || (uint64_t)len > src->size - off)) return 0;
+    if (src->data) {
+        ZXC_MEMCPY(dst, src->data + off, len);
+        return 1;
+    }
+    return src->rdr->read_at(src->rdr->ctx, dst, len, off) == (int64_t)len;
+}
+
+/**
+ * @brief Parses and validates the seek table at the end of the archive.
  *
  * Detection (backward from end):
  *   1. Read file header => block_size
  *   2. Read file footer => total_decomp_size
  *   3. Derive num_blocks = ceil(total_decomp_size / block_size)
  *   4. Compute expected seek block position, validate block_type == SEK
- *   5. Read comp_sizes; derive decomp_sizes from block_size
+ *   5. Read comp_sizes, build the compressed-offset prefix sums, and check the
+ *      layout lands exactly on the EOF block
  *
- * @param[in] data       Pointer to the whole in-memory archive.
- * @param[in] data_size  Archive size in bytes.
+ * @param[in] src  Archive source (buffer or reader; see @ref zxc_seek_source_t).
  * @return A newly allocated handle (free via @ref zxc_seekable_free), or NULL
- *         if the buffer is too small or the seek table is missing / malformed.
+ *         if the archive is too small or the seek table is missing / malformed.
  */
-static zxc_seekable* zxc_seekable_parse(const uint8_t* data, const size_t data_size) {
+static zxc_seekable* zxc_seekable_parse(const zxc_seek_source_t* src) {
     // Minimum: file_header(16) + eof_block(8) + seek_block_header(8)
     //          + file_footer(12) = 44
-    const size_t MIN_SEEKABLE_SIZE =
+    const uint64_t MIN_SEEKABLE_SIZE =
         ZXC_FILE_HEADER_SIZE + ZXC_BLOCK_HEADER_SIZE + ZXC_BLOCK_HEADER_SIZE + ZXC_FILE_FOOTER_SIZE;
-    if (UNLIKELY(data_size < MIN_SEEKABLE_SIZE)) return NULL;
+    if (UNLIKELY(src->size < MIN_SEEKABLE_SIZE)) return NULL;
 
     // Step 1: validate file header => block_size
+    uint8_t header[ZXC_FILE_HEADER_SIZE];
+    if (UNLIKELY(!zxc_seek_source_read(src, header, sizeof(header), 0))) return NULL;
+
     size_t block_size_sz = 0;
     int file_has_chk = 0;
     uint32_t header_dict_id = 0;
-    if (UNLIKELY(zxc_read_file_header(data, data_size, &block_size_sz, &file_has_chk,
+    if (UNLIKELY(zxc_read_file_header(header, sizeof(header), &block_size_sz, &file_has_chk,
                                       &header_dict_id) != ZXC_OK))
         return NULL;  // LCOV_EXCL_LINE
     const uint32_t block_size = (uint32_t)block_size_sz;
     if (UNLIKELY(block_size == 0)) return NULL;  // LCOV_EXCL_LINE
 
     // Step 2: read total decompressed size from the file footer
-    const uint8_t* const footer_ptr = data + data_size - ZXC_FILE_FOOTER_SIZE;
-    const uint64_t total_decomp = zxc_le64(footer_ptr);
+    uint8_t footer[ZXC_FILE_FOOTER_SIZE];
+    if (UNLIKELY(
+            !zxc_seek_source_read(src, footer, sizeof(footer), src->size - ZXC_FILE_FOOTER_SIZE)))
+        return NULL;
+    const uint64_t total_decomp = zxc_le64(footer);
 
     // A value of 0 means empty file - no seek table
     if (UNLIKELY(total_decomp == 0)) return NULL;
@@ -285,103 +205,88 @@ static zxc_seekable* zxc_seekable_parse(const uint8_t* data, const size_t data_s
     if (UNLIKELY(num_blocks_64 > UINT32_MAX)) return NULL;
     const uint32_t num_blocks = (uint32_t)num_blocks_64;
 
-    // Step 4: compute seek block position and validate.
-    const uint64_t entries_total_64 = num_blocks_64 * ZXC_SEEK_ENTRY_SIZE;
+    // Step 4: locate the seek block, then read and validate it. Guard the
+    // size_t multiplication before it is used as an allocation size.
+    const uint64_t entries_total_64 = (uint64_t)num_blocks * ZXC_SEEK_ENTRY_SIZE;
     if (UNLIKELY(entries_total_64 > SIZE_MAX - ZXC_BLOCK_HEADER_SIZE)) return NULL;
-    const size_t entries_total = (size_t)entries_total_64;
-    const size_t seek_block_total = ZXC_BLOCK_HEADER_SIZE + entries_total;
-    if (UNLIKELY(seek_block_total + ZXC_FILE_FOOTER_SIZE > data_size)) return NULL;
-    const uint8_t* const seek_block_start =
-        data + data_size - ZXC_FILE_FOOTER_SIZE - seek_block_total;
-    if (UNLIKELY(seek_block_start < data)) return NULL;
+    const size_t seek_block_total = ZXC_BLOCK_HEADER_SIZE + (size_t)entries_total_64;
+    if (UNLIKELY((uint64_t)seek_block_total + ZXC_FILE_FOOTER_SIZE > src->size)) return NULL;
+    const uint64_t seek_off = src->size - ZXC_FILE_FOOTER_SIZE - (uint64_t)seek_block_total;
+    if (UNLIKELY(seek_off < ZXC_BLOCK_HEADER_SIZE)) return NULL;
 
-    // Read and validate SEK block header
+    // The EOF block sits immediately before the seek block, so one read covers
+    // both: [EOF 8][SEK header 8][entries]. Keeps a reader-backed open at three
+    // reads (header, footer, tail) while validating the same layout the
+    // in-memory path does.
+    const size_t tail_total = ZXC_BLOCK_HEADER_SIZE + seek_block_total;
+    uint8_t* tail = (uint8_t*)ZXC_MALLOC(tail_total);
+    if (UNLIKELY(!tail)) return NULL;  // LCOV_EXCL_LINE
+    zxc_seekable* s = NULL;
+    if (UNLIKELY(!zxc_seek_source_read(src, tail, tail_total, seek_off - ZXC_BLOCK_HEADER_SIZE)))
+        goto fail;
+
+    const uint8_t* const eof_hdr = tail;
+    const uint8_t* const seek_blk = tail + ZXC_BLOCK_HEADER_SIZE;
+
     zxc_block_header_t bh;
-    if (UNLIKELY(zxc_read_block_header(seek_block_start, seek_block_total, &bh) != ZXC_OK))
-        return NULL;
-    if (UNLIKELY(bh.block_type != ZXC_BLOCK_SEK)) return NULL;
-    if (UNLIKELY(bh.comp_size != (uint32_t)entries_total)) return NULL;
+    if (UNLIKELY(zxc_read_block_header(seek_blk, seek_block_total, &bh) != ZXC_OK ||
+                 bh.block_type != ZXC_BLOCK_SEK || bh.comp_size != (uint32_t)entries_total_64))
+        goto fail;
 
-    // Step 5: allocate handle and parse entries
-    zxc_seekable* const s = (zxc_seekable*)ZXC_CALLOC(1, sizeof(zxc_seekable));
-    // LCOV_EXCL_START
-    if (UNLIKELY(!s)) return NULL;
-    // LCOV_EXCL_STOP
+    // Step 5: allocate the handle and parse the entries
+    s = (zxc_seekable*)ZXC_CALLOC(1, sizeof(zxc_seekable));
+    if (UNLIKELY(!s)) goto fail;  // LCOV_EXCL_LINE
 
+    if (src->rdr) s->reader = *src->rdr;
+    s->src = src->data;
+    s->src_size = src->size;
     s->num_blocks = num_blocks;
     s->block_size = block_size;
     s->file_has_checksums = file_has_chk;
     s->expected_dict_id = header_dict_id;
-    s->src = data;
-    s->src_size = (uint64_t)data_size;
-
-    // Allocate arrays
-    s->comp_sizes = (uint32_t*)ZXC_CALLOC(num_blocks, sizeof(uint32_t));
-    s->comp_offsets = (uint64_t*)ZXC_CALLOC((size_t)num_blocks + 1, sizeof(uint64_t));
-    // LCOV_EXCL_START
-    if (UNLIKELY(!s->comp_sizes || !s->comp_offsets)) {
-        zxc_seekable_free(s);
-        return NULL;
-    }
-    // LCOV_EXCL_STOP
     s->total_decomp = total_decomp;
 
-    // Parse comp_sizes and build compressed prefix sums.
-    // Validate each comp_size against data_size to prevent prefix-sum overflow
-    // and out-of-bounds reads during decompression.
-    const uint8_t* ep = seek_block_start + ZXC_BLOCK_HEADER_SIZE;
-    uint64_t comp_acc = ZXC_FILE_HEADER_SIZE; /* blocks start after file header */
-    for (uint32_t i = 0; i < num_blocks; i++) {
-        s->comp_sizes[i] = zxc_le32(ep);
-        ep += sizeof(uint32_t);
+    s->comp_sizes = (uint32_t*)ZXC_CALLOC(num_blocks, sizeof(uint32_t));
+    s->comp_offsets = (uint64_t*)ZXC_CALLOC((size_t)num_blocks + 1, sizeof(uint64_t));
+    if (UNLIKELY(!s->comp_sizes || !s->comp_offsets)) goto fail;  // LCOV_EXCL_LINE
 
-        // Reject entries below minimum (block header) or larger than the file
-        if (UNLIKELY(s->comp_sizes[i] < ZXC_BLOCK_HEADER_SIZE ||
-                     s->comp_sizes[i] > (uint64_t)data_size)) {
-            zxc_seekable_free(s);
-            return NULL;
+    // Parse comp_sizes and build compressed prefix sums. Every entry is checked
+    // against the archive size, so the prefix sum can neither overflow nor
+    // point a later read out of bounds.
+    {
+        const uint8_t* ep = seek_blk + ZXC_BLOCK_HEADER_SIZE;
+        uint64_t comp_acc = ZXC_FILE_HEADER_SIZE; /* blocks start after file header */
+        for (uint32_t i = 0; i < num_blocks; i++) {
+            s->comp_sizes[i] = zxc_le32(ep);
+            ep += sizeof(uint32_t);
+
+            // Reject entries below minimum (block header) or larger than the file
+            if (UNLIKELY(s->comp_sizes[i] < ZXC_BLOCK_HEADER_SIZE || s->comp_sizes[i] > src->size))
+                goto fail;
+            s->comp_offsets[i] = comp_acc;
+            comp_acc += s->comp_sizes[i];
+            // Reject if cumulative offset exceeds file size (inconsistent table)
+            if (UNLIKELY(comp_acc > src->size)) goto fail;  // LCOV_EXCL_LINE
         }
-        s->comp_offsets[i] = comp_acc;
-        comp_acc += s->comp_sizes[i];
-        // Reject if cumulative offset exceeds file size (inconsistent table)
-        if (UNLIKELY(comp_acc > (uint64_t)data_size)) {
-            // LCOV_EXCL_START
-            zxc_seekable_free(s);
-            return NULL;
-            // LCOV_EXCL_STOP
-        }
-    }
-    s->comp_offsets[num_blocks] = comp_acc;
+        s->comp_offsets[num_blocks] = comp_acc;
 
-    // Verify prefix-sum lands exactly at the EOF block position.
-    // Expected layout: [header 16][data blocks][EOF 8][SEK block][footer 12]
-    // So comp_acc (end of data blocks) + EOF(8) == seek_block_start.
-    const uint64_t expected_eof_offset =
-        (uint64_t)(seek_block_start - data) - ZXC_BLOCK_HEADER_SIZE;
-    if (UNLIKELY(comp_acc != expected_eof_offset)) {
-        // LCOV_EXCL_START
-        zxc_seekable_free(s);
-        return NULL;
-        // LCOV_EXCL_STOP
+        // Verify the prefix sum lands exactly on the EOF block, and that an EOF
+        // block really sits there. Expected layout:
+        // [header 16][data blocks][EOF 8][SEK block][footer 12]
+        zxc_block_header_t eof_bh;
+        if (UNLIKELY(comp_acc != seek_off - ZXC_BLOCK_HEADER_SIZE ||
+                     zxc_read_block_header(eof_hdr, ZXC_BLOCK_HEADER_SIZE, &eof_bh) != ZXC_OK ||
+                     eof_bh.block_type != ZXC_BLOCK_EOF))
+            goto fail;
     }
 
-    // Validate that an actual EOF block header exists at the computed offset
-    if (UNLIKELY(comp_acc + ZXC_BLOCK_HEADER_SIZE > data_size)) {
-        // LCOV_EXCL_START
-        zxc_seekable_free(s);
-        return NULL;
-        // LCOV_EXCL_STOP
-    }
-    zxc_block_header_t eof_bh;
-    if (UNLIKELY(zxc_read_block_header(data + comp_acc, ZXC_BLOCK_HEADER_SIZE, &eof_bh) != ZXC_OK ||
-                 eof_bh.block_type != ZXC_BLOCK_EOF)) {
-        // LCOV_EXCL_START
-        zxc_seekable_free(s);
-        return NULL;
-        // LCOV_EXCL_STOP
-    }
-
+    ZXC_FREE(tail);
     return s;
+
+fail:
+    ZXC_FREE(tail);
+    zxc_seekable_free(s);
+    return NULL;
 }
 
 /**
@@ -392,7 +297,8 @@ static zxc_seekable* zxc_seekable_parse(const uint8_t* data, const size_t data_s
  */
 zxc_seekable* zxc_seekable_open(const void* src, const size_t src_size) {
     if (UNLIKELY(!src || src_size == 0)) return NULL;
-    return zxc_seekable_parse((const uint8_t*)src, src_size);
+    const zxc_seek_source_t source = {(const uint8_t*)src, NULL, (uint64_t)src_size};
+    return zxc_seekable_parse(&source);
 }
 
 // zxc_seekable_open_file lives elsewhere: it builds a zxc_reader_t over pread()
@@ -409,128 +315,8 @@ zxc_seekable* zxc_seekable_open(const void* src, const size_t src_size) {
  */
 zxc_seekable* zxc_seekable_open_reader(const zxc_reader_t* r) {
     if (UNLIKELY(!r || !r->read_at || r->size == 0)) return NULL;
-
-    // Minimum: file_header(16) + eof_block(8) + seek_block_header(8)
-    //          + file_footer(12) = 44
-    const uint64_t MIN_SEEKABLE_SIZE =
-        ZXC_FILE_HEADER_SIZE + ZXC_BLOCK_HEADER_SIZE + ZXC_BLOCK_HEADER_SIZE + ZXC_FILE_FOOTER_SIZE;
-    if (UNLIKELY(r->size < MIN_SEEKABLE_SIZE)) return NULL;
-
-    // Read file header => block_size
-    uint8_t header[ZXC_FILE_HEADER_SIZE];
-    if (UNLIKELY(r->read_at(r->ctx, header, ZXC_FILE_HEADER_SIZE, 0) !=
-                 (int64_t)ZXC_FILE_HEADER_SIZE))
-        return NULL;
-
-    size_t bs_sz = 0;
-    int fhc = 0;
-    uint32_t header_dict_id = 0;
-    if (UNLIKELY(zxc_read_file_header(header, ZXC_FILE_HEADER_SIZE, &bs_sz, &fhc,
-                                      &header_dict_id) != ZXC_OK))
-        return NULL;  // LCOV_EXCL_LINE
-    const uint32_t bs = (uint32_t)bs_sz;
-    if (UNLIKELY(bs == 0)) return NULL;
-
-    // Read footer => total_decomp_size
-    uint8_t footer_buf[ZXC_FILE_FOOTER_SIZE];
-    if (UNLIKELY(r->read_at(r->ctx, footer_buf, ZXC_FILE_FOOTER_SIZE,
-                            r->size - ZXC_FILE_FOOTER_SIZE) != (int64_t)ZXC_FILE_FOOTER_SIZE))
-        return NULL;
-
-    const uint64_t total_decomp = zxc_le64(footer_buf);
-    if (UNLIKELY(total_decomp == 0)) return NULL;
-
-    // Derive num_blocks = ceil(total_decomp / block_size)
-    const uint64_t num_blocks_64 = (total_decomp + bs - 1) / bs;
-    if (UNLIKELY(num_blocks_64 > UINT32_MAX)) return NULL;
-    const uint32_t num_blocks = (uint32_t)num_blocks_64;
-
-    // Guard against size_t multiplication overflow
-    const uint64_t entries_total_64 = (uint64_t)num_blocks * ZXC_SEEK_ENTRY_SIZE;
-    if (UNLIKELY(entries_total_64 > SIZE_MAX - ZXC_BLOCK_HEADER_SIZE)) return NULL;
-
-    // Read the full seek block
-    const size_t seek_block_total = ZXC_BLOCK_HEADER_SIZE + (size_t)entries_total_64;
-    if (UNLIKELY(seek_block_total + ZXC_FILE_FOOTER_SIZE > r->size)) return NULL;
-
-    uint8_t* const seek_buf = (uint8_t*)ZXC_MALLOC(seek_block_total);
-    if (UNLIKELY(!seek_buf)) return NULL;
-
-    const uint64_t seek_offset = r->size - ZXC_FILE_FOOTER_SIZE - (uint64_t)seek_block_total;
-    if (UNLIKELY(r->read_at(r->ctx, seek_buf, seek_block_total, seek_offset) !=
-                 (int64_t)seek_block_total)) {
-        // LCOV_EXCL_START
-        ZXC_FREE(seek_buf);
-        return NULL;
-        // LCOV_EXCL_STOP
-    }
-
-    // Validate SEK block header
-    zxc_block_header_t bh;
-    if (UNLIKELY(zxc_read_block_header(seek_buf, seek_block_total, &bh) != ZXC_OK) ||
-        bh.block_type != ZXC_BLOCK_SEK || bh.comp_size != (uint32_t)entries_total_64) {
-        // LCOV_EXCL_START
-        ZXC_FREE(seek_buf);
-        return NULL;
-        // LCOV_EXCL_STOP
-    }
-
-    // Build seekable handle
-    zxc_seekable* const s = (zxc_seekable*)ZXC_CALLOC(1, sizeof(zxc_seekable));
-    if (UNLIKELY(!s)) {
-        // LCOV_EXCL_START
-        ZXC_FREE(seek_buf);
-        return NULL;
-        // LCOV_EXCL_STOP
-    }
-
-    s->reader = *r;
-    s->src = NULL;
-    s->src_size = r->size;
-    s->num_blocks = num_blocks;
-    s->block_size = bs;
-    s->file_has_checksums = fhc;
-    s->expected_dict_id = header_dict_id;
-
-    s->comp_sizes = (uint32_t*)ZXC_CALLOC(num_blocks, sizeof(uint32_t));
-    s->comp_offsets = (uint64_t*)ZXC_CALLOC((size_t)num_blocks + 1, sizeof(uint64_t));
-    if (UNLIKELY(!s->comp_sizes || !s->comp_offsets)) {
-        // LCOV_EXCL_START
-        ZXC_FREE(seek_buf);
-        zxc_seekable_free(s);
-        return NULL;
-        // LCOV_EXCL_STOP
-    }
-    s->total_decomp = total_decomp;
-
-    // Parse comp_sizes and build prefix sums; validate against archive size.
-    const uint8_t* ep = seek_buf + ZXC_BLOCK_HEADER_SIZE;
-    uint64_t comp_acc = ZXC_FILE_HEADER_SIZE;
-    for (uint32_t i = 0; i < num_blocks; i++) {
-        s->comp_sizes[i] = zxc_le32(ep);
-        ep += sizeof(uint32_t);
-
-        if (UNLIKELY(s->comp_sizes[i] < ZXC_BLOCK_HEADER_SIZE || s->comp_sizes[i] > r->size)) {
-            // LCOV_EXCL_START
-            ZXC_FREE(seek_buf);
-            zxc_seekable_free(s);
-            return NULL;
-            // LCOV_EXCL_STOP
-        }
-        s->comp_offsets[i] = comp_acc;
-        comp_acc += s->comp_sizes[i];
-        if (UNLIKELY(comp_acc > r->size)) {
-            // LCOV_EXCL_START
-            ZXC_FREE(seek_buf);
-            zxc_seekable_free(s);
-            return NULL;
-            // LCOV_EXCL_STOP
-        }
-    }
-    s->comp_offsets[num_blocks] = comp_acc;
-
-    ZXC_FREE(seek_buf);
-    return s;
+    const zxc_seek_source_t source = {NULL, r, r->size};
+    return zxc_seekable_parse(&source);
 }
 
 /**
@@ -927,7 +713,7 @@ int64_t zxc_seekable_decompress_range_mt(zxc_seekable* s, void* dst, const size_
     const uint32_t num_jobs = blk_end - blk_start + 1;
 
     // Auto-detect thread count (0 = use all available cores)
-    if (n_threads == 0) n_threads = zxc_seek_get_num_procs();
+    if (n_threads == 0) n_threads = zxc_num_procs();
 
     // Fallback to single-threaded path for trivial cases
     if (n_threads <= 1 || num_jobs <= 1) {
@@ -972,8 +758,7 @@ int64_t zxc_seekable_decompress_range_mt(zxc_seekable* s, void* dst, const size_
     }
 
     // Launch one persistent worker per thread
-    zxc_thread_t* const threads =
-        (zxc_thread_t*)ZXC_MALLOC((size_t)n_threads * sizeof(zxc_thread_t));
+    pthread_t* const threads = (pthread_t*)ZXC_MALLOC((size_t)n_threads * sizeof(pthread_t));
     zxc_seek_mt_stripe_t* const stripes =
         (zxc_seek_mt_stripe_t*)ZXC_MALLOC((size_t)n_threads * sizeof(zxc_seek_mt_stripe_t));
     if (UNLIKELY(!threads || !stripes)) {
@@ -991,7 +776,7 @@ int64_t zxc_seekable_decompress_range_mt(zxc_seekable* s, void* dst, const size_
         stripes[t].num_jobs = num_jobs;
         stripes[t].first = (uint32_t)t;
         stripes[t].stride = (uint32_t)n_threads;
-        if (UNLIKELY(zxc_seek_thread_create(&threads[t], zxc_seek_mt_worker, &stripes[t]) != 0)) {
+        if (UNLIKELY(pthread_create(&threads[t], NULL, zxc_seek_mt_worker, &stripes[t]) != 0)) {
             // LCOV_EXCL_START
             // Failed to create thread - mark its stripe as errored; already
             // launched workers keep running and are joined below.
@@ -1005,7 +790,7 @@ int64_t zxc_seekable_decompress_range_mt(zxc_seekable* s, void* dst, const size_
     }
 
     // Join phase
-    for (int t = 0; t < launched; t++) zxc_seek_thread_join(threads[t]);
+    for (int t = 0; t < launched; t++) pthread_join(threads[t], NULL);
 
     ZXC_FREE(threads);
     ZXC_FREE(stripes);

--- a/src/lib/zxc_seekable.c
+++ b/src/lib/zxc_seekable.c
@@ -136,14 +136,11 @@ typedef struct {
 } zxc_seek_source_t;
 
 /**
- * @brief Reads @p len bytes at @p off from the archive, whatever backs it.
+ * @brief Reads a byte range from the archive, whatever backs it.
  *
- * @param[in]  src  Archive source.
- * @param[out] dst  Destination buffer of at least @p len bytes.
- * @param[in]  len  Byte count to read.
- * @param[in]  off  Absolute offset in the archive.
- * @return 1 on success, 0 if the range falls outside the archive or the
- *         caller-supplied reader came up short.
+ * Returns 1 on success, 0 if the range falls outside the archive or the
+ * caller's reader came up short: every bounds check on a parsed offset goes
+ * through here.
  */
 static int zxc_seek_source_read(const zxc_seek_source_t* src, void* dst, const size_t len,
                                 const uint64_t off) {
@@ -166,9 +163,8 @@ static int zxc_seek_source_read(const zxc_seek_source_t* src, void* dst, const s
  *   5. Read comp_sizes, build the compressed-offset prefix sums, and check the
  *      layout lands exactly on the EOF block
  *
- * @param[in] src  Archive source (buffer or reader; see @ref zxc_seek_source_t).
- * @return A newly allocated handle (free via @ref zxc_seekable_free), or NULL
- *         if the archive is too small or the seek table is missing / malformed.
+ * Returns a handle to free via @ref zxc_seekable_free, or NULL if the archive
+ * is too small or the seek table is missing / malformed.
  */
 static zxc_seekable* zxc_seekable_parse(const zxc_seek_source_t* src) {
     // Minimum: file_header(16) + eof_block(8) + seek_block_header(8)

--- a/src/lib/zxc_seekable.c
+++ b/src/lib/zxc_seekable.c
@@ -206,12 +206,14 @@ static zxc_seekable* zxc_seekable_parse(const zxc_seek_source_t* src) {
     if (UNLIKELY(num_blocks_64 > UINT32_MAX)) return NULL;
     const uint32_t num_blocks = (uint32_t)num_blocks_64;
 
-    // Step 4: locate the seek block, then read and validate it. Guard the
-    // size_t multiplication before it is used as an allocation size.
+    // Step 4: locate and validate the seek block. Two headers of margin, not one:
+    // the tail read below spans the EOF block, so tail_total could wrap on 32 bits.
     const uint64_t entries_total_64 = (uint64_t)num_blocks * ZXC_SEEK_ENTRY_SIZE;
-    if (UNLIKELY(entries_total_64 > SIZE_MAX - ZXC_BLOCK_HEADER_SIZE)) return NULL;
+    if (UNLIKELY(entries_total_64 > SIZE_MAX - 2 * ZXC_BLOCK_HEADER_SIZE)) return NULL;
+
     const size_t seek_block_total = ZXC_BLOCK_HEADER_SIZE + (size_t)entries_total_64;
     if (UNLIKELY((uint64_t)seek_block_total + ZXC_FILE_FOOTER_SIZE > src->size)) return NULL;
+
     const uint64_t seek_off = src->size - ZXC_FILE_FOOTER_SIZE - (uint64_t)seek_block_total;
     if (UNLIKELY(seek_off < ZXC_BLOCK_HEADER_SIZE)) return NULL;
 
@@ -220,14 +222,22 @@ static zxc_seekable* zxc_seekable_parse(const zxc_seek_source_t* src) {
     // reads (header, footer, tail) while validating the same layout the
     // in-memory path does.
     const size_t tail_total = ZXC_BLOCK_HEADER_SIZE + seek_block_total;
-    uint8_t* tail = (uint8_t*)ZXC_MALLOC(tail_total);
-    if (UNLIKELY(!tail)) return NULL;  // LCOV_EXCL_LINE
-    zxc_seekable* s = NULL;
-    if (UNLIKELY(!zxc_seek_source_read(src, tail, tail_total, seek_off - ZXC_BLOCK_HEADER_SIZE)))
-        goto fail;
+    const uint64_t tail_off = seek_off - ZXC_BLOCK_HEADER_SIZE;
 
-    const uint8_t* const eof_hdr = tail;
-    const uint8_t* const seek_blk = tail + ZXC_BLOCK_HEADER_SIZE;
+    uint8_t* tail = NULL;
+    const uint8_t* tail_view = src->data ? src->data + tail_off : NULL;
+    zxc_seekable* s = NULL;
+    if (!tail_view) {
+        tail = (uint8_t*)ZXC_MALLOC(tail_total);
+        if (UNLIKELY(!tail)) return NULL;  // LCOV_EXCL_LINE
+        if (UNLIKELY(!zxc_seek_source_read(src, tail, tail_total, tail_off))) goto fail;
+        tail_view = tail;
+    } else if (UNLIKELY(tail_off + tail_total > src->size)) {
+        return NULL;  // LCOV_EXCL_LINE
+    }
+
+    const uint8_t* const eof_hdr = tail_view;
+    const uint8_t* const seek_blk = tail_view + ZXC_BLOCK_HEADER_SIZE;
 
     zxc_block_header_t bh;
     if (UNLIKELY(zxc_read_block_header(seek_blk, seek_block_total, &bh) != ZXC_OK ||
@@ -624,9 +634,12 @@ static void* zxc_seek_mt_worker(void* arg) {
     uint8_t* const dict_work = dctx.dict_buffer;
     if (dict_work) ZXC_MEMCPY(dict_work, s->dict, s->dict_size);
 
-    // One read buffer per worker (they cannot share), sized from the archive-wide
-    // maximum recorded at parse time rather than by rescanning the stripe.
-    const size_t max_csz = (size_t)s->max_comp_size;
+    // Read buffer sized for the largest compressed block of the stripe.
+    size_t max_csz = 0;
+    for (uint32_t i = st->first; i < st->num_jobs; i += st->stride) {
+        const uint32_t csz = s->comp_sizes[jobs[i].block_idx];
+        if (csz > max_csz) max_csz = csz;
+    }
     uint8_t* const read_buf = (uint8_t*)ZXC_MALLOC(max_csz + ZXC_PAD_SIZE);
     if (UNLIKELY(!read_buf)) {
         // LCOV_EXCL_START

--- a/src/lib/zxc_threads.h
+++ b/src/lib/zxc_threads.h
@@ -1,0 +1,142 @@
+/*
+ * ZXC - High-performance lossless compression
+ *
+ * Copyright (c) 2025-2026 Bertrand Lebonnois and contributors.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/**
+ * @file zxc_threads.h
+ * @brief POSIX-shaped threading layer shared by the stream engine
+ *        (zxc_driver.c) and the seekable reader (zxc_seekable.c).
+ *
+ * On POSIX this is @c <pthread.h> verbatim. On Windows it maps the handful of
+ * primitives both engines use onto the Win32 API under their POSIX names, so
+ * one body of threading logic compiles everywhere. Include this instead of
+ * @c <pthread.h>.
+ */
+
+#ifndef ZXC_THREADS_H
+#define ZXC_THREADS_H
+
+#include "zxc_internal.h"
+
+// LCOV_EXCL_START - Windows platform layer, not reachable on POSIX CI
+#if defined(_WIN32)
+
+#include <process.h> /* _beginthreadex */
+#include <windows.h>
+
+typedef CRITICAL_SECTION pthread_mutex_t;
+typedef CONDITION_VARIABLE pthread_cond_t;
+typedef HANDLE pthread_t;
+
+#define pthread_mutex_init(m, a) InitializeCriticalSection(m)
+#define pthread_mutex_destroy(m) DeleteCriticalSection(m)
+#define pthread_mutex_lock(m) EnterCriticalSection(m)
+#define pthread_mutex_unlock(m) LeaveCriticalSection(m)
+
+#define pthread_cond_init(c, a) InitializeConditionVariable(c)
+#define pthread_cond_destroy(c) (void)(0)
+#define pthread_cond_wait(c, m) SleepConditionVariableCS(c, m, INFINITE)
+#define pthread_cond_signal(c) WakeConditionVariable(c)
+#define pthread_cond_broadcast(c) WakeAllConditionVariable(c)
+
+/**
+ * @brief Trampoline payload bridging the POSIX @c void*(*)(void*) worker
+ *        signature to the @c _beginthreadex entry point.
+ *
+ * Heap-allocated by the @c pthread_create shim and freed by
+ * @ref zxc_win_thread_entry once the captured worker has started.
+ */
+typedef struct {
+    void* (*func)(void*); /* worker to invoke */
+    void* arg;            /* argument forwarded to @c func */
+} zxc_win_thread_arg_t;
+
+/**
+ * @brief @c _beginthreadex entry point: unpacks the trampoline payload, frees
+ *        it, then runs the captured POSIX-style worker.
+ *
+ * @param[in] p  Heap @ref zxc_win_thread_arg_t handed over by the creator;
+ *               ownership transfers to this function.
+ * @return Always 0 (the worker's @c void* result is discarded, as on POSIX).
+ */
+static unsigned __stdcall zxc_win_thread_entry(void* p) {
+    zxc_win_thread_arg_t* a = (zxc_win_thread_arg_t*)p;
+    void* (*f)(void*) = a->func;
+    void* arg = a->arg;
+    ZXC_FREE(a);
+    f(arg);
+    return 0;
+}
+
+/**
+ * @brief @c pthread_create shim: spawns @p start_routine(@p arg) via
+ *        @c _beginthreadex, matching the POSIX prototype.
+ *
+ * @param[out] thread        Receives the thread handle on success.
+ * @param[in]  attr          Unused (POSIX attribute object); ignored.
+ * @param[in]  start_routine Worker to run on the new thread.
+ * @param[in]  arg           Opaque argument forwarded to @p start_routine.
+ * @return 0 on success, @ref ZXC_ERROR_MEMORY on allocation or spawn failure.
+ */
+static int pthread_create(pthread_t* thread, const void* attr, void* (*start_routine)(void*),
+                          void* arg) {
+    (void)attr;
+    zxc_win_thread_arg_t* wrapper = ZXC_MALLOC(sizeof(zxc_win_thread_arg_t));
+    if (UNLIKELY(!wrapper)) return ZXC_ERROR_MEMORY;
+    wrapper->func = start_routine;
+    wrapper->arg = arg;
+    uintptr_t handle = _beginthreadex(NULL, 0, zxc_win_thread_entry, wrapper, 0, NULL);
+    if (UNLIKELY(handle == 0)) {
+        ZXC_FREE(wrapper);
+        return ZXC_ERROR_MEMORY;
+    }
+    *thread = (HANDLE)handle;
+    return 0;
+}
+
+/**
+ * @brief @c pthread_join shim: blocks until @p thread finishes, then closes its
+ *        handle.
+ *
+ * @param[in] thread  Handle from a successful @c pthread_create.
+ * @param[in] retval  Unused (POSIX exit-value out-param); ignored.
+ * @return Always 0.
+ */
+static int pthread_join(pthread_t thread, void** retval) {
+    (void)retval;
+    WaitForSingleObject(thread, INFINITE);
+    CloseHandle(thread);
+    return 0;
+}
+
+/**
+ * @brief Returns the number of logical processors reported by the OS.
+ * @return Processor count from @c GetSystemInfo (always >= 1 in practice).
+ */
+static ZXC_ALWAYS_INLINE int zxc_num_procs(void) {
+    SYSTEM_INFO si;
+    GetSystemInfo(&si);
+    return (int)si.dwNumberOfProcessors;
+}
+
+#else /* POSIX */
+// LCOV_EXCL_STOP
+
+#include <pthread.h>
+#include <unistd.h>
+
+/**
+ * @brief Returns the number of online logical processors.
+ * @return @c _SC_NPROCESSORS_ONLN, clamped to a minimum of 1 if the query fails.
+ */
+static ZXC_ALWAYS_INLINE int zxc_num_procs(void) {
+    const long n = sysconf(_SC_NPROCESSORS_ONLN);
+    return (n > 0) ? (int)n : 1;
+}
+
+#endif /* _WIN32 */
+
+#endif /* ZXC_THREADS_H */

--- a/src/lib/zxc_threads.h
+++ b/src/lib/zxc_threads.h
@@ -62,7 +62,7 @@ typedef struct {
  *               ownership transfers to this function.
  * @return Always 0 (the worker's @c void* result is discarded, as on POSIX).
  */
-static unsigned __stdcall zxc_win_thread_entry(void* p) {
+static inline unsigned __stdcall zxc_win_thread_entry(void* p) {
     zxc_win_thread_arg_t* a = (zxc_win_thread_arg_t*)p;
     void* (*f)(void*) = a->func;
     void* arg = a->arg;
@@ -81,8 +81,8 @@ static unsigned __stdcall zxc_win_thread_entry(void* p) {
  * @param[in]  arg           Opaque argument forwarded to @p start_routine.
  * @return 0 on success, @ref ZXC_ERROR_MEMORY on allocation or spawn failure.
  */
-static int pthread_create(pthread_t* thread, const void* attr, void* (*start_routine)(void*),
-                          void* arg) {
+static inline int pthread_create(pthread_t* thread, const void* attr, void* (*start_routine)(void*),
+                                 void* arg) {
     (void)attr;
     zxc_win_thread_arg_t* wrapper = ZXC_MALLOC(sizeof(zxc_win_thread_arg_t));
     if (UNLIKELY(!wrapper)) return ZXC_ERROR_MEMORY;
@@ -105,7 +105,7 @@ static int pthread_create(pthread_t* thread, const void* attr, void* (*start_rou
  * @param[in] retval  Unused (POSIX exit-value out-param); ignored.
  * @return Always 0.
  */
-static int pthread_join(pthread_t thread, void** retval) {
+static inline int pthread_join(pthread_t thread, void** retval) {
     (void)retval;
     WaitForSingleObject(thread, INFINITE);
     CloseHandle(thread);

--- a/tests/test_block_api.c
+++ b/tests/test_block_api.c
@@ -678,12 +678,10 @@ int test_block_api_large_block_varint() {
 /**
  * @brief Every destination capacity must be rejected cleanly, never overrun.
  *
- * Regression guard: the encoders open with `dst_cap - ZXC_BLOCK_HEADER_SIZE`,
- * which wraps for a destination smaller than one block header. Capacities of
- * 1..7 bytes (block API) and 16..23 (frame API, after its 16-byte file header)
- * then passed every later capacity check and wrote a 12-byte sub-header out of
- * bounds. Sweeps both APIs across the small capacities with an exactly-sized
- * heap buffer, so a sanitizer build turns any overrun into a hard failure.
+ * Regression guard: `dst_cap - ZXC_BLOCK_HEADER_SIZE` used to wrap for a
+ * destination smaller than one block header, so a 12-byte sub-header was
+ * written out of bounds. The exactly-sized heap buffer makes a sanitizer build
+ * fail hard on any overrun.
  */
 int test_block_api_tiny_capacity(void) {
     printf("=== TEST: Block API - Tiny Destination Capacities ===\n");
@@ -713,17 +711,18 @@ int test_block_api_tiny_capacity(void) {
             uint8_t* dst = (uint8_t*)malloc(cap);
             if (!dst) continue;
 
+            // SRC_SIZE far exceeds MAX_CAP: every capacity here must be refused.
             const int64_t b = zxc_compress_block(cctx, src, SRC_SIZE, dst, cap, &opts);
-            if (b > 0 && (size_t)b > cap) {
-                printf("  [FAIL] compress_block level %d cap %zu returned %lld\n", level, cap,
-                       (long long)b);
+            if (b != ZXC_ERROR_DST_TOO_SMALL) {
+                printf("  [FAIL] compress_block level %d cap %zu: expected %d, got %lld\n", level,
+                       cap, ZXC_ERROR_DST_TOO_SMALL, (long long)b);
                 failures++;
             }
 
             const int64_t f = zxc_compress(src, SRC_SIZE, dst, cap, &opts);
-            if (f > 0 && (size_t)f > cap) {
-                printf("  [FAIL] compress level %d cap %zu returned %lld\n", level, cap,
-                       (long long)f);
+            if (f >= 0) {
+                printf("  [FAIL] compress level %d cap %zu: expected a rejection, got %lld\n",
+                       level, cap, (long long)f);
                 failures++;
             }
             free(dst);
@@ -736,7 +735,7 @@ int test_block_api_tiny_capacity(void) {
         printf("FAILED: %d sub-tests failed\n", failures);
         return 0;
     }
-    printf("  [PASS] capacities 1..%d rejected without overrun (levels 1-7)\n", MAX_CAP);
+    printf("  [PASS] capacities 1..%d rejected, no overrun (levels 1-7, both APIs)\n", MAX_CAP);
     printf("PASS\n\n");
     return 1;
 }

--- a/tests/test_block_api.c
+++ b/tests/test_block_api.c
@@ -674,3 +674,69 @@ int test_block_api_large_block_varint() {
     printf("PASS\n\n");
     return 1;
 }
+
+/**
+ * @brief Every destination capacity must be rejected cleanly, never overrun.
+ *
+ * Regression guard: the encoders open with `dst_cap - ZXC_BLOCK_HEADER_SIZE`,
+ * which wraps for a destination smaller than one block header. Capacities of
+ * 1..7 bytes (block API) and 16..23 (frame API, after its 16-byte file header)
+ * then passed every later capacity check and wrote a 12-byte sub-header out of
+ * bounds. Sweeps both APIs across the small capacities with an exactly-sized
+ * heap buffer, so a sanitizer build turns any overrun into a hard failure.
+ */
+int test_block_api_tiny_capacity(void) {
+    printf("=== TEST: Block API - Tiny Destination Capacities ===\n");
+
+    enum { SRC_SIZE = 4096, MAX_CAP = 40 };
+    uint8_t* src = (uint8_t*)malloc(SRC_SIZE);
+    if (!src) {
+        printf("FAILED: allocation\n");
+        return 0;
+    }
+    for (size_t i = 0; i < SRC_SIZE; i++) src[i] = (uint8_t)('a' + (i * 7 + (i >> 5)) % 26);
+
+    int failures = 0;
+    for (int level = 1; level <= 7; level++) {
+        zxc_compress_opts_t opts;
+        memset(&opts, 0, sizeof(opts));
+        opts.level = level;
+        zxc_cctx* cctx = zxc_create_cctx(&opts);
+        if (!cctx) {
+            printf("FAILED: cctx (level %d)\n", level);
+            free(src);
+            return 0;
+        }
+
+        for (size_t cap = 1; cap <= MAX_CAP; cap++) {
+            /* Exact-size buffer: a sanitizer flags any byte written past it. */
+            uint8_t* dst = (uint8_t*)malloc(cap);
+            if (!dst) continue;
+
+            const int64_t b = zxc_compress_block(cctx, src, SRC_SIZE, dst, cap, &opts);
+            if (b > 0 && (size_t)b > cap) {
+                printf("  [FAIL] compress_block level %d cap %zu returned %lld\n", level, cap,
+                       (long long)b);
+                failures++;
+            }
+
+            const int64_t f = zxc_compress(src, SRC_SIZE, dst, cap, &opts);
+            if (f > 0 && (size_t)f > cap) {
+                printf("  [FAIL] compress level %d cap %zu returned %lld\n", level, cap,
+                       (long long)f);
+                failures++;
+            }
+            free(dst);
+        }
+        zxc_free_cctx(cctx);
+    }
+    free(src);
+
+    if (failures > 0) {
+        printf("FAILED: %d sub-tests failed\n", failures);
+        return 0;
+    }
+    printf("  [PASS] capacities 1..%d rejected without overrun (levels 1-7)\n", MAX_CAP);
+    printf("PASS\n\n");
+    return 1;
+}

--- a/tests/test_common.h
+++ b/tests/test_common.h
@@ -95,6 +95,7 @@ int test_static_ctx_null_inputs(void);
 
 /* Stream API */
 int test_null_output_decompression(void);
+int test_stream_level_clamp(void);
 int test_invalid_arguments(void);
 int test_truncated_input(void);
 int test_io_failures(void);

--- a/tests/test_common.h
+++ b/tests/test_common.h
@@ -96,6 +96,8 @@ int test_static_ctx_null_inputs(void);
 /* Stream API */
 int test_null_output_decompression(void);
 int test_stream_level_clamp(void);
+int test_stream_corrupt_block_header(void);
+int test_stream_dry_run_size(void);
 int test_invalid_arguments(void);
 int test_truncated_input(void);
 int test_io_failures(void);

--- a/tests/test_common.h
+++ b/tests/test_common.h
@@ -75,6 +75,7 @@ int test_decompress_empty_frame_null_dst(void);
 /* Block API */
 int test_block_api(void);
 int test_block_api_boundary_sizes(void);
+int test_block_api_tiny_capacity(void);
 int test_block_api_large_block_varint(void);
 int test_decompress_block_safe(void);
 int test_decompress_block_bound(void);

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -80,6 +80,7 @@ static const test_entry_t g_tests[] = {
 
     /* --- Stream API --- */
     TEST_CASE(test_null_output_decompression),
+    TEST_CASE(test_stream_level_clamp),
     TEST_CASE(test_invalid_arguments),
     TEST_CASE(test_truncated_input),
     TEST_CASE(test_io_failures),

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -81,6 +81,8 @@ static const test_entry_t g_tests[] = {
     /* --- Stream API --- */
     TEST_CASE(test_null_output_decompression),
     TEST_CASE(test_stream_level_clamp),
+    TEST_CASE(test_stream_corrupt_block_header),
+    TEST_CASE(test_stream_dry_run_size),
     TEST_CASE(test_invalid_arguments),
     TEST_CASE(test_truncated_input),
     TEST_CASE(test_io_failures),

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -60,6 +60,7 @@ static const test_entry_t g_tests[] = {
     /* --- Block API --- */
     TEST_CASE(test_block_api),
     TEST_CASE(test_block_api_boundary_sizes),
+    TEST_CASE(test_block_api_tiny_capacity),
     TEST_CASE(test_block_api_large_block_varint),
     TEST_CASE(test_decompress_block_bound),
     TEST_CASE(test_decompress_block_safe),

--- a/tests/test_stream_api.c
+++ b/tests/test_stream_api.c
@@ -961,3 +961,177 @@ int test_stream_level_clamp(void) {
     if (ok) printf("PASS\n\n");
     return ok;
 }
+
+/**
+ * @brief A block header the parser cannot read must be reported as corruption.
+ *
+ * Truncating a stream after its first block and appending a footer that agrees
+ * with what was kept used to decompress as a clean, successful short read.
+ */
+int test_stream_corrupt_block_header(void) {
+    printf("=== TEST: Stream - Unreadable block header is corruption ===\n");
+
+    const size_t bs = 64 * 1024;
+    const size_t size = 3 * bs;
+    uint8_t* input = malloc(size);
+    if (!input) return 0;
+    gen_lz_data(input, size);
+
+    FILE* f_in = tmpfile();
+    FILE* f_comp = tmpfile();
+    if (!f_in || !f_comp) {
+        printf("  [SKIP] tmpfile failed\n");
+        if (f_in) fclose(f_in);
+        if (f_comp) fclose(f_comp);
+        free(input);
+        return 1;
+    }
+    fwrite(input, 1, size, f_in);
+    fseek(f_in, 0, SEEK_SET);
+
+    // No block checksum: the forged footer then only has to carry the size.
+    zxc_compress_opts_t o = {.n_threads = 1, .level = 3, .block_size = bs};
+    const int64_t csz = zxc_stream_compress(f_in, f_comp, &o);
+    fclose(f_in);
+
+    if (csz <= 0) {
+        printf("Failed: compress returned %lld\n", (long long)csz);
+        fclose(f_comp);
+        free(input);
+        return 0;
+    }
+
+    uint8_t* const arc = malloc((size_t)csz);
+    if (!arc) {
+        fclose(f_comp);
+        free(input);
+        return 0;
+    }
+    fseek(f_comp, 0, SEEK_SET);
+    const size_t got = fread(arc, 1, (size_t)csz, f_comp);
+    fclose(f_comp);
+    if (got != (size_t)csz) {
+        printf("Failed: read back %zu of %lld bytes\n", got, (long long)csz);
+        free(arc);
+        free(input);
+        return 0;
+    }
+
+    int ok = 1;
+    zxc_block_header_t bh;
+    if (zxc_read_block_header(arc + ZXC_FILE_HEADER_SIZE, ZXC_BLOCK_HEADER_SIZE, &bh) != ZXC_OK) {
+        printf("Failed: unreadable first block header\n");
+        ok = 0;
+    }
+
+    if (ok) {
+        // [file header][block 1][8 bytes no header parser accepts][footer for 1 block]
+        const size_t keep = ZXC_FILE_HEADER_SIZE + ZXC_BLOCK_HEADER_SIZE + bh.comp_size;
+        const size_t flen = keep + ZXC_BLOCK_HEADER_SIZE + ZXC_FILE_FOOTER_SIZE;
+        uint8_t* forged = malloc(flen);
+        FILE* f_bad = tmpfile();
+        if (!forged || !f_bad) {
+            printf("  [SKIP] allocation failed\n");
+            free(forged);
+            if (f_bad) fclose(f_bad);
+            free(arc);
+            free(input);
+            return 1;
+        }
+        memcpy(forged, arc, keep);
+        memset(forged + keep, 0xFF, ZXC_BLOCK_HEADER_SIZE);
+        zxc_write_file_footer(forged + keep + ZXC_BLOCK_HEADER_SIZE, ZXC_FILE_FOOTER_SIZE, bs, 0,
+                              0);
+        fwrite(forged, 1, flen, f_bad);
+        fseek(f_bad, 0, SEEK_SET);
+
+        FILE* f_out = tmpfile();
+        const int64_t d = zxc_stream_decompress(f_bad, f_out, NULL);
+        if (d != ZXC_ERROR_CORRUPT_DATA) {
+            printf("Failed: expected ZXC_ERROR_CORRUPT_DATA, got %lld\n", (long long)d);
+            ok = 0;
+        }
+        if (f_out) fclose(f_out);
+        fclose(f_bad);
+        free(forged);
+    }
+
+    free(arc);
+    free(input);
+    if (ok) printf("PASS\n\n");
+    return ok;
+}
+
+/**
+ * @brief Compressing with a NULL output reports the size the archive would take.
+ *
+ * The file header and the seek table used to be written but not counted, so the
+ * measuring run under-reported by 16 bytes, 52 with a seek table.
+ */
+int test_stream_dry_run_size(void) {
+    printf("=== TEST: Stream - NULL output measures the exact archive size ===\n");
+
+    const size_t size = 256 * 1024;
+    uint8_t* input = malloc(size);
+    if (!input) return 0;
+    gen_lz_data(input, size);
+
+    const struct {
+        const char* name;
+        int seekable;
+        int checksum;
+    } cases[] = {{"plain", 0, 0}, {"seekable", 1, 0}, {"seekable+checksum", 1, 1}};
+    int ok = 1;
+
+    for (unsigned i = 0; i < sizeof(cases) / sizeof(cases[0]) && ok; i++) {
+        zxc_compress_opts_t o = {.n_threads = 1,
+                                 .level = 3,
+                                 .block_size = 64 * 1024,
+                                 .seekable = cases[i].seekable,
+                                 .checksum_enabled = cases[i].checksum};
+        int64_t written = 0;
+        int64_t measured = 0;
+
+        for (int pass = 0; pass < 2 && ok; pass++) {
+            FILE* f_in = tmpfile();
+            FILE* f_out = pass == 0 ? tmpfile() : NULL;
+            if (!f_in || (pass == 0 && !f_out)) {
+                printf("  [SKIP] tmpfile failed\n");
+                if (f_in) fclose(f_in);
+                if (f_out) fclose(f_out);
+                free(input);
+                return 1;
+            }
+            fwrite(input, 1, size, f_in);
+            fseek(f_in, 0, SEEK_SET);
+
+            const int64_t rc = zxc_stream_compress(f_in, f_out, &o);
+            if (rc <= 0) {
+                printf("Failed: %s compress returned %lld\n", cases[i].name, (long long)rc);
+                ok = 0;
+            } else if (pass == 0) {
+                fseek(f_out, 0, SEEK_END);
+                written = ftell(f_out);
+                if (rc != written) {
+                    printf("Failed: %s returned %lld for a %lld-byte file\n", cases[i].name,
+                           (long long)rc, (long long)written);
+                    ok = 0;
+                }
+            } else {
+                measured = rc;
+            }
+            fclose(f_in);
+            if (f_out) fclose(f_out);
+        }
+
+        if (ok && measured != written) {
+            printf("Failed: %s measured %lld, wrote %lld\n", cases[i].name, (long long)measured,
+                   (long long)written);
+            ok = 0;
+        }
+    }
+
+    free(input);
+    if (ok) printf("PASS\n\n");
+    return ok;
+}

--- a/tests/test_stream_api.c
+++ b/tests/test_stream_api.c
@@ -925,6 +925,8 @@ int test_stream_level_clamp(void) {
             printf("  [SKIP] tmpfile failed\n");
             if (f_in) fclose(f_in);
             if (f_comp) fclose(f_comp);
+            free(out[0]);
+            free(out[1]);
             free(input);
             return 1;
         }

--- a/tests/test_stream_api.c
+++ b/tests/test_stream_api.c
@@ -899,3 +899,63 @@ int test_roundtrip_offset_mixed(void) {
     free(buf);
     return ok;
 }
+
+/**
+ * @brief An out-of-range level on the streaming path behaves as the maximum one.
+ *
+ * Level 99 must produce byte-for-byte what ZXC_LEVEL_ULTRA produces.
+ */
+int test_stream_level_clamp(void) {
+    printf("=== TEST: Stream - Out-of-range level clamps to ULTRA ===\n");
+
+    const size_t size = 96 * 1024;
+    uint8_t* input = malloc(size);
+    if (!input) return 0;
+    gen_lz_data(input, size);
+
+    uint8_t* out[2] = {NULL, NULL};
+    long sz[2] = {0, 0};
+    const int levels[2] = {ZXC_LEVEL_ULTRA, 99};
+    int ok = 1;
+
+    for (int i = 0; i < 2 && ok; i++) {
+        FILE* f_in = tmpfile();
+        FILE* f_comp = tmpfile();
+        if (!f_in || !f_comp) {
+            printf("  [SKIP] tmpfile failed\n");
+            if (f_in) fclose(f_in);
+            if (f_comp) fclose(f_comp);
+            free(input);
+            return 1;
+        }
+        fwrite(input, 1, size, f_in);
+        fseek(f_in, 0, SEEK_SET);
+
+        zxc_compress_opts_t o = {.n_threads = 1, .level = levels[i]};
+        const int64_t c = zxc_stream_compress(f_in, f_comp, &o);
+        if (c <= 0) {
+            printf("Failed: level %d compress returned %lld\n", levels[i], (long long)c);
+            ok = 0;
+        } else {
+            fseek(f_comp, 0, SEEK_END);
+            sz[i] = ftell(f_comp);
+            fseek(f_comp, 0, SEEK_SET);
+            out[i] = malloc((size_t)sz[i]);
+            if (!out[i] || fread(out[i], 1, (size_t)sz[i], f_comp) != (size_t)sz[i]) ok = 0;
+        }
+        fclose(f_in);
+        fclose(f_comp);
+    }
+
+    if (ok && (sz[0] != sz[1] || memcmp(out[0], out[1], (size_t)sz[0]) != 0)) {
+        printf("Failed: level 99 produced a different stream than level %d (%ld vs %ld bytes)\n",
+               ZXC_LEVEL_ULTRA, sz[0], sz[1]);
+        ok = 0;
+    }
+
+    free(out[0]);
+    free(out[1]);
+    free(input);
+    if (ok) printf("PASS\n\n");
+    return ok;
+}


### PR DESCRIPTION
 A de-duplication and clarity pass over src/lib, plus four memory-safety fixes found while doing it.
The refactor is behaviour-preserving: compressor output is byte-for-byte identical to main.

### Fixes

**A caller passing a tiny output buffer got a heap overflow**. Both block encoders started with `dst_cap - ZXC_BLOCK_HEADER_SIZE`, which wraps under 8 bytes; every capacity check after that passed and a 12-byte sub-header went out of bounds.

**Fix potential out-of-bounds read from a crafted archive**. The seekable parser computed its block count with `(total_decomp + block_size - 1) / block_size`. `total_decomp` comes from the footer, so a crafted value wraps the addition to zero blocks while the handle still advertises a huge size, and the range decoder then indexed an empty array. Now uses overflow-safe ceiling division.

**A forged seek-table header validated against a truncated size**. The comparison cast a 64-bit table size to 32 bits, so only the low half had to match. It's a 64-bit comparison now, and oversized tables are refused.

**Two leaks on stream-engine failure paths**: mutex and condition variables on one, the seek-table buffer on the other. Both go through a single teardown now.

###  Refactor

Unified the streaming engine and seekable reader architectures around a shared cross-platform threading layer, cutting duplicate logic across modules. Rebuilt the ISA dispatch ladder to resolve all chunk entry points through a single path instead of three, and merged the dual seekable parsers into a source-abstracted engine that validates buffer and callback modes identically.

Consolidated repetitive compressor and Huffman idioms into named inline helpers, and replaced five separate RLE lookahead kernels with a single implementation powered by per-ISA mask extractors.