### PR TITLE
docs(readme): Refines README documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ ZXC is a lossless compression **C library** (with official Rust, Python, Node.js
 
 - **Faster decode than LZ4, at a smaller size.** 22–75% faster decode at the default level (best on ARM64), rising to up to 2.6× in the speed-optimized tier, always at an equal-or-better compression ratio. See the [benchmarks](#benchmarks).
 - **Independently verified.** Merged into [lzbench](https://github.com/inikep/lzbench) (@inikep) and [TurboBench](https://github.com/powturbo/TurboBench) (@powturbo); every benchmark below is reproducible against 70+ codecs.
+- **Vendored in ClickHouse.** Available there as a column codec — behind `SET enable_zxc_codec = 1`. See the [ClickHouse codec reference](https://clickhouse.com/docs/reference/statements/create/table/codec).
 - **Cross-platform.** x86_64, ARM64, ARMv7, ARMv6, RISC-V, POWER (ppc64el), s390x, i386, with hand-tuned SIMD (SSE2/AVX2/AVX-512 on x86, NEON on ARMv8+).
 - **Built for "Write Once, Read Many."** Compress once at build time, decompress millions of times at run time.
 - **Production-grade.** Continuously fuzzed by Google [OSS-Fuzz](https://github.com/google/oss-fuzz), ASan/UBSan/Valgrind-clean, SLSA-signed releases, thread-safe API, BSD-3-Clause.

--- a/README.md
+++ b/README.md
@@ -52,60 +52,33 @@ The encoder does the heavy lifting upfront — match selection, optimal parsing,
 
 ## Benchmarks
 
-To ensure consistent performance, benchmarks are automatically executed on every commit via GitHub Actions.
-We monitor metrics on both **x86_64** (Linux) and **ARM64** (Apple Silicon M2) runners to track compression speed, decompression speed, and ratios.
+Silesia corpus (202 MB), single-threaded, [lzbench](https://github.com/inikep/lzbench) 2.3.1 (from
+[@inikep](https://github.com/inikep)) built with `MOREFLAGS="-march=native"`, on four reference
+machines: Apple M2 (Clang 21, macOS 26), Google Axion / Neoverse-V2 (GCC 14, GCP C4A), AMD EPYC 9B45
+/ Zen 5 (GCP C4D) and AMD EPYC 7B13 / Zen 3 (GCP C2D) — both x86 with SMT disabled. Re-run on every
+commit ([latest logs](https://github.com/hellobertrand/zxc/actions/workflows/benchmark.yml)).
 
-*(See the [latest benchmark logs](https://github.com/hellobertrand/zxc/actions/workflows/benchmark.yml))*
+**Decompression speed, against the closest competitor at each ratio tier:**
+
+| Machine | `-1` vs `lz4 --fast` | `-3` vs `lz4` | `-6` vs `lz4hc -9` | `-7` vs `zstd -1` |
+| :--- | ---: | ---: | ---: | ---: |
+| Apple M2 | **2.62x** | **1.75x** | **1.50x** | **2.60x** |
+| Axion (Neoverse-V2) | **1.92x** | **1.41x** | **1.25x** | **1.94x** |
+| EPYC 9B45 (Zen 5) | **2.20x** | **1.36x** | **1.19x** | **2.21x** |
+| EPYC 7B13 (Zen 3) | **1.81x** | **1.22x** | **1.10x** | **2.13x** |
+
+The speed is not bought with ratio: ZXC is also *smaller* in all four pairings — 61.76 vs 62.15,
+46.09 vs 47.60, 36.28 vs 36.75 and 33.09 vs 34.53 %. Per-level tables for every machine, cycles per
+byte and memory figures live in the
+**[whitepaper](docs/WHITEPAPER.md#7-performance-analysis-benchmarks)**.
 
 *Decompression Speed vs Compressed Size — ARM64 Apple M2*
 
 ![Decompression Speed vs Compressed Size](docs/images/bench-arm64.svg)
 
-
-### 1. Mobile & Client: Apple Silicon (M2)
-*Scenario: Game Assets loading, App startup.*
-
-| Target | ZXC vs Competitor | Decompression Speed | Ratio | Verdict |
-| :--- | :--- | :--- | :--- | :--- |
-| **1. Max Speed** | **ZXC -1** vs *LZ4 --fast* | **13,524 MB/s** vs 5,166 MB/s **2.62x Faster** | **61.8** vs 62.2 **Smaller** (−0.4 pp) | **ZXC** leads in raw throughput. |
-| **2. Standard** | **ZXC -3** vs *LZ4 Default* | **8,356 MB/s** vs 4,770 MB/s **1.75x Faster** | **46.1** vs 47.6 **Smaller** (−1.5 pp) | **ZXC** outperforms LZ4 in read speed and ratio. |
-| **3. Density** | **ZXC -6** vs *LZ4HC -9* | **6,740 MB/s** vs 4,503 MB/s **1.50x Faster** | **36.3** vs 36.8 **Smaller** (−0.5 pp) | **ZXC** beats LZ4HC on both decode speed and ratio. |
-| **4. Ultra** | **ZXC -7** vs *zstd -1* | **4,628 MB/s** vs 1,777 MB/s **2.60x Faster** | **33.1** vs 34.5 **Smaller** (−1.4 pp) | **ZXC -7** bridges the gap between LZ4HC and `zstd -1` — smaller output, ~2.6x faster decode. |
-
-### 2. Cloud Server: Google Axion (ARM Neoverse V2)
-*Scenario: High-throughput Microservices, ARM Cloud Instances.*
-
-| Target | ZXC vs Competitor | Decompression Speed | Ratio | Verdict |
-| :--- | :--- | :--- | :--- | :--- |
-| **1. Max Speed** | **ZXC -1** vs *LZ4 --fast* | **9,487 MB/s** vs 4,940 MB/s **1.92x Faster** | **61.8** vs 62.2 **Smaller** (−0.4 pp) | **ZXC** leads in raw throughput. |
-| **2. Standard** | **ZXC -3** vs *LZ4 Default* | **5,980 MB/s** vs 4,256 MB/s **1.41x Faster** | **46.1** vs 47.6 **Smaller** (−1.5 pp) | **ZXC** outperforms LZ4 in read speed and ratio. |
-| **3. Density** | **ZXC -6** vs *LZ4HC -9* | **4,787 MB/s** vs 3,843 MB/s **1.25x Faster** | **36.3** vs 36.8 **Smaller** (−0.5 pp) | **ZXC** beats LZ4HC on both decode speed and ratio. |
-| **4. Ultra** | **ZXC -7** vs *zstd -1* | **3,186 MB/s** vs 1,643 MB/s **1.94x Faster** | **33.1** vs 34.5 **Smaller** (−1.4 pp) | **ZXC -7** bridges the gap between LZ4HC and `zstd -1` — smaller output, ~1.9x faster decode. |
-
-### 3. Build Server: x86_64 (AMD EPYC 9B45 / Zen 5)
-*Scenario: CI/CD Pipelines compatibility.*
-
-| Target | ZXC vs Competitor | Decompression Speed | Ratio | Verdict |
-| :--- | :--- | :--- | :--- | :--- |
-| **1. Max Speed** | **ZXC -1** vs *LZ4 --fast* | **11,377 MB/s** vs 5,179 MB/s **2.20x Faster** | **61.8** vs 62.2 **Smaller** (−0.4 pp) | **ZXC** achieves higher throughput. |
-| **2. Standard** | **ZXC -3** vs *LZ4 Default* | **6,730 MB/s** vs 4,938 MB/s **1.36x Faster** | **46.1** vs 47.6 **Smaller** (−1.5 pp) | **ZXC** offers improved speed and ratio. |
-| **3. Density** | **ZXC -6** vs *LZ4HC -9* | **5,675 MB/s** vs 4,766 MB/s **1.19x Faster** | **36.3** vs 36.8 **Smaller** (−0.5 pp) | **ZXC** beats LZ4HC on both decode speed and ratio. |
-| **4. Ultra** | **ZXC -7** vs *zstd -1* | **4,149 MB/s** vs 1,877 MB/s **2.21x Faster** | **33.1** vs 34.5 **Smaller** (−1.4 pp) | **ZXC -7** bridges the gap between LZ4HC and `zstd -1` — smaller output, ~2.2x faster decode. |
-
-### 4. Production Server: x86_64 (AMD EPYC 7B13 / Zen 3)
-*Scenario: Mainstream cloud workloads (AWS c6a, Azure HBv3, GCP n2d).*
-
-| Target | ZXC vs Competitor | Decompression Speed | Ratio | Verdict |
-| :--- | :--- | :--- | :--- | :--- |
-| **1. Max Speed** | **ZXC -1** vs *LZ4 --fast* | **8,106 MB/s** vs 4,486 MB/s **1.81x Faster** | **61.8** vs 62.2 **Smaller** (−0.4 pp) | **ZXC** holds a strong lead on the legacy x86 pipeline. |
-| **2. Standard** | **ZXC -3** vs *LZ4 Default* | **4,752 MB/s** vs 3,882 MB/s **1.22x Faster** | **46.1** vs 47.6 **Smaller** (−1.5 pp) | **ZXC** delivers faster decode and smaller output. |
-| **3. Density** | **ZXC -6** vs *LZ4HC -9* | **4,101 MB/s** vs 3,725 MB/s **1.10x Faster** | **36.3** vs 36.8 **Smaller** (−0.5 pp) | **ZXC** now clears `LZ4HC -9` by 10% on decode and wins on ratio. |
-| **4. Ultra** | **ZXC -7** vs *zstd -1* | **2,840 MB/s** vs 1,332 MB/s **2.13x Faster** | **33.1** vs 34.5 **Smaller** (−1.4 pp) | **ZXC -7** bridges the gap between LZ4HC and `zstd -1` — smaller output, ~2.1x faster decode. |
-
 *Decompression Speed: ZXC vs LZ4 family at equivalent ratio tiers, across 4 CPUs (Fast ≈ 62%, Default ≈ 47%, High ≈ 37%)*
 
 ![Decompression Speed: ZXC vs LZ4 family at equivalent ratio tiers](docs/images/bench-bars.svg)
-
 
 *Effective Throughput : Ratio-Normalized Decode across ARM64 and x86 (decode x 100 / ratio%, LZ4 baseline = 1.00x)*
 
@@ -116,105 +89,6 @@ We monitor metrics on both **x86_64** (Linux) and **ARM64** (Apple Silicon M2) r
 > Raw decode speed misses half the picture: in real workloads (asset streaming, container pulls, microservice payloads), the decoder is fed by a compressed-byte source - disk, network, inter-core - whose bandwidth is the bottleneck. The right question is *how much original data is delivered per MB of compressed input*.
 >
 > Formula: `Effective (MB/s) = Decode × 100 / Ratio (%)`: combines decode speed and ratio in one number. **Every ZXC level from -1 to -7 sits above LZ4** on every architecture, peaking at **2.19x on Apple Silicon** and ranging **1.26x–1.83x** on x86 and ARM cloud platforms for levels -1 to -6. The density-optimized ULTRA level -7 now clears LZ4 as well (**1.05x–1.40x**), at a 33.09% ratio.
-
-### Benchmark ARM64 (Apple Silicon M2)
-
-Benchmarks were conducted using lzbench 2.3.1 (from @inikep), compiled with Clang 21.0.0 using *MOREFLAGS="-march=native"* on macOS Tahoe 26 (`macos-26-xlarge`). The reference hardware is an Apple M2 processor (ARM64). All performance metrics reflect single-threaded execution on the standard Silesia Corpus and the benchmark made use of [silesia.tar](https://github.com/DataCompression/corpus-collection/tree/main/Silesia-Corpus), which contains tarred files from the Silesia compression corpus.
-
-| Compressor name         | Compression| Decompress.| Compr. size | Ratio | Filename |
-| ---------------         | -----------| -----------| ----------- | ----- | -------- |
-| memcpy                  | 52809 MB/s | 52757 MB/s |   211947520 |100.00 | 1 files|
-| **zxc 0.14.0 -1**           |   875 MB/s | **13524 MB/s** |   130896291 | **61.76** | 1 files|
-| **zxc 0.14.0 -2**           |   581 MB/s | **11338 MB/s** |   114152509 | **53.86** | 1 files|
-| **zxc 0.14.0 -3**           |   244 MB/s |  **8356 MB/s** |    97697145 | **46.09** | 1 files|
-| **zxc 0.14.0 -4**           |   156 MB/s |  **7906 MB/s** |    91125656 | **42.99** | 1 files|
-| **zxc 0.14.0 -5**           |  92.0 MB/s |  **7394 MB/s** |    85688426 | **40.43** | 1 files|
-| **zxc 0.14.0 -6**           |  12.6 MB/s |  **6740 MB/s** |    76900563 | **36.28** | 1 files|
-| **zxc 0.14.0 -7**           |  8.36 MB/s |  **4628 MB/s** |    70129884 | **33.09** | 1 files|
-| lz4 1.10.0              |   796 MB/s |  4770 MB/s |   100880800 | 47.60 | 1 files|
-| lz4 1.10.0 --fast -17   |  1347 MB/s |  5166 MB/s |   131732802 | 62.15 | 1 files|
-| lz4hc 1.10.0 -9         |  42.2 MB/s |  4503 MB/s |    77884448 | 36.75 | 1 files|
-| lzav 5.16 -1            |   681 MB/s |  3860 MB/s |    84577911 | 39.91 | 1 files|
-| snappy 1.2.2            |   877 MB/s |  3253 MB/s |   101415443 | 47.85 | 1 files|
-| zstd 1.5.7 --fast --1   |   690 MB/s |  2513 MB/s |    86916294 | 41.01 | 1 files|
-| zstd 1.5.7 -1           |   572 MB/s |  1777 MB/s |    73193704 | 34.53 | 1 files|
-| zstd 1.5.7 -3           |   392 MB/s |  1695 MB/s |    66133500 | 31.20 | 1 files|
-| zlib 1.3.2 -1           |   148 MB/s |   410 MB/s |    77259029 | 36.45 | 1 files|
-
-
-### Benchmark ARM64 (Google Axion Neoverse-V2)
-
-Benchmarks were conducted using lzbench 2.3.1 (from @inikep), compiled with GCC 14.3.0 using *MOREFLAGS="-march=native"* on 64-bit Linux. The reference hardware is a Google Axion (Neoverse-V2) processor on a **Google Cloud C4A** instance (ARM64, 1 thread per core). All performance metrics reflect single-threaded execution on the standard Silesia Corpus and the benchmark made use of [silesia.tar](https://github.com/DataCompression/corpus-collection/tree/main/Silesia-Corpus), which contains tarred files from the Silesia compression corpus.
-
-| Compressor name         | Compression| Decompress.| Compr. size | Ratio | Filename |
-| ---------------         | -----------| -----------| ----------- | ----- | -------- |
-| memcpy                  | 25659 MB/s | 25055 MB/s |   211947520 |100.00 | 1 files|
-| **zxc 0.14.0 -1**           |   878 MB/s |  **9487 MB/s** |   130896291 | **61.76** | 1 files|
-| **zxc 0.14.0 -2**           |   589 MB/s |  **7834 MB/s** |   114152509 | **53.86** | 1 files|
-| **zxc 0.14.0 -3**           |   237 MB/s |  **5980 MB/s** |    97697145 | **46.09** | 1 files|
-| **zxc 0.14.0 -4**           |   163 MB/s |  **5675 MB/s** |    91125656 | **42.99** | 1 files|
-| **zxc 0.14.0 -5**           |  95.7 MB/s |  **5310 MB/s** |    85688426 | **40.43** | 1 files|
-| **zxc 0.14.0 -6**           |  11.5 MB/s |  **4787 MB/s** |    76900563 | **36.28** | 1 files|
-| **zxc 0.14.0 -7**           |  7.81 MB/s |  **3186 MB/s** |    70129884 | **33.09** | 1 files|
-| lz4 1.10.0              |   728 MB/s |  4256 MB/s |   100880800 | 47.60 | 1 files|
-| lz4 1.10.0 --fast -17   |  1272 MB/s |  4940 MB/s |   131732802 | 62.15 | 1 files|
-| lz4hc 1.10.0 -9         |  44.2 MB/s |  3843 MB/s |    77884448 | 36.75 | 1 files|
-| lzav 5.16 -1            |   649 MB/s |  2916 MB/s |    84577911 | 39.91 | 1 files|
-| snappy 1.2.2            |   755 MB/s |  2289 MB/s |   101415443 | 47.85 | 1 files|
-| zstd 1.5.7 --fast --1   |   605 MB/s |  2291 MB/s |    86916294 | 41.01 | 1 files|
-| zstd 1.5.7 -1           |   522 MB/s |  1643 MB/s |    73193704 | 34.53 | 1 files|
-| zstd 1.5.7 -3           |   324 MB/s |  1518 MB/s |    66133500 | 31.20 | 1 files|
-| zlib 1.3.2 -1           |   115 MB/s |   389 MB/s |    77259029 | 36.45 | 1 files|
-
-
-### Benchmark x86_64 (AMD EPYC 9B45)
-
-Benchmarks were conducted using lzbench 2.3.1 (from @inikep), compiled with GCC 14.3.0 using *MOREFLAGS="-march=native"* on 64-bit Linux. The reference hardware is an AMD EPYC 9B45 processor on a **Google Cloud C4D** instance (x86_64, SMT disabled — 1 thread per core). All performance metrics reflect single-threaded execution on the standard Silesia Corpus and the benchmark made use of [silesia.tar](https://github.com/DataCompression/corpus-collection/tree/main/Silesia-Corpus), which contains tarred files from the Silesia compression corpus.
-
-| Compressor name         | Compression| Decompress.| Compr. size | Ratio | Filename |
-| ---------------         | -----------| -----------| ----------- | ----- | -------- |
-| memcpy                  | 26038 MB/s | 26039 MB/s |   211947520 |100.00 | 1 files|
-| **zxc 0.14.0 -1**           |   848 MB/s | **11377 MB/s** |   130896291 | **61.76** | 1 files|
-| **zxc 0.14.0 -2**           |   570 MB/s | **10243 MB/s** |   114152509 | **53.86** | 1 files|
-| **zxc 0.14.0 -3**           |   240 MB/s |  **6730 MB/s** |    97697145 | **46.09** | 1 files|
-| **zxc 0.14.0 -4**           |   164 MB/s |  **6357 MB/s** |    91125656 | **42.99** | 1 files|
-| **zxc 0.14.0 -5**           |  97.7 MB/s |  **5970 MB/s** |    85688426 | **40.43** | 1 files|
-| **zxc 0.14.0 -6**           |  12.4 MB/s |  **5675 MB/s** |    76900563 | **36.28** | 1 files|
-| **zxc 0.14.0 -7**           |  7.32 MB/s |  **4149 MB/s** |    70129884 | **33.09** | 1 files|
-| lz4 1.10.0              |   767 MB/s |  4938 MB/s |   100880800 | 47.60 | 1 files|
-| lz4 1.10.0 --fast -17   |  1284 MB/s |  5179 MB/s |   131732802 | 62.15 | 1 files|
-| lz4hc 1.10.0 -9         |  45.0 MB/s |  4766 MB/s |    77884448 | 36.75 | 1 files|
-| lzav 5.16 -1            |   683 MB/s |  3483 MB/s |    84577911 | 39.91 | 1 files|
-| snappy 1.2.2            |   741 MB/s |  2073 MB/s |   101512076 | 47.89 | 1 files|
-| zstd 1.5.7 --fast --1   |   657 MB/s |  2423 MB/s |    86916294 | 41.01 | 1 files|
-| zstd 1.5.7 -1           |   599 MB/s |  1877 MB/s |    73193704 | 34.53 | 1 files|
-| zstd 1.5.7 -3           |   363 MB/s |  1709 MB/s |    66133500 | 31.20 | 1 files|
-| zlib 1.3.2 -1           |   135 MB/s |   392 MB/s |    77259029 | 36.45 | 1 files|
-
-
-### Benchmark x86_64 (AMD EPYC 7B13)
-
-Benchmarks were conducted using lzbench 2.3.1 (from @inikep), compiled with GCC 14.3.0 using *MOREFLAGS="-march=native"* on 64-bit Linux. The reference hardware is an AMD EPYC 7B13 64-Core processor on a **Google Cloud C2D** instance (x86_64, SMT disabled — 1 thread per core). All performance metrics reflect single-threaded execution on the standard Silesia Corpus and the benchmark made use of [silesia.tar](https://github.com/DataCompression/corpus-collection/tree/main/Silesia-Corpus), which contains tarred files from the Silesia compression corpus.
-
-| Compressor name         | Compression| Decompress.| Compr. size | Ratio | Filename |
-| ---------------         | -----------| -----------| ----------- | ----- | -------- |
-| memcpy                  | 23720 MB/s | 23767 MB/s |   211947520 |100.00 | 1 files|
-| **zxc 0.14.0 -1**           |   712 MB/s |  **8106 MB/s** |   130896291 | **61.76** | 1 files|
-| **zxc 0.14.0 -2**           |   470 MB/s |  **6746 MB/s** |   114152509 | **53.86** | 1 files|
-| **zxc 0.14.0 -3**           |   198 MB/s |  **4752 MB/s** |    97697145 | **46.09** | 1 files|
-| **zxc 0.14.0 -4**           |   139 MB/s |  **4562 MB/s** |    91125656 | **42.99** | 1 files|
-| **zxc 0.14.0 -5**           |  83.3 MB/s |  **4403 MB/s** |    85688426 | **40.43** | 1 files|
-| **zxc 0.14.0 -6**           |  10.2 MB/s |  **4101 MB/s** |    76900563 | **36.28** | 1 files|
-| **zxc 0.14.0 -7**           |  6.89 MB/s |  **2840 MB/s** |    70129884 | **33.09** | 1 files|
-| lz4 1.10.0              |   640 MB/s |  3882 MB/s |   100880800 | 47.60 | 1 files|
-| lz4 1.10.0 --fast -17   |  1113 MB/s |  4486 MB/s |   131732802 | 62.15 | 1 files|
-| lz4hc 1.10.0 -9         |  37.0 MB/s |  3725 MB/s |    77884448 | 36.75 | 1 files|
-| lzav 5.16 -1            |   491 MB/s |  2958 MB/s |    84577911 | 39.91 | 1 files|
-| snappy 1.2.2            |   663 MB/s |  1737 MB/s |   101512076 | 47.89 | 1 files|
-| zstd 1.5.7 --fast --1   |   482 MB/s |  1766 MB/s |    86916294 | 41.01 | 1 files|
-| zstd 1.5.7 -1           |   439 MB/s |  1332 MB/s |    73193704 | 34.53 | 1 files|
-| zstd 1.5.7 -3           |   231 MB/s |  1194 MB/s |    66133500 | 31.20 | 1 files|
-| zlib 1.3.2 -1           |   106 MB/s |   356 MB/s |    77259029 | 36.45 | 1 files|
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -106,283 +106,56 @@ ZXC is packaged across major ecosystems and kept current by their maintainers:
 [![PyPi](https://img.shields.io/pypi/v/zxc-compress)](https://pypi.org/project/zxc-compress)
 [![npm](https://img.shields.io/npm/v/zxc-compress)](https://www.npmjs.com/package/zxc-compress)
 
-### Option 1: Download Release (GitHub)
+| Ecosystem | Install |
+| :--- | :--- |
+| [vcpkg](https://vcpkg.io/) | `vcpkg install zxc`, or `"dependencies": ["zxc"]` in `vcpkg.json` |
+| [Conan](https://conan.io/) | `conan install -r conancenter --requires="zxc/[*]" --build=missing`, or `zxc/[*]` under `[requires]` in `conanfile.txt` |
+| [Homebrew](https://formulae.brew.sh/formula/zxc) | `brew install zxc` |
+| winget (Windows 10 1709+) | `winget install hellobertrand.zxc` |
+| Rust / Python / Node.js | `cargo add zxc-compress` &middot; `pip install zxc-compress` &middot; `npm install zxc-compress` |
 
-1.  Go to the [Releases page](https://github.com/hellobertrand/zxc/releases).
-2.  Download the archive matching your architecture (replace `<version>` with the release, e.g. `0.14.0`):
+The vcpkg and Conan Center recipes are maintained by their respective communities; if a version
+lags behind, open an issue on that registry's index repository.
 
-    **macOS:**
-    *   `zxc-<version>-macos-arm64.tar.gz` (NEON optimizations included).
+### From a release archive
 
-    **Linux:**
-    *   `zxc-<version>-linux-arm64.tar.gz` (NEON optimizations included).
-    *   `zxc-<version>-linux-x86_64.tar.gz` (Runtime dispatch for AVX2/AVX512).
+Pick the archive for your platform on the [Releases page](https://github.com/hellobertrand/zxc/releases)
+— `zxc-<version>-{linux,macos}-{x86_64,arm64}.tar.gz` or `zxc-<version>-windows-{x86_64,arm64}.zip`.
+x86_64 builds dispatch AVX2/AVX-512 at runtime; ARM64 builds carry NEON. `zxc-<version>.tar.gz` is
+the canonical source, reproducible with
+`git archive --format=tar --prefix=zxc-<version>/ v<version> | gzip -n -9`; `zxc-<version>.tar.zxc`
+is that same tar compressed with `zxc -7`, readable only by a `zxc` whose format version matches, so
+keep the `.tar.gz` for archival.
 
-    **Windows:**
-    *   `zxc-<version>-windows-x86_64.zip` (Runtime dispatch for AVX2/AVX512).
-    *   `zxc-<version>-windows-arm64.zip` (NEON optimizations included).
+Verify before extracting — the manifest is signed, so check it first:
 
-    **Source:**
-    *   `zxc-<version>.tar.gz` — canonical source, reproducible with
-        `git archive --format=tar --prefix=zxc-<version>/ v<version> | gzip -n -9`.
-    *   `zxc-<version>.tar.zxc` — the same tar compressed with `zxc -7`. Readable only by a
-        `zxc` whose format version matches, so keep the `.tar.gz` for archival.
-
-3.  Verify, then extract:
-    ```bash
-    # Integrity: the manifest is signed, so verify it before trusting it
-    minisign -Vm checksums.sha256 -P 'RWQV0cpiyJYPkxF5iIysJzKNtzcGphqeyyFkiFErLMo5UZkWisGBxkNB'
-    sha256sum -c checksums.sha256 --ignore-missing      # macOS: grep <file> checksums.sha256 | shasum -a 256 -c
-
-    # Authenticity: this workflow, from the commit the release points at
-    gh attestation verify zxc-<version>-linux-x86_64.tar.gz --repo hellobertrand/zxc
-
-    # Extract
-    tar -xzf zxc-<version>-linux-x86_64.tar.gz
-    sudo cp -r zxc-<version>-linux-x86_64/* /usr/local/
-    ```
-
-    Release tags are PGP-signed: `curl -sS https://github.com/hellobertrand.gpg | gpg --import`
-    then `git verify-tag v<version>`.
-
-    Each archive contains a versioned top-level directory with:
-    ```
-    bin/zxc                          # CLI binary
-    include/                         # C headers (zxc.h, zxc_buffer.h, ...)
-    lib/libzxc.a                     # Static library
-    lib/pkgconfig/libzxc.pc          # pkg-config support
-    lib/cmake/zxc/zxcConfig.cmake    # CMake find_package(zxc) support
-    ```
-
-4.  Use in your project:
-
-    **CMake:**
-    ```cmake
-    find_package(zxc REQUIRED)
-    target_link_libraries(myapp PRIVATE zxc::zxc_lib)
-    ```
-
-    **pkg-config:**
-    ```bash
-    cc myapp.c $(pkg-config --cflags --libs libzxc) -o myapp
-    ```
-
-### Option 2: vcpkg
-
-**Classic mode:**
 ```bash
-vcpkg install zxc
+minisign -Vm checksums.sha256 -P 'RWQV0cpiyJYPkxF5iIysJzKNtzcGphqeyyFkiFErLMo5UZkWisGBxkNB'
+sha256sum -c checksums.sha256 --ignore-missing      # macOS: grep <file> checksums.sha256 | shasum -a 256 -c
+gh attestation verify zxc-<version>-linux-x86_64.tar.gz --repo hellobertrand/zxc
+
+tar -xzf zxc-<version>-linux-x86_64.tar.gz
+sudo cp -r zxc-<version>-linux-x86_64/* /usr/local/
 ```
 
-**Manifest mode** (add to `vcpkg.json`):
-```json
-{
-  "dependencies": ["zxc"]
-}
-```
+Each archive holds `bin/zxc`, `include/`, `lib/libzxc.a`, `lib/pkgconfig/libzxc.pc` and
+`lib/cmake/zxc/zxcConfig.cmake`. Release tags are PGP-signed: `curl -sS https://github.com/hellobertrand.gpg | gpg --import`
+then `git verify-tag v<version>`. Full verification path: [SECURITY.md](.github/SECURITY.md).
 
-Then in your CMake project:
+### In your project
+
 ```cmake
-find_package(zxc CONFIG REQUIRED)
+find_package(zxc REQUIRED)          # find_package(zxc CONFIG REQUIRED) via vcpkg or Conan
 target_link_libraries(myapp PRIVATE zxc::zxc_lib)
 ```
 
-### Option 3: Conan
-
-You also can download and install zxc using the [Conan](https://conan.io/) package manager:
-
 ```bash
-    conan install -r conancenter --requires="zxc/[*]" --build=missing
+cc myapp.c $(pkg-config --cflags --libs libzxc) -o myapp
 ```
 
-Or add to your `conanfile.txt`:
-```ini
-[requires]
-zxc/[*]
-```
-
-The zxc package in Conan Center is kept up to date by
-[ConanCenterIndex](https://github.com/conan-io/conan-center-index) contributors.
-If the version is out of date, please create an issue or pull request on the Conan Center Index repository.
-
-### Option 4: Homebrew
-
-```bash
-brew install zxc
-```
-
-The formula is maintained in [homebrew-core](https://formulae.brew.sh/formula/zxc).
-
-### Option 5: Meson Subproject
-
-zxc ships a native `meson.build`, so any Meson project can pull it in as a
-subproject or via [WrapDB](https://mesonbuild.com/Wrapdb-projects.html).
-
-**1. Create `subprojects/zxc.wrap`:**
-```ini
-[wrap-git]
-url = https://github.com/hellobertrand/zxc.git
-revision = head
-depth = 1
-
-[provide]
-libzxc = libzxc_dep
-```
-
-**2. Use the dependency in your `meson.build`:**
-```meson
-zxc_dep = dependency('libzxc', fallback : ['zxc', 'libzxc_dep'])
-executable('myapp', 'main.c', dependencies : zxc_dep)
-```
-
-**3. Build:**
-```bash
-meson setup build
-meson compile -C build
-```
-
-When consumed as a subproject, only the library is built (CLI and tests are
-skipped automatically).
-
-### Option 6: CMake Subproject (vendored)
-
-zxc can be vendored directly into a CMake build, either as a git submodule with
-`add_subdirectory()` or through `FetchContent`:
-
-```cmake
-include(FetchContent)
-FetchContent_Declare(zxc
-    GIT_REPOSITORY https://github.com/hellobertrand/zxc.git
-    GIT_TAG        v0.14.0
-)
-FetchContent_MakeAvailable(zxc)
-
-target_link_libraries(myapp PRIVATE zxc::zxc_lib)
-```
-
-`zxc::zxc_lib` is the same target name the installed package exports, so
-switching between a vendored copy and `find_package(zxc)` needs no other
-change.
-
-When zxc is not the top-level project it builds the library only: the CLI, the
-tests, `-march=native`, LTO and the install rules all default to off, so the
-embedding project keeps full control of its own CTest registration and install
-set. Any of them can still be turned back on explicitly (`-DZXC_BUILD_CLI=ON`,
-`-DZXC_NATIVE_ARCH=ON`, `-DZXC_INSTALL=ON`, ...). `-march=native` is also
-ignored whenever CMake is cross-compiling, since it would encode the build
-host's ISA.
-
-Compiler flags follow the same rule. Vendored, zxc adds nothing to what it
-inherits from the parent: the optimisation level comes from the build type, and
-the warning level (`-Wall -Wextra`, `/W3`) and code generation policy
-(`-fomit-frame-pointer`, `-fstrict-aliasing`, `-ffunction-sections`,
-`-fdata-sections` and the matching dead-strip link options) are the embedding
-project's to set. An embedder that builds with frame pointers for its profiler,
-its own aliasing rules or a quiet build log keeps them. A configure-time warning
-fires if neither a build type nor an optimisation flag is set, since zxc would
-then be built unoptimised.
-
-Third-party code is vendored, never probed: `rapidhash.h` comes from the copy in
-the tree unless `-DZXC_USE_SYSTEM_RAPIDHASH=ON` asks for a system one, so a
-build cannot silently pick up a header from the host.
-
-### Option 7: Winget
-
-**Requirements:** Windows 10 1709 (or later)
-
-Use winget to install the zxc CLI: 
-
-```ps1
-winget install hellobertrand.zxc
-```
-
-### Option 8: Building from Source (CMake)
-
-**Requirements:** CMake (3.14+), C17 Compiler (Clang/GCC/MSVC).
-
-```bash
-git clone https://github.com/hellobertrand/zxc.git
-cd zxc
-cmake -B build -DCMAKE_BUILD_TYPE=Release
-cmake --build build --parallel
-
-# Run tests
-ctest --test-dir build -C Release --output-on-failure
-
-# CLI usage
-./build/zxc --help
-
-# Install library, headers, and CMake/pkg-config files
-sudo cmake --install build
-```
-
-#### CMake Options
-
-| Option | Default (standalone) | Default (vendored) | Description |
-|--------|----------------------|--------------------|-------------|
-| `BUILD_SHARED_LIBS` | OFF | OFF | Build shared libraries instead of static (`libzxc.so`, `libzxc.dylib`, `zxc.dll`) |
-| `ZXC_NATIVE_ARCH` | ON | OFF | Enable `-march=native` for maximum performance |
-| `ZXC_ENABLE_LTO` | ON | OFF | Enable Link-Time Optimization (LTO) |
-| `ZXC_PGO_MODE` | OFF | OFF | Profile-Guided Optimization mode (`OFF`, `GENERATE`, `USE`) |
-| `ZXC_BUILD_CLI` | ON | OFF | Build command-line interface |
-| `ZXC_BUILD_TESTS` | ON | OFF | Build unit tests |
-| `ZXC_INSTALL` | ON | OFF | Generate install rules (headers, pkg-config, CMake package) |
-| `ZXC_ENABLE_COVERAGE` | OFF | OFF | Enable code coverage generation (disables LTO/PGO) |
-| `ZXC_DISABLE_SIMD` | OFF | OFF | Disable hand-written SIMD paths (AVX2/AVX512/NEON) |
-| `ZXC_USE_SYSTEM_RAPIDHASH` | OFF | OFF | Use a system-installed `rapidhash.h` instead of the vendored copy |
-
-"Vendored" is a build where zxc is not the top-level project (`add_subdirectory()`,
-`FetchContent`): the embedding project then keeps control of its own compiler flags,
-test registration and install set.
-
-```bash
-# Build shared library
-cmake -B build -DBUILD_SHARED_LIBS=ON
-
-# Portable build (without -march=native)
-cmake -B build -DZXC_NATIVE_ARCH=OFF
-
-# Library only (no CLI, no tests)
-cmake -B build -DZXC_BUILD_CLI=OFF -DZXC_BUILD_TESTS=OFF
-
-# Code coverage build
-cmake -B build -DZXC_ENABLE_COVERAGE=ON
-
-# Disable explicit SIMD code paths (compiler auto-vectorisation is unaffected)
-cmake -B build -DZXC_DISABLE_SIMD=ON
-```
-
-#### Profile-Guided Optimization (PGO)
-
-PGO uses runtime profiling data to optimize branch layout, inlining decisions, and code placement.
-
-**Step 1 - Build with instrumentation:**
-```bash
-cmake -B build -DCMAKE_BUILD_TYPE=Release -DZXC_PGO_MODE=GENERATE
-cmake --build build --parallel
-```
-
-**Step 2 - Run a representative workload to collect profile data:**
-```bash
-# Run the test suite (exercises all block types and compression levels)
-./build/zxc_test
-
-# Or compress/decompress representative data
-./build/zxc -b your_data_file
-```
-
-**Step 3 - (Clang only) Merge raw profiles:**
-```bash
-# Clang generates .profraw files that must be merged before use
-llvm-profdata merge -output=build/pgo/default.profdata build/pgo/*.profraw
-```
-> GCC uses a directory-based format and does not require this step.
-
-**Step 4 - Rebuild with profile data:**
-```bash
-cmake -B build -DCMAKE_BUILD_TYPE=Release -DZXC_PGO_MODE=USE
-cmake --build build --parallel
-```
+Vendoring zxc instead — CMake `FetchContent` or `add_subdirectory()`, a Meson subproject or WrapDB —
+and building from source, with the full option table and the PGO workflow:
+**[docs/INSTALL.md](docs/INSTALL.md)**.
 
 ### Packaging Status
 
@@ -508,30 +281,20 @@ The dictionary is stored as an external `.zxd` file — content plus shared lite
 The CLI is perfect for benchmarking or manually compressing assets.
 
 ```bash
-# Basic Compression (Level 3 is default)
-zxc -z input_file output_file
+# Compress. -z is implied, and the output name defaults to <input>.zxc
+zxc assets.tar                        # level 3 (default) -> assets.tar.zxc
+zxc -z -5 assets.tar assets.tar.zxc   # level 5
+zxc -z -S assets.tar assets.tar.zxc   # seekable: O(1) random-access decompression
 
-# High Compression (Level 5)
-zxc -z -5 input_file output_file
+# Decompress. "unzxc" is installed as an alias for "zxc -d"
+zxc -d assets.tar.zxc assets.tar
+unzxc assets.tar.zxc assets.tar
 
-# Seekable Archive (enables O(1) random-access decompression)
-zxc -z -S input_file output_file
-
-# -z for compression can be omitted
-zxc input_file output_file
-
-# as well as output file; it will be automatically assigned to input_file.zxc
-zxc input_file
-
-# Decompression
-zxc -d compressed_file output_file
-
-# When installed, "unzxc" is an alias for "zxc -d"
-unzxc compressed_file output_file
-
-# Benchmark Mode (Testing speed on your machine)
-zxc -b input_file
+# Benchmark mode (testing speed on your machine)
+zxc -b assets.tar
 ```
+
+Every option is in `zxc --help` and the [man page](docs/man/zxc.1.md).
 
 #### Using with `tar`
 
@@ -553,9 +316,12 @@ zxc -d < archive.tar.zxc | tar xf -
 
 ### 2. API
 
-ZXC provides a **thread-safe API** with two usage patterns. Parameters are passed through dedicated options structs, making call sites self-documenting and forward-compatible.
+ZXC provides a **thread-safe API** with two usage patterns. Parameters are passed through dedicated
+options structs, making call sites self-documenting and forward-compatible. Buffers are
+caller-allocated with explicit bounds, calls are stateless, checksum validation is optional, block
+sizes run from 4 KB to 2 MB (powers of two), and streaming is multi-threaded with auto-detection of
+the CPU core count.
 
-#### Buffer API (In-Memory)
 ```c
 #include "zxc.h"
 
@@ -573,55 +339,14 @@ zxc_decompress_opts_t d_opts = { .checksum_enabled = 1 };
 int64_t decompressed_size = zxc_decompress(src, src_size, dst, dst_capacity, &d_opts);
 ```
 
-#### Stream API (Files, Multi-Threaded)
-```c
-#include "zxc.h"
+The same options structs drive the other entry points: `zxc_stream_compress()` /
+`zxc_stream_decompress()` for multi-threaded file streaming, reusable `zxc_cctx` / `zxc_dctx`
+contexts for tight loops where per-call `malloc`/`free` overhead matters (settings are **sticky**,
+so passing `NULL` reuses those given at creation), and `.seekable = 1` to append a seek table for
+O(1) random-access decompression.
 
-// Compression (auto-detect threads, level 3, checksum on)
-zxc_compress_opts_t c_opts = {
-    .n_threads        = 0,               // 0 = auto
-    .level            = ZXC_LEVEL_DEFAULT,
-    .checksum_enabled = 1,
-    /* .block_size = 0 -> 512 KB default */
-};
-int64_t bytes_written = zxc_stream_compress(f_in, f_out, &c_opts);
-
-// Decompression
-zxc_decompress_opts_t d_opts = { .n_threads = 0, .checksum_enabled = 1 };
-int64_t bytes_out = zxc_stream_decompress(f_in, f_out, &d_opts);
-```
-
-#### Reusable Context API (Low-Latency / Embedded)
-
-For tight loops (e.g. filesystem plug-ins) where per-call `malloc`/`free`
-overhead matters, use opaque reusable contexts.
-Options are **sticky** - settings from `zxc_create_cctx()` are reused when
-passing `NULL`:
-```c
-#include "zxc.h"
-
-zxc_compress_opts_t opts = { .level = 3, .checksum_enabled = 0 };
-zxc_cctx* cctx = zxc_create_cctx(&opts);   // allocate once, settings remembered
-zxc_dctx* dctx = zxc_create_dctx();        // allocate once
-
-// reuse across many blocks - NULL reuses sticky settings:
-int64_t csz = zxc_compress_cctx(cctx, src, src_sz, dst, dst_cap, NULL);
-int64_t dsz = zxc_decompress_dctx(dctx, dst, csz, out, src_sz, NULL);
-
-zxc_free_cctx(cctx);
-zxc_free_dctx(dctx);
-```
-
-**Features:**
-- Caller-allocated buffers with explicit bounds
-- Thread-safe (stateless)
-- Configurable block sizes (4 KB – 2 MB, powers of 2)
-- Multi-threaded streaming (auto-detects CPU cores)
-- Optional checksum validation
-- Reusable contexts for high-frequency call sites
-- Seekable archives: optional seek table for O(1) random-access decompression (`.seekable = 1`)
-
-**[👉 See complete examples and advanced usage](docs/EXAMPLES.md)**
+**[👉 See complete examples and advanced usage](docs/EXAMPLES.md)** — stream API, reusable contexts,
+seekable readers, dictionaries and numeric pre-filters, as full compilable programs.
 
 ## Language Bindings
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ZXC - Seekable Lossless Compression Built for Ultra-Fast Decode
+# ZXC - Lossless Compression Built for Ultra-Fast Decode
 
 [![Build & Release](https://github.com/hellobertrand/zxc/actions/workflows/build.yml/badge.svg)](https://github.com/hellobertrand/zxc/actions/workflows/build.yml)
 [![Code Quality](https://github.com/hellobertrand/zxc/actions/workflows/quality.yml/badge.svg)](https://github.com/hellobertrand/zxc/actions/workflows/quality.yml)
@@ -139,8 +139,21 @@ sudo cp -r zxc-<version>-linux-x86_64/* /usr/local/
 ```
 
 Each archive holds `bin/zxc`, `include/`, `lib/libzxc.a`, `lib/pkgconfig/libzxc.pc` and
-`lib/cmake/zxc/zxcConfig.cmake`. Release tags are PGP-signed: `curl -sS https://github.com/hellobertrand.gpg | gpg --import`
-then `git verify-tag v<version>`. Full verification path: [SECURITY.md](.github/SECURITY.md).
+`lib/cmake/zxc/zxcConfig.cmake`.
+
+Release tags are PGP-signed. Check the key's fingerprint against the one published in
+[SECURITY.md](.github/SECURITY.md) *before* importing it — otherwise the import is circular, and
+`git verify-tag` would validate a signature made by whatever key the download happened to supply
+(it also exits 0 for a key you have never certified):
+
+```bash
+curl -sS https://github.com/hellobertrand.gpg -o zxc-maintainer.gpg
+gpg --show-keys --with-fingerprint zxc-maintainer.gpg   # compare with .github/SECURITY.md
+gpg --import zxc-maintainer.gpg                         # only once it matches
+git verify-tag v<version>
+```
+
+Full verification path: [SECURITY.md](.github/SECURITY.md).
 
 ### In your project
 

--- a/README.md
+++ b/README.md
@@ -216,61 +216,38 @@ The required margin is one block, the accumulated per-block framing overhead, th
 
 ## Dictionary Compression
 
-For workloads compressed in **small blocks** (4 KB–128 KB), a pre-trained dictionary dramatically improves compression ratio. Because the dictionary prefills the LZ77 sliding window at the *start of each block*, the benefit is per-block: a block only has its own preceding bytes as history, so the smaller the block, the more it leans on the dictionary for representative patterns. This applies whether the input is a single small payload or a large payload split into many small blocks — any time the block size is small enough that early bytes would otherwise lack history to match against.
+For workloads compressed in **small blocks** (4 KB–128 KB), a pre-trained dictionary dramatically
+improves compression ratio. It prefills the LZ77 sliding window at the *start of each block*, so the
+benefit is per-block: the smaller the block, the less history of its own it has and the more it
+leans on the dictionary. That holds for a single small payload as much as for a large one split into
+many small blocks — anywhere early bytes would otherwise have nothing to match against.
 
-A `.zxd` also carries a **shared literal Huffman table**, trained on the post-LZ literal distribution of the corpus: blocks it encodes well drop their own 128-byte table header, a fixed cost small blocks cannot amortize. It applies at levels 6-7 only (the levels with Huffman-coded literals), and the CLI handles it end to end — `--train` always writes one, `-D` always loads it. Attaching it from the C API is [API.md §11b](docs/API.md#11b-dictionary-api).
+A `.zxd` also carries a **shared literal Huffman table**, trained on the post-LZ literal
+distribution of the corpus: blocks it encodes well drop their own 128-byte table header, a fixed
+cost small blocks cannot amortize. It codes literals at levels 6-7 only, and the CLI handles it end
+to end — `--train` always writes one, `-D` always loads it.
 
-**Typical use cases:** JSON API responses, small game assets, structured logs, key-value store records, RPC messages, and any large but homogeneous corpus compressed in small blocks for random access (e.g. seekable archives).
-
-### Training a dictionary
+**Typical use cases:** JSON API responses, small game assets, structured logs, key-value store
+records, RPC messages, and any large but homogeneous corpus compressed in small blocks for random
+access (e.g. seekable archives).
 
 ```bash
-# Train a dictionary from a corpus of similar files.
-# Without -o the dictionary is written as ./dictionary_<dict_id>.zxd.
+# Train from a corpus of similar files. Without -o: ./dictionary_<dict_id>.zxd
 zxc --train samples/*.json
+zxc --train -o corpus.zxd samples/*.json     # -o also accepts a directory
 
-# Choose the output file explicitly with -o:
-zxc --train -o corpus.zxd samples/*.json
-
-# Or point -o at a directory: the dictionary is saved as dictionary_<dict_id>.zxd
-# inside it (the dict_id embeds in the name), e.g. dicts/dictionary_bc46eec1.zxd
-zxc --train -o dicts/ samples/*.json
-```
-
-```c
-// C API
-const void* samples[] = { buf1, buf2, buf3 };
-size_t sizes[] = { len1, len2, len3 };
-uint8_t dict[32768];
-int64_t dict_sz = zxc_train_dict(samples, sizes, 3, dict, sizeof(dict));
-```
-
-### Compressing with a dictionary
-
-```bash
-# CLI — the same dictionary is required to decompress (pass it with -D)
+# The same dictionary is required to decompress: pass it with -D, there is no auto-lookup
 zxc -z -D corpus.zxd input.json
 zxc -d -D corpus.zxd input.json.zxc
 ```
 
-```c
-// C API — compression
-zxc_compress_opts_t copts = {
-    .level = ZXC_LEVEL_DEFAULT,
-    .dict = dict_content,
-    .dict_size = dict_sz,
-};
-int64_t compressed_size = zxc_compress(src, src_size, dst, dst_cap, &copts);
-
-// C API — decompression (same dictionary required)
-zxc_decompress_opts_t dopts = {
-    .dict = dict_content,
-    .dict_size = dict_sz,
-};
-int64_t original_size = zxc_decompress(compressed, comp_size, out, out_cap, &dopts);
-```
-
-The dictionary is stored as an external `.zxd` file — content plus shared literal table — and referenced by a 32-bit ID (`dict_id`) in the ZXC file header, covering both parts. The **same dictionary is required to decompress** and must be supplied explicitly with `-D` — there is no auto-lookup. Decompressing an archive that needs a dictionary without supplying one returns `ZXC_ERROR_DICT_REQUIRED`; supplying the wrong one returns `ZXC_ERROR_DICT_MISMATCH`. Training to a directory names the file `dictionary_<dict_id>.zxd`. See [FORMAT.md](docs/FORMAT.md) §12 for the full specification.
+The dictionary is an external `.zxd` file — content plus shared literal table — referenced by a
+32-bit `dict_id` in the archive header that covers both parts. Decompressing an archive that needs
+one without supplying it returns `ZXC_ERROR_DICT_REQUIRED`; supplying the wrong one returns
+`ZXC_ERROR_DICT_MISMATCH`. Training and attaching a dictionary from C:
+[EXAMPLES.md](docs/EXAMPLES.md#using-a-pre-trained-dictionary) and
+[API.md §11b](docs/API.md#11b-dictionary-api). Wire format:
+[FORMAT.md §12](docs/FORMAT.md#12-pre-trained-dictionary-support).
 
 ---
 

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -657,41 +657,9 @@ dictionary format and §3.1 for the header fields.
 
 ## Meson Integration
 
-zxc can be consumed as a Meson subproject. This is the recommended approach for
-Meson-based projects that want to vendor or pin a specific zxc version.
-
-**Step 1 — Create `subprojects/zxc.wrap`:**
-
-```ini
-[wrap-git]
-url = https://github.com/hellobertrand/zxc.git
-revision = head
-depth = 1
-
-[provide]
-libzxc = libzxc_dep
-```
-
-**Step 2 — Declare the dependency in your `meson.build`:**
-
-```meson
-project('my_project', 'c', default_options : ['c_std=c17'])
-
-zxc_dep = dependency('libzxc', fallback : ['zxc', 'libzxc_dep'])
-
-executable('my_app', 'main.c', dependencies : zxc_dep)
-```
-
-When `zxc` is used as a subproject, the CLI and test suite are automatically
-skipped. Only the library is built.
-
-**Step 3 — Build and run:**
-
-```bash
-meson setup build
-meson compile -C build
-./build/my_app
-```
+Consuming zxc as a Meson subproject or through WrapDB — the `.wrap` file, the
+`meson.build` dependency and the build commands — is documented in
+[INSTALL.md](INSTALL.md#meson-subproject-or-wrapdb).
 
 ---
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -89,7 +89,7 @@ cmake -B build -DZXC_ENABLE_COVERAGE=ON
 cmake -B build -DZXC_DISABLE_SIMD=ON
 ```
 
-### Profile-Guided Optimization (PGO — Clang and GCC only)
+### Profile-Guided Optimization (PGO — Clang and GCC, single-config generators)
 
 PGO uses runtime profiling data to optimize branch layout, inlining decisions, and code placement.
 
@@ -97,6 +97,12 @@ PGO uses runtime profiling data to optimize branch layout, inlining decisions, a
 > profile-use flags: `cmake/zxcCompilerFlags.cmake` gates the whole PGO block on `NOT MSVC`, and so
 > does the missing-profile check. `GENERATE` and `USE` therefore produce an ordinary build, without
 > a warning. The steps below assume Clang or GCC.
+
+> **Written for a single-config generator** (Ninja, Unix Makefiles). Clang and GCC also drive Xcode
+> and Ninja Multi-Config, which ignore `CMAKE_BUILD_TYPE`: there, add `--config Release` to every
+> `cmake --build`, and run the workload from the per-configuration directory —
+> `build/Release/zxc_test` and `build/Release/zxc`. The profile directory is `build/pgo/` either
+> way, so step 3 is unchanged.
 
 **Step 1 - Build with instrumentation:**
 ```bash

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -1,0 +1,170 @@
+# Building and Integrating ZXC
+
+Prebuilt binaries, package managers and the release archives are covered in the
+[README](../README.md#installation). This document is for the two cases that
+need more room: **vendoring** zxc into another build, and **building it from
+source**.
+
+## Building from source (CMake)
+
+**Requirements:** CMake (3.14+), C17 Compiler (Clang/GCC/MSVC).
+
+```bash
+git clone https://github.com/hellobertrand/zxc.git
+cd zxc
+cmake -B build -DCMAKE_BUILD_TYPE=Release
+cmake --build build --parallel
+
+# Run tests
+ctest --test-dir build -C Release --output-on-failure
+
+# CLI usage
+./build/zxc --help
+
+# Install library, headers, and CMake/pkg-config files
+sudo cmake --install build
+```
+
+### CMake options
+
+| Option | Default (standalone) | Default (vendored) | Description |
+|--------|----------------------|--------------------|-------------|
+| `BUILD_SHARED_LIBS` | OFF | OFF | Build shared libraries instead of static (`libzxc.so`, `libzxc.dylib`, `zxc.dll`) |
+| `ZXC_NATIVE_ARCH` | ON | OFF | Enable `-march=native` for maximum performance |
+| `ZXC_ENABLE_LTO` | ON | OFF | Enable Link-Time Optimization (LTO) |
+| `ZXC_PGO_MODE` | OFF | OFF | Profile-Guided Optimization mode (`OFF`, `GENERATE`, `USE`) |
+| `ZXC_BUILD_CLI` | ON | OFF | Build command-line interface |
+| `ZXC_BUILD_TESTS` | ON | OFF | Build unit tests |
+| `ZXC_INSTALL` | ON | OFF | Generate install rules (headers, pkg-config, CMake package) |
+| `ZXC_ENABLE_COVERAGE` | OFF | OFF | Enable code coverage generation (disables LTO/PGO) |
+| `ZXC_DISABLE_SIMD` | OFF | OFF | Disable hand-written SIMD paths (AVX2/AVX512/NEON) |
+| `ZXC_USE_SYSTEM_RAPIDHASH` | OFF | OFF | Use a system-installed `rapidhash.h` instead of the vendored copy |
+
+"Vendored" is a build where zxc is not the top-level project (`add_subdirectory()`,
+`FetchContent`): the embedding project then keeps control of its own compiler flags,
+test registration and install set.
+
+```bash
+# Build shared library
+cmake -B build -DBUILD_SHARED_LIBS=ON
+
+# Portable build (without -march=native)
+cmake -B build -DZXC_NATIVE_ARCH=OFF
+
+# Library only (no CLI, no tests)
+cmake -B build -DZXC_BUILD_CLI=OFF -DZXC_BUILD_TESTS=OFF
+
+# Code coverage build
+cmake -B build -DZXC_ENABLE_COVERAGE=ON
+
+# Disable explicit SIMD code paths (compiler auto-vectorisation is unaffected)
+cmake -B build -DZXC_DISABLE_SIMD=ON
+```
+
+### Profile-Guided Optimization (PGO)
+
+PGO uses runtime profiling data to optimize branch layout, inlining decisions, and code placement.
+
+**Step 1 - Build with instrumentation:**
+```bash
+cmake -B build -DCMAKE_BUILD_TYPE=Release -DZXC_PGO_MODE=GENERATE
+cmake --build build --parallel
+```
+
+**Step 2 - Run a representative workload to collect profile data:**
+```bash
+# Run the test suite (exercises all block types and compression levels)
+./build/zxc_test
+
+# Or compress/decompress representative data
+./build/zxc -b your_data_file
+```
+
+**Step 3 - (Clang only) Merge raw profiles:**
+```bash
+# Clang generates .profraw files that must be merged before use
+llvm-profdata merge -output=build/pgo/default.profdata build/pgo/*.profraw
+```
+> GCC uses a directory-based format and does not require this step.
+
+**Step 4 - Rebuild with profile data:**
+```bash
+cmake -B build -DCMAKE_BUILD_TYPE=Release -DZXC_PGO_MODE=USE
+cmake --build build --parallel
+```
+
+## CMake subproject (vendored)
+
+zxc can be vendored directly into a CMake build, either as a git submodule with
+`add_subdirectory()` or through `FetchContent`:
+
+```cmake
+include(FetchContent)
+FetchContent_Declare(zxc
+    GIT_REPOSITORY https://github.com/hellobertrand/zxc.git
+    GIT_TAG        v0.14.0
+)
+FetchContent_MakeAvailable(zxc)
+
+target_link_libraries(myapp PRIVATE zxc::zxc_lib)
+```
+
+`zxc::zxc_lib` is the same target name the installed package exports, so
+switching between a vendored copy and `find_package(zxc)` needs no other
+change.
+
+When zxc is not the top-level project it builds the library only: the CLI, the
+tests, `-march=native`, LTO and the install rules all default to off, so the
+embedding project keeps full control of its own CTest registration and install
+set. Any of them can still be turned back on explicitly (`-DZXC_BUILD_CLI=ON`,
+`-DZXC_NATIVE_ARCH=ON`, `-DZXC_INSTALL=ON`, ...). `-march=native` is also
+ignored whenever CMake is cross-compiling, since it would encode the build
+host's ISA.
+
+Compiler flags follow the same rule. Vendored, zxc adds nothing to what it
+inherits from the parent: the optimisation level comes from the build type, and
+the warning level (`-Wall -Wextra`, `/W3`) and code generation policy
+(`-fomit-frame-pointer`, `-fstrict-aliasing`, `-ffunction-sections`,
+`-fdata-sections` and the matching dead-strip link options) are the embedding
+project's to set. An embedder that builds with frame pointers for its profiler,
+its own aliasing rules or a quiet build log keeps them. A configure-time warning
+fires if neither a build type nor an optimisation flag is set, since zxc would
+then be built unoptimised.
+
+Third-party code is vendored, never probed: `rapidhash.h` comes from the copy in
+the tree unless `-DZXC_USE_SYSTEM_RAPIDHASH=ON` asks for a system one, so a
+build cannot silently pick up a header from the host.
+
+## Meson subproject (or WrapDB)
+
+zxc ships a native `meson.build`, so any Meson project can pull it in as a
+subproject or via [WrapDB](https://mesonbuild.com/Wrapdb-projects.html).
+
+**1. Create `subprojects/zxc.wrap`:**
+```ini
+[wrap-git]
+url = https://github.com/hellobertrand/zxc.git
+revision = head
+depth = 1
+
+[provide]
+libzxc = libzxc_dep
+```
+
+**2. Use the dependency in your `meson.build`:**
+```meson
+project('my_project', 'c', default_options : ['c_std=c17'])
+
+zxc_dep = dependency('libzxc', fallback : ['zxc', 'libzxc_dep'])
+executable('my_app', 'main.c', dependencies : zxc_dep)
+```
+
+**3. Build and run:**
+```bash
+meson setup build
+meson compile -C build
+./build/my_app
+```
+
+When consumed as a subproject, only the library is built (CLI and tests are
+skipped automatically).

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -7,23 +7,51 @@ source**.
 
 ## Building from source (CMake)
 
-**Requirements:** CMake (3.14+), C17 Compiler (Clang/GCC/MSVC).
+**Requirements:** CMake 3.14+, a C17 compiler (Clang, GCC or MSVC).
 
 ```bash
 git clone https://github.com/hellobertrand/zxc.git
 cd zxc
+```
+
+### Single-config generators (Unix Makefiles, Ninja)
+
+The default on Linux and macOS. The build type is fixed at configure time.
+
+```bash
 cmake -B build -DCMAKE_BUILD_TYPE=Release
 cmake --build build --parallel
 
-# Run tests
-ctest --test-dir build -C Release --output-on-failure
+# Run tests. CMake 3.20+ can use: ctest --test-dir build --output-on-failure
+cd build && ctest --output-on-failure && cd ..
 
 # CLI usage
 ./build/zxc --help
 
-# Install library, headers, and CMake/pkg-config files
-sudo cmake --install build
+# Install library, headers, pkg-config and CMake package files.
+# CMake 3.15+ can use: sudo cmake --install build
+sudo cmake --build build --target install
 ```
+
+### Multi-config generators (Visual Studio, Xcode, Ninja Multi-Config)
+
+Here the build type is chosen at *build* time, so `CMAKE_BUILD_TYPE` is ignored at configure time
+and `--config` is required at build, test and install time. Artifacts land in a per-configuration
+subdirectory: the CLI is `build/Release/zxc`, not `build/zxc`.
+
+```bash
+cmake -B build
+cmake --build build --config Release --parallel
+
+cd build
+ctest -C Release --output-on-failure
+cd ..
+
+cmake --build build --config Release --target install
+```
+
+Installing into a system prefix needs `sudo` on Unix or an elevated shell on Windows. Pass
+`-DCMAKE_INSTALL_PREFIX=<dir>` at configure time to install somewhere writable instead.
 
 ### CMake options
 
@@ -61,9 +89,14 @@ cmake -B build -DZXC_ENABLE_COVERAGE=ON
 cmake -B build -DZXC_DISABLE_SIMD=ON
 ```
 
-### Profile-Guided Optimization (PGO)
+### Profile-Guided Optimization (PGO — Clang and GCC only)
 
 PGO uses runtime profiling data to optimize branch layout, inlining decisions, and code placement.
+
+> **Not available with MSVC.** `ZXC_PGO_MODE` is accepted there but emits no instrumentation and no
+> profile-use flags: `cmake/zxcCompilerFlags.cmake` gates the whole PGO block on `NOT MSVC`, and so
+> does the missing-profile check. `GENERATE` and `USE` therefore produce an ordinary build, without
+> a warning. The steps below assume Clang or GCC.
 
 **Step 1 - Build with instrumentation:**
 ```bash


### PR DESCRIPTION
Reduce README by condensing detailed technical sections and relocating comprehensive build and advanced usage guides to dedicated documentation files. 
This improves overall readability and maintainability, allowing the `README.md` to serve as a high-level overview while providing clear pointers to in-depth information.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded README coverage with ClickHouse support, consolidated benchmark data, streamlined installation and verification guidance, and concise dictionary, CLI, API, and advanced usage instructions.
  * Added documentation for CMake source builds, single- and multi-config workflows, build options, compiler and dependency behavior, vendoring, and Clang/GCC-only profile-guided optimization.
  * Added Meson subproject and WrapDB integration guidance.
  * Simplified Meson examples by linking to centralized installation instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->