### PR TITLE
fix(lib): enforce strict block size bounds for static decompression contexts

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -571,7 +571,10 @@ static context returns `ZXC_ERROR_DICT_UNSUPPORTED` for any dictionary.
 
 **Returns**: decompressed size (> 0) on success, or negative `zxc_error_t`.
 Returns `ZXC_ERROR_BAD_BLOCK_SIZE` if `dst_capacity` exceeds the per-block
-limit.
+limit. On a static context the carved block is the effective capacity: a
+larger block returns `ZXC_ERROR_BAD_BLOCK_SIZE` when its sub-header or decoded
+size tells (`dst` may then hold the decoded bytes), and fails like a too-small
+destination otherwise.
 
 ### `zxc_decompress_block_safe`
 
@@ -599,7 +602,9 @@ strict-tail decoder, which is slightly slower than the wild-copy fast path
 Strict-tail variant: `dst_capacity` is the exact uncompressed size with no
 tail-pad margin, so the upper limit is `ZXC_BLOCK_SIZE_MAX` (not
 `MAX+TAIL_PAD` as for `zxc_decompress_block`). Returns
-`ZXC_ERROR_BAD_BLOCK_SIZE` if `dst_capacity > ZXC_BLOCK_SIZE_MAX`.
+`ZXC_ERROR_BAD_BLOCK_SIZE` if `dst_capacity > ZXC_BLOCK_SIZE_MAX`. A static
+context applies the same block bound as `zxc_decompress_block` and accepts a
+larger `dst_capacity` alike.
 
 Same options as `zxc_decompress_block`: `checksum_enabled` and the dictionary
 fields; a dictionary routes through its bounce path.
