### PR TITLE
feat(dict): Adds shared literal table support to block API

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -534,7 +534,10 @@ ZXC_EXPORT int64_t zxc_compress_block(
 ```
 
 Compresses a single block using a reusable context.  
-Only `level`, `block_size`, and `checksum_enabled` fields of `opts` are used.
+`level`, `block_size`, `checksum_enabled` and the dictionary fields (`dict`,
+`dict_size`, `dict_huf`) of `opts` are used; the shared literal table is
+rebuilt only when it changes. A static context returns
+`ZXC_ERROR_DICT_UNSUPPORTED` for any dictionary.
 
 `src_size` must be in `[1, ZXC_BLOCK_SIZE_MAX]` (2 MiB). For larger payloads,
 use the frame API (`zxc_compress`) or streaming API (`zxc_cstream_*`), which
@@ -561,7 +564,9 @@ Decompresses a single block produced by `zxc_compress_block()`.
 `zxc_decompress_block_bound(uncompressed_size)` to enable the fast path, and
 **must not exceed** `ZXC_BLOCK_SIZE_MAX + ZXC_DECOMPRESS_TAIL_PAD`. For payloads
 produced by the frame or streaming APIs, use `zxc_decompress` instead.
-Only `checksum_enabled` is used.
+`checksum_enabled` and the dictionary fields are used; a block carries no
+dictionary id, so pass the same (content, table) pair as at compression. A
+static context returns `ZXC_ERROR_DICT_UNSUPPORTED` for any dictionary.
 
 **Returns**: decompressed size (> 0) on success, or negative `zxc_error_t`.
 Returns `ZXC_ERROR_BAD_BLOCK_SIZE` if `dst_capacity` exceeds the per-block

--- a/docs/API.md
+++ b/docs/API.md
@@ -399,7 +399,8 @@ ZXC_EXPORT int64_t zxc_decompress(
 );
 ```
 
-Decompresses `src` into `dst`. Only `checksum_enabled` is used.
+Decompresses `src` into `dst`. `checksum_enabled` and the dictionary fields
+(`dict`, `dict_size`, `dict_huf`) are used.
 `src` and `dst` must not overlap (same contract as `memcpy`); for overlapping
 single-buffer decode, use `zxc_decompress_inplace` below.
 
@@ -600,7 +601,8 @@ tail-pad margin, so the upper limit is `ZXC_BLOCK_SIZE_MAX` (not
 `MAX+TAIL_PAD` as for `zxc_decompress_block`). Returns
 `ZXC_ERROR_BAD_BLOCK_SIZE` if `dst_capacity > ZXC_BLOCK_SIZE_MAX`.
 
-Only `checksum_enabled` is used.
+Same options as `zxc_decompress_block`: `checksum_enabled` and the dictionary
+fields; a dictionary routes through its bounce path.
 
 **Returns**: decompressed size (> 0) on success, or negative `zxc_error_t`.
 

--- a/include/zxc_buffer.h
+++ b/include/zxc_buffer.h
@@ -285,9 +285,10 @@ ZXC_EXPORT uint64_t zxc_decompress_block_bound(const size_t uncompressed_size);
  * @param[in]     src_size     Source size in bytes, in [1, @ref ZXC_BLOCK_SIZE_MAX].
  * @param[out]    dst          Destination buffer.
  * @param[in]     dst_capacity Capacity of @p dst (see zxc_compress_block_bound()).
- * @param[in]     opts         Compression options, or NULL for defaults. Only
- *                             @c level, @c block_size and @c checksum_enabled
- *                             are used.
+ * @param[in]     opts         Compression options, or NULL for defaults.
+ *                             @c level, @c block_size, @c checksum_enabled and
+ *                             the dictionary fields are used; the shared table
+ *                             is rebuilt only when it changes.
  *
  * @note @p src and @p dst must not overlap (same contract as memcpy).
  *
@@ -295,7 +296,8 @@ ZXC_EXPORT uint64_t zxc_decompress_block_bound(const size_t uncompressed_size);
  *         @ref ZXC_ERROR_BAD_BLOCK_SIZE if @p src_size exceeds
  *         @ref ZXC_BLOCK_SIZE_MAX; @ref ZXC_ERROR_BAD_LEVEL on a static
  *         context for a level raise its workspace cannot accommodate (levels
- *         above @ref ZXC_LEVEL_ULTRA are otherwise silently clamped).
+ *         above @ref ZXC_LEVEL_ULTRA are otherwise silently clamped);
+ *         @ref ZXC_ERROR_DICT_UNSUPPORTED on a static context with a dictionary.
  */
 ZXC_EXPORT int64_t zxc_compress_block(zxc_cctx* cctx, const void* src, size_t src_size, void* dst,
                                       size_t dst_capacity, const zxc_compress_opts_t* opts);
