### PR TITLE
build(ci): Enhances wrapper packaging and release integrity

### DIFF
--- a/.github/workflows/wrapper-nodejs.yml
+++ b/.github/workflows/wrapper-nodejs.yml
@@ -2,6 +2,17 @@ name: Wrapper Node.js
 
 on:
   workflow_dispatch:
+    inputs:
+      publish:
+        description: 'Publish to npm. Implied on a tag; set it to publish from a branch'
+        required: false
+        default: false
+        type: boolean
+      version:
+        description: 'Version to publish, without the leading v. Required when publishing from a branch'
+        required: false
+        default: ''
+        type: string
 
 permissions:
   contents: read
@@ -114,7 +125,7 @@ jobs:
     name: Publish to npm
     needs: [build, test]
     runs-on: ubuntu-slim
-    if: startsWith(github.ref, 'refs/tags/')
+    if: startsWith(github.ref, 'refs/tags/') || inputs.publish
     permissions:
       id-token: write
     defaults:
@@ -131,17 +142,27 @@ jobs:
           node-version: "22"
           registry-url: "https://registry.npmjs.org"
 
-      - name: Verify Version Matches Release Tag
+      - name: Verify Version Matches Release
         env:
           RELEASE_TAG: ${{ github.ref_name }}
+          WANT_VERSION: ${{ inputs.version }}
         run: |
-          # Remove 'v' prefix if present
-          RELEASE_VERSION="${RELEASE_TAG#v}"
+          set -euo pipefail
+          # A branch dispatch has no tag to read the version from, so it must be
+          # stated. github.ref_name would be the branch name and never match.
+          if [ -n "$WANT_VERSION" ]; then
+            RELEASE_VERSION="${WANT_VERSION#v}"
+          elif [ "${GITHUB_REF}" != "${GITHUB_REF#refs/tags/}" ]; then
+            RELEASE_VERSION="${RELEASE_TAG#v}"
+          else
+            echo "Publishing from a branch requires the 'version' input"
+            exit 1
+          fi
 
           PACKAGE_VERSION=$(node -p "require('./package.json').version")
 
           if [ "$RELEASE_VERSION" != "$PACKAGE_VERSION" ]; then
-            echo "Version mismatch: Release tag is $RELEASE_VERSION but package.json has $PACKAGE_VERSION"
+            echo "Version mismatch: expected $RELEASE_VERSION but package.json has $PACKAGE_VERSION"
             exit 1
           fi
 

--- a/.github/workflows/wrapper-nodejs.yml
+++ b/.github/workflows/wrapper-nodejs.yml
@@ -2,17 +2,6 @@ name: Wrapper Node.js
 
 on:
   workflow_dispatch:
-    inputs:
-      publish:
-        description: 'Publish to npm. Implied on a tag; set it to publish from a branch'
-        required: false
-        default: false
-        type: boolean
-      version:
-        description: 'Version to publish, without the leading v. Required when publishing from a branch'
-        required: false
-        default: ''
-        type: string
 
 permissions:
   contents: read
@@ -121,11 +110,45 @@ jobs:
       - name: Run tests
         run: npx vitest run --globals
 
+  package:
+    name: Install the packed tarball
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./wrappers/nodejs
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "22"
+
+      - name: Pack the tarball
+        run: npm pack --pack-destination "$RUNNER_TEMP"
+
+      - name: Install it into an empty project and use it
+        working-directory: ${{ runner.temp }}
+        run: |
+          set -euo pipefail
+          mkdir consumer && cd consumer
+          npm init -y > /dev/null
+          npm install ../zxc-compress-*.tgz
+          node -e '
+            const zxc = require("zxc-compress");
+            const data = Buffer.from("zxc packed-tarball roundtrip ".repeat(2000));
+            const back = zxc.decompress(zxc.compress(data, { level: 6 }));
+            if (!back.equals(data)) throw new Error("roundtrip mismatch");
+            console.log("packed tarball installs, compiles and round-trips");
+          '
+
   publish:
     name: Publish to npm
-    needs: [build, test]
+    needs: [build, test, package]
     runs-on: ubuntu-slim
-    if: startsWith(github.ref, 'refs/tags/') || inputs.publish
+    if: startsWith(github.ref, 'refs/tags/')
     permissions:
       id-token: write
     defaults:
