### PR TITLE
feat(dict): Enables dictionary support for static contexts with ABI bump

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,7 +61,7 @@ add_library(zxc::zxc_lib ALIAS zxc_lib)
 # ABI Versioning (Debian/Linux shared libraries)
 # =============================================================================
 # Increment this number ONLY when breaking the ABI.
-set(ZXC_SOVERSION 4)
+set(ZXC_SOVERSION 5)
 
 # Set library output name and version
 set_target_properties(zxc_lib PROPERTIES

--- a/docs/API.md
+++ b/docs/API.md
@@ -669,7 +669,7 @@ Same as `zxc_compress()` but reuses internal buffers from `cctx`.
 Automatically re-initializes when `block_size` or `level` changes. Dictionary
 options are honoured as in `zxc_compress()` but are not sticky; the shared
 literal table is rebuilt only when it changes. A static context returns
-`ZXC_ERROR_DICT_UNSUPPORTED` for any dictionary.
+`ZXC_ERROR_DICT_UNSUPPORTED` for a dictionary beyond its carved capacity.
 
 ### `zxc_create_dctx`
 
@@ -702,7 +702,8 @@ ZXC_EXPORT int64_t zxc_decompress_dctx(
 
 Same as `zxc_decompress()`, dictionary options included, but reuses buffers
 from `dctx`; the shared literal table is rebuilt only when it changes between
-calls. A static context returns `ZXC_ERROR_DICT_UNSUPPORTED` for any dictionary.
+calls. A static context returns `ZXC_ERROR_DICT_UNSUPPORTED` for a dictionary
+beyond its carved capacity.
 
 ---
 
@@ -745,19 +746,18 @@ maximum block size up front.
 ```c
 ZXC_EXPORT size_t zxc_static_cctx_workspace_size(
     const size_t block_size,
-    const int    level
+    const int    level,
+    const size_t dict_capacity
 );
 ```
 
-Returns the exact byte count required by a static compression workspace
-for the given `block_size` and `level`. Sum of the opaque `zxc_cctx`
-wrapper plus every persistent sub-buffer the library would partition.
+Exact workspace size for `zxc_init_static_cctx` at the given `block_size` and
+`level`. A non-zero `dict_capacity` (at most `ZXC_DICT_SIZE_MAX`) also carves
+the `[dict | block]` input and the shared-table state; the carved block grows
+to the power of two above `dict_capacity + block_size`. Pass the same capacity
+as `dict_size` in the `opts` given to `zxc_init_static_cctx`.
 
-**Returns**: workspace size in bytes, or `0` if either argument is invalid
-(non-power-of-two `block_size`, out-of-range level, ...).
-
-**Note**: level 6 (`ZXC_LEVEL_DENSITY`) adds the optimal-parser scratch
-(~8.125 × `block_size`); levels 1–5 share the same workspace size.
+**Returns**: bytes required, or 0 on an invalid parameter.
 
 ### `zxc_init_static_cctx`
 
@@ -773,7 +773,9 @@ Initialises a compression context inside a caller-supplied workspace.
 `workspace_size` must be at least `zxc_static_cctx_workspace_size` for the
 same `block_size` / `level`. `opts` is **required**: `block_size` and
 `level` are pinned at init time and must be set explicitly.
-Dictionaries are rejected: `ZXC_ERROR_DICT_UNSUPPORTED`.
+`dict_size` in `opts` is the dictionary capacity to carve (size the workspace
+with `zxc_static_cctx_workspace_size`); a larger dictionary later returns
+`ZXC_ERROR_DICT_UNSUPPORTED`.
 
 The returned handle points **inside** `workspace`; the workspace must
 remain valid for the lifetime of the handle. `zxc_free_cctx` is a no-op.
@@ -786,17 +788,16 @@ is `NULL`.
 
 ```c
 ZXC_EXPORT size_t zxc_static_dctx_workspace_size(
-    const size_t block_size
+    const size_t block_size,
+    const size_t dict_capacity
 );
 ```
 
-Returns the exact byte count required by a static decompression workspace
-for the given `block_size`. Unlike the compression variant, this size is
-**independent of the source archive's level**: `lit_buffer` is always
-provisioned worst-case because the decoder cannot predict the per-block
-literal encoding (RAW / RLE / HUFFMAN) until it sees each block header.
+Exact workspace size for `zxc_init_static_dctx`. A non-zero `dict_capacity`
+(at most `ZXC_DICT_SIZE_MAX`) also carves the dictionary prefix and the
+shared-table state.
 
-**Returns**: workspace size in bytes, or `0` if `block_size` is invalid.
+**Returns**: bytes required, or 0 on an invalid parameter.
 
 ### `zxc_init_static_dctx`
 
@@ -804,22 +805,23 @@ literal encoding (RAW / RLE / HUFFMAN) until it sees each block header.
 ZXC_EXPORT zxc_dctx* zxc_init_static_dctx(
     void*         workspace,
     const size_t  workspace_size,
-    const size_t  block_size
+    const size_t  block_size,
+    const size_t  dict_capacity
 );
 ```
 
 Initialises a decompression context inside a caller-supplied workspace.
 `block_size` is **pinned** at init time: feeding the returned handle an
 archive whose file header declares a different `block_size` returns
-`ZXC_ERROR_BAD_BLOCK_SIZE`. Dictionaries are not supported:
+`ZXC_ERROR_BAD_BLOCK_SIZE`. Dictionaries up to `dict_capacity` are honoured; a
+larger one, or any dictionary when the capacity is 0, returns
 `ZXC_ERROR_DICT_UNSUPPORTED`.
 
 The returned handle points inside `workspace`; the workspace must remain
 valid for the lifetime of the handle. `zxc_free_dctx` is a no-op.
 
 **Returns**: handle pointing inside `workspace`, or `NULL` if the
-workspace is too small, `block_size` is invalid, or `workspace` is
-`NULL`.
+workspace is too small or a parameter is invalid.
 
 ### Typical usage
 
@@ -830,7 +832,7 @@ workspace is too small, `block_size` is invalid, or `workspace` is
 #define LEVEL      ZXC_LEVEL_DEFAULT
 
 /* --- Compression side --- */
-size_t cws_sz = zxc_static_cctx_workspace_size(BLOCK_SZ, LEVEL);
+size_t cws_sz = zxc_static_cctx_workspace_size(BLOCK_SZ, LEVEL, 0);
 void  *cws    = NULL;
 posix_memalign(&cws, 64, cws_sz);                  /* or kmalloc / vmalloc / .bss */
 
@@ -844,11 +846,11 @@ zxc_free_cctx(cctx);  /* no-op for static */
 free(cws);            /* caller owns the workspace */
 
 /* --- Decompression side --- */
-size_t dws_sz = zxc_static_dctx_workspace_size(BLOCK_SZ);
+size_t dws_sz = zxc_static_dctx_workspace_size(BLOCK_SZ, 0);
 void  *dws    = NULL;
 posix_memalign(&dws, 64, dws_sz);
 
-zxc_dctx *dctx = zxc_init_static_dctx(dws, dws_sz, BLOCK_SZ);
+zxc_dctx *dctx = zxc_init_static_dctx(dws, dws_sz, BLOCK_SZ, 0);
 zxc_decompress_dctx(dctx, in, in_sz, out, out_cap, NULL);
 zxc_free_dctx(dctx);  /* no-op */
 free(dws);
@@ -919,7 +921,7 @@ must know it *before* calling `init`. Four patterns cover every use case:
    archive at the cost of over-allocation (~4 MB dctx).
 
    ```c
-   size_t dws_sz = zxc_static_dctx_workspace_size(ZXC_BLOCK_SIZE_MAX);
+   size_t dws_sz = zxc_static_dctx_workspace_size(ZXC_BLOCK_SIZE_MAX, 0);
    ```
 
    If the workspace pool must stay tight and worst-case sizing is too

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,7 +1,7 @@
 # ZXC API & ABI Reference
 
 **Library version**: 0.14.0
-**SOVERSION**: 4  
+**SOVERSION**: 5  
 **License**: BSD-3-Clause
 
 This document is the authoritative reference for the public API surface and ABI
@@ -137,7 +137,7 @@ libzxc.so.{SOVERSION}.{MAJOR}.{MINOR}.{PATCH}
 
 | Field | Description | Current |
 |-------|-------------|---------|
-| `SOVERSION` | Bumped on **ABI-breaking** changes (struct layout, removed symbols, changed signatures). | **4** |
+| `SOVERSION` | Bumped on **ABI-breaking** changes (struct layout, removed symbols, changed signatures). | **5** |
 | `VERSION` | Tracks the library release. | **0.14.0** |
 
 **Compatibility rule**: any binary compiled against SOVERSION N will load against
@@ -538,7 +538,7 @@ Compresses a single block using a reusable context.
 `level`, `block_size`, `checksum_enabled` and the dictionary fields (`dict`,
 `dict_size`, `dict_huf`) of `opts` are used; the shared literal table is
 rebuilt only when it changes. A static context returns
-`ZXC_ERROR_DICT_UNSUPPORTED` for any dictionary.
+`ZXC_ERROR_DICT_UNSUPPORTED` for a dictionary beyond its carved capacity.
 
 `src_size` must be in `[1, ZXC_BLOCK_SIZE_MAX]` (2 MiB). For larger payloads,
 use the frame API (`zxc_compress`) or streaming API (`zxc_cstream_*`), which
@@ -567,7 +567,8 @@ Decompresses a single block produced by `zxc_compress_block()`.
 produced by the frame or streaming APIs, use `zxc_decompress` instead.
 `checksum_enabled` and the dictionary fields are used; a block carries no
 dictionary id, so pass the same (content, table) pair as at compression. A
-static context returns `ZXC_ERROR_DICT_UNSUPPORTED` for any dictionary.
+static context returns `ZXC_ERROR_DICT_UNSUPPORTED` for a dictionary beyond its
+carved capacity.
 
 **Returns**: decompressed size (> 0) on success, or negative `zxc_error_t`.
 Returns `ZXC_ERROR_BAD_BLOCK_SIZE` if `dst_capacity` exceeds the per-block

--- a/include/zxc_buffer.h
+++ b/include/zxc_buffer.h
@@ -442,7 +442,8 @@ ZXC_EXPORT void zxc_free_cctx(zxc_cctx* cctx);
  * Dictionary options are the exception: honoured as in zxc_compress() but
  * never remembered, so pass them on every call; the shared table is rebuilt
  * only when it changes. A static context returns
- * @ref ZXC_ERROR_DICT_UNSUPPORTED for any dictionary.
+ * @ref ZXC_ERROR_DICT_UNSUPPORTED for a dictionary beyond the capacity carved
+ * at init (none by default).
  *
  * @param[in,out] cctx         Reusable compression context.
  * @param[in]     src          Source data.
@@ -482,8 +483,8 @@ ZXC_EXPORT void zxc_free_dctx(zxc_dctx* dctx);
  *
  * Like zxc_decompress(), dictionary options included, but reuses @p dctx's
  * buffers; the shared literal table is rebuilt only when it changes between
- * calls. A static context returns @ref ZXC_ERROR_DICT_UNSUPPORTED for any
- * dictionary.
+ * calls. A static context returns @ref ZXC_ERROR_DICT_UNSUPPORTED for a
+ * dictionary beyond the capacity carved at init (none by default).
  *
  * @param[in,out] dctx         Reusable decompression context.
  * @param[in]     src          Compressed data.
@@ -535,22 +536,21 @@ ZXC_EXPORT int64_t zxc_decompress_dctx(zxc_dctx* dctx, const void* src, size_t s
  */
 
 /**
- * @brief Exact size of a static compression workspace.
+ * @brief Workspace size for a static compression context.
  *
- * Sums the opaque @ref zxc_cctx wrapper and every persistent sub-buffer the
- * library partitions out of it (hash tables, chain table, sequence buffers,
- * literal scratch, plus the optimal-parser scratch at
- * @ref ZXC_LEVEL_DENSITY). The workspace must be at least cache-line aligned,
- * so round up for @c posix_memalign / @c aligned_alloc.
+ * With a non-zero @p dict_capacity the workspace also carves the [dict | block]
+ * input and the shared-table state, and the carved block grows to the power of
+ * two above @c dict_capacity + @c block_size. Pass the same capacity as
+ * @c dict_size to zxc_init_static_cctx().
  *
- * @param[in] block_size  Block size in bytes (power of two in
- *                        [@ref ZXC_BLOCK_SIZE_MIN, @ref ZXC_BLOCK_SIZE_MAX]).
- * @param[in] level       Compression level (1..7); levels at or above
- *                        @ref ZXC_LEVEL_DENSITY add the optimal-parser
- *                        scratch (~8.125 x block_size).
- * @return Workspace size in bytes, or 0 if either argument is invalid.
+ * @param[in] block_size     Block size (power of two).
+ * @param[in] level          Compression level the workspace must support.
+ * @param[in] dict_capacity  Largest dictionary to accept, at most
+ *                           @ref ZXC_DICT_SIZE_MAX; 0 means none.
+ * @return Bytes required, or 0 on an invalid parameter.
  */
-ZXC_EXPORT size_t zxc_static_cctx_workspace_size(const size_t block_size, const int level);
+ZXC_EXPORT size_t zxc_static_cctx_workspace_size(const size_t block_size, const int level,
+                                                 const size_t dict_capacity);
 
 /**
  * @brief Initialises a compression context inside a caller-supplied workspace.
@@ -567,7 +567,8 @@ ZXC_EXPORT size_t zxc_static_cctx_workspace_size(const size_t block_size, const 
  * @c level / @c checksum_enabled is honoured per call without re-partitioning,
  * except a raise into @ref ZXC_LEVEL_DENSITY on a workspace carved below it:
  * the optimal-parser scratch is absent, so the call returns
- * @ref ZXC_ERROR_BAD_LEVEL. Dictionaries are rejected too:
+ * @ref ZXC_ERROR_BAD_LEVEL. @c dict_size in @p opts is the dictionary
+ * capacity to carve (pointer not kept); larger dictionaries later return
  * @ref ZXC_ERROR_DICT_UNSUPPORTED.
  *
  * @param[in,out] workspace       Caller-allocated buffer, cache-line aligned.
@@ -582,42 +583,43 @@ ZXC_EXPORT zxc_cctx* zxc_init_static_cctx(void* workspace, const size_t workspac
                                           const zxc_compress_opts_t* opts);
 
 /**
- * @brief Exact size of a static decompression workspace.
+ * @brief Workspace size for a static decompression context.
  *
- * Unlike the compression variant this is independent of the archive's level:
- * @c lit_buffer is always provisioned worst-case, because the decoder cannot
- * know a block's literal encoding until it reads that block's header.
+ * With a non-zero @p dict_capacity the workspace also carves the dictionary
+ * prefix and the shared-table state.
  *
- * @param[in] block_size  Largest block size the decoder will meet (same
- *                        constraints as everywhere else).
- * @return Workspace size in bytes, or 0 if @p block_size is invalid.
+ * @param[in] block_size     Block size the decoder will accept (power of two).
+ * @param[in] dict_capacity  Largest dictionary to accept, at most
+ *                           @ref ZXC_DICT_SIZE_MAX; 0 means none.
+ * @return Bytes required, or 0 on an invalid parameter.
  */
-ZXC_EXPORT size_t zxc_static_dctx_workspace_size(const size_t block_size);
+ZXC_EXPORT size_t zxc_static_dctx_workspace_size(const size_t block_size,
+                                                 const size_t dict_capacity);
 
 /**
  * @brief Initialises a decompression context inside a caller-supplied workspace.
  *
  * @p workspace_size must be at least @ref zxc_static_dctx_workspace_size for
- * the same @p block_size. The workspace must be cache-line aligned and must
- * outlive the returned handle. The caller owns it; @ref zxc_free_dctx is a
- * no-op on this handle.
+ * the same @p block_size and @p dict_capacity. The workspace must be cache-line
+ * aligned and must outlive the returned handle. The caller owns it;
+ * @ref zxc_free_dctx is a no-op on this handle.
  *
- * @par Locked block size
+ * @par Locked parameters
  * @p block_size is pinned at init time: an archive whose header declares a
  * different @c block_size is rejected with @ref ZXC_ERROR_BAD_BLOCK_SIZE.
- *
- * @par No dictionary
- * Any dictionary is rejected with @ref ZXC_ERROR_DICT_UNSUPPORTED: the
- * workspace has no room for the prefix.
+ * Dictionaries up to @p dict_capacity are honoured; a larger one, or any
+ * dictionary when the capacity is 0, is rejected with
+ * @ref ZXC_ERROR_DICT_UNSUPPORTED.
  *
  * @param[in,out] workspace       Caller-allocated buffer, cache-line aligned.
  * @param[in]     workspace_size  Capacity of @p workspace in bytes.
  * @param[in]     block_size      Block size the decoder will accept.
+ * @param[in]     dict_capacity   Largest dictionary to accept; 0 means none.
  * @return Handle pointing inside @p workspace, or @c NULL if the workspace is
- *         too small or @p block_size is invalid.
+ *         too small or a parameter is invalid.
  */
 ZXC_EXPORT zxc_dctx* zxc_init_static_dctx(void* workspace, const size_t workspace_size,
-                                          const size_t block_size);
+                                          const size_t block_size, const size_t dict_capacity);
 
 /** @} */ /* end of static_context_api */
 /** @} */ /* end of context_api */

--- a/include/zxc_buffer.h
+++ b/include/zxc_buffer.h
@@ -297,7 +297,8 @@ ZXC_EXPORT uint64_t zxc_decompress_block_bound(const size_t uncompressed_size);
  *         @ref ZXC_BLOCK_SIZE_MAX; @ref ZXC_ERROR_BAD_LEVEL on a static
  *         context for a level raise its workspace cannot accommodate (levels
  *         above @ref ZXC_LEVEL_ULTRA are otherwise silently clamped);
- *         @ref ZXC_ERROR_DICT_UNSUPPORTED on a static context with a dictionary.
+ *         @ref ZXC_ERROR_DICT_UNSUPPORTED on a static context for a dictionary
+ *         beyond its carved capacity.
  */
 ZXC_EXPORT int64_t zxc_compress_block(zxc_cctx* cctx, const void* src, size_t src_size, void* dst,
                                       size_t dst_capacity, const zxc_compress_opts_t* opts);
@@ -322,7 +323,8 @@ ZXC_EXPORT int64_t zxc_compress_block(zxc_cctx* cctx, const void* src, size_t sr
  *                             @c checksum_enabled and the dictionary fields are
  *                             used; a block carries no dictionary id, so pass
  *                             the same (content, table) pair as at compression.
- *                             Static context: @ref ZXC_ERROR_DICT_UNSUPPORTED.
+ *                             Static context: @ref ZXC_ERROR_DICT_UNSUPPORTED
+ *                             beyond its carved capacity.
  *
  * @note @p src and @p dst must not overlap (same contract as memcpy).
  *
@@ -522,7 +524,7 @@ ZXC_EXPORT int64_t zxc_decompress_dctx(zxc_dctx* dctx, const void* src, size_t s
  *
  * @par Typical usage
  * @code
- * size_t ws_sz = zxc_static_cctx_workspace_size(64 * 1024, ZXC_LEVEL_DEFAULT);
+ * size_t ws_sz = zxc_static_cctx_workspace_size(64 * 1024, ZXC_LEVEL_DEFAULT, 0);
  * void *ws = aligned_alloc(64, ws_sz);                   // or kmalloc, vmalloc, .bss
  * zxc_compress_opts_t opts = { .level = ZXC_LEVEL_DEFAULT, .block_size = 64 * 1024 };
  * zxc_cctx *cctx = zxc_init_static_cctx(ws, ws_sz, &opts);

--- a/meson.build
+++ b/meson.build
@@ -23,7 +23,7 @@ is_cl = cc.get_id() == 'msvc'
 msvc_narrowing_args = msvc_syntax ? ['/wd4244'] : []
 
 # Keep in sync with ZXC_SOVERSION in CMakeLists.txt (bumps only on an ABI break).
-zxc_soversion = '4'
+zxc_soversion = '5'
 
 # =============================================================================
 # Windows DLL export control

--- a/src/lib/zxc_dispatch.c
+++ b/src/lib/zxc_dispatch.c
@@ -1634,12 +1634,15 @@ int64_t zxc_decompress_block(zxc_dctx* dctx, const void* RESTRICT src, const siz
     const size_t dict_size = ZXC_OPTS_DICT_SIZE(opts);
     if (UNLIKELY(dict_size > ZXC_DICT_SIZE_MAX)) return ZXC_ERROR_DICT_TOO_LARGE;
 
-    // Static dctx: the carved block and dictionary capacity are locked.
-    if (UNLIKELY(dctx->owns_workspace &&
-                 dst_capacity > dctx->last_block_size + ZXC_DECOMPRESS_TAIL_PAD))
-        return ZXC_ERROR_BAD_BLOCK_SIZE;
+    // Static dctx: the carved block and dictionary capacity are locked. A GLO
+    // block announcing more literals than the carved block is rejected up
+    // front; anything else larger is caught after decoding (see below).
     if (UNLIKELY(dctx->owns_workspace && dict_size > dctx->dict_cap))
         return ZXC_ERROR_DICT_UNSUPPORTED;
+    if (dctx->owns_workspace && ((const uint8_t*)src)[0] == ZXC_BLOCK_GLO &&
+        src_size >= ZXC_BLOCK_HEADER_SIZE + 8 &&
+        zxc_le32((const uint8_t*)src + ZXC_BLOCK_HEADER_SIZE + 4) > dctx->last_block_size)
+        return ZXC_ERROR_BAD_BLOCK_SIZE;
 
     // Derive the block_size from dst_capacity (callers know the original size)
     const size_t block_size =
@@ -1686,8 +1689,9 @@ int64_t zxc_decompress_block(zxc_dctx* dctx, const void* RESTRICT src, const siz
             ZXC_MEMCPY(dst, dec_buf + dict_size, (size_t)res);
         }
     } else if (LIKELY(dst_capacity >= work_sz)) {
-        res = zxc_decompress_chunk_wrapper(ctx, (const uint8_t*)src, src_size, (uint8_t*)dst,
-                                           dst_capacity);
+        // A static context never decodes past its carved block.
+        const size_t cap = dctx->owns_workspace && dst_capacity > work_sz ? work_sz : dst_capacity;
+        res = zxc_decompress_chunk_wrapper(ctx, (const uint8_t*)src, src_size, (uint8_t*)dst, cap);
     } else {
         // Bounce through work_buf when output can't absorb wild copies.
         res = zxc_decompress_chunk_wrapper(ctx, (const uint8_t*)src, src_size, ctx->work_buf,
@@ -1696,6 +1700,14 @@ int64_t zxc_decompress_block(zxc_dctx* dctx, const void* RESTRICT src, const siz
             if (UNLIKELY((size_t)res > dst_capacity)) return ZXC_ERROR_DST_TOO_SMALL;
             ZXC_MEMCPY(dst, ctx->work_buf, (size_t)res);
         }
+    }
+    if (dctx->owns_workspace) {
+        // Static dctx: a block larger than the carved block is a block-size
+        // violation, whether it overflowed the capped destination or not.
+        if (UNLIKELY(res == ZXC_ERROR_DST_TOO_SMALL && dst_capacity > dctx->last_block_size))
+            return ZXC_ERROR_BAD_BLOCK_SIZE;
+        if (UNLIKELY(res > 0 && (size_t)res > dctx->last_block_size))
+            return ZXC_ERROR_BAD_BLOCK_SIZE;
     }
     if (UNLIKELY(res < 0)) return res;
     return (int64_t)res;
@@ -1717,6 +1729,9 @@ int64_t zxc_decompress_block_safe(zxc_dctx* dctx, const void* RESTRICT src, cons
 
     // Strict-tail variant: dst_capacity matches the exact uncompressed size
     if (UNLIKELY(dst_capacity > ZXC_BLOCK_SIZE_MAX)) return ZXC_ERROR_BAD_BLOCK_SIZE;
+    // Static dctx: the carved block is locked, whichever path decodes it.
+    if (UNLIKELY(dctx->owns_workspace && dst_capacity > dctx->last_block_size))
+        return ZXC_ERROR_BAD_BLOCK_SIZE;
 
     // A dict needs the [dict|payload] bounce; route to the bounce-capable path.
     if (opts && opts->dict && opts->dict_size > 0) {
@@ -1731,9 +1746,6 @@ int64_t zxc_decompress_block_safe(zxc_dctx* dctx, const void* RESTRICT src, cons
 
     // GLO/GHI: use the strict-tail decoder (no bounce buffer required).
     const int checksum_enabled = opts ? opts->checksum_enabled : 0;
-    // Static dctx: the carved block is locked.
-    if (UNLIKELY(dctx->owns_workspace && dst_capacity > dctx->last_block_size))
-        return ZXC_ERROR_BAD_BLOCK_SIZE;
     const size_t block_size =
         dctx->owns_workspace ? dctx->last_block_size : zxc_block_size_ceil(dst_capacity);
     if (UNLIKELY(!dctx->owns_workspace &&
@@ -1755,6 +1767,8 @@ int64_t zxc_decompress_block_safe(zxc_dctx* dctx, const void* RESTRICT src, cons
         dctx->inner.checksum_enabled = checksum_enabled;
     }
     dctx->inner.dict_size = 0;
+    // No dictionary here: a table attached by an earlier call must not linger.
+    (void)zxc_ctx_sync_dict_huf(&dctx->inner, dctx->huf_cache, &dctx->huf_cached, NULL);
 
     const int res = zxc_decompress_chunk_wrapper_safe_public(&dctx->inner, (const uint8_t*)src,
                                                              src_size, (uint8_t*)dst, dst_capacity);

--- a/src/lib/zxc_dispatch.c
+++ b/src/lib/zxc_dispatch.c
@@ -1112,6 +1112,7 @@ struct zxc_cctx_s {
     int stored_level;
     int stored_checksum;
     size_t stored_block_size;
+    size_t dict_cap;                       /* static: dictionary capacity carved at init */
     int huf_cached;                        /* inner carries the table below */
     uint8_t huf_cache[ZXC_HUF_TABLE_SIZE]; /* last table attached */
 };
@@ -1205,10 +1206,10 @@ int64_t zxc_compress_cctx(zxc_cctx* cctx, const void* RESTRICT src, const size_t
     if (UNLIKELY(dict_size > ZXC_DICT_SIZE_MAX)) return ZXC_ERROR_DICT_TOO_LARGE;
     if (UNLIKELY(!zxc_validate_block_size(block_size))) return ZXC_ERROR_BAD_BLOCK_SIZE;
 
-    // Static cctx: no room for a dictionary prefix, and the workspace cannot
-    // grow, so reject a block_size change or a level raise into the
-    // optimal-parser tier it was carved without.
-    if (UNLIKELY(cctx->owns_workspace && dict_size > 0)) return ZXC_ERROR_DICT_UNSUPPORTED;
+    // Static cctx: never re-carved, so reject a dictionary beyond the carved
+    // capacity, a block_size change, or a level raise it was carved without.
+    if (UNLIKELY(cctx->owns_workspace && dict_size > cctx->dict_cap))
+        return ZXC_ERROR_DICT_UNSUPPORTED;
     if (UNLIKELY(cctx->owns_workspace && block_size != cctx->last_block_size))
         return ZXC_ERROR_BAD_BLOCK_SIZE;
     if (UNLIKELY(cctx->owns_workspace && level >= ZXC_LEVEL_DENSITY && !cctx->inner.opt_scratch))
@@ -1225,9 +1226,11 @@ int64_t zxc_compress_cctx(zxc_cctx* cctx, const void* RESTRICT src, const size_t
 
     // Re-init when the chunk changed, a level raise needs the optimal-parser
     // scratch, or a dictionary arrives on a context carved without its prefix.
-    if (UNLIKELY(!cctx->initialized || cctx->last_block_size != eff_chunk ||
-                 (level >= ZXC_LEVEL_DENSITY && !cctx->inner.opt_scratch) ||
-                 (dict_size > 0 && !cctx->inner.dict_buffer))) {
+    // Static contexts are never re-carved.
+    if (UNLIKELY(!cctx->owns_workspace &&
+                 (!cctx->initialized || cctx->last_block_size != eff_chunk ||
+                  (level >= ZXC_LEVEL_DENSITY && !cctx->inner.opt_scratch) ||
+                  (dict_size > 0 && !cctx->inner.dict_buffer)))) {
         if (cctx->initialized) {
             zxc_cctx_free(&cctx->inner);
             cctx->initialized = 0;
@@ -1326,6 +1329,7 @@ struct zxc_dctx_s {
     int owns_workspace;     /* 0 = library-allocated (free in zxc_free_dctx),
                                1 = caller-supplied static workspace (no-op free,
                                block_size pinned at init) */
+    size_t dict_cap;        /* static: dictionary capacity carved at init */
     int huf_cached;         /* inner carries the table below */
     uint8_t huf_cache[ZXC_HUF_TABLE_SIZE]; /* last table attached */
 };
@@ -1384,12 +1388,11 @@ int64_t zxc_decompress_dctx(zxc_dctx* dctx, const void* RESTRICT src, const size
                                       &header_dict_id) != ZXC_OK))
         return ZXC_ERROR_BAD_HEADER;
 
-    // Static dctx: block_size is locked at workspace init; reject any
-    // archive whose declared block_size would require a re-partition.
+    // Static dctx: block_size and dictionary capacity are locked at init.
     if (UNLIKELY(dctx->owns_workspace && runtime_chunk_size != dctx->last_block_size))
         return ZXC_ERROR_BAD_BLOCK_SIZE;
-    // Static dctx: no room for a dictionary prefix.
-    if (UNLIKELY(dctx->owns_workspace && (header_dict_id != 0 || dict_size != 0)))
+    if (UNLIKELY(dctx->owns_workspace &&
+                 (dict_size > dctx->dict_cap || (header_dict_id != 0 && dctx->dict_cap == 0))))
         return ZXC_ERROR_DICT_UNSUPPORTED;
 
     // Dictionary binding: same contract as zxc_decompress().
@@ -1400,9 +1403,10 @@ int64_t zxc_decompress_dctx(zxc_dctx* dctx, const void* RESTRICT src, const size
     }
 
     // Re-init when the block or dictionary size changed (the block API shares
-    // this context).
-    if (UNLIKELY(!dctx->initialized || dctx->last_block_size != runtime_chunk_size ||
-                 dctx->last_dict_size != dict_size)) {
+    // this context); static contexts are never re-carved.
+    if (UNLIKELY(!dctx->owns_workspace &&
+                 (!dctx->initialized || dctx->last_block_size != runtime_chunk_size ||
+                  dctx->last_dict_size != dict_size))) {
         if (dctx->initialized) {
             zxc_cctx_free(&dctx->inner);
             dctx->initialized = 0;
@@ -1421,7 +1425,7 @@ int64_t zxc_decompress_dctx(zxc_dctx* dctx, const void* RESTRICT src, const size
     }
 
     zxc_cctx_t* const ctx = &dctx->inner;
-
+    ctx->dict_size = dict_size; /* static: carved for its capacity */
     if (UNLIKELY(zxc_ctx_sync_dict_huf(ctx, dctx->huf_cache, &dctx->huf_cached, dict_huf) !=
                  ZXC_OK))
         return ZXC_ERROR_CORRUPT_DATA;
@@ -1434,7 +1438,7 @@ int64_t zxc_decompress_dctx(zxc_dctx* dctx, const void* RESTRICT src, const size
     const size_t work_sz = runtime_chunk_size + ZXC_DECOMPRESS_TAIL_PAD;
 
     // [dict | decode + PAD] scratch, NULL without a dictionary.
-    uint8_t* const dict_dec = ctx->dict_buffer;
+    uint8_t* const dict_dec = dict_size > 0 ? ctx->dict_buffer : NULL;
     if (dict_dec) ZXC_MEMCPY(dict_dec, dict, dict_size);
 
     while (ip < ip_end) {
@@ -1543,9 +1547,10 @@ int64_t zxc_compress_block(zxc_cctx* cctx, const void* RESTRICT src, const size_
     // optimal-parser tier it carries no opt_scratch for. Re-initing on the heap
     // would break the no-allocation contract and leak: zxc_free_cctx is a no-op
     // for static contexts.
-    if (UNLIKELY(cctx->owns_workspace && b_dict_size > 0)) return ZXC_ERROR_DICT_UNSUPPORTED;
-    if (UNLIKELY(cctx->owns_workspace && effective_block_size != cctx->last_block_size))
-        return ZXC_ERROR_BAD_BLOCK_SIZE;  // LCOV_EXCL_LINE
+    if (UNLIKELY(cctx->owns_workspace && b_dict_size > cctx->dict_cap))
+        return ZXC_ERROR_DICT_UNSUPPORTED;
+    if (UNLIKELY(cctx->owns_workspace && base_block_size != cctx->last_block_size))
+        return ZXC_ERROR_BAD_BLOCK_SIZE;
     if (UNLIKELY(cctx->owns_workspace && level >= ZXC_LEVEL_DENSITY && !cctx->inner.opt_scratch))
         return ZXC_ERROR_BAD_LEVEL;
 
@@ -1556,9 +1561,11 @@ int64_t zxc_compress_block(zxc_cctx* cctx, const void* RESTRICT src, const size_
     // Re-init when block_size changed, a level raise needs the optimal-parser
     // scratch, or a dictionary arrives on a context carved without its prefix
     // (a block_size switch can round [dict | block] back to the same size).
-    if (UNLIKELY(!cctx->initialized || cctx->last_block_size != effective_block_size ||
-                 (level >= ZXC_LEVEL_DENSITY && !cctx->inner.opt_scratch) ||
-                 (b_dict_size > 0 && !cctx->inner.dict_buffer))) {
+    // Static contexts are never re-carved.
+    if (UNLIKELY(!cctx->owns_workspace &&
+                 (!cctx->initialized || cctx->last_block_size != effective_block_size ||
+                  (level >= ZXC_LEVEL_DENSITY && !cctx->inner.opt_scratch) ||
+                  (b_dict_size > 0 && !cctx->inner.dict_buffer)))) {
         if (cctx->initialized) {
             // LCOV_EXCL_START
             zxc_cctx_free(&cctx->inner);
@@ -1626,12 +1633,20 @@ int64_t zxc_decompress_block(zxc_dctx* dctx, const void* RESTRICT src, const siz
     const uint8_t* dict = opts ? (const uint8_t*)opts->dict : NULL;
     const size_t dict_size = ZXC_OPTS_DICT_SIZE(opts);
     if (UNLIKELY(dict_size > ZXC_DICT_SIZE_MAX)) return ZXC_ERROR_DICT_TOO_LARGE;
-    if (UNLIKELY(dctx->owns_workspace && dict_size > 0)) return ZXC_ERROR_DICT_UNSUPPORTED;
+
+    // Static dctx: the carved block and dictionary capacity are locked.
+    if (UNLIKELY(dctx->owns_workspace &&
+                 dst_capacity > dctx->last_block_size + ZXC_DECOMPRESS_TAIL_PAD))
+        return ZXC_ERROR_BAD_BLOCK_SIZE;
+    if (UNLIKELY(dctx->owns_workspace && dict_size > dctx->dict_cap))
+        return ZXC_ERROR_DICT_UNSUPPORTED;
 
     // Derive the block_size from dst_capacity (callers know the original size)
-    const size_t block_size = zxc_block_size_ceil(dst_capacity);
-    if (UNLIKELY(!dctx->initialized || dctx->last_block_size != block_size ||
-                 dctx->last_dict_size != dict_size)) {
+    const size_t block_size =
+        dctx->owns_workspace ? dctx->last_block_size : zxc_block_size_ceil(dst_capacity);
+    if (UNLIKELY(!dctx->owns_workspace &&
+                 (!dctx->initialized || dctx->last_block_size != block_size ||
+                  dctx->last_dict_size != dict_size))) {
         if (dctx->initialized) {
             zxc_cctx_free(&dctx->inner);
             dctx->initialized = 0;
@@ -1716,9 +1731,14 @@ int64_t zxc_decompress_block_safe(zxc_dctx* dctx, const void* RESTRICT src, cons
 
     // GLO/GHI: use the strict-tail decoder (no bounce buffer required).
     const int checksum_enabled = opts ? opts->checksum_enabled : 0;
-    const size_t block_size = zxc_block_size_ceil(dst_capacity);
-    if (UNLIKELY(!dctx->initialized || dctx->last_block_size != block_size ||
-                 dctx->last_dict_size != 0)) {
+    // Static dctx: the carved block is locked.
+    if (UNLIKELY(dctx->owns_workspace && dst_capacity > dctx->last_block_size))
+        return ZXC_ERROR_BAD_BLOCK_SIZE;
+    const size_t block_size =
+        dctx->owns_workspace ? dctx->last_block_size : zxc_block_size_ceil(dst_capacity);
+    if (UNLIKELY(!dctx->owns_workspace &&
+                 (!dctx->initialized || dctx->last_block_size != block_size ||
+                  dctx->last_dict_size != 0))) {
         if (dctx->initialized) {
             zxc_cctx_free(&dctx->inner);
             dctx->initialized = 0;
@@ -1763,10 +1783,18 @@ int64_t zxc_decompress_block_safe(zxc_dctx* dctx, const void* RESTRICT src, cons
  * and the persistent buffer that @ref zxc_init_static_cctx carves for the given
  * @p block_size / @p level. Performs no allocation.
  */
-size_t zxc_static_cctx_workspace_size(const size_t block_size, const int level) {
+/* Compression carves [dict | block]. */
+static size_t static_cctx_chunk(const size_t block_size, const size_t dict_cap) {
+    return dict_cap > 0 ? zxc_block_size_ceil(dict_cap + block_size) : block_size;
+}
+
+size_t zxc_static_cctx_workspace_size(const size_t block_size, const int level,
+                                      const size_t dict_capacity) {
     if (UNLIKELY(!zxc_validate_block_size(block_size))) return 0;
     if (UNLIKELY(level < ZXC_LEVEL_FASTEST || level > ZXC_LEVEL_ULTRA)) return 0;
-    const size_t inner_sz = zxc_cctx_compute_workspace_size(block_size, 1, level, 0);
+    if (UNLIKELY(dict_capacity > ZXC_DICT_SIZE_MAX)) return 0;
+    const size_t inner_sz = zxc_cctx_compute_workspace_size(
+        static_cctx_chunk(block_size, dict_capacity), 1, level, dict_capacity);
     if (UNLIKELY(inner_sz == 0)) return 0;
     return ZXC_STATIC_CCTX_HDR_SIZE + inner_sz;
 }
@@ -1778,11 +1806,14 @@ zxc_cctx* zxc_init_static_cctx(void* RESTRICT workspace, const size_t workspace_
     const int level = (opts->level > 0) ? opts->level : ZXC_LEVEL_DEFAULT;
     const size_t block_size = (opts->block_size > 0) ? opts->block_size : ZXC_BLOCK_SIZE_DEFAULT;
     const int checksum_enabled = opts->checksum_enabled;
+    const size_t dict_cap = opts->dict_size; /* capacity to carve, pointer not kept */
 
     if (UNLIKELY(!zxc_validate_block_size(block_size))) return NULL;
     if (UNLIKELY(level < ZXC_LEVEL_FASTEST || level > ZXC_LEVEL_ULTRA)) return NULL;
+    if (UNLIKELY(dict_cap > ZXC_DICT_SIZE_MAX)) return NULL;
 
-    const size_t inner_sz = zxc_cctx_compute_workspace_size(block_size, 1, level, 0);
+    const size_t chunk = static_cctx_chunk(block_size, dict_cap);
+    const size_t inner_sz = zxc_cctx_compute_workspace_size(chunk, 1, level, dict_cap);
     if (UNLIKELY(inner_sz == 0)) return NULL;
     if (UNLIKELY(workspace_size < ZXC_STATIC_CCTX_HDR_SIZE + inner_sz)) return NULL;
 
@@ -1790,13 +1821,14 @@ zxc_cctx* zxc_init_static_cctx(void* RESTRICT workspace, const size_t workspace_
     ZXC_MEMSET(cctx, 0, sizeof(*cctx));
 
     uint8_t* const inner_ws = (uint8_t*)workspace + ZXC_STATIC_CCTX_HDR_SIZE;
-    if (UNLIKELY(zxc_cctx_init_in_workspace(&cctx->inner, inner_ws, inner_sz, block_size, 1, level,
-                                            checksum_enabled, 0, 0) != ZXC_OK))
+    if (UNLIKELY(zxc_cctx_init_in_workspace(&cctx->inner, inner_ws, inner_sz, chunk, 1, level,
+                                            checksum_enabled, dict_cap, 0) != ZXC_OK))
         return NULL;
 
     cctx->owns_workspace = 1;
     cctx->initialized = 1;
     cctx->last_block_size = block_size;
+    cctx->dict_cap = dict_cap;
     cctx->stored_level = level;
     cctx->stored_block_size = block_size;
     cctx->stored_checksum = checksum_enabled;
@@ -1810,19 +1842,21 @@ zxc_cctx* zxc_init_static_cctx(void* RESTRICT workspace, const size_t workspace_
  * and the persistent buffer that @ref zxc_init_static_dctx carves for the given
  * @p block_size. Performs no allocation.
  */
-size_t zxc_static_dctx_workspace_size(const size_t block_size) {
+size_t zxc_static_dctx_workspace_size(const size_t block_size, const size_t dict_capacity) {
     if (UNLIKELY(!zxc_validate_block_size(block_size))) return 0;
-    const size_t inner_sz = zxc_cctx_compute_workspace_size(block_size, 0, 0, 0);
+    if (UNLIKELY(dict_capacity > ZXC_DICT_SIZE_MAX)) return 0;
+    const size_t inner_sz = zxc_cctx_compute_workspace_size(block_size, 0, 0, dict_capacity);
     if (UNLIKELY(inner_sz == 0)) return 0;
     return ZXC_STATIC_DCTX_HDR_SIZE + inner_sz;
 }
 
 zxc_dctx* zxc_init_static_dctx(void* RESTRICT workspace, const size_t workspace_size,
-                               const size_t block_size) {
+                               const size_t block_size, const size_t dict_capacity) {
     if (UNLIKELY(!workspace)) return NULL;
     if (UNLIKELY(!zxc_validate_block_size(block_size))) return NULL;
+    if (UNLIKELY(dict_capacity > ZXC_DICT_SIZE_MAX)) return NULL;
 
-    const size_t inner_sz = zxc_cctx_compute_workspace_size(block_size, 0, 0, 0);
+    const size_t inner_sz = zxc_cctx_compute_workspace_size(block_size, 0, 0, dict_capacity);
     if (UNLIKELY(inner_sz == 0)) return NULL;
     if (UNLIKELY(workspace_size < ZXC_STATIC_DCTX_HDR_SIZE + inner_sz)) return NULL;
 
@@ -1833,11 +1867,12 @@ zxc_dctx* zxc_init_static_dctx(void* RESTRICT workspace, const size_t workspace_
     // mode == 0 init: checksum_enabled is updated per-call from the file
     // header flags, so it does not need to be locked at workspace init.
     if (UNLIKELY(zxc_cctx_init_in_workspace(&dctx->inner, inner_ws, inner_sz, block_size, 0, 0, 0,
-                                            0, 0) != ZXC_OK))
+                                            dict_capacity, 0) != ZXC_OK))
         return NULL;
 
     dctx->owns_workspace = 1;
     dctx->initialized = 1;
     dctx->last_block_size = block_size;
+    dctx->dict_cap = dict_capacity;
     return dctx;
 }

--- a/tests/fuzz_dict.c
+++ b/tests/fuzz_dict.c
@@ -217,6 +217,28 @@ int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
         assert(memcmp(comp_buf, comp2_buf, (size_t)csize) == 0);
     }
 
+    /* Static contexts carved for the largest dictionary must round-trip too. */
+    static zxc_cctx* scctx = NULL;
+    static zxc_dctx* sdctx = NULL;
+    static int static_tried = 0;
+    if (!static_tried) {
+        static_tried = 1;
+        const zxc_compress_opts_t init = {.level = zxc_max_level(),
+                                          .block_size = ZXC_BLOCK_SIZE_DEFAULT,
+                                          .dict_size = ZXC_DICT_SIZE_MAX};
+        const size_t cws = zxc_static_cctx_workspace_size(ZXC_BLOCK_SIZE_DEFAULT, zxc_max_level(),
+                                                          ZXC_DICT_SIZE_MAX);
+        const size_t dws =
+            zxc_static_dctx_workspace_size(ZXC_BLOCK_SIZE_DEFAULT, ZXC_DICT_SIZE_MAX);
+        void* cws_mem = NULL;
+        void* dws_mem = NULL;
+        if (cws && dws && posix_memalign(&cws_mem, 64, cws) == 0 &&
+            posix_memalign(&dws_mem, 64, dws) == 0) {
+            scctx = zxc_init_static_cctx(cws_mem, cws, &init);
+            sdctx = zxc_init_static_dctx(dws_mem, dws, ZXC_BLOCK_SIZE_DEFAULT, ZXC_DICT_SIZE_MAX);
+        }
+    }
+
     if (size > decomp_cap) {
         void* nb = realloc(decomp_buf, size);
         if (!nb) return 0;
@@ -234,6 +256,16 @@ int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
     if (dsize >= 0) {
         assert((size_t)dsize == size);
         assert(memcmp(data, decomp_buf, size) == 0);
+    }
+
+    if (scctx && sdctx) {
+        const int64_t c3 = zxc_compress_cctx(scctx, data, size, comp2_buf, bound, &copts);
+        assert(c3 > 0);
+        const int64_t d3 =
+            zxc_decompress_dctx(sdctx, comp2_buf, (size_t)c3, decomp_buf, size, &dopts);
+        assert(d3 == (int64_t)size && memcmp(data, decomp_buf, size) == 0);
+        /* A static-context archive is an ordinary archive. */
+        assert(zxc_decompress(comp2_buf, (size_t)c3, decomp_buf, size, &dopts) == (int64_t)size);
     }
 
     /* Same archive through a reusable context: must agree with the one-shot path. */

--- a/tests/test_common.h
+++ b/tests/test_common.h
@@ -228,6 +228,7 @@ int test_dict_block_huf_roundtrip(void);
 int test_dict_block_stored_block_size(void);
 int test_dict_static_ctx_roundtrip(void);
 int test_dict_static_ctx_capacity(void);
+int test_dict_static_ctx_block_guards(void);
 int test_dict_huf_zxd_roundtrip(void);
 int test_dict_huf_table_roundtrip(void);
 int test_dict_huf_degenerate_corpus(void);

--- a/tests/test_common.h
+++ b/tests/test_common.h
@@ -226,6 +226,8 @@ int test_dict_ctx_table_without_dict(void);
 int test_dict_oversized_rejected_everywhere(void);
 int test_dict_block_huf_roundtrip(void);
 int test_dict_block_stored_block_size(void);
+int test_dict_static_ctx_roundtrip(void);
+int test_dict_static_ctx_capacity(void);
 int test_dict_huf_zxd_roundtrip(void);
 int test_dict_huf_table_roundtrip(void);
 int test_dict_huf_degenerate_corpus(void);

--- a/tests/test_dict.c
+++ b/tests/test_dict.c
@@ -19,6 +19,20 @@ static void build_test_huf_lengths(const void* data, size_t n, uint8_t out[ZXC_H
     zxc_huf_pack_lengths(code_len, out);
 }
 
+/* Cache-line aligned workspace for the static contexts. */
+#if defined(_WIN32)
+#include <malloc.h>
+static void* static_ws_alloc(size_t size) { return size ? _aligned_malloc(size, 64) : NULL; }
+static void static_ws_free(void* p) { _aligned_free(p); }
+#else
+static void* static_ws_alloc(size_t size) {
+    void* p = NULL;
+    if (size == 0 || posix_memalign(&p, 64, (size + 63) & ~(size_t)63) != 0) return NULL;
+    return p;
+}
+static void static_ws_free(void* p) { free(p); }
+#endif
+
 static void gen_dict_friendly_data(uint8_t* buf, size_t size, const uint8_t* dict,
                                    size_t dict_size) {
     for (size_t i = 0; i < size; i++) {
@@ -1580,7 +1594,7 @@ int test_dict_static_dctx_rejected(void) {
     const int64_t n0 = dctx_make_archive(3, block_size, src, src_size, NULL, 0, NULL, a0, cap);
 
     const size_t ws_sz = zxc_static_dctx_workspace_size(block_size, 0);
-    void* ws = malloc(ws_sz);
+    void* ws = static_ws_alloc(ws_sz);
     zxc_dctx* dctx = ws ? zxc_init_static_dctx(ws, ws_sz, block_size, 0) : NULL;
     int ok = n3 > 0 && n0 > 0 && dctx != NULL;
     if (!ok) printf("  [FAIL] setup: %lld %lld ws=%zu\n", (long long)n3, (long long)n0, ws_sz);
@@ -1598,7 +1612,7 @@ int test_dict_static_dctx_rejected(void) {
     if (ok) ok = dctx_run_steps(dctx, steps, sizeof(steps) / sizeof(steps[0]), src, src_size, dec);
 
     zxc_free_dctx(dctx); /* no-op for a static context */
-    free(ws);
+    static_ws_free(ws);
     free(src);
     free(a3);
     free(a0);
@@ -1675,7 +1689,7 @@ int test_dict_cctx_roundtrip(void) {
 
         /* Static cctx rejects dictionaries explicitly. */
         const size_t ws_sz = zxc_static_cctx_workspace_size(ZXC_BLOCK_SIZE_MIN, 3, 0);
-        void* ws = malloc(ws_sz);
+        void* ws = static_ws_alloc(ws_sz);
         const zxc_compress_opts_t so = {.level = 3, .block_size = ZXC_BLOCK_SIZE_MIN};
         zxc_cctx* sc = ws ? zxc_init_static_cctx(ws, ws_sz, &so) : NULL;
         const zxc_compress_opts_t sdict = {.level = 3,
@@ -1684,7 +1698,7 @@ int test_dict_cctx_roundtrip(void) {
                                            .dict_size = dict_size};
         const int64_t r1 = sc ? zxc_compress_cctx(sc, src, src_size, comp, cap, &sdict) : -1;
         const int64_t r2 = sc ? zxc_compress_cctx(sc, src, src_size, comp, cap, NULL) : -1;
-        free(ws);
+        static_ws_free(ws);
         if (r1 != ZXC_ERROR_DICT_UNSUPPORTED || r2 <= 0) {
             printf("  [FAIL] static cctx: dict -> %lld, plain -> %lld\n", (long long)r1,
                    (long long)r2);
@@ -2002,11 +2016,11 @@ int test_dict_block_huf_roundtrip(void) {
         /* Static cctx: no dictionary prefix in the workspace, explicit error. */
         {
             const size_t ws_sz = zxc_static_cctx_workspace_size(BLK, 6, 0);
-            void* ws = malloc(ws_sz);
+            void* ws = static_ws_alloc(ws_sz);
             const zxc_compress_opts_t so = {.level = 6, .block_size = BLK};
             zxc_cctx* sc = ws ? zxc_init_static_cctx(ws, ws_sz, &so) : NULL;
             const int64_t r = sc ? zxc_compress_block(sc, heldout, BLK, comp, cap, &co) : -1;
-            free(ws);
+            static_ws_free(ws);
             if (r != ZXC_ERROR_DICT_UNSUPPORTED) {
                 printf("  [FAIL] static cctx + dict: %lld\n", (long long)r);
                 break;
@@ -2094,20 +2108,6 @@ int test_dict_block_stored_block_size(void) {
     if (ok) printf("PASS\n\n");
     return ok;
 }
-
-/* Cache-line aligned workspace for the static contexts. */
-#if defined(_WIN32)
-#include <malloc.h>
-static void* static_ws_alloc(size_t size) { return size ? _aligned_malloc(size, 64) : NULL; }
-static void static_ws_free(void* p) { _aligned_free(p); }
-#else
-static void* static_ws_alloc(size_t size) {
-    void* p = NULL;
-    if (size == 0 || posix_memalign(&p, 64, (size + 63) & ~(size_t)63) != 0) return NULL;
-    return p;
-}
-static void static_ws_free(void* p) { free(p); }
-#endif
 
 int test_dict_static_ctx_roundtrip(void) {
     printf("=== TEST: Dict - static contexts carved with a dictionary capacity ===\n");
@@ -2237,8 +2237,7 @@ int test_dict_static_ctx_capacity(void) {
         const size_t cd = zxc_static_cctx_workspace_size(block, 3, dict_size);
         const size_t d0 = zxc_static_dctx_workspace_size(block, 0);
         const size_t dd = zxc_static_dctx_workspace_size(block, dict_size);
-        if (zxc_static_cctx_workspace_size(block, 3, 0) != c0 || cd <= c0 ||
-            zxc_static_dctx_workspace_size(block, 0) != d0 || dd <= d0 ||
+        if (c0 == 0 || cd <= c0 || d0 == 0 || dd <= d0 ||
             zxc_static_cctx_workspace_size(block, 3, ZXC_DICT_SIZE_MAX + 1) != 0 ||
             zxc_static_dctx_workspace_size(block, ZXC_DICT_SIZE_MAX + 1) != 0) {
             printf("  [FAIL] sizing: %zu/%zu %zu/%zu\n", c0, cd, d0, dd);
@@ -2288,16 +2287,13 @@ int test_dict_static_ctx_capacity(void) {
         printf(
             "  [PASS] dictionary beyond the capacity -> DICT_UNSUPPORTED, none -> DICT_REQUIRED\n");
 
-        /* Block decoders on a static dctx are bounded by the carved block. */
-        const int64_t b1 = zxc_decompress_block(sd, comp, (size_t)arch, dec,
-                                                block + ZXC_DECOMPRESS_TAIL_PAD + 1, NULL);
+        /* The strict decoder is bounded by the carved block before any routing. */
         const int64_t b2 = zxc_decompress_block_safe(sd, comp, (size_t)arch, dec, block + 1, NULL);
-        if (b1 != ZXC_ERROR_BAD_BLOCK_SIZE || b2 != ZXC_ERROR_BAD_BLOCK_SIZE) {
-            printf("  [FAIL] block bound on static dctx: %lld %lld\n", (long long)b1,
-                   (long long)b2);
+        if (b2 != ZXC_ERROR_BAD_BLOCK_SIZE) {
+            printf("  [FAIL] strict decoder bound on static dctx: %lld\n", (long long)b2);
             break;
         }
-        printf("  [PASS] block decoders bounded by the carved block\n");
+        printf("  [PASS] strict decoder bounded by the carved block\n");
         ok = 1;
     } while (0);
     static_ws_free(cw);
@@ -2305,6 +2301,125 @@ int test_dict_static_ctx_capacity(void) {
     free(src);
     free(comp);
     free(dec);
+    if (ok) printf("PASS\n\n");
+    return ok;
+}
+
+/* A static dctx never decodes past its carved block, whatever the caller's
+ * buffer, and the strict decoder never keeps a table from an earlier call. */
+int test_dict_static_ctx_block_guards(void) {
+    printf("=== TEST: Dict - static dctx block guards ===\n");
+    enum { NS = 6, SCAP = 16384, PIN = 4096, BIG = 6000 };
+    uint8_t* bufs[NS];
+    const void* samples[NS];
+    size_t sizes[NS];
+    for (int i = 0; i < NS; i++) {
+        bufs[i] = (uint8_t*)malloc(SCAP);
+        sizes[i] = gen_structured_sample(bufs[i], SCAP, 0x6000U + (uint32_t)i);
+        samples[i] = bufs[i];
+    }
+    uint8_t dict_buf[8192];
+    uint8_t huf[ZXC_HUF_TABLE_SIZE];
+    const size_t cap = (size_t)zxc_compress_block_bound(SCAP);
+    uint8_t* comp = (uint8_t*)malloc(cap);
+    uint8_t* out = (uint8_t*)malloc(SCAP + ZXC_DECOMPRESS_TAIL_PAD);
+    uint8_t* noise = (uint8_t*)malloc(BIG);
+    uint64_t x = 0x9E3779B97F4A7C15ull; /* xorshift: incompressible, stored RAW */
+    for (size_t i = 0; i < BIG; i++) {
+        x ^= x << 13;
+        x ^= x >> 7;
+        x ^= x << 17;
+        noise[i] = (uint8_t)(x >> 24);
+    }
+    zxc_cctx* cctx = zxc_create_cctx(NULL);
+    const size_t dws = zxc_static_dctx_workspace_size(PIN, sizeof(dict_buf));
+    void* dw = static_ws_alloc(dws);
+    zxc_dctx* sd = dw ? zxc_init_static_dctx(dw, dws, PIN, sizeof(dict_buf)) : NULL;
+    int ok = 0;
+    do {
+        const int64_t dsz = zxc_train_dict(samples, sizes, NS, dict_buf, sizeof(dict_buf));
+        if (dsz <= 0 || !cctx || !sd ||
+            zxc_train_dict_huf(samples, sizes, NS, dict_buf, (size_t)dsz, huf) != ZXC_OK) {
+            printf("  [FAIL] setup\n");
+            break;
+        }
+        /* Blocks larger than the carved block: GLO (compressible) and RAW. */
+        const zxc_compress_opts_t plain = {.level = 3};
+        const int64_t g = zxc_compress_block(cctx, bufs[0], BIG, comp, cap, &plain);
+        const int64_t e1 =
+            g > 0 ? zxc_decompress_block(sd, comp, (size_t)g, out, BIG + 200, NULL) : 0;
+        const int64_t e2 =
+            g > 0 ? zxc_decompress_block_safe(sd, comp, (size_t)g, out, BIG, NULL) : 0;
+        const int64_t r = zxc_compress_block(cctx, noise, BIG, comp, cap, &plain);
+        const int64_t e3 =
+            r > 0 ? zxc_decompress_block(sd, comp, (size_t)r, out, BIG + 200, NULL) : 0;
+        const int64_t e4 =
+            r > 0 ? zxc_decompress_block_safe(sd, comp, (size_t)r, out, BIG, NULL) : 0;
+        if (g <= 0 || r <= 0 || comp[0] != ZXC_BLOCK_RAW || e1 != ZXC_ERROR_BAD_BLOCK_SIZE ||
+            e2 != ZXC_ERROR_BAD_BLOCK_SIZE || e3 != ZXC_ERROR_BAD_BLOCK_SIZE ||
+            e4 != ZXC_ERROR_BAD_BLOCK_SIZE) {
+            printf("  [FAIL] oversized blocks: GLO %lld/%lld, RAW(type %u) %lld/%lld\n",
+                   (long long)e1, (long long)e2, r > 0 ? comp[0] : 0, (long long)e3, (long long)e4);
+            break;
+        }
+        printf("  [PASS] blocks larger than the carved block -> BAD_BLOCK_SIZE on both decoders\n");
+
+        /* A table attached by the fast decoder must not serve the strict one.
+         * The block must use the table without referencing the dictionary
+         * content, so only the table can stop the strict decoder: compress a
+         * corpus window against a zero dictionary (no match lands in it) with
+         * the trained table attached. Decoding it with the real dictionary of
+         * the same size, content identical, proves there is no back-reference. */
+        uint8_t* zeros = (uint8_t*)calloc((size_t)dsz, 1);
+        uint8_t huf_z[ZXC_HUF_TABLE_SIZE]; /* trained against the zero dictionary */
+        const zxc_compress_opts_t co_z = {
+            .level = 6, .dict = zeros, .dict_size = (size_t)dsz, .dict_huf = huf_z};
+        const zxc_decompress_opts_t d_z = {
+            .dict = zeros, .dict_size = (size_t)dsz, .dict_huf = huf_z};
+        const zxc_decompress_opts_t d_real = {
+            .dict = dict_buf, .dict_size = (size_t)dsz, .dict_huf = huf_z};
+        zxc_dctx* heap = zxc_create_dctx();
+        int found = 0,
+            bad = !zeros || !heap ||
+                  zxc_train_dict_huf(samples, sizes, NS, zeros, (size_t)dsz, huf_z) != ZXC_OK;
+        for (size_t off = 0; off + 2048 <= sizes[2] && !found && !bad; off += 2048) {
+            const uint8_t* blk = bufs[2] + off;
+            const int64_t n = zxc_compress_block(cctx, blk, 2048, comp, cap, &co_z);
+            if (n <= 0) {
+                bad = 1;
+                break;
+            }
+            if (!(comp[0] == ZXC_BLOCK_GLO && comp[ZXC_BLOCK_HEADER_SIZE + 8] == 3)) continue;
+            if (zxc_decompress_block(heap, comp, (size_t)n, out, 2048 + ZXC_DECOMPRESS_TAIL_PAD,
+                                     &d_real) != 2048 ||
+                memcmp(out, blk, 2048) != 0)
+                continue; /* references the dictionary content: not this one */
+            found = 1;
+            const int64_t f = zxc_decompress_block(sd, comp, (size_t)n, out,
+                                                   2048 + ZXC_DECOMPRESS_TAIL_PAD, &d_z);
+            const int64_t s2 = zxc_decompress_block_safe(sd, comp, (size_t)n, out, 2048, NULL);
+            if (f != 2048 || s2 >= 0) {
+                printf("  [FAIL] enc_lit=3 block: fast %lld, strict without dict %lld\n",
+                       (long long)f, (long long)s2);
+                bad = 1;
+            }
+        }
+        zxc_free_dctx(heap);
+        free(zeros);
+        if (bad) break;
+        if (!found) {
+            printf("  [FAIL] no table-only enc_lit=3 block found to exercise the strict decoder\n");
+            break;
+        }
+        printf("  [PASS] strict decoder refuses an enc_lit=3 block without the dictionary\n");
+        ok = 1;
+    } while (0);
+    zxc_free_cctx(cctx);
+    static_ws_free(dw);
+    free(comp);
+    free(out);
+    free(noise);
+    for (int i = 0; i < NS; i++) free(bufs[i]);
     if (ok) printf("PASS\n\n");
     return ok;
 }

--- a/tests/test_dict.c
+++ b/tests/test_dict.c
@@ -1579,9 +1579,9 @@ int test_dict_static_dctx_rejected(void) {
         dctx_make_archive(3, block_size, src, src_size, k_dctx_dict, dict_size, NULL, a3, cap);
     const int64_t n0 = dctx_make_archive(3, block_size, src, src_size, NULL, 0, NULL, a0, cap);
 
-    const size_t ws_sz = zxc_static_dctx_workspace_size(block_size);
+    const size_t ws_sz = zxc_static_dctx_workspace_size(block_size, 0);
     void* ws = malloc(ws_sz);
-    zxc_dctx* dctx = ws ? zxc_init_static_dctx(ws, ws_sz, block_size) : NULL;
+    zxc_dctx* dctx = ws ? zxc_init_static_dctx(ws, ws_sz, block_size, 0) : NULL;
     int ok = n3 > 0 && n0 > 0 && dctx != NULL;
     if (!ok) printf("  [FAIL] setup: %lld %lld ws=%zu\n", (long long)n3, (long long)n0, ws_sz);
 
@@ -1674,7 +1674,7 @@ int test_dict_cctx_roundtrip(void) {
         printf("  [PASS] cctx dict archive -> DICT_REQUIRED without the dictionary\n");
 
         /* Static cctx rejects dictionaries explicitly. */
-        const size_t ws_sz = zxc_static_cctx_workspace_size(ZXC_BLOCK_SIZE_MIN, 3);
+        const size_t ws_sz = zxc_static_cctx_workspace_size(ZXC_BLOCK_SIZE_MIN, 3, 0);
         void* ws = malloc(ws_sz);
         const zxc_compress_opts_t so = {.level = 3, .block_size = ZXC_BLOCK_SIZE_MIN};
         zxc_cctx* sc = ws ? zxc_init_static_cctx(ws, ws_sz, &so) : NULL;
@@ -2001,7 +2001,7 @@ int test_dict_block_huf_roundtrip(void) {
 
         /* Static cctx: no dictionary prefix in the workspace, explicit error. */
         {
-            const size_t ws_sz = zxc_static_cctx_workspace_size(BLK, 6);
+            const size_t ws_sz = zxc_static_cctx_workspace_size(BLK, 6, 0);
             void* ws = malloc(ws_sz);
             const zxc_compress_opts_t so = {.level = 6, .block_size = BLK};
             zxc_cctx* sc = ws ? zxc_init_static_cctx(ws, ws_sz, &so) : NULL;
@@ -2018,9 +2018,9 @@ int test_dict_block_huf_roundtrip(void) {
          * routing dictionary calls through the fast one. */
         {
             const int64_t n = zxc_compress_block(cctx, heldout, BLK, comp, cap, &co);
-            const size_t ws_sz = zxc_static_dctx_workspace_size(BLK);
+            const size_t ws_sz = zxc_static_dctx_workspace_size(BLK, 0);
             void* ws = malloc(ws_sz);
-            zxc_dctx* sd = ws ? zxc_init_static_dctx(ws, ws_sz, BLK) : NULL;
+            zxc_dctx* sd = ws ? zxc_init_static_dctx(ws, ws_sz, BLK, 0) : NULL;
             const int64_t r1 = sd && n > 0
                                    ? zxc_decompress_block(sd, comp, (size_t)n, out,
                                                           BLK + ZXC_DECOMPRESS_TAIL_PAD, &d_tab)
@@ -2091,6 +2091,220 @@ int test_dict_block_stored_block_size(void) {
         ok = 1;
     } while (0);
     zxc_free_cctx(cctx);
+    if (ok) printf("PASS\n\n");
+    return ok;
+}
+
+/* Cache-line aligned workspace for the static contexts. */
+#if defined(_WIN32)
+#include <malloc.h>
+static void* static_ws_alloc(size_t size) { return size ? _aligned_malloc(size, 64) : NULL; }
+static void static_ws_free(void* p) { _aligned_free(p); }
+#else
+static void* static_ws_alloc(size_t size) {
+    void* p = NULL;
+    if (size == 0 || posix_memalign(&p, 64, (size + 63) & ~(size_t)63) != 0) return NULL;
+    return p;
+}
+static void static_ws_free(void* p) { free(p); }
+#endif
+
+int test_dict_static_ctx_roundtrip(void) {
+    printf("=== TEST: Dict - static contexts carved with a dictionary capacity ===\n");
+    const size_t dict_size = sizeof(k_dctx_dict) - 1;
+    const size_t block = ZXC_BLOCK_SIZE_MIN;
+    const size_t src_size = block;
+    uint8_t* src = (uint8_t*)malloc(src_size);
+    gen_dict_friendly_data(src, src_size, k_dctx_dict, dict_size);
+    uint8_t huf[ZXC_HUF_TABLE_SIZE];
+    build_test_huf_lengths(k_dctx_dict, dict_size, huf);
+    const size_t cap = (size_t)zxc_compress_bound(src_size);
+    uint8_t* comp = (uint8_t*)malloc(cap);
+    uint8_t* dec = (uint8_t*)malloc(src_size + ZXC_DECOMPRESS_TAIL_PAD);
+
+    const zxc_compress_opts_t init = {.level = 7, .block_size = block, .dict_size = dict_size};
+    const size_t cws = zxc_static_cctx_workspace_size(block, 7, dict_size);
+    const size_t dws = zxc_static_dctx_workspace_size(block, dict_size);
+    void* cw = static_ws_alloc(cws);
+    void* dw = static_ws_alloc(dws);
+    zxc_cctx* sc = cw ? zxc_init_static_cctx(cw, cws, &init) : NULL;
+    zxc_dctx* sd = dw ? zxc_init_static_dctx(dw, dws, block, dict_size) : NULL;
+
+    const zxc_compress_opts_t c7 = {.level = 7,
+                                    .block_size = block,
+                                    .dict = k_dctx_dict,
+                                    .dict_size = dict_size,
+                                    .dict_huf = huf};
+    const zxc_compress_opts_t c_plain = {.level = 7, .block_size = block};
+    const zxc_compress_opts_t c_half = {
+        .level = 3, .block_size = block, .dict = k_dctx_dict, .dict_size = dict_size / 2};
+    const zxc_decompress_opts_t d7 = {.dict = k_dctx_dict, .dict_size = dict_size, .dict_huf = huf};
+    const zxc_decompress_opts_t d3 = {.dict = k_dctx_dict, .dict_size = dict_size};
+    const zxc_decompress_opts_t d_half = {.dict = k_dctx_dict, .dict_size = dict_size / 2};
+    int ok = 0;
+    do {
+        if (!sc || !sd) {
+            printf("  [FAIL] static init: cctx %p (ws %zu) dctx %p (ws %zu)\n", (void*)sc, cws,
+                   (void*)sd, dws);
+            break;
+        }
+        /* Frame API with dictionary + table, cross-checked against the one-shot decoder. */
+        int64_t cs = zxc_compress_cctx(sc, src, src_size, comp, cap, &c7);
+        int64_t r = cs > 0 ? zxc_decompress(comp, (size_t)cs, dec, src_size, &d7) : -1;
+        if (cs <= 0 ||
+            zxc_get_dict_id(comp, (size_t)cs) != zxc_dict_id(k_dctx_dict, dict_size, huf) ||
+            r != (int64_t)src_size || memcmp(dec, src, src_size) != 0) {
+            printf("  [FAIL] static cctx L7 + table: cs=%lld r=%lld\n", (long long)cs,
+                   (long long)r);
+            break;
+        }
+        memset(dec, 0, src_size);
+        r = zxc_decompress_dctx(sd, comp, (size_t)cs, dec, src_size, &d7);
+        if (r != (int64_t)src_size || memcmp(dec, src, src_size) != 0) {
+            printf("  [FAIL] static dctx L7 + table: %lld\n", (long long)r);
+            break;
+        }
+        printf("  [PASS] frame API, dictionary + table, both static contexts\n");
+
+        /* A dictionary-less archive still goes through the same contexts. */
+        cs = zxc_compress_cctx(sc, src, src_size, comp, cap, &c_plain);
+        memset(dec, 0, src_size);
+        r = cs > 0 ? zxc_decompress_dctx(sd, comp, (size_t)cs, dec, src_size, NULL) : -1;
+        if (cs <= 0 || zxc_get_dict_id(comp, (size_t)cs) != 0 || r != (int64_t)src_size ||
+            memcmp(dec, src, src_size) != 0) {
+            printf("  [FAIL] plain archive through dict-capable contexts: %lld %lld\n",
+                   (long long)cs, (long long)r);
+            break;
+        }
+        printf("  [PASS] plain archive through the same contexts\n");
+
+        /* The capacity is an upper bound: a smaller dictionary fits. */
+        cs = zxc_compress_cctx(sc, src, src_size, comp, cap, &c_half);
+        memset(dec, 0, src_size);
+        r = cs > 0 ? zxc_decompress_dctx(sd, comp, (size_t)cs, dec, src_size, &d_half) : -1;
+        if (cs <= 0 || r != (int64_t)src_size || memcmp(dec, src, src_size) != 0) {
+            printf("  [FAIL] half-size dictionary: %lld %lld\n", (long long)cs, (long long)r);
+            break;
+        }
+        printf("  [PASS] smaller dictionary than the capacity\n");
+
+        /* Block API through the same static contexts. */
+        const size_t bcap = (size_t)zxc_compress_block_bound(src_size);
+        const zxc_compress_opts_t cb = {
+            .level = 3, .block_size = block, .dict = k_dctx_dict, .dict_size = dict_size};
+        cs = zxc_compress_block(sc, src, src_size, comp, bcap, &cb);
+        memset(dec, 0, src_size);
+        r = cs > 0 ? zxc_decompress_block(sd, comp, (size_t)cs, dec,
+                                          src_size + ZXC_DECOMPRESS_TAIL_PAD, &d3)
+                   : -1;
+        const int64_t rs =
+            cs > 0 ? zxc_decompress_block_safe(sd, comp, (size_t)cs, dec, src_size, &d3) : -1;
+        if (cs <= 0 || r != (int64_t)src_size || rs != (int64_t)src_size ||
+            memcmp(dec, src, src_size) != 0) {
+            printf("  [FAIL] block API: cs=%lld r=%lld rs=%lld\n", (long long)cs, (long long)r,
+                   (long long)rs);
+            break;
+        }
+        printf("  [PASS] block API, dictionary, both static contexts\n");
+        ok = 1;
+    } while (0);
+    static_ws_free(cw);
+    static_ws_free(dw);
+    free(src);
+    free(comp);
+    free(dec);
+    if (ok) printf("PASS\n\n");
+    return ok;
+}
+
+int test_dict_static_ctx_capacity(void) {
+    printf("=== TEST: Dict - static contexts enforce the dictionary capacity ===\n");
+    const size_t dict_size = sizeof(k_dctx_dict) - 1;
+    const size_t small = dict_size / 2;
+    const size_t block = ZXC_BLOCK_SIZE_MIN;
+    const size_t src_size = block;
+    uint8_t* src = (uint8_t*)malloc(src_size);
+    gen_dict_friendly_data(src, src_size, k_dctx_dict, dict_size);
+    const size_t cap = (size_t)zxc_compress_bound(src_size);
+    uint8_t* comp = (uint8_t*)malloc(cap);
+    uint8_t* dec = (uint8_t*)malloc(src_size + ZXC_DECOMPRESS_TAIL_PAD);
+    void* cw = NULL;
+    void* dw = NULL;
+    int ok = 0;
+    do {
+        /* Sizing: a capacity costs room, none costs nothing, too much is refused. */
+        const size_t c0 = zxc_static_cctx_workspace_size(block, 3, 0);
+        const size_t cd = zxc_static_cctx_workspace_size(block, 3, dict_size);
+        const size_t d0 = zxc_static_dctx_workspace_size(block, 0);
+        const size_t dd = zxc_static_dctx_workspace_size(block, dict_size);
+        if (zxc_static_cctx_workspace_size(block, 3, 0) != c0 || cd <= c0 ||
+            zxc_static_dctx_workspace_size(block, 0) != d0 || dd <= d0 ||
+            zxc_static_cctx_workspace_size(block, 3, ZXC_DICT_SIZE_MAX + 1) != 0 ||
+            zxc_static_dctx_workspace_size(block, ZXC_DICT_SIZE_MAX + 1) != 0) {
+            printf("  [FAIL] sizing: %zu/%zu %zu/%zu\n", c0, cd, d0, dd);
+            break;
+        }
+        printf("  [PASS] workspace sizing with and without a capacity\n");
+
+        /* A workspace sized without the capacity cannot carve it. */
+        cw = static_ws_alloc(cd);
+        dw = static_ws_alloc(dd);
+        const zxc_compress_opts_t init_full = {
+            .level = 3, .block_size = block, .dict_size = dict_size};
+        if (!cw || !dw || zxc_init_static_cctx(cw, c0, &init_full) != NULL ||
+            zxc_init_static_dctx(dw, d0, block, dict_size) != NULL) {
+            printf("  [FAIL] undersized workspace accepted\n");
+            break;
+        }
+        printf("  [PASS] undersized workspace refused\n");
+
+        /* Contexts carved for half the dictionary reject the full one everywhere. */
+        const zxc_compress_opts_t init_small = {
+            .level = 3, .block_size = block, .dict_size = small};
+        zxc_cctx* sc = zxc_init_static_cctx(cw, cd, &init_small);
+        zxc_dctx* sd = zxc_init_static_dctx(dw, dd, block, small);
+        const zxc_compress_opts_t c_full = {
+            .level = 3, .block_size = block, .dict = k_dctx_dict, .dict_size = dict_size};
+        const zxc_decompress_opts_t d_full = {.dict = k_dctx_dict, .dict_size = dict_size};
+        const int64_t arch = zxc_compress(src, src_size, comp, cap, &c_full);
+        if (!sc || !sd || arch <= 0) {
+            printf("  [FAIL] setup for capacity checks\n");
+            break;
+        }
+        const int64_t e1 = zxc_compress_cctx(sc, src, src_size, comp + 0, cap, &c_full);
+        const int64_t e2 = zxc_compress_block(sc, src, src_size, dec, src_size + 64, &c_full);
+        const int64_t e3 = zxc_decompress_dctx(sd, comp, (size_t)arch, dec, src_size, &d_full);
+        const int64_t e4 = zxc_decompress_dctx(sd, comp, (size_t)arch, dec, src_size, NULL);
+        const int64_t e5 = zxc_decompress_block(sd, comp + ZXC_FILE_HEADER_SIZE,
+                                                (size_t)arch - ZXC_FILE_HEADER_SIZE, dec,
+                                                src_size + ZXC_DECOMPRESS_TAIL_PAD, &d_full);
+        if (e1 != ZXC_ERROR_DICT_UNSUPPORTED || e2 != ZXC_ERROR_DICT_UNSUPPORTED ||
+            e3 != ZXC_ERROR_DICT_UNSUPPORTED || e4 != ZXC_ERROR_DICT_REQUIRED ||
+            e5 != ZXC_ERROR_DICT_UNSUPPORTED) {
+            printf("  [FAIL] capacity: %lld %lld %lld %lld %lld\n", (long long)e1, (long long)e2,
+                   (long long)e3, (long long)e4, (long long)e5);
+            break;
+        }
+        printf(
+            "  [PASS] dictionary beyond the capacity -> DICT_UNSUPPORTED, none -> DICT_REQUIRED\n");
+
+        /* Block decoders on a static dctx are bounded by the carved block. */
+        const int64_t b1 = zxc_decompress_block(sd, comp, (size_t)arch, dec,
+                                                block + ZXC_DECOMPRESS_TAIL_PAD + 1, NULL);
+        const int64_t b2 = zxc_decompress_block_safe(sd, comp, (size_t)arch, dec, block + 1, NULL);
+        if (b1 != ZXC_ERROR_BAD_BLOCK_SIZE || b2 != ZXC_ERROR_BAD_BLOCK_SIZE) {
+            printf("  [FAIL] block bound on static dctx: %lld %lld\n", (long long)b1,
+                   (long long)b2);
+            break;
+        }
+        printf("  [PASS] block decoders bounded by the carved block\n");
+        ok = 1;
+    } while (0);
+    static_ws_free(cw);
+    static_ws_free(dw);
+    free(src);
+    free(comp);
+    free(dec);
     if (ok) printf("PASS\n\n");
     return ok;
 }

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -151,6 +151,8 @@ static const test_entry_t g_tests[] = {
     TEST_CASE(test_dict_oversized_rejected_everywhere),
     TEST_CASE(test_dict_block_huf_roundtrip),
     TEST_CASE(test_dict_block_stored_block_size),
+    TEST_CASE(test_dict_static_ctx_roundtrip),
+    TEST_CASE(test_dict_static_ctx_capacity),
     TEST_CASE(test_dict_huf_zxd_roundtrip),
     TEST_CASE(test_dict_huf_table_roundtrip),
     TEST_CASE(test_dict_huf_degenerate_corpus),

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -153,6 +153,7 @@ static const test_entry_t g_tests[] = {
     TEST_CASE(test_dict_block_stored_block_size),
     TEST_CASE(test_dict_static_ctx_roundtrip),
     TEST_CASE(test_dict_static_ctx_capacity),
+    TEST_CASE(test_dict_static_ctx_block_guards),
     TEST_CASE(test_dict_huf_zxd_roundtrip),
     TEST_CASE(test_dict_huf_table_roundtrip),
     TEST_CASE(test_dict_huf_degenerate_corpus),

--- a/tests/test_static_ctx.c
+++ b/tests/test_static_ctx.c
@@ -54,7 +54,7 @@ int test_static_ctx_roundtrip_all_levels(void) {
 
     for (int lvl = zxc_min_level(); lvl <= zxc_max_level(); ++lvl) {
         /* Size the cctx workspace exactly. */
-        const size_t cctx_ws_sz = zxc_static_cctx_workspace_size(block_size, lvl);
+        const size_t cctx_ws_sz = zxc_static_cctx_workspace_size(block_size, lvl, 0);
         if (cctx_ws_sz == 0) {
             printf("  [FAIL] level %d: cctx_ws_sz == 0\n", lvl);
             goto fail;
@@ -82,7 +82,7 @@ int test_static_ctx_roundtrip_all_levels(void) {
         }
 
         /* Size + init the dctx workspace. */
-        const size_t dctx_ws_sz = zxc_static_dctx_workspace_size(block_size);
+        const size_t dctx_ws_sz = zxc_static_dctx_workspace_size(block_size, 0);
         if (dctx_ws_sz == 0) {
             printf("  [FAIL] level %d: dctx_ws_sz == 0\n", lvl);
             goto fail;
@@ -92,7 +92,7 @@ int test_static_ctx_roundtrip_all_levels(void) {
             printf("  [FAIL] level %d: aligned_alloc(dctx_ws)\n", lvl);
             goto fail;
         }
-        zxc_dctx* const dctx = zxc_init_static_dctx(dctx_ws, dctx_ws_sz, block_size);
+        zxc_dctx* const dctx = zxc_init_static_dctx(dctx_ws, dctx_ws_sz, block_size, 0);
         if (!dctx) {
             printf("  [FAIL] level %d: zxc_init_static_dctx returned NULL\n", lvl);
             test_aligned_free(dctx_ws);
@@ -130,33 +130,33 @@ int test_static_ctx_size_query(void) {
     printf("=== TEST: Static Context API - workspace_size queries ===\n");
 
     /* Invalid: zero block_size. */
-    if (zxc_static_cctx_workspace_size(0, ZXC_LEVEL_DEFAULT) != 0) {
+    if (zxc_static_cctx_workspace_size(0, ZXC_LEVEL_DEFAULT, 0) != 0) {
         printf("  [FAIL] cctx_size(0) should be 0\n");
         return 0;
     }
-    if (zxc_static_dctx_workspace_size(0) != 0) {
+    if (zxc_static_dctx_workspace_size(0, 0) != 0) {
         printf("  [FAIL] dctx_size(0) should be 0\n");
         return 0;
     }
     /* Invalid: non-power-of-two block_size. */
-    if (zxc_static_cctx_workspace_size(63 * 1024, ZXC_LEVEL_DEFAULT) != 0) {
+    if (zxc_static_cctx_workspace_size(63 * 1024, ZXC_LEVEL_DEFAULT, 0) != 0) {
         printf("  [FAIL] cctx_size(non-pow2) should be 0\n");
         return 0;
     }
     /* Invalid: out-of-range level. */
-    if (zxc_static_cctx_workspace_size(64 * 1024, 0) != 0) {
+    if (zxc_static_cctx_workspace_size(64 * 1024, 0, 0) != 0) {
         printf("  [FAIL] cctx_size(level=0) should be 0\n");
         return 0;
     }
-    if (zxc_static_cctx_workspace_size(64 * 1024, 99) != 0) {
+    if (zxc_static_cctx_workspace_size(64 * 1024, 99, 0) != 0) {
         printf("  [FAIL] cctx_size(level=99) should be 0\n");
         return 0;
     }
 
     /* Valid sizes are strictly increasing across levels (level 6 adds opt_scratch). */
-    const size_t s3 = zxc_static_cctx_workspace_size(64 * 1024, 3);
-    const size_t s5 = zxc_static_cctx_workspace_size(64 * 1024, 5);
-    const size_t s6 = zxc_static_cctx_workspace_size(64 * 1024, 6);
+    const size_t s3 = zxc_static_cctx_workspace_size(64 * 1024, 3, 0);
+    const size_t s5 = zxc_static_cctx_workspace_size(64 * 1024, 5, 0);
+    const size_t s6 = zxc_static_cctx_workspace_size(64 * 1024, 6, 0);
     if (s3 == 0 || s5 == 0 || s6 == 0) {
         printf("  [FAIL] one of s3/s5/s6 is 0\n");
         return 0;
@@ -178,7 +178,7 @@ int test_static_ctx_workspace_too_small(void) {
     printf("=== TEST: Static Context API - workspace too small ===\n");
 
     const size_t block_size = 64 * 1024;
-    const size_t needed = zxc_static_cctx_workspace_size(block_size, ZXC_LEVEL_DEFAULT);
+    const size_t needed = zxc_static_cctx_workspace_size(block_size, ZXC_LEVEL_DEFAULT, 0);
     /* Provide exactly one byte less than needed. */
     void* const ws = test_aligned_alloc(64, needed);
     if (!ws) {
@@ -211,7 +211,7 @@ int test_static_ctx_block_size_locked(void) {
     printf("=== TEST: Static Context API - block_size lock ===\n");
 
     const size_t pinned_bs = 64 * 1024;
-    const size_t ws_sz = zxc_static_cctx_workspace_size(pinned_bs, ZXC_LEVEL_DEFAULT);
+    const size_t ws_sz = zxc_static_cctx_workspace_size(pinned_bs, ZXC_LEVEL_DEFAULT, 0);
     void* const ws = test_aligned_alloc(64, ws_sz);
     if (!ws) {
         printf("  [FAIL] aligned_alloc\n");
@@ -262,7 +262,7 @@ int test_static_ctx_level_raise_rejected(void) {
     printf("=== TEST: Static Context API - level raise rejected ===\n");
 
     const size_t pinned_bs = 64 * 1024;
-    const size_t ws_sz = zxc_static_cctx_workspace_size(pinned_bs, ZXC_LEVEL_DEFAULT);
+    const size_t ws_sz = zxc_static_cctx_workspace_size(pinned_bs, ZXC_LEVEL_DEFAULT, 0);
     void* const ws = test_aligned_alloc(64, ws_sz);
     if (!ws) {
         printf("  [FAIL] aligned_alloc\n");
@@ -305,7 +305,7 @@ int test_static_ctx_level_raise_rejected(void) {
 
     /* A static workspace carved AT the dense tier accepts its own level. */
     {
-        const size_t ws7_sz = zxc_static_cctx_workspace_size(pinned_bs, ZXC_LEVEL_ULTRA);
+        const size_t ws7_sz = zxc_static_cctx_workspace_size(pinned_bs, ZXC_LEVEL_ULTRA, 0);
         void* const ws7 = test_aligned_alloc(64, ws7_sz);
         if (!ws7) {
             printf("  [FAIL] aligned_alloc (level 7 ws)\n");
@@ -346,7 +346,7 @@ int test_static_ctx_null_inputs(void) {
         printf("  [FAIL] init_static_cctx(NULL opts) should fail\n");
         return 0;
     }
-    if (zxc_init_static_dctx(NULL, 65536, 4096) != NULL) {
+    if (zxc_init_static_dctx(NULL, 65536, 4096, 0) != NULL) {
         printf("  [FAIL] init_static_dctx(NULL workspace) should fail\n");
         return 0;
     }

--- a/wrappers/rust/zxc-sys/src/lib.rs
+++ b/wrappers/rust/zxc-sys/src/lib.rs
@@ -657,12 +657,18 @@ unsafe extern "C" {
     ) -> i64;
 
     /// Returns the exact byte count required by a static compression
-    /// workspace for the given `block_size` and `level`.
+    /// workspace for the given `block_size`, `level` and dictionary capacity
+    /// (0 = no dictionary; pass the same value as `dict_size` in the options
+    /// given to `zxc_init_static_cctx`).
     ///
     /// # Returns
     ///
-    /// Workspace size in bytes, or 0 if either argument is invalid.
-    pub fn zxc_static_cctx_workspace_size(block_size: usize, level: c_int) -> usize;
+    /// Workspace size in bytes, or 0 if an argument is invalid.
+    pub fn zxc_static_cctx_workspace_size(
+        block_size: usize,
+        level: c_int,
+        dict_capacity: usize,
+    ) -> usize;
 
     /// Initialises a compression context inside a caller-supplied workspace
     /// (no heap allocation).
@@ -679,12 +685,13 @@ unsafe extern "C" {
     ) -> *mut zxc_cctx;
 
     /// Returns the exact byte count required by a static decompression
-    /// workspace for the given `block_size`.
+    /// workspace for the given `block_size` and dictionary capacity
+    /// (0 = no dictionary).
     ///
     /// # Returns
     ///
-    /// Workspace size in bytes, or 0 if `block_size` is invalid.
-    pub fn zxc_static_dctx_workspace_size(block_size: usize) -> usize;
+    /// Workspace size in bytes, or 0 if an argument is invalid.
+    pub fn zxc_static_dctx_workspace_size(block_size: usize, dict_capacity: usize) -> usize;
 
     /// Initialises a decompression context inside a caller-supplied
     /// workspace (no heap allocation).
@@ -697,6 +704,7 @@ unsafe extern "C" {
         workspace: *mut c_void,
         workspace_size: usize,
         block_size: usize,
+        dict_capacity: usize,
     ) -> *mut zxc_dctx;
 }
 


### PR DESCRIPTION
Adds support for optional, pre-allocated dictionary capacity in static compression/decompression contexts—enabling dictionary usage without dynamic allocation.

- **ABI Bump** (`SOVERSION` -> 5): Updated internal structures (`zxc_cctx_s`, `zxc_dctx_s`) and added a dict_capacity parameter to public static init APIs.
- **Configurable Workspace Size**: `zxc_static_[c|d]ctx_workspace_size()` now accept `dict_capacity` to reserve fixed dictionary space upfront.
- **Runtime Capacity Enforcement**: Static contexts reject dictionaries exceeding pre-allocated capacity with `ZXC_ERROR_DICT_UNSUPPORTED`.
- **Block Safety Guards**: Added explicit bounds checks during static decompression to prevent overflowing carved block sizes (`ZXC_ERROR_BAD_BLOCK_SIZE`).
- **Docs & Tests**: Updated public API headers (`zxc_init_static_*`) and added tests covering round-trip flow, capacity limits, and block guards.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Static compression and decompression contexts now support caller-configured dictionary capacity.
  - Dictionaries within the reserved capacity can be used for frame and block operations.
  - Rust bindings and API documentation now expose the dictionary-capacity options.

- **Bug Fixes**
  - Oversized dictionaries are rejected with a specific unsupported-dictionary error.
  - Static block operations now reject blocks exceeding the configured workspace size.

- **Breaking Changes**
  - Static workspace-sizing and decompression-context initialization APIs now require a dictionary-capacity parameter.
  - The shared library ABI version has been incremented from 4 to 5.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->