@@ -317,7 +319,10 @@ ZXC_EXPORT int64_t zxc_compress_block(zxc_cctx* cctx, const void* src, size_t sr
  *                             @ref ZXC_BLOCK_SIZE_MAX +
  *                             @ref ZXC_DECOMPRESS_TAIL_PAD.
  * @param[in]     opts         Decompression options, or NULL for defaults.
- *                             Only @c checksum_enabled is used.
+ *                             @c checksum_enabled and the dictionary fields are
+ *                             used; a block carries no dictionary id, so pass
+ *                             the same (content, table) pair as at compression.
+ *                             Static context: @ref ZXC_ERROR_DICT_UNSUPPORTED.
  *
  * @note @p src and @p dst must not overlap (same contract as memcpy).
  *
@@ -351,7 +356,8 @@ ZXC_EXPORT int64_t zxc_decompress_block(zxc_dctx* dctx, const void* src, size_t 
  *                             @ref ZXC_BLOCK_SIZE_MAX (no tail-pad margin
  *                             needed, unlike zxc_decompress_block).
  * @param[in]     opts         Decompression options, or NULL for defaults.
- *                             Only @c checksum_enabled is used.
+ *                             Same fields as zxc_decompress_block(); a
+ *                             dictionary routes through its bounce path.
  *
  * @note @p src and @p dst must not overlap (same contract as memcpy).
  *

--- a/src/lib/zxc_dispatch.c
+++ b/src/lib/zxc_dispatch.c
@@ -1626,6 +1626,7 @@ int64_t zxc_decompress_block(zxc_dctx* dctx, const void* RESTRICT src, const siz
     const uint8_t* dict = opts ? (const uint8_t*)opts->dict : NULL;
     const size_t dict_size = ZXC_OPTS_DICT_SIZE(opts);
     if (UNLIKELY(dict_size > ZXC_DICT_SIZE_MAX)) return ZXC_ERROR_DICT_TOO_LARGE;
+    if (UNLIKELY(dctx->owns_workspace && dict_size > 0)) return ZXC_ERROR_DICT_UNSUPPORTED;
 
     // Derive the block_size from dst_capacity (callers know the original size)
     const size_t block_size = zxc_block_size_ceil(dst_capacity);

--- a/src/lib/zxc_dispatch.c
+++ b/src/lib/zxc_dispatch.c
@@ -1545,7 +1545,7 @@ int64_t zxc_compress_block(zxc_cctx* cctx, const void* RESTRICT src, const size_
     // for static contexts.
     if (UNLIKELY(cctx->owns_workspace && b_dict_size > 0)) return ZXC_ERROR_DICT_UNSUPPORTED;
     if (UNLIKELY(cctx->owns_workspace && effective_block_size != cctx->last_block_size))
-        return ZXC_ERROR_BAD_BLOCK_SIZE;
+        return ZXC_ERROR_BAD_BLOCK_SIZE;  // LCOV_EXCL_LINE
     if (UNLIKELY(cctx->owns_workspace && level >= ZXC_LEVEL_DENSITY && !cctx->inner.opt_scratch))
         return ZXC_ERROR_BAD_LEVEL;
 
@@ -1581,7 +1581,7 @@ int64_t zxc_compress_block(zxc_cctx* cctx, const void* RESTRICT src, const size_
     cctx->inner.dict_size = b_dict_size;
     if (UNLIKELY(zxc_ctx_sync_dict_huf(&cctx->inner, cctx->huf_cache, &cctx->huf_cached,
                                        ZXC_OPTS_DICT_HUF(opts)) != ZXC_OK))
-        return ZXC_ERROR_CORRUPT_DATA;
+        return ZXC_ERROR_CORRUPT_DATA;  // LCOV_EXCL_LINE
 
     int res;
     if (b_dict && b_dict_size > 0) {
@@ -1652,7 +1652,7 @@ int64_t zxc_decompress_block(zxc_dctx* dctx, const void* RESTRICT src, const siz
     ctx->dict_size = dict_size;
     if (UNLIKELY(zxc_ctx_sync_dict_huf(ctx, dctx->huf_cache, &dctx->huf_cached,
                                        ZXC_OPTS_DICT_HUF(opts)) != ZXC_OK))
-        return ZXC_ERROR_CORRUPT_DATA;
+        return ZXC_ERROR_CORRUPT_DATA;  // LCOV_EXCL_LINE
 
     // work_buf was pre-sized to block_size + ZXC_DECOMPRESS_TAIL_PAD inside
     // the matching zxc_cctx_init call above.

--- a/src/lib/zxc_dispatch.c
+++ b/src/lib/zxc_dispatch.c
@@ -1543,6 +1543,7 @@ int64_t zxc_compress_block(zxc_cctx* cctx, const void* RESTRICT src, const size_
     // optimal-parser tier it carries no opt_scratch for. Re-initing on the heap
     // would break the no-allocation contract and leak: zxc_free_cctx is a no-op
     // for static contexts.
+    if (UNLIKELY(cctx->owns_workspace && b_dict_size > 0)) return ZXC_ERROR_DICT_UNSUPPORTED;
     if (UNLIKELY(cctx->owns_workspace && effective_block_size != cctx->last_block_size))
         return ZXC_ERROR_BAD_BLOCK_SIZE;
     if (UNLIKELY(cctx->owns_workspace && level >= ZXC_LEVEL_DENSITY && !cctx->inner.opt_scratch))
@@ -1578,6 +1579,9 @@ int64_t zxc_compress_block(zxc_cctx* cctx, const void* RESTRICT src, const size_
     }
 
     cctx->inner.dict_size = b_dict_size;
+    if (UNLIKELY(zxc_ctx_sync_dict_huf(&cctx->inner, cctx->huf_cache, &cctx->huf_cached,
+                                       ZXC_OPTS_DICT_HUF(opts)) != ZXC_OK))
+        return ZXC_ERROR_CORRUPT_DATA;
 
     int res;
     if (b_dict && b_dict_size > 0) {
@@ -1646,6 +1650,9 @@ int64_t zxc_decompress_block(zxc_dctx* dctx, const void* RESTRICT src, const siz
 
     zxc_cctx_t* const ctx = &dctx->inner;
     ctx->dict_size = dict_size;
+    if (UNLIKELY(zxc_ctx_sync_dict_huf(ctx, dctx->huf_cache, &dctx->huf_cached,
+                                       ZXC_OPTS_DICT_HUF(opts)) != ZXC_OK))
+        return ZXC_ERROR_CORRUPT_DATA;
 
     // work_buf was pre-sized to block_size + ZXC_DECOMPRESS_TAIL_PAD inside
     // the matching zxc_cctx_init call above.

--- a/src/lib/zxc_dispatch.c
+++ b/src/lib/zxc_dispatch.c
@@ -1550,7 +1550,7 @@ int64_t zxc_compress_block(zxc_cctx* cctx, const void* RESTRICT src, const size_
         return ZXC_ERROR_BAD_LEVEL;
 
     cctx->stored_level = level;
-    cctx->stored_block_size = effective_block_size;
+    cctx->stored_block_size = base_block_size;
     cctx->stored_checksum = checksum_enabled;
 
     // Re-init when block_size changed, a level raise needs the optimal-parser

--- a/tests/test_common.h
+++ b/tests/test_common.h
@@ -224,6 +224,7 @@ int test_dict_block_cctx_dict_reinit(void);
 int test_dict_ctx_table_cache_recovers(void);
 int test_dict_ctx_table_without_dict(void);
 int test_dict_oversized_rejected_everywhere(void);
+int test_dict_block_huf_roundtrip(void);
 int test_dict_huf_zxd_roundtrip(void);
 int test_dict_huf_table_roundtrip(void);
 int test_dict_huf_degenerate_corpus(void);

--- a/tests/test_common.h
+++ b/tests/test_common.h
@@ -225,6 +225,7 @@ int test_dict_ctx_table_cache_recovers(void);
 int test_dict_ctx_table_without_dict(void);
 int test_dict_oversized_rejected_everywhere(void);
 int test_dict_block_huf_roundtrip(void);
+int test_dict_block_stored_block_size(void);
 int test_dict_huf_zxd_roundtrip(void);
 int test_dict_huf_table_roundtrip(void);
 int test_dict_huf_degenerate_corpus(void);

--- a/tests/test_dict.c
+++ b/tests/test_dict.c
@@ -2014,6 +2014,27 @@ int test_dict_block_huf_roundtrip(void) {
             printf("  [PASS] static cctx + dict -> DICT_UNSUPPORTED\n");
         }
 
+        /* Static dctx: same contract on both block decoders, the strict one
+         * routing dictionary calls through the fast one. */
+        {
+            const int64_t n = zxc_compress_block(cctx, heldout, BLK, comp, cap, &co);
+            const size_t ws_sz = zxc_static_dctx_workspace_size(BLK);
+            void* ws = malloc(ws_sz);
+            zxc_dctx* sd = ws ? zxc_init_static_dctx(ws, ws_sz, BLK) : NULL;
+            const int64_t r1 = sd && n > 0
+                                   ? zxc_decompress_block(sd, comp, (size_t)n, out,
+                                                          BLK + ZXC_DECOMPRESS_TAIL_PAD, &d_tab)
+                                   : -1;
+            const int64_t r2 =
+                sd && n > 0 ? zxc_decompress_block_safe(sd, comp, (size_t)n, out, BLK, &d_tab) : -1;
+            free(ws);
+            if (r1 != ZXC_ERROR_DICT_UNSUPPORTED || r2 != ZXC_ERROR_DICT_UNSUPPORTED) {
+                printf("  [FAIL] static dctx + dict: %lld / %lld\n", (long long)r1, (long long)r2);
+                break;
+            }
+            printf("  [PASS] static dctx + dict -> DICT_UNSUPPORTED on both decoders\n");
+        }
+
         ok = 1;
     } while (0);
 

--- a/tests/test_dict.c
+++ b/tests/test_dict.c
@@ -1920,3 +1920,109 @@ int test_dict_oversized_rejected_everywhere(void) {
     if (ok) printf("  [PASS] six entry points -> DICT_TOO_LARGE\nPASS\n\n");
     return ok;
 }
+
+int test_dict_block_huf_roundtrip(void) {
+    printf("=== TEST: Dict - block API honours the shared literal table ===\n");
+    enum { NS = 6, SCAP = 16384, HCAP = 32768, BLK = 4096 };
+    uint8_t* bufs[NS];
+    const void* samples[NS];
+    size_t sizes[NS];
+    for (int i = 0; i < NS; i++) {
+        bufs[i] = (uint8_t*)malloc(SCAP);
+        sizes[i] = gen_structured_sample(bufs[i], SCAP, 0x3000U + (uint32_t)i);
+        samples[i] = bufs[i];
+    }
+    uint8_t* heldout = (uint8_t*)malloc(HCAP);
+    const size_t hsz = gen_structured_sample(heldout, HCAP, 0xC0DEU);
+    uint8_t dict_buf[8192];
+    uint8_t huf[ZXC_HUF_TABLE_SIZE];
+    const size_t cap = (size_t)zxc_compress_block_bound(BLK);
+    uint8_t* comp = (uint8_t*)malloc(cap);
+    uint8_t* out = (uint8_t*)malloc(BLK + ZXC_DECOMPRESS_TAIL_PAD);
+    zxc_cctx* cctx = zxc_create_cctx(NULL);
+    zxc_dctx* dctx = zxc_create_dctx();
+    int ok = 0;
+    do {
+        const int64_t dsz = zxc_train_dict(samples, sizes, NS, dict_buf, sizeof(dict_buf));
+        if (dsz <= 0 || !cctx || !dctx ||
+            zxc_train_dict_huf(samples, sizes, NS, dict_buf, (size_t)dsz, huf) != ZXC_OK) {
+            printf("  [FAIL] setup\n");
+            break;
+        }
+        const zxc_compress_opts_t co = {
+            .level = 6, .dict = dict_buf, .dict_size = (size_t)dsz, .dict_huf = huf};
+        const zxc_decompress_opts_t d_tab = {
+            .dict = dict_buf, .dict_size = (size_t)dsz, .dict_huf = huf};
+        const zxc_decompress_opts_t d_no = {.dict = dict_buf, .dict_size = (size_t)dsz};
+
+        int n_table = 0, n_blocks = 0, bad = 0;
+        for (size_t off = 0; off + BLK <= hsz && !bad; off += BLK, n_blocks++) {
+            const int64_t cs = zxc_compress_block(cctx, heldout + off, BLK, comp, cap, &co);
+            if (cs <= 0) {
+                printf("  [FAIL] compress_block @%zu: %lld\n", off, (long long)cs);
+                bad = 1;
+                break;
+            }
+            /* enc_lit sits at sub-header offset 8, right after the block header. */
+            const int table_used = comp[0] == ZXC_BLOCK_GLO && comp[ZXC_BLOCK_HEADER_SIZE + 8] == 3;
+            n_table += table_used;
+            int64_t r = zxc_decompress_block(dctx, comp, (size_t)cs, out,
+                                             BLK + ZXC_DECOMPRESS_TAIL_PAD, &d_tab);
+            if (r != BLK || memcmp(out, heldout + off, BLK) != 0) {
+                printf("  [FAIL] decompress_block @%zu: %lld\n", off, (long long)r);
+                bad = 1;
+                break;
+            }
+            r = zxc_decompress_block_safe(dctx, comp, (size_t)cs, out, BLK, &d_tab);
+            if (r != BLK || memcmp(out, heldout + off, BLK) != 0) {
+                printf("  [FAIL] decompress_block_safe @%zu: %lld\n", off, (long long)r);
+                bad = 1;
+                break;
+            }
+            /* enc_lit=3 cannot decode without the table. */
+            r = zxc_decompress_block(dctx, comp, (size_t)cs, out, BLK + ZXC_DECOMPRESS_TAIL_PAD,
+                                     &d_no);
+            if (table_used ? (r >= 0) : (r != BLK)) {
+                printf("  [FAIL] table-less decode @%zu: %lld (table_used=%d)\n", off, (long long)r,
+                       table_used);
+                bad = 1;
+                break;
+            }
+        }
+        if (bad) break;
+        if (n_table == 0) {
+            printf(
+                "  [FAIL] no block selected enc_lit=3: the table was never "
+                "exercised\n");
+            break;
+        }
+        printf("  [PASS] %d/%d blocks coded with the shared table, all roundtrip\n", n_table,
+               n_blocks);
+
+        /* Static cctx: no dictionary prefix in the workspace, explicit error. */
+        {
+            const size_t ws_sz = zxc_static_cctx_workspace_size(BLK, 6);
+            void* ws = malloc(ws_sz);
+            const zxc_compress_opts_t so = {.level = 6, .block_size = BLK};
+            zxc_cctx* sc = ws ? zxc_init_static_cctx(ws, ws_sz, &so) : NULL;
+            const int64_t r = sc ? zxc_compress_block(sc, heldout, BLK, comp, cap, &co) : -1;
+            free(ws);
+            if (r != ZXC_ERROR_DICT_UNSUPPORTED) {
+                printf("  [FAIL] static cctx + dict: %lld\n", (long long)r);
+                break;
+            }
+            printf("  [PASS] static cctx + dict -> DICT_UNSUPPORTED\n");
+        }
+
+        ok = 1;
+    } while (0);
+
+    zxc_free_cctx(cctx);
+    zxc_free_dctx(dctx);
+    free(comp);
+    free(out);
+    free(heldout);
+    for (int i = 0; i < NS; i++) free(bufs[i]);
+    if (ok) printf("PASS\n\n");
+    return ok;
+}

--- a/tests/test_dict.c
+++ b/tests/test_dict.c
@@ -2026,3 +2026,50 @@ int test_dict_block_huf_roundtrip(void) {
     if (ok) printf("PASS\n\n");
     return ok;
 }
+
+/* The block API must remember the caller's block size, not the [dict | block]
+ * chunk it carves: fed back as the next base, the chunk doubled on every call
+ * until the context could not be allocated. The stored size is observable in
+ * the Chunk Size Code that a later frame compression writes with NULL opts. */
+int test_dict_block_stored_block_size(void) {
+    printf("=== TEST: Dict - block API keeps the caller's block size ===\n");
+    enum { BLK = 4096, CALLS = 4 };
+    uint8_t src[BLK], dict_buf[1024], huf[ZXC_HUF_TABLE_SIZE], comp[BLK + 512];
+    for (size_t i = 0; i < sizeof(src); i++) src[i] = (uint8_t)('a' + (i * 7) % 26);
+    for (size_t i = 0; i < sizeof(dict_buf); i++) dict_buf[i] = (uint8_t)('a' + i % 26);
+    const void* samples[1] = {src};
+    const size_t sizes[1] = {sizeof(src)};
+    uint8_t expected_code = 0;
+    for (size_t bs = ZXC_BLOCK_SIZE_DEFAULT; bs > 1; bs >>= 1) expected_code++;
+    zxc_cctx* cctx = zxc_create_cctx(NULL); /* default block size */
+    int ok = 0;
+    do {
+        if (!cctx ||
+            zxc_train_dict_huf(samples, sizes, 1, dict_buf, sizeof(dict_buf), huf) != ZXC_OK) {
+            printf("  [FAIL] setup\n");
+            break;
+        }
+        const zxc_compress_opts_t co = {
+            .level = 6, .dict = dict_buf, .dict_size = sizeof(dict_buf), .dict_huf = huf};
+        int64_t r = 0;
+        for (int i = 0; i < CALLS && r >= 0; i++)
+            r = zxc_compress_block(cctx, src, sizeof(src), comp, sizeof(comp), &co);
+        if (r <= 0) {
+            printf("  [FAIL] compress_block: %lld\n", (long long)r);
+            break;
+        }
+        /* NULL opts: the frame path uses the stored block size for its header. */
+        const int64_t f = zxc_compress_cctx(cctx, src, sizeof(src), comp, sizeof(comp), NULL);
+        if (f <= 0 || comp[5] != expected_code) {
+            printf("  [FAIL] frame after %d block calls: %lld, chunk code %u (want %u)\n", CALLS,
+                   (long long)f, f > 0 ? comp[5] : 0U, expected_code);
+            break;
+        }
+        printf("  [PASS] %d dict block calls, then a frame still carries chunk code %u\n", CALLS,
+               expected_code);
+        ok = 1;
+    } while (0);
+    zxc_free_cctx(cctx);
+    if (ok) printf("PASS\n\n");
+    return ok;
+}

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -150,6 +150,7 @@ static const test_entry_t g_tests[] = {
     TEST_CASE(test_dict_ctx_table_without_dict),
     TEST_CASE(test_dict_oversized_rejected_everywhere),
     TEST_CASE(test_dict_block_huf_roundtrip),
+    TEST_CASE(test_dict_block_stored_block_size),
     TEST_CASE(test_dict_huf_zxd_roundtrip),
     TEST_CASE(test_dict_huf_table_roundtrip),
     TEST_CASE(test_dict_huf_degenerate_corpus),

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -149,6 +149,7 @@ static const test_entry_t g_tests[] = {
     TEST_CASE(test_dict_ctx_table_cache_recovers),
     TEST_CASE(test_dict_ctx_table_without_dict),
     TEST_CASE(test_dict_oversized_rejected_everywhere),
+    TEST_CASE(test_dict_block_huf_roundtrip),
     TEST_CASE(test_dict_huf_zxd_roundtrip),
     TEST_CASE(test_dict_huf_table_roundtrip),
     TEST_CASE(test_dict_huf_degenerate_corpus),


### PR DESCRIPTION
Adds support for shared literal tables (dictionary Huffman tables) to the block compression and decompression API.

- **Block API Integration**: zxc_compress_block, zxc_decompress_block, and zxc_decompress_block_safe now utilize the dict_huf field from options structs.
- **Static Context Guard**: Static contexts now return ZXC_ERROR_DICT_UNSUPPORTED when used with a dictionary to prevent invalid operations.
- **Documentation & Tests**: Updated block API documentation with dictionary requirements and added test_dict_block_huf_roundtrip to cover full roundtrips and error handling.

This allows block-level compression workflows to leverage pre-trained dictionary Huffman tables for lower overhead and improved efficiency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Block compression and decompression now consistently honor dictionary-provided Huffman tables.
  - Standard and safe block decompression support dictionary settings with matching compression information.

- **Bug Fixes**
  - Improved dictionary table synchronization during block processing.
  - Static contexts now clearly reject unsupported dictionary usage.
  - Corrected block-size handling when dictionaries are used.

- **Documentation**
  - Updated API references with dictionary requirements, table behavior, and related error conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->