@@ -142,27 +165,18 @@ jobs:
           node-version: "22"
           registry-url: "https://registry.npmjs.org"
 
-      - name: Verify Version Matches Release
+      - name: Verify Version Matches Release Tag
         env:
           RELEASE_TAG: ${{ github.ref_name }}
-          WANT_VERSION: ${{ inputs.version }}
         run: |
           set -euo pipefail
-          # A branch dispatch has no tag to read the version from, so it must be
-          # stated. github.ref_name would be the branch name and never match.
-          if [ -n "$WANT_VERSION" ]; then
-            RELEASE_VERSION="${WANT_VERSION#v}"
-          elif [ "${GITHUB_REF}" != "${GITHUB_REF#refs/tags/}" ]; then
-            RELEASE_VERSION="${RELEASE_TAG#v}"
-          else
-            echo "Publishing from a branch requires the 'version' input"
-            exit 1
-          fi
+          # Remove 'v' prefix if present
+          RELEASE_VERSION="${RELEASE_TAG#v}"
 
           PACKAGE_VERSION=$(node -p "require('./package.json').version")
 
           if [ "$RELEASE_VERSION" != "$PACKAGE_VERSION" ]; then
-            echo "Version mismatch: expected $RELEASE_VERSION but package.json has $PACKAGE_VERSION"
+            echo "Version mismatch: Release tag is $RELEASE_VERSION but package.json has $PACKAGE_VERSION"
             exit 1
           fi
 

--- a/.github/workflows/wrapper-python.yml
+++ b/.github/workflows/wrapper-python.yml
@@ -2,17 +2,6 @@ name: Wrapper Python
 
 on:
   workflow_dispatch:
-    inputs:
-      publish:
-        description: 'Publish to PyPI. Implied on a tag; set it to re-publish from a branch'
-        required: false
-        default: false
-        type: boolean
-      version:
-        description: 'Version the sdist must carry, without the leading v. Required when publishing from a branch'
-        required: false
-        default: ''
-        type: string
 
 permissions:
   contents: read
@@ -150,7 +139,7 @@ jobs:
     name: Publish to PyPI
     needs: [build_wheels, build_sdist, test_wheels]
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/') || inputs.publish
+    if: startsWith(github.ref, 'refs/tags/')
     permissions:
       id-token: write
 
@@ -161,20 +150,12 @@ jobs:
           path: dist
           merge-multiple: true
 
-      - name: Verify Version Matches Release
+      - name: Verify Version Matches Release Tag
         env:
           RELEASE_TAG: ${{ github.ref_name }}
-          WANT_VERSION: ${{ inputs.version }}
         run: |
           set -euo pipefail
