### PR TITLE
ci(nodejs): resolve dependency resolution in wrapper test (#410)

### DIFF
--- a/.github/workflows/wrapper-nodejs.yml
+++ b/.github/workflows/wrapper-nodejs.yml
@@ -134,10 +134,11 @@ jobs:
         run: |
           set -euo pipefail
           mkdir consumer && cd consumer
-          npm init -y > /dev/null
-          npm install ../zxc-compress-*.tgz
+          tar xzf ../zxc-compress-*.tgz
+          cp "$GITHUB_WORKSPACE/wrappers/nodejs/package-lock.json" package/
+          (cd package && npm ci --omit=dev)
           node -e '
-            const zxc = require("zxc-compress");
+            const zxc = require("./package");
             const data = Buffer.from("zxc packed-tarball roundtrip ".repeat(2000));
             const back = zxc.decompress(zxc.compress(data, { level: 6 }));
             if (!back.equals(data)) throw new Error("roundtrip mismatch");


### PR DESCRIPTION
Update the Node.js wrapper CI test to explicitly install dependencies from the local package-lock.json using `npm ci`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated package verification to validate the packed package directly from its extracted contents.
  * Verification now installs only production dependencies using the repository lockfile.
  * Removed the temporary consumer-project setup and tarball installation step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->