@@ -810,8 +815,9 @@ ZXC_EXPORT zxc_dctx* zxc_init_static_dctx(
 
 Initialises a decompression context inside a caller-supplied workspace.
 `block_size` is **pinned** at init time: feeding the returned handle an
-archive whose file header declares a different `block_size` returns
-`ZXC_ERROR_BAD_BLOCK_SIZE`. Dictionaries are not supported:
+archive whose file header declares a different `block_size`, or a block larger
+than it through the block API, returns `ZXC_ERROR_BAD_BLOCK_SIZE`.
+Dictionaries are not supported:
 `ZXC_ERROR_DICT_UNSUPPORTED`.
 
 The returned handle points inside `workspace`; the workspace must remain

--- a/docs/API.md
+++ b/docs/API.md
@@ -572,9 +572,9 @@ static context returns `ZXC_ERROR_DICT_UNSUPPORTED` for any dictionary.
 **Returns**: decompressed size (> 0) on success, or negative `zxc_error_t`.
 Returns `ZXC_ERROR_BAD_BLOCK_SIZE` if `dst_capacity` exceeds the per-block
 limit. On a static context the carved block is the effective capacity: a
-larger block returns `ZXC_ERROR_BAD_BLOCK_SIZE` when its sub-header or decoded
-size tells (`dst` may then hold the decoded bytes), and fails like a too-small
-destination otherwise.
+larger block returns `ZXC_ERROR_BAD_BLOCK_SIZE` while it fits the workspace
+margin and fails like a too-small destination beyond it. `dst` contents are
+unspecified on error.
 
 ### `zxc_decompress_block_safe`
 
@@ -603,8 +603,8 @@ Strict-tail variant: `dst_capacity` is the exact uncompressed size with no
 tail-pad margin, so the upper limit is `ZXC_BLOCK_SIZE_MAX` (not
 `MAX+TAIL_PAD` as for `zxc_decompress_block`). Returns
 `ZXC_ERROR_BAD_BLOCK_SIZE` if `dst_capacity > ZXC_BLOCK_SIZE_MAX`. A static
-context applies the same block bound as `zxc_decompress_block` and accepts a
-larger `dst_capacity` alike.
+context applies the same bound and codes as `zxc_decompress_block` and accepts
+a larger `dst_capacity` alike.
 
 Same options as `zxc_decompress_block`: `checksum_enabled` and the dictionary
 fields; a dictionary routes through its bounce path.
@@ -815,8 +815,9 @@ ZXC_EXPORT zxc_dctx* zxc_init_static_dctx(
 
 Initialises a decompression context inside a caller-supplied workspace.
 `block_size` is **pinned** at init time: feeding the returned handle an
-archive whose file header declares a different `block_size`, or a block larger
-than it through the block API, returns `ZXC_ERROR_BAD_BLOCK_SIZE`.
+archive whose file header declares a different `block_size` returns
+`ZXC_ERROR_BAD_BLOCK_SIZE`; a block larger than it never decodes through the
+block API (see `zxc_decompress_block` for the codes).
 Dictionaries are not supported:
 `ZXC_ERROR_DICT_UNSUPPORTED`.
 

--- a/include/zxc_buffer.h
+++ b/include/zxc_buffer.h
@@ -328,7 +328,10 @@ ZXC_EXPORT int64_t zxc_compress_block(zxc_cctx* cctx, const void* src, size_t sr
  *
  * @return Decompressed size (> 0), or a negative @ref zxc_error_t;
  *         @ref ZXC_ERROR_BAD_BLOCK_SIZE if @p dst_capacity exceeds the
- *         per-block limit.
+ *         per-block limit. Static context: the carved block is the effective
+ *         capacity; a larger block is @ref ZXC_ERROR_BAD_BLOCK_SIZE when its
+ *         sub-header or decoded size tells (@p dst may then hold the decoded
+ *         bytes), otherwise it fails like a too-small destination.
  */
 ZXC_EXPORT int64_t zxc_decompress_block(zxc_dctx* dctx, const void* src, size_t src_size, void* dst,
                                         size_t dst_capacity, const zxc_decompress_opts_t* opts);
@@ -363,7 +366,8 @@ ZXC_EXPORT int64_t zxc_decompress_block(zxc_dctx* dctx, const void* src, size_t 
  *
  * @return Decompressed size (> 0), or a negative @ref zxc_error_t;
  *         @ref ZXC_ERROR_BAD_BLOCK_SIZE if @p dst_capacity >
- *         @ref ZXC_BLOCK_SIZE_MAX.
+ *         @ref ZXC_BLOCK_SIZE_MAX. Static context: same block bound as
+ *         zxc_decompress_block(), a larger @p dst_capacity accepted alike.
  */
 ZXC_EXPORT int64_t zxc_decompress_block_safe(zxc_dctx* dctx, const void* src, const size_t src_size,
                                              void* dst, const size_t dst_capacity,
@@ -604,7 +608,8 @@ ZXC_EXPORT size_t zxc_static_dctx_workspace_size(const size_t block_size);
  *
  * @par Locked block size
  * @p block_size is pinned at init time: an archive whose header declares a
- * different @c block_size is rejected with @ref ZXC_ERROR_BAD_BLOCK_SIZE.
+ * different @c block_size is rejected with @ref ZXC_ERROR_BAD_BLOCK_SIZE, and
+ * so is a block larger than it through the block API.
  *
  * @par No dictionary
  * Any dictionary is rejected with @ref ZXC_ERROR_DICT_UNSUPPORTED: the

--- a/include/zxc_buffer.h
+++ b/include/zxc_buffer.h
@@ -329,9 +329,9 @@ ZXC_EXPORT int64_t zxc_compress_block(zxc_cctx* cctx, const void* src, size_t sr
  * @return Decompressed size (> 0), or a negative @ref zxc_error_t;
  *         @ref ZXC_ERROR_BAD_BLOCK_SIZE if @p dst_capacity exceeds the
  *         per-block limit. Static context: the carved block is the effective
- *         capacity; a larger block is @ref ZXC_ERROR_BAD_BLOCK_SIZE when its
- *         sub-header or decoded size tells (@p dst may then hold the decoded
- *         bytes), otherwise it fails like a too-small destination.
+ *         capacity; a larger block is @ref ZXC_ERROR_BAD_BLOCK_SIZE while it
+ *         fits the workspace margin and fails like a too-small destination
+ *         beyond it. @p dst contents are unspecified on error.
  */
 ZXC_EXPORT int64_t zxc_decompress_block(zxc_dctx* dctx, const void* src, size_t src_size, void* dst,
                                         size_t dst_capacity, const zxc_decompress_opts_t* opts);
@@ -366,7 +366,7 @@ ZXC_EXPORT int64_t zxc_decompress_block(zxc_dctx* dctx, const void* src, size_t 
  *
  * @return Decompressed size (> 0), or a negative @ref zxc_error_t;
  *         @ref ZXC_ERROR_BAD_BLOCK_SIZE if @p dst_capacity >
- *         @ref ZXC_BLOCK_SIZE_MAX. Static context: same block bound as
+ *         @ref ZXC_BLOCK_SIZE_MAX. Static context: same bound and codes as
  *         zxc_decompress_block(), a larger @p dst_capacity accepted alike.
  */
 ZXC_EXPORT int64_t zxc_decompress_block_safe(zxc_dctx* dctx, const void* src, const size_t src_size,
@@ -608,8 +608,9 @@ ZXC_EXPORT size_t zxc_static_dctx_workspace_size(const size_t block_size);
  *
  * @par Locked block size
  * @p block_size is pinned at init time: an archive whose header declares a
- * different @c block_size is rejected with @ref ZXC_ERROR_BAD_BLOCK_SIZE, and
- * so is a block larger than it through the block API.
+ * different @c block_size is rejected with @ref ZXC_ERROR_BAD_BLOCK_SIZE; a
+ * block larger than it never decodes through the block API (see
+ * zxc_decompress_block() for the codes).
  *
  * @par No dictionary
  * Any dictionary is rejected with @ref ZXC_ERROR_DICT_UNSUPPORTED: the

--- a/src/lib/zxc_decompress.c
+++ b/src/lib/zxc_decompress.c
@@ -773,7 +773,7 @@ static ZXC_NOINLINE ZXC_COLD int zxc_decode_lit_pivco(const zxc_cctx_t* RESTRICT
     if (UNLIKELY(arc != ZXC_OK)) return arc;
     if (UNLIKELY(ctx->lit_buffer_cap < required_size + ZXC_PAD_SIZE ||
                  ctx->pivco_scratch_cap < required_size + ZXC_PIVCO_SCRATCH_PAD))
-        return ZXC_ERROR_CORRUPT_DATA;
+        return ZXC_ERROR_DST_TOO_SMALL;
     return zxc_huf_decode_section(payload, psize, ctx->lit_buffer, required_size,
                                   ctx->pivco_scratch);
 }
@@ -787,7 +787,7 @@ static ZXC_NOINLINE ZXC_COLD int zxc_decode_lit_pivco_dict(const zxc_cctx_t* RES
     if (UNLIKELY(arc != ZXC_OK)) return arc;
     if (UNLIKELY(ctx->lit_buffer_cap < required_size + ZXC_PAD_SIZE ||
                  ctx->pivco_scratch_cap < required_size + ZXC_PIVCO_SCRATCH_PAD))
-        return ZXC_ERROR_CORRUPT_DATA;
+        return ZXC_ERROR_DST_TOO_SMALL;
     return zxc_huf_decode_section_dict(payload, psize, ctx->lit_buffer, required_size,
                                        &ctx->dict_huf->tree, &ctx->dict_huf->dec,
                                        ctx->pivco_scratch);
@@ -800,7 +800,7 @@ static ZXC_NOINLINE ZXC_COLD int zxc_decode_tok_pivco(const zxc_cctx_t* RESTRICT
     if (UNLIKELY(arc != ZXC_OK)) return arc;
     if (UNLIKELY(n_tok + ZXC_PAD_SIZE > ctx->tok_buffer_cap ||
                  n_tok + ZXC_PIVCO_SCRATCH_PAD > ctx->pivco_scratch_cap))
-        return ZXC_ERROR_CORRUPT_DATA;
+        return ZXC_ERROR_DST_TOO_SMALL;
     return zxc_huf_decode_section(payload, psize, ctx->tok_buffer, n_tok, ctx->pivco_scratch);
 }
 
@@ -911,7 +911,7 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(const zxc_cctx_t* RESTRIC
 
             // lit_buffer is pre-allocated to chunk_size + ZXC_PAD_SIZE by
             // zxc_cctx_init (mode == 0).
-            if (UNLIKELY(ctx->lit_buffer_cap < alloc_size)) return ZXC_ERROR_CORRUPT_DATA;
+            if (UNLIKELY(ctx->lit_buffer_cap < alloc_size)) return ZXC_ERROR_DST_TOO_SMALL;
 
             rle_buf = ctx->lit_buffer;
             if (UNLIKELY(!rle_buf || lit_stream_size > (size_t)(src + src_size - p_curr)))

--- a/src/lib/zxc_dispatch.c
+++ b/src/lib/zxc_dispatch.c
@@ -1602,48 +1602,32 @@ int64_t zxc_compress_block(zxc_cctx* cctx, const void* RESTRICT src, const size_
 /**
  * @brief Block decode on a static dctx: the carved block is the effective capacity.
  *
- * A larger block is @ref ZXC_ERROR_BAD_BLOCK_SIZE when the sub-header or the
- * decoded size tells, and fails like a too-small destination otherwise; decoder
- * codes are never reinterpreted. @p strict selects the strict-tail decoder for
- * GLO/GHI; RAW is a bounded copy either way.
+ * Fast decoder: carved block plus wild-copy margin; strict: at most that. A
+ * larger block still within the margin is @ref ZXC_ERROR_BAD_BLOCK_SIZE, beyond
+ * it the decoder's own too-small-destination code, never reinterpreted.
  */
 static int64_t zxc_static_decompress_block(zxc_dctx* RESTRICT dctx, const uint8_t* RESTRICT src,
                                            const size_t src_size, uint8_t* RESTRICT dst,
                                            const size_t dst_capacity, const size_t dict_size,
                                            const int checksum_enabled, const int strict) {
+    if (UNLIKELY(dict_size > ZXC_DICT_SIZE_MAX)) return ZXC_ERROR_DICT_TOO_LARGE;
     if (UNLIKELY(dict_size > 0)) return ZXC_ERROR_DICT_UNSUPPORTED;
     const size_t carved = dctx->last_block_size;
-    const uint8_t type = src[0];
-    // More literals than the carved block cannot fit it; a malformed
-    // sub-header is left to the decoder.
-    if (type == ZXC_BLOCK_GLO || type == ZXC_BLOCK_GHI) {
-        zxc_gnr_header_t gh;
-        uint32_t lit_comp, tok_comp;
-        const uint8_t* const body = src + ZXC_BLOCK_HEADER_SIZE;
-        const size_t body_size = src_size - ZXC_BLOCK_HEADER_SIZE;
-        const int rc = type == ZXC_BLOCK_GLO ? zxc_read_glo_header_and_desc(body, body_size, &gh,
-                                                                            &lit_comp, &tok_comp)
-                                             : zxc_read_ghi_header(body, body_size, &gh);
-        if (rc >= 0 && gh.n_literals > carved) return ZXC_ERROR_BAD_BLOCK_SIZE;
-    }
-
+    const size_t work_sz = carved + ZXC_DECOMPRESS_TAIL_PAD;
     zxc_cctx_t* const ctx = &dctx->inner;
     ctx->checksum_enabled = checksum_enabled;
     ctx->dict_size = 0;
-    const size_t work_sz = carved + ZXC_DECOMPRESS_TAIL_PAD;
     int res;
-    if (strict || dst_capacity >= work_sz) {
-        // Strict decoder and RAW copy are bounded by dst_capacity; the fast
-        // decoder gets the carved block plus its wild-copy margin.
-        const int direct_strict = strict && type != ZXC_BLOCK_RAW;
-        res = direct_strict
-                  ? zxc_decompress_chunk_wrapper_safe_public(ctx, src, src_size, dst, dst_capacity)
-                  : zxc_decompress_chunk_wrapper(ctx, src, src_size, dst,
-                                                 strict ? dst_capacity : work_sz);
+    if (strict) {
+        const size_t cap = dst_capacity < work_sz ? dst_capacity : work_sz;
+        res = zxc_decompress_chunk_wrapper_safe_public(ctx, src, src_size, dst, cap);
+    } else if (dst_capacity >= work_sz) {
+        res = zxc_decompress_chunk_wrapper(ctx, src, src_size, dst, work_sz);
     } else {
         // Bounce through work_buf when dst cannot absorb wild copies.
         res = zxc_decompress_chunk_wrapper(ctx, src, src_size, ctx->work_buf, ctx->work_buf_cap);
-        if (res > 0 && (size_t)res <= carved) {
+        if (UNLIKELY(res > 0 && (size_t)res > carved)) return ZXC_ERROR_BAD_BLOCK_SIZE;
+        if (LIKELY(res > 0)) {
             if (UNLIKELY((size_t)res > dst_capacity)) return ZXC_ERROR_DST_TOO_SMALL;
             ZXC_MEMCPY(dst, ctx->work_buf, (size_t)res);
         }
@@ -1744,8 +1728,9 @@ int64_t zxc_decompress_block(zxc_dctx* dctx, const void* RESTRICT src, const siz
 /**
  * @brief Safe-variant block decompressor: accepts dst_capacity == uncompressed_size.
  *
- * Dict inputs and RAW blocks route to @ref zxc_decompress_block; plain GLO/GHI
- * use the strict safe decoder (no bounce buffer, no +ZXC_DECOMPRESS_TAIL_PAD).
+ * Static dctx: shared static path. Heap dctx: dict inputs and RAW route to
+ * @ref zxc_decompress_block, plain GLO/GHI use the strict decoder (no bounce
+ * buffer, no +ZXC_DECOMPRESS_TAIL_PAD).
  *
  * Public API; full contract in @c zxc_buffer.h.
  */

--- a/src/lib/zxc_dispatch.c
+++ b/src/lib/zxc_dispatch.c
@@ -1627,12 +1627,7 @@ int64_t zxc_decompress_block(zxc_dctx* dctx, const void* RESTRICT src, const siz
     const size_t dict_size = ZXC_OPTS_DICT_SIZE(opts);
     if (UNLIKELY(dict_size > ZXC_DICT_SIZE_MAX)) return ZXC_ERROR_DICT_TOO_LARGE;
     if (UNLIKELY(dctx->owns_workspace && dict_size > 0)) return ZXC_ERROR_DICT_UNSUPPORTED;
-    // Static dctx: never re-carved. A GLO block announcing more literals than
-    // the carved block is refused here, any other oversize after decoding.
-    if (dctx->owns_workspace && ((const uint8_t*)src)[0] == ZXC_BLOCK_GLO &&
-        src_size >= ZXC_BLOCK_HEADER_SIZE + 8 &&
-        zxc_le32((const uint8_t*)src + ZXC_BLOCK_HEADER_SIZE + 4) > dctx->last_block_size)
-        return ZXC_ERROR_BAD_BLOCK_SIZE;
+    // Static dctx: never re-carved; an oversized block is caught after decoding.
 
     // Derive the block_size from dst_capacity (callers know the original size)
     const size_t block_size =
@@ -1693,7 +1688,8 @@ int64_t zxc_decompress_block(zxc_dctx* dctx, const void* RESTRICT src, const siz
     }
     if (dctx->owns_workspace) {
         // Static dctx: a block beyond the carved block is a size violation.
-        if (UNLIKELY(res == ZXC_ERROR_DST_TOO_SMALL && dst_capacity > dctx->last_block_size))
+        if (UNLIKELY((res == ZXC_ERROR_DST_TOO_SMALL || res == ZXC_ERROR_OVERFLOW) &&
+                     dst_capacity > dctx->last_block_size))
             return ZXC_ERROR_BAD_BLOCK_SIZE;
         if (UNLIKELY(res > 0 && (size_t)res > dctx->last_block_size))
             return ZXC_ERROR_BAD_BLOCK_SIZE;

--- a/src/lib/zxc_dispatch.c
+++ b/src/lib/zxc_dispatch.c
@@ -1627,11 +1627,19 @@ int64_t zxc_decompress_block(zxc_dctx* dctx, const void* RESTRICT src, const siz
     const size_t dict_size = ZXC_OPTS_DICT_SIZE(opts);
     if (UNLIKELY(dict_size > ZXC_DICT_SIZE_MAX)) return ZXC_ERROR_DICT_TOO_LARGE;
     if (UNLIKELY(dctx->owns_workspace && dict_size > 0)) return ZXC_ERROR_DICT_UNSUPPORTED;
+    // Static dctx: never re-carved. A GLO block announcing more literals than
+    // the carved block is refused here, any other oversize after decoding.
+    if (dctx->owns_workspace && ((const uint8_t*)src)[0] == ZXC_BLOCK_GLO &&
+        src_size >= ZXC_BLOCK_HEADER_SIZE + 8 &&
+        zxc_le32((const uint8_t*)src + ZXC_BLOCK_HEADER_SIZE + 4) > dctx->last_block_size)
+        return ZXC_ERROR_BAD_BLOCK_SIZE;
 
     // Derive the block_size from dst_capacity (callers know the original size)
-    const size_t block_size = zxc_block_size_ceil(dst_capacity);
-    if (UNLIKELY(!dctx->initialized || dctx->last_block_size != block_size ||
-                 dctx->last_dict_size != dict_size)) {
+    const size_t block_size =
+        dctx->owns_workspace ? dctx->last_block_size : zxc_block_size_ceil(dst_capacity);
+    if (UNLIKELY(!dctx->owns_workspace &&
+                 (!dctx->initialized || dctx->last_block_size != block_size ||
+                  dctx->last_dict_size != dict_size))) {
         if (dctx->initialized) {
             zxc_cctx_free(&dctx->inner);
             dctx->initialized = 0;
@@ -1671,8 +1679,9 @@ int64_t zxc_decompress_block(zxc_dctx* dctx, const void* RESTRICT src, const siz
             ZXC_MEMCPY(dst, dec_buf + dict_size, (size_t)res);
         }
     } else if (LIKELY(dst_capacity >= work_sz)) {
-        res = zxc_decompress_chunk_wrapper(ctx, (const uint8_t*)src, src_size, (uint8_t*)dst,
-                                           dst_capacity);
+        // A static context never decodes past its carved block.
+        const size_t cap = dctx->owns_workspace && dst_capacity > work_sz ? work_sz : dst_capacity;
+        res = zxc_decompress_chunk_wrapper(ctx, (const uint8_t*)src, src_size, (uint8_t*)dst, cap);
     } else {
         // Bounce through work_buf when output can't absorb wild copies.
         res = zxc_decompress_chunk_wrapper(ctx, (const uint8_t*)src, src_size, ctx->work_buf,
@@ -1681,6 +1690,13 @@ int64_t zxc_decompress_block(zxc_dctx* dctx, const void* RESTRICT src, const siz
             if (UNLIKELY((size_t)res > dst_capacity)) return ZXC_ERROR_DST_TOO_SMALL;
             ZXC_MEMCPY(dst, ctx->work_buf, (size_t)res);
         }
+    }
+    if (dctx->owns_workspace) {
+        // Static dctx: a block beyond the carved block is a size violation.
+        if (UNLIKELY(res == ZXC_ERROR_DST_TOO_SMALL && dst_capacity > dctx->last_block_size))
+            return ZXC_ERROR_BAD_BLOCK_SIZE;
+        if (UNLIKELY(res > 0 && (size_t)res > dctx->last_block_size))
+            return ZXC_ERROR_BAD_BLOCK_SIZE;
     }
     if (UNLIKELY(res < 0)) return res;
     return (int64_t)res;
@@ -1702,6 +1718,9 @@ int64_t zxc_decompress_block_safe(zxc_dctx* dctx, const void* RESTRICT src, cons
 
     // Strict-tail variant: dst_capacity matches the exact uncompressed size
     if (UNLIKELY(dst_capacity > ZXC_BLOCK_SIZE_MAX)) return ZXC_ERROR_BAD_BLOCK_SIZE;
+    // Static dctx: the carved block is locked, whichever path decodes it.
+    if (UNLIKELY(dctx->owns_workspace && dst_capacity > dctx->last_block_size))
+        return ZXC_ERROR_BAD_BLOCK_SIZE;
 
     // A dict needs the [dict|payload] bounce; route to the bounce-capable path.
     if (opts && opts->dict && opts->dict_size > 0) {
@@ -1716,9 +1735,11 @@ int64_t zxc_decompress_block_safe(zxc_dctx* dctx, const void* RESTRICT src, cons
 
     // GLO/GHI: use the strict-tail decoder (no bounce buffer required).
     const int checksum_enabled = opts ? opts->checksum_enabled : 0;
-    const size_t block_size = zxc_block_size_ceil(dst_capacity);
-    if (UNLIKELY(!dctx->initialized || dctx->last_block_size != block_size ||
-                 dctx->last_dict_size != 0)) {
+    const size_t block_size =
+        dctx->owns_workspace ? dctx->last_block_size : zxc_block_size_ceil(dst_capacity);
+    if (UNLIKELY(!dctx->owns_workspace &&
+                 (!dctx->initialized || dctx->last_block_size != block_size ||
+                  dctx->last_dict_size != 0))) {
         if (dctx->initialized) {
             zxc_cctx_free(&dctx->inner);
             dctx->initialized = 0;

--- a/src/lib/zxc_dispatch.c
+++ b/src/lib/zxc_dispatch.c
@@ -1600,6 +1600,59 @@ int64_t zxc_compress_block(zxc_cctx* cctx, const void* RESTRICT src, const size_
 }
 
 /**
+ * @brief Block decode on a static dctx: the carved block is the effective capacity.
+ *
+ * A larger block is @ref ZXC_ERROR_BAD_BLOCK_SIZE when the sub-header or the
+ * decoded size tells, and fails like a too-small destination otherwise; decoder
+ * codes are never reinterpreted. @p strict selects the strict-tail decoder for
+ * GLO/GHI; RAW is a bounded copy either way.
+ */
+static int64_t zxc_static_decompress_block(zxc_dctx* RESTRICT dctx, const uint8_t* RESTRICT src,
+                                           const size_t src_size, uint8_t* RESTRICT dst,
+                                           const size_t dst_capacity, const size_t dict_size,
+                                           const int checksum_enabled, const int strict) {
+    if (UNLIKELY(dict_size > 0)) return ZXC_ERROR_DICT_UNSUPPORTED;
+    const size_t carved = dctx->last_block_size;
+    const uint8_t type = src[0];
+    // More literals than the carved block cannot fit it; a malformed
+    // sub-header is left to the decoder.
+    if (type == ZXC_BLOCK_GLO || type == ZXC_BLOCK_GHI) {
+        zxc_gnr_header_t gh;
+        uint32_t lit_comp, tok_comp;
+        const uint8_t* const body = src + ZXC_BLOCK_HEADER_SIZE;
+        const size_t body_size = src_size - ZXC_BLOCK_HEADER_SIZE;
+        const int rc = type == ZXC_BLOCK_GLO ? zxc_read_glo_header_and_desc(body, body_size, &gh,
+                                                                            &lit_comp, &tok_comp)
+                                             : zxc_read_ghi_header(body, body_size, &gh);
+        if (rc >= 0 && gh.n_literals > carved) return ZXC_ERROR_BAD_BLOCK_SIZE;
+    }
+
+    zxc_cctx_t* const ctx = &dctx->inner;
+    ctx->checksum_enabled = checksum_enabled;
+    ctx->dict_size = 0;
+    const size_t work_sz = carved + ZXC_DECOMPRESS_TAIL_PAD;
+    int res;
+    if (strict || dst_capacity >= work_sz) {
+        // Strict decoder and RAW copy are bounded by dst_capacity; the fast
+        // decoder gets the carved block plus its wild-copy margin.
+        const int direct_strict = strict && type != ZXC_BLOCK_RAW;
+        res = direct_strict
+                  ? zxc_decompress_chunk_wrapper_safe_public(ctx, src, src_size, dst, dst_capacity)
+                  : zxc_decompress_chunk_wrapper(ctx, src, src_size, dst,
+                                                 strict ? dst_capacity : work_sz);
+    } else {
+        // Bounce through work_buf when dst cannot absorb wild copies.
+        res = zxc_decompress_chunk_wrapper(ctx, src, src_size, ctx->work_buf, ctx->work_buf_cap);
+        if (res > 0 && (size_t)res <= carved) {
+            if (UNLIKELY((size_t)res > dst_capacity)) return ZXC_ERROR_DST_TOO_SMALL;
+            ZXC_MEMCPY(dst, ctx->work_buf, (size_t)res);
+        }
+    }
+    if (UNLIKELY(res > 0 && (size_t)res > carved)) return ZXC_ERROR_BAD_BLOCK_SIZE;
+    return res;
+}
+
+/**
  * @brief Decompresses a single block (no file framing), reusing @p dctx.
  *
  * Public API; full contract in @c zxc_buffer.h. Decodes one format-conformant
@@ -1626,15 +1679,14 @@ int64_t zxc_decompress_block(zxc_dctx* dctx, const void* RESTRICT src, const siz
     const uint8_t* dict = opts ? (const uint8_t*)opts->dict : NULL;
     const size_t dict_size = ZXC_OPTS_DICT_SIZE(opts);
     if (UNLIKELY(dict_size > ZXC_DICT_SIZE_MAX)) return ZXC_ERROR_DICT_TOO_LARGE;
-    if (UNLIKELY(dctx->owns_workspace && dict_size > 0)) return ZXC_ERROR_DICT_UNSUPPORTED;
-    // Static dctx: never re-carved; an oversized block is caught after decoding.
+    if (UNLIKELY(dctx->owns_workspace))
+        return zxc_static_decompress_block(dctx, (const uint8_t*)src, src_size, (uint8_t*)dst,
+                                           dst_capacity, dict_size, checksum_enabled, 0);
 
     // Derive the block_size from dst_capacity (callers know the original size)
-    const size_t block_size =
-        dctx->owns_workspace ? dctx->last_block_size : zxc_block_size_ceil(dst_capacity);
-    if (UNLIKELY(!dctx->owns_workspace &&
-                 (!dctx->initialized || dctx->last_block_size != block_size ||
-                  dctx->last_dict_size != dict_size))) {
+    const size_t block_size = zxc_block_size_ceil(dst_capacity);
+    if (UNLIKELY(!dctx->initialized || dctx->last_block_size != block_size ||
+                 dctx->last_dict_size != dict_size)) {
         if (dctx->initialized) {
             zxc_cctx_free(&dctx->inner);
             dctx->initialized = 0;
@@ -1663,7 +1715,6 @@ int64_t zxc_decompress_block(zxc_dctx* dctx, const void* RESTRICT src, const siz
     const size_t work_sz = block_size + ZXC_DECOMPRESS_TAIL_PAD;
 
     int res;
-    int bounced = 0;
     if (dict && dict_size > 0) {
         // [dict | decode] assembled in the cctx-owned dict_buffer
         uint8_t* const dec_buf = ctx->dict_buffer;
@@ -1675,28 +1726,18 @@ int64_t zxc_decompress_block(zxc_dctx* dctx, const void* RESTRICT src, const siz
             ZXC_MEMCPY(dst, dec_buf + dict_size, (size_t)res);
         }
     } else if (LIKELY(dst_capacity >= work_sz)) {
-        // A static context never decodes past its carved block.
-        const size_t cap = dctx->owns_workspace && dst_capacity > work_sz ? work_sz : dst_capacity;
-        res = zxc_decompress_chunk_wrapper(ctx, (const uint8_t*)src, src_size, (uint8_t*)dst, cap);
+        res = zxc_decompress_chunk_wrapper(ctx, (const uint8_t*)src, src_size, (uint8_t*)dst,
+                                           dst_capacity);
     } else {
         // Bounce through work_buf when output can't absorb wild copies.
         res = zxc_decompress_chunk_wrapper(ctx, (const uint8_t*)src, src_size, ctx->work_buf,
                                            ctx->work_buf_cap);
-        bounced = 1;
-    }
-    if (dctx->owns_workspace) {
-        // Static dctx: a block beyond the carved block is a size violation,
-        // whatever the caller's buffer (the decoder only ever sees the carved
-        // capacity here, so its overflow codes mean exactly that).
-        if (UNLIKELY(res == ZXC_ERROR_DST_TOO_SMALL || res == ZXC_ERROR_OVERFLOW ||
-                     (res > 0 && (size_t)res > dctx->last_block_size)))
-            return ZXC_ERROR_BAD_BLOCK_SIZE;
+        if (LIKELY(res > 0)) {
+            if (UNLIKELY((size_t)res > dst_capacity)) return ZXC_ERROR_DST_TOO_SMALL;
+            ZXC_MEMCPY(dst, ctx->work_buf, (size_t)res);
+        }
     }
     if (UNLIKELY(res < 0)) return res;
-    if (bounced) {
-        if (UNLIKELY((size_t)res > dst_capacity)) return ZXC_ERROR_DST_TOO_SMALL;
-        ZXC_MEMCPY(dst, ctx->work_buf, (size_t)res);
-    }
     return (int64_t)res;
 }
 
@@ -1716,9 +1757,10 @@ int64_t zxc_decompress_block_safe(zxc_dctx* dctx, const void* RESTRICT src, cons
 
     // Strict-tail variant: dst_capacity matches the exact uncompressed size
     if (UNLIKELY(dst_capacity > ZXC_BLOCK_SIZE_MAX)) return ZXC_ERROR_BAD_BLOCK_SIZE;
-    // Static dctx: the carved block is locked, whichever path decodes it.
-    if (UNLIKELY(dctx->owns_workspace && dst_capacity > dctx->last_block_size))
-        return ZXC_ERROR_BAD_BLOCK_SIZE;
+    if (UNLIKELY(dctx->owns_workspace))
+        return zxc_static_decompress_block(dctx, (const uint8_t*)src, src_size, (uint8_t*)dst,
+                                           dst_capacity, ZXC_OPTS_DICT_SIZE(opts),
+                                           opts ? opts->checksum_enabled : 0, 1);
 
     // A dict needs the [dict|payload] bounce; route to the bounce-capable path.
     if (opts && opts->dict && opts->dict_size > 0) {
@@ -1733,11 +1775,9 @@ int64_t zxc_decompress_block_safe(zxc_dctx* dctx, const void* RESTRICT src, cons
 
     // GLO/GHI: use the strict-tail decoder (no bounce buffer required).
     const int checksum_enabled = opts ? opts->checksum_enabled : 0;
-    const size_t block_size =
-        dctx->owns_workspace ? dctx->last_block_size : zxc_block_size_ceil(dst_capacity);
-    if (UNLIKELY(!dctx->owns_workspace &&
-                 (!dctx->initialized || dctx->last_block_size != block_size ||
-                  dctx->last_dict_size != 0))) {
+    const size_t block_size = zxc_block_size_ceil(dst_capacity);
+    if (UNLIKELY(!dctx->initialized || dctx->last_block_size != block_size ||
+                 dctx->last_dict_size != 0)) {
         if (dctx->initialized) {
             zxc_cctx_free(&dctx->inner);
             dctx->initialized = 0;

--- a/src/lib/zxc_dispatch.c
+++ b/src/lib/zxc_dispatch.c
@@ -1663,6 +1663,7 @@ int64_t zxc_decompress_block(zxc_dctx* dctx, const void* RESTRICT src, const siz
     const size_t work_sz = block_size + ZXC_DECOMPRESS_TAIL_PAD;
 
     int res;
+    int bounced = 0;
     if (dict && dict_size > 0) {
         // [dict | decode] assembled in the cctx-owned dict_buffer
         uint8_t* const dec_buf = ctx->dict_buffer;
@@ -1681,20 +1682,21 @@ int64_t zxc_decompress_block(zxc_dctx* dctx, const void* RESTRICT src, const siz
         // Bounce through work_buf when output can't absorb wild copies.
         res = zxc_decompress_chunk_wrapper(ctx, (const uint8_t*)src, src_size, ctx->work_buf,
                                            ctx->work_buf_cap);
-        if (LIKELY(res > 0)) {
-            if (UNLIKELY((size_t)res > dst_capacity)) return ZXC_ERROR_DST_TOO_SMALL;
-            ZXC_MEMCPY(dst, ctx->work_buf, (size_t)res);
-        }
+        bounced = 1;
     }
     if (dctx->owns_workspace) {
-        // Static dctx: a block beyond the carved block is a size violation.
-        if (UNLIKELY((res == ZXC_ERROR_DST_TOO_SMALL || res == ZXC_ERROR_OVERFLOW) &&
-                     dst_capacity > dctx->last_block_size))
-            return ZXC_ERROR_BAD_BLOCK_SIZE;
-        if (UNLIKELY(res > 0 && (size_t)res > dctx->last_block_size))
+        // Static dctx: a block beyond the carved block is a size violation,
+        // whatever the caller's buffer (the decoder only ever sees the carved
+        // capacity here, so its overflow codes mean exactly that).
+        if (UNLIKELY(res == ZXC_ERROR_DST_TOO_SMALL || res == ZXC_ERROR_OVERFLOW ||
+                     (res > 0 && (size_t)res > dctx->last_block_size)))
             return ZXC_ERROR_BAD_BLOCK_SIZE;
     }
     if (UNLIKELY(res < 0)) return res;
+    if (bounced) {
+        if (UNLIKELY((size_t)res > dst_capacity)) return ZXC_ERROR_DST_TOO_SMALL;
+        ZXC_MEMCPY(dst, ctx->work_buf, (size_t)res);
+    }
     return (int64_t)res;
 }
 

--- a/tests/test_common.h
+++ b/tests/test_common.h
@@ -92,6 +92,7 @@ int test_static_ctx_workspace_too_small(void);
 int test_static_ctx_block_size_locked(void);
 int test_static_ctx_level_raise_rejected(void);
 int test_static_ctx_null_inputs(void);
+int test_static_dctx_block_bounds(void);
 
 /* Stream API */
 int test_null_output_decompression(void);

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -77,6 +77,7 @@ static const test_entry_t g_tests[] = {
     TEST_CASE(test_static_ctx_level_raise_rejected),
     TEST_CASE(test_static_ctx_null_inputs),
     TEST_CASE(test_static_ctx_roundtrip_all_levels),
+    TEST_CASE(test_static_dctx_block_bounds),
 
     /* --- Stream API --- */
     TEST_CASE(test_null_output_decompression),

--- a/tests/test_static_ctx.c
+++ b/tests/test_static_ctx.c
@@ -361,10 +361,10 @@ int test_static_ctx_null_inputs(void) {
  * caller buffer is fine. */
 int test_static_dctx_block_bounds(void) {
     printf("=== TEST: Static dctx - blocks bounded by the carved block ===\n");
-    enum { PIN = 4096, BIG = 6000 };
-    uint8_t* text = (uint8_t*)malloc(BIG);
-    uint8_t* noise = (uint8_t*)malloc(BIG);
-    const size_t cap = (size_t)zxc_compress_block_bound(BIG);
+    enum { PIN = 4096, BIG = 6000, HUGE = 8000 };
+    uint8_t* text = (uint8_t*)malloc(HUGE);
+    uint8_t* noise = (uint8_t*)malloc(HUGE);
+    const size_t cap = (size_t)zxc_compress_block_bound(HUGE);
     uint8_t* comp = (uint8_t*)malloc(cap);
     uint8_t* out = (uint8_t*)malloc(2 * PIN + ZXC_DECOMPRESS_TAIL_PAD);
     const size_t ws_sz = zxc_static_dctx_workspace_size(PIN);
@@ -377,9 +377,9 @@ int test_static_dctx_block_bounds(void) {
             printf("  [FAIL] setup\n");
             break;
         }
-        for (size_t i = 0; i < BIG; i++) text[i] = (uint8_t)("static block "[i % 13]);
+        for (size_t i = 0; i < HUGE; i++) text[i] = (uint8_t)("static block "[i % 13]);
         uint64_t x = 0x9E3779B97F4A7C15ull; /* incompressible: stored RAW */
-        for (size_t i = 0; i < BIG; i++) {
+        for (size_t i = 0; i < HUGE; i++) {
             x ^= x << 13;
             x ^= x >> 7;
             x ^= x << 17;
@@ -388,6 +388,7 @@ int test_static_dctx_block_bounds(void) {
         const zxc_compress_opts_t co = {.level = 3};
         /* Oversized GLO and RAW blocks, both decoders. */
         const int64_t g = zxc_compress_block(cctx, text, BIG, comp, cap, &co);
+        const uint8_t g_type = g > 0 ? comp[0] : 0; /* comp is reused for RAW below */
         const int64_t e1 =
             g > 0 ? zxc_decompress_block(sd, comp, (size_t)g, out, BIG + 200, NULL) : 0;
         const int64_t e2 =
@@ -397,15 +398,47 @@ int test_static_dctx_block_bounds(void) {
             r > 0 ? zxc_decompress_block(sd, comp, (size_t)r, out, BIG + 200, NULL) : 0;
         const int64_t e4 =
             r > 0 ? zxc_decompress_block_safe(sd, comp, (size_t)r, out, BIG, NULL) : 0;
-        if (g <= 0 || r <= 0 || comp[0] != ZXC_BLOCK_RAW || e1 != ZXC_ERROR_BAD_BLOCK_SIZE ||
-            e2 != ZXC_ERROR_BAD_BLOCK_SIZE || e3 != ZXC_ERROR_BAD_BLOCK_SIZE ||
-            e4 != ZXC_ERROR_BAD_BLOCK_SIZE) {
-            printf("  [FAIL] oversized blocks: GLO %lld/%lld, RAW(type %u) %lld/%lld\n",
+        if (g <= 0 || r <= 0 || g_type != ZXC_BLOCK_GLO || comp[0] != ZXC_BLOCK_RAW ||
+            e1 != ZXC_ERROR_BAD_BLOCK_SIZE || e2 != ZXC_ERROR_BAD_BLOCK_SIZE ||
+            e3 != ZXC_ERROR_BAD_BLOCK_SIZE || e4 != ZXC_ERROR_BAD_BLOCK_SIZE) {
+            printf("  [FAIL] oversized blocks: type %u %lld/%lld, type %u %lld/%lld\n", g_type,
                    (long long)e1, (long long)e2, r > 0 ? (unsigned)comp[0] : 0U, (long long)e3,
                    (long long)e4);
             break;
         }
         printf("  [PASS] blocks larger than the carved block -> BAD_BLOCK_SIZE on both decoders\n");
+        /* Overflowing the capped destination: 8000 bytes RAW then GLO, and a
+         * GLO block with more Huffman-coded literals than the carved block
+         * (7000 bytes over a 16-symbol alphabet, a 1000-byte repeat, level 6). */
+        const int64_t h1 = zxc_compress_block(cctx, noise, HUGE, comp, cap, &co);
+        const int64_t e5 =
+            h1 > 0 ? zxc_decompress_block(sd, comp, (size_t)h1, out, HUGE + 200, NULL) : 0;
+        const int64_t h2 = zxc_compress_block(cctx, text, HUGE, comp, cap, &co);
+        const int64_t e6 =
+            h2 > 0 ? zxc_decompress_block(sd, comp, (size_t)h2, out, HUGE + 200, NULL) : 0;
+        for (size_t i = 0; i < 7000; i++) {
+            x ^= x << 13;
+            x ^= x >> 7;
+            x ^= x << 17;
+            noise[i] = (uint8_t)("0123456789abcdef"[x >> 60]);
+        }
+        memcpy(noise + 7000, noise, 1000);
+        const zxc_compress_opts_t co6 = {.level = 6};
+        const int64_t l = zxc_compress_block(cctx, noise, HUGE, comp, cap, &co6);
+        const uint8_t l_type = l > 0 ? comp[0] : 0;
+        const uint8_t l_enc = l > 0 ? comp[ZXC_BLOCK_HEADER_SIZE + 8] : 0; /* enc_lit */
+        const int64_t e7 =
+            l > 0 ? zxc_decompress_block(sd, comp, (size_t)l, out, HUGE + 200, NULL) : 0;
+        if (h1 <= 0 || h2 <= 0 || l <= 0 || l_type != ZXC_BLOCK_GLO || l_enc != 2 ||
+            e5 != ZXC_ERROR_BAD_BLOCK_SIZE || e6 != ZXC_ERROR_BAD_BLOCK_SIZE ||
+            e7 != ZXC_ERROR_BAD_BLOCK_SIZE) {
+            printf(
+                "  [FAIL] early exits: RAW %lld, GLO %lld, literal-heavy (type %u, enc_lit %u) "
+                "%lld\n",
+                (long long)e5, (long long)e6, l_type, l_enc, (long long)e7);
+            break;
+        }
+        printf("  [PASS] destination overflow, literal-heavy block included -> BAD_BLOCK_SIZE\n");
         /* A fitting block, both decoders, larger buffer included. */
         const int64_t n = zxc_compress_block(cctx, text, PIN, comp, cap, &co);
         const int64_t f1 = n > 0 ? zxc_decompress_block(sd, comp, (size_t)n, out,

--- a/tests/test_static_ctx.c
+++ b/tests/test_static_ctx.c
@@ -357,129 +357,195 @@ int test_static_ctx_null_inputs(void) {
     return 1;
 }
 
-/* Both decoders refuse a block beyond a static dctx's carved block; a larger
- * caller buffer is fine. */
+/* Decodes the n-byte block; a failed compression (n <= 0) propagates. */
+static int64_t dec(zxc_dctx* d, const uint8_t* blk, int64_t n, uint8_t* out, size_t cap,
+                   int strict) {
+    if (n <= 0) return n;
+    return strict ? zxc_decompress_block_safe(d, blk, (size_t)n, out, cap, NULL)
+                  : zxc_decompress_block(d, blk, (size_t)n, out, cap, NULL);
+}
+
+/* Static dctx block API: the carved block is the effective capacity. Fitting
+ * blocks decode whatever the buffer; larger ones are BAD_BLOCK_SIZE when the
+ * sub-header or decoded size tells, else a too-small-destination code;
+ * corruption keeps the dynamic codes. */
 int test_static_dctx_block_bounds(void) {
     printf("=== TEST: Static dctx - blocks bounded by the carved block ===\n");
-    enum { PIN = 4096, BIG = 6000, HUGE = 8000 };
-    uint8_t* text = (uint8_t*)malloc(HUGE);
-    uint8_t* noise = (uint8_t*)malloc(HUGE);
-    const size_t cap = (size_t)zxc_compress_block_bound(HUGE);
+    enum { PIN = 4096, MID = 5000, XL = 8000, LIT = 4500, PAD = ZXC_DECOMPRESS_TAIL_PAD };
+    const size_t cap = (size_t)zxc_compress_block_bound(XL);
+    uint8_t* lz = (uint8_t*)malloc(XL);          /* compressible: GLO */
+    uint8_t* rnd = (uint8_t*)malloc(XL);         /* incompressible: RAW */
+    uint8_t* lit = (uint8_t*)malloc(LIT + 1000); /* Huffman literals, then a repeat */
     uint8_t* comp = (uint8_t*)malloc(cap);
-    uint8_t* out = (uint8_t*)malloc(2 * PIN + ZXC_DECOMPRESS_TAIL_PAD);
+    uint8_t* mut = (uint8_t*)malloc(cap);
+    uint8_t* out = (uint8_t*)malloc(2 * PIN + PAD);
+    uint8_t* out2 = (uint8_t*)malloc(2 * PIN + PAD);
     const size_t ws_sz = zxc_static_dctx_workspace_size(PIN);
     void* ws = test_aligned_alloc(64, ws_sz);
     zxc_cctx* cctx = zxc_create_cctx(NULL);
+    zxc_dctx* hd = zxc_create_dctx();
     zxc_dctx* sd = ws ? zxc_init_static_dctx(ws, ws_sz, PIN) : NULL;
     int ok = 0;
     do {
-        if (!text || !noise || !comp || !out || !cctx || !sd) {
+        if (!lz || !rnd || !lit || !comp || !mut || !out || !out2 || !cctx || !hd || !sd) {
             printf("  [FAIL] setup\n");
             break;
         }
-        for (size_t i = 0; i < HUGE; i++) text[i] = (uint8_t)("static block "[i % 13]);
-        uint64_t x = 0x9E3779B97F4A7C15ull; /* incompressible: stored RAW */
-        for (size_t i = 0; i < HUGE; i++) {
-            x ^= x << 13;
-            x ^= x >> 7;
-            x ^= x << 17;
-            noise[i] = (uint8_t)(x >> 24);
-        }
-        const zxc_compress_opts_t co = {.level = 3};
-        /* Oversized GLO and RAW blocks, both decoders. */
-        const int64_t g = zxc_compress_block(cctx, text, BIG, comp, cap, &co);
-        const uint8_t g_type = g > 0 ? comp[0] : 0; /* comp is reused for RAW below */
-        const int64_t e1 =
-            g > 0 ? zxc_decompress_block(sd, comp, (size_t)g, out, BIG + 200, NULL) : 0;
-        const int64_t e2 =
-            g > 0 ? zxc_decompress_block_safe(sd, comp, (size_t)g, out, BIG, NULL) : 0;
-        const int64_t r = zxc_compress_block(cctx, noise, BIG, comp, cap, &co);
-        const int64_t e3 =
-            r > 0 ? zxc_decompress_block(sd, comp, (size_t)r, out, BIG + 200, NULL) : 0;
-        const int64_t e4 =
-            r > 0 ? zxc_decompress_block_safe(sd, comp, (size_t)r, out, BIG, NULL) : 0;
-        if (g <= 0 || r <= 0 || g_type != ZXC_BLOCK_GLO || comp[0] != ZXC_BLOCK_RAW ||
-            e1 != ZXC_ERROR_BAD_BLOCK_SIZE || e2 != ZXC_ERROR_BAD_BLOCK_SIZE ||
-            e3 != ZXC_ERROR_BAD_BLOCK_SIZE || e4 != ZXC_ERROR_BAD_BLOCK_SIZE) {
-            printf("  [FAIL] oversized blocks: type %u %lld/%lld, type %u %lld/%lld\n", g_type,
-                   (long long)e1, (long long)e2, r > 0 ? (unsigned)comp[0] : 0U, (long long)e3,
-                   (long long)e4);
+        zxc_test_srand(0x5747u);
+        gen_lz_data(lz, XL);
+        gen_random_data(rnd, XL);
+        for (size_t i = 0; i < LIT; i++)
+            lit[i] = (uint8_t)("0123456789abcdef"[zxc_test_rand() & 15]);
+        memcpy(lit + LIT, lit, 1000);
+        const zxc_compress_opts_t l3 = {.level = 3};
+        const zxc_compress_opts_t l6 = {.level = 6};
+
+        /* A fitting block: both decoders, exact and larger buffers. */
+        const int64_t f = zxc_compress_block(cctx, lz, PIN, comp, cap, &l3);
+        const int64_t f1 = dec(sd, comp, f, out, PIN + PAD, 0);
+        const int64_t f2 = dec(sd, comp, f, out2, 2 * PIN + PAD, 0);
+        const int64_t f3 = dec(sd, comp, f, out, PIN, 1);
+        const int64_t f4 = dec(sd, comp, f, out2, 2 * PIN, 1);
+        if (f1 != PIN || f2 != PIN || f3 != PIN || f4 != PIN || memcmp(out, lz, PIN) != 0 ||
+            memcmp(out2, lz, PIN) != 0) {
+            printf("  [FAIL] fitting block: %lld %lld %lld %lld\n", (long long)f1, (long long)f2,
+                   (long long)f3, (long long)f4);
             break;
         }
-        printf("  [PASS] blocks larger than the carved block -> BAD_BLOCK_SIZE on both decoders\n");
-        /* Overflowing the capped destination: 8000 bytes RAW then GLO, and a
-         * GLO block with more Huffman-coded literals than the carved block
-         * (7000 bytes over a 16-symbol alphabet, a 1000-byte repeat, level 6). */
-        const int64_t h1 = zxc_compress_block(cctx, noise, HUGE, comp, cap, &co);
-        const int64_t e5 =
-            h1 > 0 ? zxc_decompress_block(sd, comp, (size_t)h1, out, HUGE + 200, NULL) : 0;
-        const int64_t h2 = zxc_compress_block(cctx, text, HUGE, comp, cap, &co);
-        const int64_t e6 =
-            h2 > 0 ? zxc_decompress_block(sd, comp, (size_t)h2, out, HUGE + 200, NULL) : 0;
-        for (size_t i = 0; i < 7000; i++) {
-            x ^= x << 13;
-            x ^= x >> 7;
-            x ^= x << 17;
-            noise[i] = (uint8_t)("0123456789abcdef"[x >> 60]);
-        }
-        memcpy(noise + 7000, noise, 1000);
-        const zxc_compress_opts_t co6 = {.level = 6};
-        const int64_t l = zxc_compress_block(cctx, noise, HUGE, comp, cap, &co6);
-        const uint8_t l_type = l > 0 ? comp[0] : 0;
-        const uint8_t l_enc = l > 0 ? comp[ZXC_BLOCK_HEADER_SIZE + 8] : 0; /* enc_lit */
-        const int64_t e7 =
-            l > 0 ? zxc_decompress_block(sd, comp, (size_t)l, out, HUGE + 200, NULL) : 0;
-        if (h1 <= 0 || h2 <= 0 || l <= 0 || l_type != ZXC_BLOCK_GLO || l_enc != 2 ||
-            e5 != ZXC_ERROR_BAD_BLOCK_SIZE || e6 != ZXC_ERROR_BAD_BLOCK_SIZE ||
-            e7 != ZXC_ERROR_BAD_BLOCK_SIZE) {
-            printf(
-                "  [FAIL] early exits: RAW %lld, GLO %lld, literal-heavy (type %u, enc_lit %u) "
-                "%lld\n",
-                (long long)e5, (long long)e6, l_type, l_enc, (long long)e7);
+        printf("  [PASS] a fitting block decodes on both decoders, larger buffers included\n");
+
+        /* Within the margin: the decoded size tells, whatever the buffer; the
+         * strict decoder at exactly the carved size says "does not fit", as a
+         * dynamic dctx would. */
+        const int64_t m = zxc_compress_block(cctx, lz, MID, comp, cap, &l3);
+        const int64_t m1 = dec(sd, comp, m, out, MID + PAD, 0);
+        const int64_t m2 = dec(sd, comp, m, out, PIN, 0);
+        const int64_t m3 = dec(sd, comp, m, out, MID, 1);
+        const int64_t m4 = dec(sd, comp, m, out, PIN, 1);
+        const int64_t mr = zxc_compress_block(cctx, rnd, MID, comp, cap, &l3);
+        const uint8_t mr_type = mr > 0 ? comp[0] : 0;
+        const int64_t m5 = dec(sd, comp, mr, out, MID + PAD, 0);
+        const int64_t m6 = dec(sd, comp, mr, out, MID, 1);
+        const int64_t m7 = dec(sd, comp, mr, out, PIN, 1);
+        if (m1 != ZXC_ERROR_BAD_BLOCK_SIZE || m2 != ZXC_ERROR_BAD_BLOCK_SIZE ||
+            m3 != ZXC_ERROR_BAD_BLOCK_SIZE || m4 != ZXC_ERROR_OVERFLOW ||
+            mr_type != ZXC_BLOCK_RAW || m5 != ZXC_ERROR_BAD_BLOCK_SIZE ||
+            m6 != ZXC_ERROR_BAD_BLOCK_SIZE || m7 != ZXC_ERROR_DST_TOO_SMALL) {
+            printf("  [FAIL] within margin: GLO %lld %lld %lld %lld, RAW(type %u) %lld %lld %lld\n",
+                   (long long)m1, (long long)m2, (long long)m3, (long long)m4, mr_type,
+                   (long long)m5, (long long)m6, (long long)m7);
             break;
         }
-        printf("  [PASS] destination overflow, literal-heavy block included -> BAD_BLOCK_SIZE\n");
-        /* The caller's buffer never changes the verdict: oversized blocks into
-         * a buffer of exactly the carved size (overflowing the workspace, then
-         * fitting it but not the block) stay BAD_BLOCK_SIZE, while a buffer too
-         * small for a block that fits is DST_TOO_SMALL. */
-        const int64_t h3 = zxc_compress_block(cctx, text, HUGE, comp, cap, &co);
-        const int64_t e8 = h3 > 0 ? zxc_decompress_block(sd, comp, (size_t)h3, out, PIN, NULL) : 0;
-        const int64_t m = zxc_compress_block(cctx, text, 5000, comp, cap, &co);
-        const int64_t e9 = m > 0 ? zxc_decompress_block(sd, comp, (size_t)m, out, PIN, NULL) : 0;
-        const int64_t f = zxc_compress_block(cctx, text, PIN, comp, cap, &co);
-        const int64_t e10 = f > 0 ? zxc_decompress_block(sd, comp, (size_t)f, out, 2000, NULL) : 0;
-        if (h3 <= 0 || m <= 0 || f <= 0 || e8 != ZXC_ERROR_BAD_BLOCK_SIZE ||
-            e9 != ZXC_ERROR_BAD_BLOCK_SIZE || e10 != ZXC_ERROR_DST_TOO_SMALL) {
-            printf("  [FAIL] exact-size buffer: %lld / %lld, small buffer: %lld\n", (long long)e8,
-                   (long long)e9, (long long)e10);
+        printf(
+            "  [PASS] within the margin -> BAD_BLOCK_SIZE, strict at exact size -> not fitting\n");
+
+        /* Beyond the margin: workspace overflow, the codes a dynamic dctx
+         * gives for a too-small destination, buffer-independent. */
+        const int64_t x = zxc_compress_block(cctx, lz, XL, comp, cap, &l3);
+        const int64_t x1 = dec(sd, comp, x, out, XL + 200, 0);
+        const int64_t x2 = dec(sd, comp, x, out, PIN, 0);
+        const int64_t x3 = dec(sd, comp, x, out, XL, 1);
+        const int64_t xr = zxc_compress_block(cctx, rnd, XL, comp, cap, &l3);
+        const int64_t x4 = dec(sd, comp, xr, out, XL + 200, 0);
+        const int64_t x5 = dec(sd, comp, xr, out, PIN, 0);
+        const int64_t x6 = dec(sd, comp, xr, out, XL, 1);
+        if (x1 != ZXC_ERROR_OVERFLOW || x2 != ZXC_ERROR_OVERFLOW ||
+            x3 != ZXC_ERROR_BAD_BLOCK_SIZE || x4 != ZXC_ERROR_DST_TOO_SMALL ||
+            x5 != ZXC_ERROR_DST_TOO_SMALL || x6 != ZXC_ERROR_BAD_BLOCK_SIZE) {
+            printf("  [FAIL] beyond margin: GLO %lld %lld %lld, RAW %lld %lld %lld\n",
+                   (long long)x1, (long long)x2, (long long)x3, (long long)x4, (long long)x5,
+                   (long long)x6);
             break;
         }
-        printf("  [PASS] verdict independent of the caller's buffer\n");
-        /* A fitting block, both decoders, larger buffer included. */
-        const int64_t n = zxc_compress_block(cctx, text, PIN, comp, cap, &co);
-        const int64_t f1 = n > 0 ? zxc_decompress_block(sd, comp, (size_t)n, out,
-                                                        2 * PIN + ZXC_DECOMPRESS_TAIL_PAD, NULL)
-                                 : 0;
-        const int bad1 = f1 != PIN || memcmp(out, text, PIN) != 0;
-        memset(out, 0, PIN);
-        const int64_t f2 =
-            n > 0 ? zxc_decompress_block_safe(sd, comp, (size_t)n, out, PIN, NULL) : 0;
-        if (n <= 0 || bad1 || f2 != PIN || memcmp(out, text, PIN) != 0) {
-            printf("  [FAIL] fitting block: fast %lld, strict %lld\n", (long long)f1,
-                   (long long)f2);
+        printf("  [PASS] beyond the margin -> workspace overflow codes, buffer-independent\n");
+
+        /* More Huffman literals than the carved block: told by the sub-header,
+         * both decoders. */
+        const int64_t h = zxc_compress_block(cctx, lit, LIT + 1000, comp, cap, &l6);
+        zxc_gnr_header_t gh = {0};
+        uint32_t lc = 0, tc = 0;
+        const int hdr =
+            h > 0 ? zxc_read_glo_header_and_desc(comp + ZXC_BLOCK_HEADER_SIZE,
+                                                 (size_t)h - ZXC_BLOCK_HEADER_SIZE, &gh, &lc, &tc)
+                  : -1;
+        const int64_t h1 = dec(sd, comp, h, out, LIT + 1000 + PAD, 0);
+        const int64_t h2 = dec(sd, comp, h, out, LIT + 1000, 1);
+        if (h <= 0 || comp[0] != ZXC_BLOCK_GLO || hdr <= 0 ||
+            gh.enc_lit != ZXC_SECTION_ENCODING_HUFFMAN || gh.n_literals <= PIN ||
+            h1 != ZXC_ERROR_BAD_BLOCK_SIZE || h2 != ZXC_ERROR_BAD_BLOCK_SIZE) {
+            printf("  [FAIL] literal-heavy: type %u enc_lit %u n_literals %u -> %lld %lld\n",
+                   h > 0 ? comp[0] : 0U, gh.enc_lit, gh.n_literals, (long long)h1, (long long)h2);
             break;
         }
-        printf("  [PASS] a fitting block decodes on both decoders, larger buffer included\n");
+        const zxc_compress_opts_t l1 = {.level = 1};
+        const int64_t k = zxc_compress_block(cctx, lit, LIT + 1000, comp, cap, &l1);
+        const int64_t k1 = dec(sd, comp, k, out, LIT + 1000 + PAD, 0);
+        const int64_t k2 = dec(sd, comp, k, out, LIT + 1000, 1);
+        if (k <= 0 || comp[0] != ZXC_BLOCK_GHI || k1 != ZXC_ERROR_BAD_BLOCK_SIZE ||
+            k2 != ZXC_ERROR_BAD_BLOCK_SIZE) {
+            printf("  [FAIL] literal-heavy GHI: type %u -> %lld %lld\n", k > 0 ? comp[0] : 0U,
+                   (long long)k1, (long long)k2);
+            break;
+        }
+        printf(
+            "  [PASS] %u Huffman literals (GLO) and the GHI form -> BAD_BLOCK_SIZE before "
+            "decoding\n",
+            gh.n_literals);
+
+        /* A dictionary is refused first, on both decoders, whatever the buffer. */
+        const zxc_decompress_opts_t with_dict = {.dict = lz, .dict_size = 16};
+        const int64_t d1 =
+            zxc_decompress_block(sd, comp, (size_t)h, out, 2 * PIN + PAD, &with_dict);
+        const int64_t d2 = zxc_decompress_block_safe(sd, comp, (size_t)h, out, 2 * PIN, &with_dict);
+        if (d1 != ZXC_ERROR_DICT_UNSUPPORTED || d2 != ZXC_ERROR_DICT_UNSUPPORTED) {
+            printf("  [FAIL] dictionary on a static dctx: %lld %lld\n", (long long)d1,
+                   (long long)d2);
+            break;
+        }
+        printf("  [PASS] dictionary -> DICT_UNSUPPORTED on both decoders\n");
+
+        /* Corruption keeps its codes: each single-bit flip gives the same
+         * verdict on the static and on a dynamic dctx, bar two by design: a
+         * block grown past the carved block (static names it, dynamic says
+         * too-small destination) and a sub-header announcing more literals
+         * than the carved block (a size violation before decoding). */
+        const int64_t g = zxc_compress_block(cctx, lz, PIN, comp, cap, &l3);
+        int mismatches = 0;
+        for (size_t bit = 0; g > 0 && bit < (size_t)g * 8; bit++) {
+            memcpy(mut, comp, (size_t)g);
+            mut[bit >> 3] ^= (uint8_t)(1u << (bit & 7));
+            const int64_t rs = zxc_decompress_block(sd, mut, (size_t)g, out, PIN, NULL);
+            const int64_t rd = zxc_decompress_block(hd, mut, (size_t)g, out2, PIN, NULL);
+            const int same = rs == rd && (rs <= 0 || memcmp(out, out2, (size_t)rs) == 0);
+            const int grown = rs == ZXC_ERROR_BAD_BLOCK_SIZE && rd == ZXC_ERROR_DST_TOO_SMALL;
+            zxc_gnr_header_t mh;
+            uint32_t mlc, mtc;
+            const int announced = rs == ZXC_ERROR_BAD_BLOCK_SIZE &&
+                                  zxc_read_glo_header_and_desc(mut + ZXC_BLOCK_HEADER_SIZE,
+                                                               (size_t)g - ZXC_BLOCK_HEADER_SIZE,
+                                                               &mh, &mlc, &mtc) > 0 &&
+                                  mh.n_literals > PIN;
+            if (!same && !grown && !announced) {
+                if (mismatches++ < 3)
+                    printf("  [FAIL] bit %zu: static %lld, dynamic %lld\n", bit, (long long)rs,
+                           (long long)rd);
+            }
+        }
+        if (g <= 0 || mismatches) break;
+        printf("  [PASS] %lld bit flips: same verdict as a dynamic dctx\n", (long long)g * 8);
         ok = 1;
     } while (0);
     zxc_free_cctx(cctx);
+    zxc_free_dctx(hd);
     zxc_free_dctx(sd); /* no-op for a static context */
     test_aligned_free(ws);
-    free(text);
-    free(noise);
+    free(lz);
+    free(rnd);
+    free(lit);
     free(comp);
+    free(mut);
     free(out);
+    free(out2);
     if (ok) printf("PASS\n\n");
     return ok;
 }

--- a/tests/test_static_ctx.c
+++ b/tests/test_static_ctx.c
@@ -356,3 +356,80 @@ int test_static_ctx_null_inputs(void) {
     printf("  [PASS] NULL inputs rejected; NULL free is idempotent\n");
     return 1;
 }
+
+/* Both decoders refuse a block beyond a static dctx's carved block; a larger
+ * caller buffer is fine. */
+int test_static_dctx_block_bounds(void) {
+    printf("=== TEST: Static dctx - blocks bounded by the carved block ===\n");
+    enum { PIN = 4096, BIG = 6000 };
+    uint8_t* text = (uint8_t*)malloc(BIG);
+    uint8_t* noise = (uint8_t*)malloc(BIG);
+    const size_t cap = (size_t)zxc_compress_block_bound(BIG);
+    uint8_t* comp = (uint8_t*)malloc(cap);
+    uint8_t* out = (uint8_t*)malloc(2 * PIN + ZXC_DECOMPRESS_TAIL_PAD);
+    const size_t ws_sz = zxc_static_dctx_workspace_size(PIN);
+    void* ws = test_aligned_alloc(64, ws_sz);
+    zxc_cctx* cctx = zxc_create_cctx(NULL);
+    zxc_dctx* sd = ws ? zxc_init_static_dctx(ws, ws_sz, PIN) : NULL;
+    int ok = 0;
+    do {
+        if (!text || !noise || !comp || !out || !cctx || !sd) {
+            printf("  [FAIL] setup\n");
+            break;
+        }
+        for (size_t i = 0; i < BIG; i++) text[i] = (uint8_t)("static block "[i % 13]);
+        uint64_t x = 0x9E3779B97F4A7C15ull; /* incompressible: stored RAW */
+        for (size_t i = 0; i < BIG; i++) {
+            x ^= x << 13;
+            x ^= x >> 7;
+            x ^= x << 17;
+            noise[i] = (uint8_t)(x >> 24);
+        }
+        const zxc_compress_opts_t co = {.level = 3};
+        /* Oversized GLO and RAW blocks, both decoders. */
+        const int64_t g = zxc_compress_block(cctx, text, BIG, comp, cap, &co);
+        const int64_t e1 =
+            g > 0 ? zxc_decompress_block(sd, comp, (size_t)g, out, BIG + 200, NULL) : 0;
+        const int64_t e2 =
+            g > 0 ? zxc_decompress_block_safe(sd, comp, (size_t)g, out, BIG, NULL) : 0;
+        const int64_t r = zxc_compress_block(cctx, noise, BIG, comp, cap, &co);
+        const int64_t e3 =
+            r > 0 ? zxc_decompress_block(sd, comp, (size_t)r, out, BIG + 200, NULL) : 0;
+        const int64_t e4 =
+            r > 0 ? zxc_decompress_block_safe(sd, comp, (size_t)r, out, BIG, NULL) : 0;
+        if (g <= 0 || r <= 0 || comp[0] != ZXC_BLOCK_RAW || e1 != ZXC_ERROR_BAD_BLOCK_SIZE ||
+            e2 != ZXC_ERROR_BAD_BLOCK_SIZE || e3 != ZXC_ERROR_BAD_BLOCK_SIZE ||
+            e4 != ZXC_ERROR_BAD_BLOCK_SIZE) {
+            printf("  [FAIL] oversized blocks: GLO %lld/%lld, RAW(type %u) %lld/%lld\n",
+                   (long long)e1, (long long)e2, r > 0 ? (unsigned)comp[0] : 0U, (long long)e3,
+                   (long long)e4);
+            break;
+        }
+        printf("  [PASS] blocks larger than the carved block -> BAD_BLOCK_SIZE on both decoders\n");
+        /* A fitting block, both decoders, larger buffer included. */
+        const int64_t n = zxc_compress_block(cctx, text, PIN, comp, cap, &co);
+        const int64_t f1 = n > 0 ? zxc_decompress_block(sd, comp, (size_t)n, out,
+                                                        2 * PIN + ZXC_DECOMPRESS_TAIL_PAD, NULL)
+                                 : 0;
+        const int bad1 = f1 != PIN || memcmp(out, text, PIN) != 0;
+        memset(out, 0, PIN);
+        const int64_t f2 =
+            n > 0 ? zxc_decompress_block_safe(sd, comp, (size_t)n, out, PIN, NULL) : 0;
+        if (n <= 0 || bad1 || f2 != PIN || memcmp(out, text, PIN) != 0) {
+            printf("  [FAIL] fitting block: fast %lld, strict %lld\n", (long long)f1,
+                   (long long)f2);
+            break;
+        }
+        printf("  [PASS] a fitting block decodes on both decoders, larger buffer included\n");
+        ok = 1;
+    } while (0);
+    zxc_free_cctx(cctx);
+    zxc_free_dctx(sd); /* no-op for a static context */
+    test_aligned_free(ws);
+    free(text);
+    free(noise);
+    free(comp);
+    free(out);
+    if (ok) printf("PASS\n\n");
+    return ok;
+}

--- a/tests/test_static_ctx.c
+++ b/tests/test_static_ctx.c
@@ -357,192 +357,252 @@ int test_static_ctx_null_inputs(void) {
     return 1;
 }
 
-/* Decodes the n-byte block; a failed compression (n <= 0) propagates. */
-static int64_t dec(zxc_dctx* d, const uint8_t* blk, int64_t n, uint8_t* out, size_t cap,
-                   int strict) {
-    if (n <= 0) return n;
-    return strict ? zxc_decompress_block_safe(d, blk, (size_t)n, out, cap, NULL)
-                  : zxc_decompress_block(d, blk, (size_t)n, out, cap, NULL);
+/* A prepared block: compressed image and source. */
+typedef struct {
+    const char* name;
+    uint8_t* comp;
+    int64_t n;
+    const uint8_t* src;
+    size_t size;
+} bound_block_t;
+
+/* A decode on the static dctx and its verdict (> 0: size, bytes checked;
+ * < 0: error code). */
+typedef struct {
+    int block;
+    int strict;
+    size_t cap;
+    int64_t want;
+} bound_case_t;
+
+static int64_t bound_decode(zxc_dctx* d, const bound_block_t* b, int strict, uint8_t* out,
+                            size_t cap, const zxc_decompress_opts_t* o) {
+    if (b->n <= 0) return b->n;
+    return strict ? zxc_decompress_block_safe(d, b->comp, (size_t)b->n, out, cap, o)
+                  : zxc_decompress_block(d, b->comp, (size_t)b->n, out, cap, o);
 }
 
 /* Static dctx block API: the carved block is the effective capacity. Fitting
- * blocks decode whatever the buffer; larger ones are BAD_BLOCK_SIZE when the
- * sub-header or decoded size tells, else a too-small-destination code;
- * corruption keeps the dynamic codes. */
+ * blocks decode whatever the buffer; larger ones are BAD_BLOCK_SIZE within
+ * the margin, the decoder's too-small codes beyond; corruption keeps the
+ * dynamic codes. */
 int test_static_dctx_block_bounds(void) {
     printf("=== TEST: Static dctx - blocks bounded by the carved block ===\n");
-    enum { PIN = 4096, MID = 5000, XL = 8000, LIT = 4500, PAD = ZXC_DECOMPRESS_TAIL_PAD };
-    const size_t cap = (size_t)zxc_compress_block_bound(XL);
-    uint8_t* lz = (uint8_t*)malloc(XL);          /* compressible: GLO */
-    uint8_t* rnd = (uint8_t*)malloc(XL);         /* incompressible: RAW */
-    uint8_t* lit = (uint8_t*)malloc(LIT + 1000); /* Huffman literals, then a repeat */
-    uint8_t* comp = (uint8_t*)malloc(cap);
+    enum {
+        PIN = 4096,
+        MID = 5000,
+        XL = 8000,
+        LIT = 5500,
+        SEQ = 65536,
+        PAD = ZXC_DECOMPRESS_TAIL_PAD
+    };
+    enum {
+        B_FIT,
+        B_FIT_CK,
+        B_LZ_MID,
+        B_RAW_MID,
+        B_LZ_XL,
+        B_RAW_XL,
+        B_LIT6,
+        B_LIT1,
+        B_SEQ7,
+        B_HDR_LIT,
+        B_HDR_LIT_CK,
+        NB
+    };
+    const size_t cap = (size_t)zxc_compress_block_bound(SEQ);
+    uint8_t* lz = (uint8_t*)malloc(XL);   /* compressible: GLO */
+    uint8_t* rnd = (uint8_t*)malloc(XL);  /* incompressible: RAW */
+    uint8_t* lit = (uint8_t*)malloc(LIT); /* 16-symbol text, then a repeat: many literals */
+    uint8_t* seq = (uint8_t*)malloc(SEQ); /* 23 fixed bytes + 1 random: thousands of matches */
     uint8_t* mut = (uint8_t*)malloc(cap);
-    uint8_t* out = (uint8_t*)malloc(2 * PIN + PAD);
-    uint8_t* out2 = (uint8_t*)malloc(2 * PIN + PAD);
+    uint8_t* out = (uint8_t*)malloc(SEQ + PAD);
+    uint8_t* out2 = (uint8_t*)malloc(SEQ + PAD);
+    bound_block_t blocks[NB] = {{"fit", 0, 0, 0, 0}};
     const size_t ws_sz = zxc_static_dctx_workspace_size(PIN);
     void* ws = test_aligned_alloc(64, ws_sz);
     zxc_cctx* cctx = zxc_create_cctx(NULL);
     zxc_dctx* hd = zxc_create_dctx();
     zxc_dctx* sd = ws ? zxc_init_static_dctx(ws, ws_sz, PIN) : NULL;
-    int ok = 0;
+    int ok = 0, blocks_ok = 1;
+    for (int i = 0; i < NB; i++) blocks_ok &= (blocks[i].comp = (uint8_t*)malloc(cap)) != NULL;
     do {
-        if (!lz || !rnd || !lit || !comp || !mut || !out || !out2 || !cctx || !hd || !sd) {
+        if (!lz || !rnd || !lit || !seq || !mut || !out || !out2 || !cctx || !hd || !sd ||
+            !blocks_ok) {
             printf("  [FAIL] setup\n");
             break;
         }
         zxc_test_srand(0x5747u);
         gen_lz_data(lz, XL);
         gen_random_data(rnd, XL);
-        for (size_t i = 0; i < LIT; i++)
+        for (size_t i = 0; i < LIT - 1000; i++)
             lit[i] = (uint8_t)("0123456789abcdef"[zxc_test_rand() & 15]);
-        memcpy(lit + LIT, lit, 1000);
-        const zxc_compress_opts_t l3 = {.level = 3};
-        const zxc_compress_opts_t l6 = {.level = 6};
+        memcpy(lit + LIT - 1000, lit, 1000);
+        for (size_t i = 0; i < SEQ; i++)
+            seq[i] = (i % 24) == 23 ? (uint8_t)zxc_test_rand() : lz[i % 24];
 
-        /* A fitting block: both decoders, exact and larger buffers. */
-        const int64_t f = zxc_compress_block(cctx, lz, PIN, comp, cap, &l3);
-        const int64_t f1 = dec(sd, comp, f, out, PIN + PAD, 0);
-        const int64_t f2 = dec(sd, comp, f, out2, 2 * PIN + PAD, 0);
-        const int64_t f3 = dec(sd, comp, f, out, PIN, 1);
-        const int64_t f4 = dec(sd, comp, f, out2, 2 * PIN, 1);
-        if (f1 != PIN || f2 != PIN || f3 != PIN || f4 != PIN || memcmp(out, lz, PIN) != 0 ||
-            memcmp(out2, lz, PIN) != 0) {
-            printf("  [FAIL] fitting block: %lld %lld %lld %lld\n", (long long)f1, (long long)f2,
-                   (long long)f3, (long long)f4);
-            break;
-        }
-        printf("  [PASS] a fitting block decodes on both decoders, larger buffers included\n");
-
-        /* Within the margin: the decoded size tells, whatever the buffer; the
-         * strict decoder at exactly the carved size says "does not fit", as a
-         * dynamic dctx would. */
-        const int64_t m = zxc_compress_block(cctx, lz, MID, comp, cap, &l3);
-        const int64_t m1 = dec(sd, comp, m, out, MID + PAD, 0);
-        const int64_t m2 = dec(sd, comp, m, out, PIN, 0);
-        const int64_t m3 = dec(sd, comp, m, out, MID, 1);
-        const int64_t m4 = dec(sd, comp, m, out, PIN, 1);
-        const int64_t mr = zxc_compress_block(cctx, rnd, MID, comp, cap, &l3);
-        const uint8_t mr_type = mr > 0 ? comp[0] : 0;
-        const int64_t m5 = dec(sd, comp, mr, out, MID + PAD, 0);
-        const int64_t m6 = dec(sd, comp, mr, out, MID, 1);
-        const int64_t m7 = dec(sd, comp, mr, out, PIN, 1);
-        if (m1 != ZXC_ERROR_BAD_BLOCK_SIZE || m2 != ZXC_ERROR_BAD_BLOCK_SIZE ||
-            m3 != ZXC_ERROR_BAD_BLOCK_SIZE || m4 != ZXC_ERROR_OVERFLOW ||
-            mr_type != ZXC_BLOCK_RAW || m5 != ZXC_ERROR_BAD_BLOCK_SIZE ||
-            m6 != ZXC_ERROR_BAD_BLOCK_SIZE || m7 != ZXC_ERROR_DST_TOO_SMALL) {
-            printf("  [FAIL] within margin: GLO %lld %lld %lld %lld, RAW(type %u) %lld %lld %lld\n",
-                   (long long)m1, (long long)m2, (long long)m3, (long long)m4, mr_type,
-                   (long long)m5, (long long)m6, (long long)m7);
-            break;
-        }
-        printf(
-            "  [PASS] within the margin -> BAD_BLOCK_SIZE, strict at exact size -> not fitting\n");
-
-        /* Beyond the margin: workspace overflow, the codes a dynamic dctx
-         * gives for a too-small destination, buffer-independent. */
-        const int64_t x = zxc_compress_block(cctx, lz, XL, comp, cap, &l3);
-        const int64_t x1 = dec(sd, comp, x, out, XL + 200, 0);
-        const int64_t x2 = dec(sd, comp, x, out, PIN, 0);
-        const int64_t x3 = dec(sd, comp, x, out, XL, 1);
-        const int64_t xr = zxc_compress_block(cctx, rnd, XL, comp, cap, &l3);
-        const int64_t x4 = dec(sd, comp, xr, out, XL + 200, 0);
-        const int64_t x5 = dec(sd, comp, xr, out, PIN, 0);
-        const int64_t x6 = dec(sd, comp, xr, out, XL, 1);
-        if (x1 != ZXC_ERROR_OVERFLOW || x2 != ZXC_ERROR_OVERFLOW ||
-            x3 != ZXC_ERROR_BAD_BLOCK_SIZE || x4 != ZXC_ERROR_DST_TOO_SMALL ||
-            x5 != ZXC_ERROR_DST_TOO_SMALL || x6 != ZXC_ERROR_BAD_BLOCK_SIZE) {
-            printf("  [FAIL] beyond margin: GLO %lld %lld %lld, RAW %lld %lld %lld\n",
-                   (long long)x1, (long long)x2, (long long)x3, (long long)x4, (long long)x5,
-                   (long long)x6);
-            break;
-        }
-        printf("  [PASS] beyond the margin -> workspace overflow codes, buffer-independent\n");
-
-        /* More Huffman literals than the carved block: told by the sub-header,
-         * both decoders. */
-        const int64_t h = zxc_compress_block(cctx, lit, LIT + 1000, comp, cap, &l6);
-        zxc_gnr_header_t gh = {0};
-        uint32_t lc = 0, tc = 0;
-        const int hdr =
-            h > 0 ? zxc_read_glo_header_and_desc(comp + ZXC_BLOCK_HEADER_SIZE,
-                                                 (size_t)h - ZXC_BLOCK_HEADER_SIZE, &gh, &lc, &tc)
-                  : -1;
-        const int64_t h1 = dec(sd, comp, h, out, LIT + 1000 + PAD, 0);
-        const int64_t h2 = dec(sd, comp, h, out, LIT + 1000, 1);
-        if (h <= 0 || comp[0] != ZXC_BLOCK_GLO || hdr <= 0 ||
-            gh.enc_lit != ZXC_SECTION_ENCODING_HUFFMAN || gh.n_literals <= PIN ||
-            h1 != ZXC_ERROR_BAD_BLOCK_SIZE || h2 != ZXC_ERROR_BAD_BLOCK_SIZE) {
-            printf("  [FAIL] literal-heavy: type %u enc_lit %u n_literals %u -> %lld %lld\n",
-                   h > 0 ? comp[0] : 0U, gh.enc_lit, gh.n_literals, (long long)h1, (long long)h2);
-            break;
-        }
-        const zxc_compress_opts_t l1 = {.level = 1};
-        const int64_t k = zxc_compress_block(cctx, lit, LIT + 1000, comp, cap, &l1);
-        const int64_t k1 = dec(sd, comp, k, out, LIT + 1000 + PAD, 0);
-        const int64_t k2 = dec(sd, comp, k, out, LIT + 1000, 1);
-        if (k <= 0 || comp[0] != ZXC_BLOCK_GHI || k1 != ZXC_ERROR_BAD_BLOCK_SIZE ||
-            k2 != ZXC_ERROR_BAD_BLOCK_SIZE) {
-            printf("  [FAIL] literal-heavy GHI: type %u -> %lld %lld\n", k > 0 ? comp[0] : 0U,
-                   (long long)k1, (long long)k2);
-            break;
-        }
-        printf(
-            "  [PASS] %u Huffman literals (GLO) and the GHI form -> BAD_BLOCK_SIZE before "
-            "decoding\n",
-            gh.n_literals);
-
-        /* A dictionary is refused first, on both decoders, whatever the buffer. */
-        const zxc_decompress_opts_t with_dict = {.dict = lz, .dict_size = 16};
-        const int64_t d1 =
-            zxc_decompress_block(sd, comp, (size_t)h, out, 2 * PIN + PAD, &with_dict);
-        const int64_t d2 = zxc_decompress_block_safe(sd, comp, (size_t)h, out, 2 * PIN, &with_dict);
-        if (d1 != ZXC_ERROR_DICT_UNSUPPORTED || d2 != ZXC_ERROR_DICT_UNSUPPORTED) {
-            printf("  [FAIL] dictionary on a static dctx: %lld %lld\n", (long long)d1,
-                   (long long)d2);
-            break;
-        }
-        printf("  [PASS] dictionary -> DICT_UNSUPPORTED on both decoders\n");
-
-        /* Corruption keeps its codes: each single-bit flip gives the same
-         * verdict on the static and on a dynamic dctx, bar two by design: a
-         * block grown past the carved block (static names it, dynamic says
-         * too-small destination) and a sub-header announcing more literals
-         * than the carved block (a size violation before decoding). */
-        const int64_t g = zxc_compress_block(cctx, lz, PIN, comp, cap, &l3);
-        int mismatches = 0;
-        for (size_t bit = 0; g > 0 && bit < (size_t)g * 8; bit++) {
-            memcpy(mut, comp, (size_t)g);
-            mut[bit >> 3] ^= (uint8_t)(1u << (bit & 7));
-            const int64_t rs = zxc_decompress_block(sd, mut, (size_t)g, out, PIN, NULL);
-            const int64_t rd = zxc_decompress_block(hd, mut, (size_t)g, out2, PIN, NULL);
-            const int same = rs == rd && (rs <= 0 || memcmp(out, out2, (size_t)rs) == 0);
-            const int grown = rs == ZXC_ERROR_BAD_BLOCK_SIZE && rd == ZXC_ERROR_DST_TOO_SMALL;
-            zxc_gnr_header_t mh;
-            uint32_t mlc, mtc;
-            const int announced = rs == ZXC_ERROR_BAD_BLOCK_SIZE &&
-                                  zxc_read_glo_header_and_desc(mut + ZXC_BLOCK_HEADER_SIZE,
-                                                               (size_t)g - ZXC_BLOCK_HEADER_SIZE,
-                                                               &mh, &mlc, &mtc) > 0 &&
-                                  mh.n_literals > PIN;
-            if (!same && !grown && !announced) {
-                if (mismatches++ < 3)
-                    printf("  [FAIL] bit %zu: static %lld, dynamic %lld\n", bit, (long long)rs,
-                           (long long)rd);
+        /* Prepare the blocks once, each in its own buffer. */
+        const zxc_compress_opts_t l3 = {.level = 3}, l3ck = {.level = 3, .checksum_enabled = 1};
+        const zxc_compress_opts_t l1 = {.level = 1}, l6 = {.level = 6}, l7 = {.level = 7};
+        const struct {
+            const char* name;
+            const uint8_t* src;
+            size_t size;
+            const zxc_compress_opts_t* opts;
+        } plan[NB] = {{"fit", lz, PIN, &l3},
+                      {"fit+checksum", lz, PIN, &l3ck},
+                      {"GLO 5000", lz, MID, &l3},
+                      {"RAW 5000", rnd, MID, &l3},
+                      {"GLO 8000", lz, XL, &l3},
+                      {"RAW 8000", rnd, XL, &l3},
+                      {"literals L6", lit, LIT, &l6},
+                      {"literals L1", lit, LIT, &l1},
+                      {"sequences L7", seq, SEQ, &l7},
+                      {"header literals", 0, 0, 0},
+                      {"header literals+checksum", 0, 0, 0}};
+        int prepared = 1;
+        for (int i = 0; i < NB; i++) {
+            blocks[i].name = plan[i].name;
+            blocks[i].src = plan[i].src;
+            blocks[i].size = plan[i].size;
+            if (!plan[i].opts) continue;
+            blocks[i].n = zxc_compress_block(cctx, plan[i].src, plan[i].size, blocks[i].comp, cap,
+                                             plan[i].opts);
+            if (blocks[i].n <= 0) {
+                printf("  [FAIL] compress %s: %lld\n", plan[i].name, (long long)blocks[i].n);
+                prepared = 0;
             }
         }
-        if (g <= 0 || mismatches) break;
-        printf("  [PASS] %lld bit flips: same verdict as a dynamic dctx\n", (long long)g * 8);
+        if (!prepared) break;
+        /* Forged sub-headers: one literal more than the carved block; the
+         * second keeps a stale checksum. */
+        for (int i = B_HDR_LIT; i <= B_HDR_LIT_CK; i++) {
+            const bound_block_t* from = &blocks[i == B_HDR_LIT ? B_LIT6 : B_FIT_CK];
+            memcpy(blocks[i].comp, from->comp, (size_t)from->n);
+            blocks[i].n = from->n;
+            zxc_store_le32(blocks[i].comp + ZXC_BLOCK_HEADER_SIZE + 4, PIN + 1);
+        }
+        if (blocks[B_RAW_MID].comp[0] != ZXC_BLOCK_RAW ||
+            blocks[B_RAW_XL].comp[0] != ZXC_BLOCK_RAW || blocks[B_LIT6].comp[0] != ZXC_BLOCK_GLO ||
+            blocks[B_LIT1].comp[0] != ZXC_BLOCK_GHI) {
+            printf("  [FAIL] block types: RAW %u %u, literals %u %u\n", blocks[B_RAW_MID].comp[0],
+                   blocks[B_RAW_XL].comp[0], blocks[B_LIT6].comp[0], blocks[B_LIT1].comp[0]);
+            break;
+        }
+
+        /* The table: (block, decoder, buffer) -> verdict. */
+        static const bound_case_t cases[] = {
+            /* fits: both decoders, exact and larger buffers */
+            {B_FIT, 0, PIN + PAD, PIN},
+            {B_FIT, 0, 2 * PIN + PAD, PIN},
+            {B_FIT, 1, PIN, PIN},
+            {B_FIT, 1, 2 * PIN, PIN},
+            /* within the margin: named whatever the buffer; strict at the exact
+             * carved size: "does not fit", as a dynamic dctx */
+            {B_LZ_MID, 0, MID + PAD, ZXC_ERROR_BAD_BLOCK_SIZE},
+            {B_LZ_MID, 0, PIN, ZXC_ERROR_BAD_BLOCK_SIZE},
+            {B_LZ_MID, 1, MID, ZXC_ERROR_BAD_BLOCK_SIZE},
+            {B_LZ_MID, 1, PIN, ZXC_ERROR_OVERFLOW},
+            {B_RAW_MID, 0, MID + PAD, ZXC_ERROR_BAD_BLOCK_SIZE},
+            {B_RAW_MID, 1, MID, ZXC_ERROR_BAD_BLOCK_SIZE},
+            {B_RAW_MID, 1, PIN, ZXC_ERROR_DST_TOO_SMALL},
+            /* beyond the margin: the decoder's own codes, buffer-independent */
+            {B_LZ_XL, 0, XL + 200, ZXC_ERROR_OVERFLOW},
+            {B_LZ_XL, 0, PIN, ZXC_ERROR_OVERFLOW},
+            {B_LZ_XL, 1, XL, ZXC_ERROR_OVERFLOW},
+            {B_RAW_XL, 0, XL + 200, ZXC_ERROR_DST_TOO_SMALL},
+            {B_RAW_XL, 1, XL, ZXC_ERROR_DST_TOO_SMALL},
+            /* more literals or sequences than the carved block's scratch */
+            {B_LIT6, 0, LIT + PAD, ZXC_ERROR_DST_TOO_SMALL},
+            {B_LIT6, 1, LIT, ZXC_ERROR_DST_TOO_SMALL},
+            {B_LIT1, 0, LIT + PAD, ZXC_ERROR_BAD_BLOCK_SIZE},
+            {B_LIT1, 1, LIT, ZXC_ERROR_BAD_BLOCK_SIZE},
+            {B_SEQ7, 0, SEQ + PAD, ZXC_ERROR_DST_TOO_SMALL},
+            {B_SEQ7, 1, SEQ, ZXC_ERROR_DST_TOO_SMALL},
+            {B_HDR_LIT, 0, LIT + PAD, ZXC_ERROR_DST_TOO_SMALL},
+            {B_HDR_LIT, 1, LIT, ZXC_ERROR_DST_TOO_SMALL},
+        };
+        int failed = 0;
+        for (size_t c = 0; c < sizeof(cases) / sizeof(cases[0]); c++) {
+            const bound_case_t* k = &cases[c];
+            const bound_block_t* b = &blocks[k->block];
+            const int64_t got = bound_decode(sd, b, k->strict, out, k->cap, NULL);
+            const int bytes_ok = got <= 0 || memcmp(out, b->src, (size_t)got) == 0;
+            if (got != k->want || !bytes_ok) {
+                printf("  [FAIL] %s, %s, cap %zu: got %lld, want %lld%s\n", b->name,
+                       k->strict ? "strict" : "fast", k->cap, (long long)got, (long long)k->want,
+                       bytes_ok ? "" : " (bytes differ)");
+                failed++;
+            }
+        }
+        if (failed) break;
+        printf("  [PASS] %zu (block, decoder, buffer) verdicts\n",
+               sizeof(cases) / sizeof(cases[0]));
+
+        /* The stale checksum wins over the forged count, static as dynamic. */
+        const zxc_decompress_opts_t ck = {.checksum_enabled = 1};
+        const int64_t c1 = bound_decode(sd, &blocks[B_HDR_LIT_CK], 0, out, PIN + PAD, &ck);
+        const int64_t c2 = bound_decode(sd, &blocks[B_HDR_LIT_CK], 1, out, PIN, &ck);
+        const int64_t c3 = bound_decode(hd, &blocks[B_HDR_LIT_CK], 0, out, PIN + PAD, &ck);
+        if (c1 != ZXC_ERROR_BAD_CHECKSUM || c2 != ZXC_ERROR_BAD_CHECKSUM ||
+            c3 != ZXC_ERROR_BAD_CHECKSUM) {
+            printf("  [FAIL] stale checksum: static %lld %lld, dynamic %lld\n", (long long)c1,
+                   (long long)c2, (long long)c3);
+            break;
+        }
+        printf("  [PASS] stale checksum -> BAD_CHECKSUM before any size verdict\n");
+
+        /* Dictionaries: the same two answers as the dynamic path, in order. */
+        const zxc_decompress_opts_t small_dict = {.dict = lz, .dict_size = 16};
+        const zxc_decompress_opts_t huge_dict = {.dict = lz, .dict_size = ZXC_DICT_SIZE_MAX + 1};
+        const int64_t d1 = bound_decode(sd, &blocks[B_FIT], 0, out, 2 * PIN + PAD, &small_dict);
+        const int64_t d2 = bound_decode(sd, &blocks[B_FIT], 1, out, 2 * PIN, &small_dict);
+        const int64_t d3 = bound_decode(sd, &blocks[B_FIT], 0, out, PIN + PAD, &huge_dict);
+        const int64_t d4 = bound_decode(sd, &blocks[B_FIT], 1, out, PIN, &huge_dict);
+        if (d1 != ZXC_ERROR_DICT_UNSUPPORTED || d2 != ZXC_ERROR_DICT_UNSUPPORTED ||
+            d3 != ZXC_ERROR_DICT_TOO_LARGE || d4 != ZXC_ERROR_DICT_TOO_LARGE) {
+            printf("  [FAIL] dictionary: %lld %lld, oversized %lld %lld\n", (long long)d1,
+                   (long long)d2, (long long)d3, (long long)d4);
+            break;
+        }
+        printf(
+            "  [PASS] dictionary -> DICT_UNSUPPORTED, oversized -> DICT_TOO_LARGE, both "
+            "decoders\n");
+
+        /* Corruption keeps its codes: every bit flip of a fitting block,
+         * checksum off then on, gets the same verdict on both dctx, bar a block
+         * grown past the carved block (static names it, dynamic says too-small
+         * destination). */
+        int mismatches = 0;
+        long flips = 0;
+        for (int pass = 0; pass < 2 && !mismatches; pass++) {
+            const bound_block_t* b = &blocks[pass ? B_FIT_CK : B_FIT];
+            const zxc_decompress_opts_t* o = pass ? &ck : NULL;
+            for (size_t bit = 0; bit < (size_t)b->n * 8; bit++, flips++) {
+                memcpy(mut, b->comp, (size_t)b->n);
+                mut[bit >> 3] ^= (uint8_t)(1u << (bit & 7));
+                const int64_t rs = zxc_decompress_block(sd, mut, (size_t)b->n, out, PIN, o);
+                const int64_t rd = zxc_decompress_block(hd, mut, (size_t)b->n, out2, PIN, o);
+                const int same = rs == rd && (rs <= 0 || memcmp(out, out2, (size_t)rs) == 0);
+                const int grown = rs == ZXC_ERROR_BAD_BLOCK_SIZE && rd == ZXC_ERROR_DST_TOO_SMALL;
+                if (!same && !grown && mismatches++ < 3)
+                    printf("  [FAIL] %s bit %zu: static %lld, dynamic %lld\n", b->name, bit,
+                           (long long)rs, (long long)rd);
+            }
+        }
+        if (mismatches) break;
+        printf("  [PASS] %ld bit flips: same verdict as a dynamic dctx\n", flips);
         ok = 1;
     } while (0);
     zxc_free_cctx(cctx);
     zxc_free_dctx(hd);
     zxc_free_dctx(sd); /* no-op for a static context */
     test_aligned_free(ws);
+    for (int i = 0; i < NB; i++) free(blocks[i].comp);
     free(lz);
     free(rnd);
     free(lit);
-    free(comp);
+    free(seq);
     free(mut);
     free(out);
     free(out2);

--- a/tests/test_static_ctx.c
+++ b/tests/test_static_ctx.c
@@ -439,6 +439,23 @@ int test_static_dctx_block_bounds(void) {
             break;
         }
         printf("  [PASS] destination overflow, literal-heavy block included -> BAD_BLOCK_SIZE\n");
+        /* The caller's buffer never changes the verdict: oversized blocks into
+         * a buffer of exactly the carved size (overflowing the workspace, then
+         * fitting it but not the block) stay BAD_BLOCK_SIZE, while a buffer too
+         * small for a block that fits is DST_TOO_SMALL. */
+        const int64_t h3 = zxc_compress_block(cctx, text, HUGE, comp, cap, &co);
+        const int64_t e8 = h3 > 0 ? zxc_decompress_block(sd, comp, (size_t)h3, out, PIN, NULL) : 0;
+        const int64_t m = zxc_compress_block(cctx, text, 5000, comp, cap, &co);
+        const int64_t e9 = m > 0 ? zxc_decompress_block(sd, comp, (size_t)m, out, PIN, NULL) : 0;
+        const int64_t f = zxc_compress_block(cctx, text, PIN, comp, cap, &co);
+        const int64_t e10 = f > 0 ? zxc_decompress_block(sd, comp, (size_t)f, out, 2000, NULL) : 0;
+        if (h3 <= 0 || m <= 0 || f <= 0 || e8 != ZXC_ERROR_BAD_BLOCK_SIZE ||
+            e9 != ZXC_ERROR_BAD_BLOCK_SIZE || e10 != ZXC_ERROR_DST_TOO_SMALL) {
+            printf("  [FAIL] exact-size buffer: %lld / %lld, small buffer: %lld\n", (long long)e8,
+                   (long long)e9, (long long)e10);
+            break;
+        }
+        printf("  [PASS] verdict independent of the caller's buffer\n");
         /* A fitting block, both decoders, larger buffer included. */
         const int64_t n = zxc_compress_block(cctx, text, PIN, comp, cap, &co);
         const int64_t f1 = n > 0 ? zxc_decompress_block(sd, comp, (size_t)n, out,


### PR DESCRIPTION
Static decompression contexts use a fixed-size workspace and must not decode data exceeding the carved block size. This update enforces size validation in both standard and safe decompression entry points, ensuring that any block size exceeding the static context's limit is rejected. This prevents potential buffer overflows or memory safety issues when using static contexts.

Includes a regression test to verify these bounds.

Signed-off-by: Bertrand Lebonnois <5901952+hellobertrand@users.noreply.github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Static decompression now consistently enforces its configured block size.
  * Oversized blocks are rejected with an appropriate block-size or destination-capacity error, even when a larger output buffer is provided.
  * Prevents static-context decoding from exceeding its allocated workspace.
  * Capacity-related decoding failures now report destination-too-small errors.
  * Valid blocks continue to decode successfully across supported output buffer sizes.

* **Documentation**
  * Clarified block-size limits, error codes, and destination-buffer behavior for static decompression APIs.

* **Tests**
  * Added coverage for oversized and valid blocks across standard and safe decompression paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->