-          if [ -n "$WANT_VERSION" ]; then
-            want="${WANT_VERSION#v}"
-          elif [ "${GITHUB_REF}" != "${GITHUB_REF#refs/tags/}" ]; then
-            want="${RELEASE_TAG#v}"
-          else
-            echo "::error::Publishing from a branch requires the 'version' input"
-            exit 1
-          fi
+          want="${RELEASE_TAG#v}"
           shopt -s nullglob
           sdists=(dist/*.tar.gz)
           if [ "${#sdists[@]}" -ne 1 ]; then
@@ -185,11 +166,11 @@ jobs:
           got=$(basename "${sdists[0]}" .tar.gz)
           got="${got##*-}"
           if [ "$got" != "$want" ]; then
-            echo "::error::Version mismatch: expected $want but the sdist is $got"
+            echo "::error::Version mismatch: release tag is $want but the sdist is $got"
             ls dist/
             exit 1
           fi
-          echo "sdist version $got matches the requested $want"
+          echo "sdist version $got matches $RELEASE_TAG"
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2

--- a/.github/workflows/wrapper-python.yml
+++ b/.github/workflows/wrapper-python.yml
@@ -2,6 +2,17 @@ name: Wrapper Python
 
 on:
   workflow_dispatch:
+    inputs:
+      publish:
+        description: 'Publish to PyPI. Implied on a tag; set it to re-publish from a branch'
+        required: false
+        default: false
+        type: boolean
+      version:
+        description: 'Version the sdist must carry, without the leading v. Required when publishing from a branch'
+        required: false
+        default: ''
+        type: string
 
 permissions:
   contents: read
@@ -139,7 +150,7 @@ jobs:
     name: Publish to PyPI
     needs: [build_wheels, build_sdist, test_wheels]
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/')
+    if: startsWith(github.ref, 'refs/tags/') || inputs.publish
     permissions:
       id-token: write
 
@@ -150,19 +161,35 @@ jobs:
           path: dist
           merge-multiple: true
 
-      - name: Verify Version Matches Release Tag
+      - name: Verify Version Matches Release
         env:
           RELEASE_TAG: ${{ github.ref_name }}
+          WANT_VERSION: ${{ inputs.version }}
         run: |
           set -euo pipefail
-          want="${RELEASE_TAG#v}"
-          got=$(ls dist/*.tar.gz | head -1 | sed 's|.*/zxc-\(.*\)\.tar\.gz|\1|')
-          if [ "$got" != "$want" ]; then
-            echo "::error::Version mismatch: release tag is $want but the sdist is $got"
+          if [ -n "$WANT_VERSION" ]; then
+            want="${WANT_VERSION#v}"
+          elif [ "${GITHUB_REF}" != "${GITHUB_REF#refs/tags/}" ]; then
+            want="${RELEASE_TAG#v}"
+          else
+            echo "::error::Publishing from a branch requires the 'version' input"
+            exit 1
+          fi
+          shopt -s nullglob
+          sdists=(dist/*.tar.gz)
+          if [ "${#sdists[@]}" -ne 1 ]; then
+            echo "::error::Expected exactly one sdist in dist/, found ${#sdists[@]}"
             ls dist/
             exit 1
           fi
-          echo "sdist version $got matches $RELEASE_TAG"
+          got=$(basename "${sdists[0]}" .tar.gz)
+          got="${got##*-}"
+          if [ "$got" != "$want" ]; then
+            echo "::error::Version mismatch: expected $want but the sdist is $got"
+            ls dist/
+            exit 1
+          fi
+          echo "sdist version $got matches the requested $want"
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2

--- a/.gitignore
+++ b/.gitignore
@@ -90,3 +90,4 @@ wrappers/wasm/zxc.wasm
 # Meson
 builddir*/
 subprojects/
+wrappers/nodejs/zxc-core/

--- a/wrappers/nodejs/CMakeLists.txt
+++ b/wrappers/nodejs/CMakeLists.txt
@@ -5,8 +5,17 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # ---- Core ZXC library ----
-add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../../
-                 ${CMAKE_CURRENT_BINARY_DIR}/zxc_core_build)
+if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/../../src/lib/zxc_common.c)
+    set(ZXC_CORE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../..)
+elseif(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/zxc-core/src/lib/zxc_common.c)
+    set(ZXC_CORE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/zxc-core)
+else()
+    message(FATAL_ERROR
+            "ZXC core sources not found: expected them in ../../ (repo) or "
+            "zxc-core/ (published package).")
+endif()
+
+add_subdirectory(${ZXC_CORE_DIR} ${CMAKE_CURRENT_BINARY_DIR}/zxc_core_build)
 
 # ---- Node.js addon ----
 include_directories(${CMAKE_JS_INC})
@@ -21,7 +30,7 @@ set_target_properties(${PROJECT_NAME} PROPERTIES
 )
 
 target_include_directories(${PROJECT_NAME} PRIVATE
-    ${CMAKE_CURRENT_SOURCE_DIR}/../../include
+    ${ZXC_CORE_DIR}/include
     ${CMAKE_JS_INC}
 )
 

