### PR TITLE
Formalizes dictionary ID calculation and enhances fuzzer (#ossf-557281704)

### DIFF
--- a/docs/FORMAT.md
+++ b/docs/FORMAT.md
@@ -559,7 +559,9 @@ These protect metadata/navigation fields.
 When file header has `HAS_CHECKSUM=1`:
 - each data block appends a 4-byte checksum after payload.
 - checksum input is **compressed payload bytes only** (not block header).
-- algorithm id currently `0` (RapidHash folded to 32-bit).
+- algorithm id currently `0`: `fold32(rapidhash(payload))`, where `rapidhash`
+  is rapidhash v3 (default secret, seed 0) and
+  `fold32(h) = (h XOR (h >> 32)) AND 0xFFFFFFFF`.
 
 ## 7.3 Global stream hash
 
@@ -735,9 +737,13 @@ When `HAS_DICTIONARY` (flag bit 6) is set, the reserved bytes at offsets
 1. Verify that a dictionary is provided; reject the archive if not.
 2. Verify that the dictionary id matches `header.dict_id`
    ; reject on mismatch. For a raw in-memory dictionary without
-   a shared table, the id is `zxc_dict_id(dict, dict_size, NULL)`. When a shared
-   literal table is attached, the id also binds the table:
-   `id = fold32(hash(table_128_bytes, seed = hash(content)))` (i.e. `zxc_dict_id(content, size, table)`).
+   a shared table, the id is `fold32(rapidhash(content))`
+   (`zxc_dict_id(dict, dict_size, NULL)`). When a shared literal table is
+   attached, the id also binds the table:
+   `id = fold32(rapidhash(table_128_bytes, seed = fold32(rapidhash(content))))`
+   (`zxc_dict_id(content, size, table)`). The seed is the **folded 32-bit**
+   content hash, zero-extended to rapidhash's 64-bit seed. `rapidhash` and
+   `fold32` are defined in [7.2](#72-per-block-checksum-optional).
 
 Older decoders that do not recognize the `HAS_DICTIONARY` flag will ignore it
 (per §10.3: reserved flag bits are ignored). However, blocks compressed with a
@@ -769,9 +775,10 @@ Offset  Size  Field
 - **Flags**: bits `0..3` carry the checksum algorithm id (`0` = RapidHash-based folding), matching the ZXC file header flags; bits `4..7` are reserved (must be 0).
 - **Shared literal Huffman table**: code lengths for the `enc_lit=3` literal
   sections (§ 5.2.2), trained on the corpus' post-LZ literal distribution.
-- **dict_id**: `fold32(hash(table_128_bytes, seed = hash(content)))` —
-  binds the exact (content, table) pair. Must match the `dict_id` stored in
-  any ZXC file header that references this dictionary.
+- **dict_id**: `fold32(rapidhash(table_128_bytes, seed = fold32(rapidhash(content))))`
+  (see [12.3](#123-file-header-encoding)) — binds the exact (content, table)
+  pair. Must match the `dict_id` stored in any ZXC file header that references
+  this dictionary.
 - **Header Checksum**: the 16-bit header checksum of [7.1](#71-header-checksums), computed over the 16-byte header with bytes `0x0C..0x0F` zeroed.
 - **Content**: raw bytes that prefill the LZ77 window. Not compressed.
 

--- a/tests/fuzz_dict.c
+++ b/tests/fuzz_dict.c
@@ -155,21 +155,24 @@ int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
     /* Re-save (the DST_TOO_SMALL attempt left zxd_buf untouched, but be safe). */
     assert(zxc_dict_save(dict_buf, (size_t)dict_sz, huf, zxd_buf, zxd_bound) == (int64_t)zxd_sz);
 
-    /* Flip one byte and re-load: must not crash. A surviving ZXC_OK can only
-     * come from a reserved-byte flip (offsets 12-13, zeroed before the checksum),
-     * which cannot change the recovered content. */
+    /* Flip one byte and re-load: must not crash. A header flip that survives
+     * (reserved or flags byte) leaves the content intact; a payload flip that
+     * survives is a dict_id collision, which a fuzzer can forge, so there the
+     * only invariant is load's contract: OK means the id binds (content, table). */
     {
         const size_t pos = corrupt_pos % (size_t)zxd_sz;
         const uint8_t saved = zxd_buf[pos];
         zxd_buf[pos] ^= (uint8_t)(corrupt_mask | 1U); /* guaranteed to differ */
 
         const void* cc = NULL;
+        const void* ch = NULL;
         size_t ccs = 0;
         uint32_t cid = 0;
-        const int rc = zxc_dict_load(zxd_buf, (size_t)zxd_sz, &cc, &ccs, NULL, &cid);
+        const int rc = zxc_dict_load(zxd_buf, (size_t)zxd_sz, &cc, &ccs, &ch, &cid);
         if (rc == ZXC_OK) {
             assert(ccs == (size_t)dict_sz);
-            assert(memcmp(cc, dict_buf, (size_t)dict_sz) == 0);
+            assert(zxc_dict_id(cc, ccs, ch) == cid);
+            if (pos < ZXC_DICT_HEADER_SIZE) assert(memcmp(cc, dict_buf, (size_t)dict_sz) == 0);
         }
         zxd_buf[pos] = saved;
     }


### PR DESCRIPTION
Enhances the dictionary fuzzer to refine corruption assertions. The fuzzer now accurately validates dictionary loading behavior after byte flips, distinguishing between header and payload corruptions.
It asserts that a successful load correctly binds the content and Huffman table to the expected dictionary ID, accounting for scenarios where payload corruption might lead to a `dict_id` collision rather than identical content.

Fixes ossf-557281704

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified checksum documentation to specify RapidHash v3 and its folded 32-bit output.
  - Documented how dictionary IDs are calculated from content and the shared Huffman table.

- **Tests**
  - Improved corruption testing to validate dictionary IDs against loaded content and Huffman tables.
  - Refined validation for header and payload corruption scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->