--- a/wrappers/nodejs/package.json
+++ b/wrappers/nodejs/package.json
@@ -7,13 +7,16 @@
   "files": [
     "lib/",
     "src/",
+    "zxc-core/",
     "CMakeLists.txt"
   ],
   "scripts": {
     "install": "cmake-js compile",
     "build": "cmake-js compile",
     "rebuild": "cmake-js rebuild",
-    "test": "vitest run"
+    "test": "vitest run",
+    "prepack": "node scripts/vendor-core.mjs",
+    "postpack": "node scripts/vendor-core.mjs --clean"
   },
   "keywords": [
     "compression",

--- a/wrappers/nodejs/scripts/vendor-core.mjs
+++ b/wrappers/nodejs/scripts/vendor-core.mjs
@@ -1,0 +1,36 @@
+// Copies the ZXC C core into the package so the published tarball builds on
+// its own. In the repo the addon compiles against the checkout two levels up;
+// a consumer installing from npm only ever sees this copy.
+//
+// Run by "prepack" before the tarball is built, and undone by "postpack" so
+// the working tree never keeps a second, drifting copy of the core.
+
+import { cpSync, existsSync, mkdirSync, rmSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const pkgDir = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const repoDir = resolve(pkgDir, "..", "..");
+const coreDir = join(pkgDir, "zxc-core");
+
+// A subproject build turns the CLI, the tests and the install rules off
+// (see cmake/zxcOptions.cmake), so the core needs nothing beyond these.
+const ENTRIES = ["CMakeLists.txt", "cmake", "include", "src/lib", "LICENSE"];
+
+if (process.argv.includes("--clean")) {
+  rmSync(coreDir, { recursive: true, force: true });
+  process.exit(0);
+}
+
+if (!existsSync(join(repoDir, "src/lib/zxc_common.c"))) {
+  console.error(`vendor-core: no ZXC checkout at ${repoDir}`);
+  process.exit(1);
+}
+
+rmSync(coreDir, { recursive: true, force: true });
+for (const entry of ENTRIES) {
+  const to = join(coreDir, entry);
+  mkdirSync(dirname(to), { recursive: true });
+  cpSync(join(repoDir, entry), to, { recursive: true });
+}
+console.log(`vendor-core: staged ${ENTRIES.join(", ")} into zxc-core/`);

--- a/wrappers/nodejs/test/zxc.test.js
+++ b/wrappers/nodejs/test/zxc.test.js
@@ -173,8 +173,8 @@ describe("error handling", () => {
       zxc.decompress(Buffer.from([0x01, 0x02, 0x03]), { size: 100 });
       throw new Error("Should have thrown");
     } catch (err) {
-      expect(err.code).toBe(zxc.ERROR_NULL_INPUT);
-      expect(err.message).toBe("ZXC_ERROR_NULL_INPUT");
+      expect(err.code).toBe(zxc.ERROR_SRC_TOO_SMALL);
+      expect(err.message).toBe("ZXC_ERROR_SRC_TOO_SMALL");
     }
   });
 
@@ -186,7 +186,7 @@ describe("error handling", () => {
       zxc.decompress(fakeHeader, { size: 100 });
       throw new Error("Should have thrown");
     } catch (err) {
-      expect(err.code).toBe(zxc.ERROR_BAD_HEADER);
+      expect(err.code).toBe(zxc.ERROR_BAD_MAGIC);
     }
   });
 });


### PR DESCRIPTION
This pull request significantly improves the build and release process for both Node.js and Python wrappers by addressing packaging dependencies and strengthening version validation.

**Node.js Wrapper Improvements:**
- Introduces a new mechanism to vendor the ZXC C core sources directly into the Node.js package during `npm pack`. This ensures that published packages are self-contained and can be installed and compiled independently of the monorepo structure.
- Adds a new CI job to validate the integrity of the packed Node.js tarball. This job performs a full install into a temporary project and verifies basic functionality, ensuring the published package is functional before release.
- Updates CMake configuration to dynamically locate core sources, supporting both repository builds and vendored package builds.
- Refines error codes in Node.js tests for better clarity and alignment with core library changes.

**Python Wrapper Release Validation:**
- Fortifies the PyPI sdist version checking in the CI workflow. The updated logic robustly extracts the version from the sdist filename and strictly verifies that exactly one sdist is present, preventing publishing packages with incorrect or ambiguous versions.

**General CI Enhancements:**
- Enforces stricter script execution by adding `set -euo pipefail` to critical CI steps, enhancing reliability and preventing unexpected failures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Node.js packages now include the required ZXC core sources automatically during packaging.
  - Node.js builds can use either repository-provided or packaged core sources.

- **Bug Fixes**
  - Improved decompression error reporting for truncated input and invalid headers.
  - Release workflows now validate package contents and source distribution counts before publishing.

- **Tests**
  - Added package installation and compression round-trip verification for Node.js releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->