### PR TITLE
perf(lib): Optimizes block decompression for direct and flexible output

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -562,9 +562,11 @@ ZXC_EXPORT int64_t zxc_decompress_block(
 
 Decompresses a single block produced by `zxc_compress_block()`.
 `dst_capacity` is the uncompressed size plus `ZXC_DECOMPRESS_TAIL_PAD`, as
-returned by `zxc_decompress_block_bound(uncompressed_size)`: the block then
-decodes straight into `dst`. A buffer without the pad still decodes, falling
-back to an internal bounce buffer and a copy when the tail is too tight.
+returned by `zxc_decompress_block_bound(uncompressed_size)`: a dictionary-free
+block then decodes straight into `dst`. A buffer without the pad still decodes,
+falling back to an internal bounce buffer and a copy when the tail is too tight.
+A dictionary block always bounces, the decoder needing the dictionary and the
+payload contiguous.
 `dst_capacity` **must not exceed**
 `ZXC_BLOCK_SIZE_MAX + ZXC_DECOMPRESS_TAIL_PAD`. For payloads
 produced by the frame or streaming APIs, use `zxc_decompress` instead.

--- a/docs/API.md
+++ b/docs/API.md
@@ -561,9 +561,11 @@ ZXC_EXPORT int64_t zxc_decompress_block(
 ```
 
 Decompresses a single block produced by `zxc_compress_block()`.
-`dst_capacity` should be at least
-`zxc_decompress_block_bound(uncompressed_size)` to enable the fast path, and
-**must not exceed** `ZXC_BLOCK_SIZE_MAX + ZXC_DECOMPRESS_TAIL_PAD`. For payloads
+`dst_capacity` is the uncompressed size plus `ZXC_DECOMPRESS_TAIL_PAD`, as
+returned by `zxc_decompress_block_bound(uncompressed_size)`: the block then
+decodes in place. A buffer without the pad still decodes, through an internal
+bounce buffer and a copy. `dst_capacity` **must not exceed**
+`ZXC_BLOCK_SIZE_MAX + ZXC_DECOMPRESS_TAIL_PAD`. For payloads
 produced by the frame or streaming APIs, use `zxc_decompress` instead.
 `checksum_enabled` and the dictionary fields are used; a block carries no
 dictionary id, so pass the same (content, table) pair as at compression. A

--- a/docs/API.md
+++ b/docs/API.md
@@ -563,8 +563,9 @@ ZXC_EXPORT int64_t zxc_decompress_block(
 Decompresses a single block produced by `zxc_compress_block()`.
 `dst_capacity` is the uncompressed size plus `ZXC_DECOMPRESS_TAIL_PAD`, as
 returned by `zxc_decompress_block_bound(uncompressed_size)`: the block then
-decodes in place. A buffer without the pad still decodes, through an internal
-bounce buffer and a copy. `dst_capacity` **must not exceed**
+decodes straight into `dst`. A buffer without the pad still decodes, falling
+back to an internal bounce buffer and a copy when the tail is too tight.
+`dst_capacity` **must not exceed**
 `ZXC_BLOCK_SIZE_MAX + ZXC_DECOMPRESS_TAIL_PAD`. For payloads
 produced by the frame or streaming APIs, use `zxc_decompress` instead.
 `checksum_enabled` and the dictionary fields are used; a block carries no

--- a/docs/API.md
+++ b/docs/API.md
@@ -561,12 +561,14 @@ ZXC_EXPORT int64_t zxc_decompress_block(
 ```
 
 Decompresses a single block produced by `zxc_compress_block()`.
-`dst_capacity` is the uncompressed size plus `ZXC_DECOMPRESS_TAIL_PAD`, as
-returned by `zxc_decompress_block_bound(uncompressed_size)`: a dictionary-free
-block then decodes straight into `dst`. A buffer without the pad still decodes,
-falling back to an internal bounce buffer and a copy when the tail is too tight.
+`dst_capacity` is at least the uncompressed size. Adding
+`ZXC_DECOMPRESS_TAIL_PAD` to it, as `zxc_decompress_block_bound(uncompressed_size)`
+returns, lets a dictionary-free block on a heap context decode straight into
+`dst`; otherwise the decode falls back to an internal bounce buffer and a copy.
 A dictionary block always bounces, the decoder needing the dictionary and the
-payload contiguous.
+payload contiguous, and so does a static context sized for a larger block.
+On error `dst` holds whatever the aborted decode wrote: its previous contents do
+not survive a failed call.
 `dst_capacity` **must not exceed**
 `ZXC_BLOCK_SIZE_MAX + ZXC_DECOMPRESS_TAIL_PAD`. For payloads
 produced by the frame or streaming APIs, use `zxc_decompress` instead.

--- a/include/zxc_buffer.h
+++ b/include/zxc_buffer.h
@@ -259,10 +259,8 @@ ZXC_EXPORT uint64_t zxc_compress_block_bound(size_t input_size);
  *        @p uncompressed_size bytes.
  *
  * The decoder uses speculative (wild-copy) writes on its fast path, so it
- * needs a tail pad beyond the declared size. Passing exactly
- * @p uncompressed_size forces the slow tail path and may trip
- * @ref ZXC_ERROR_OVERFLOW on some inputs; the value returned here always
- * enables the fast path.
+ * needs a tail pad beyond the declared size: with this value the block decodes
+ * in place; without the pad, through an internal bounce buffer and a copy.
  *
  * @param[in] uncompressed_size Original block size in bytes
  *                              (must be <= @ref ZXC_BLOCK_SIZE_MAX).
@@ -314,9 +312,10 @@ ZXC_EXPORT int64_t zxc_compress_block(zxc_cctx* cctx, const void* src, size_t sr
  * @param[in]     src          Compressed block.
  * @param[in]     src_size     Compressed size in bytes.
  * @param[out]    dst          Destination buffer.
- * @param[in]     dst_capacity Capacity of @p dst: at least the original
- *                             uncompressed size, at most
- *                             @ref ZXC_BLOCK_SIZE_MAX +
+ * @param[in]     dst_capacity Uncompressed size plus @ref ZXC_DECOMPRESS_TAIL_PAD
+ *                             (zxc_decompress_block_bound()): the block decodes
+ *                             in place; without the pad, through a bounce and a
+ *                             copy. At most @ref ZXC_BLOCK_SIZE_MAX +
  *                             @ref ZXC_DECOMPRESS_TAIL_PAD.
  * @param[in]     opts         Decompression options, or NULL for defaults.
  *                             @c checksum_enabled and the dictionary fields are

--- a/include/zxc_buffer.h
+++ b/include/zxc_buffer.h
@@ -259,9 +259,10 @@ ZXC_EXPORT uint64_t zxc_compress_block_bound(size_t input_size);
  *        @p uncompressed_size bytes.
  *
  * The decoder uses speculative (wild-copy) writes on its fast path, so it
- * needs a tail pad beyond the declared size: with this value the block always
- * decodes straight into @c dst; without it, through a bounce and a copy when the
- * tail is too tight.
+ * needs a tail pad beyond the declared size: with this value a dictionary-free
+ * block always decodes straight into @c dst; without it, through a bounce and a
+ * copy when the tail is too tight. A dictionary block always bounces: the
+ * decoder needs the dictionary and the payload contiguous.
  *
  * @param[in] uncompressed_size Original block size in bytes
  *                              (must be <= @ref ZXC_BLOCK_SIZE_MAX).
@@ -314,9 +315,10 @@ ZXC_EXPORT int64_t zxc_compress_block(zxc_cctx* cctx, const void* src, size_t sr
  * @param[in]     src_size     Compressed size in bytes.
  * @param[out]    dst          Destination buffer.
  * @param[in]     dst_capacity Uncompressed size plus @ref ZXC_DECOMPRESS_TAIL_PAD
- *                             (zxc_decompress_block_bound()): the block decodes
- *                             straight into @p dst; without the pad, possibly
- *                             through a bounce. At most @ref ZXC_BLOCK_SIZE_MAX +
+ *                             (zxc_decompress_block_bound()): a dictionary-free
+ *                             block decodes straight into @p dst; without the
+ *                             pad, possibly through a bounce, and always so with
+ *                             a dictionary. At most @ref ZXC_BLOCK_SIZE_MAX +
  *                             @ref ZXC_DECOMPRESS_TAIL_PAD.
  * @param[in]     opts         Decompression options, or NULL for defaults.
  *                             @c checksum_enabled and the dictionary fields are

--- a/include/zxc_buffer.h
+++ b/include/zxc_buffer.h
@@ -259,8 +259,9 @@ ZXC_EXPORT uint64_t zxc_compress_block_bound(size_t input_size);
  *        @p uncompressed_size bytes.
  *
  * The decoder uses speculative (wild-copy) writes on its fast path, so it
- * needs a tail pad beyond the declared size: with this value the block decodes
- * in place; without the pad, through an internal bounce buffer and a copy.
+ * needs a tail pad beyond the declared size: with this value the block always
+ * decodes straight into @c dst; without it, through a bounce and a copy when the
+ * tail is too tight.
  *
  * @param[in] uncompressed_size Original block size in bytes
  *                              (must be <= @ref ZXC_BLOCK_SIZE_MAX).
@@ -314,8 +315,8 @@ ZXC_EXPORT int64_t zxc_compress_block(zxc_cctx* cctx, const void* src, size_t sr
  * @param[out]    dst          Destination buffer.
  * @param[in]     dst_capacity Uncompressed size plus @ref ZXC_DECOMPRESS_TAIL_PAD
  *                             (zxc_decompress_block_bound()): the block decodes
- *                             in place; without the pad, through a bounce and a
- *                             copy. At most @ref ZXC_BLOCK_SIZE_MAX +
+ *                             straight into @p dst; without the pad, possibly
+ *                             through a bounce. At most @ref ZXC_BLOCK_SIZE_MAX +
  *                             @ref ZXC_DECOMPRESS_TAIL_PAD.
  * @param[in]     opts         Decompression options, or NULL for defaults.
  *                             @c checksum_enabled and the dictionary fields are

--- a/include/zxc_buffer.h
+++ b/include/zxc_buffer.h
@@ -260,9 +260,9 @@ ZXC_EXPORT uint64_t zxc_compress_block_bound(size_t input_size);
  *
  * The decoder uses speculative (wild-copy) writes on its fast path, so it
  * needs a tail pad beyond the declared size: with this value a dictionary-free
- * block always decodes straight into @c dst; without it, through a bounce and a
- * copy when the tail is too tight. A dictionary block always bounces: the
- * decoder needs the dictionary and the payload contiguous.
+ * block decodes straight into @c dst on a heap context; without it, through a
+ * bounce and a copy. A dictionary block always bounces, needing the dictionary
+ * and the payload contiguous, and so does an over-sized static context.
  *
  * @param[in] uncompressed_size Original block size in bytes
  *                              (must be <= @ref ZXC_BLOCK_SIZE_MAX).
@@ -314,12 +314,12 @@ ZXC_EXPORT int64_t zxc_compress_block(zxc_cctx* cctx, const void* src, size_t sr
  * @param[in]     src          Compressed block.
  * @param[in]     src_size     Compressed size in bytes.
  * @param[out]    dst          Destination buffer.
- * @param[in]     dst_capacity Uncompressed size plus @ref ZXC_DECOMPRESS_TAIL_PAD
- *                             (zxc_decompress_block_bound()): a dictionary-free
- *                             block decodes straight into @p dst; without the
- *                             pad, possibly through a bounce, and always so with
- *                             a dictionary. At most @ref ZXC_BLOCK_SIZE_MAX +
- *                             @ref ZXC_DECOMPRESS_TAIL_PAD.
+ * @param[in]     dst_capacity At least the uncompressed size, at most
+ *                             @ref ZXC_BLOCK_SIZE_MAX +
+ *                             @ref ZXC_DECOMPRESS_TAIL_PAD. At
+ *                             zxc_decompress_block_bound() a dictionary-free
+ *                             block on a heap context decodes straight into
+ *                             @p dst, else possibly through a bounce.
  * @param[in]     opts         Decompression options, or NULL for defaults.
  *                             @c checksum_enabled and the dictionary fields are
  *                             used; a block carries no dictionary id, so pass
@@ -333,7 +333,8 @@ ZXC_EXPORT int64_t zxc_compress_block(zxc_cctx* cctx, const void* src, size_t sr
  *         per-block limit. Static context: the carved block is the effective
  *         capacity; a larger block is @ref ZXC_ERROR_BAD_BLOCK_SIZE while it
  *         fits the workspace margin and fails like a too-small destination
- *         beyond it. @p dst contents are unspecified on error.
+ *         beyond it. On error @p dst holds whatever the aborted decode wrote;
+ *         its previous contents do not survive.
  */
 ZXC_EXPORT int64_t zxc_decompress_block(zxc_dctx* dctx, const void* src, size_t src_size, void* dst,
                                         size_t dst_capacity, const zxc_decompress_opts_t* opts);
@@ -369,7 +370,8 @@ ZXC_EXPORT int64_t zxc_decompress_block(zxc_dctx* dctx, const void* src, size_t 
  * @return Decompressed size (> 0), or a negative @ref zxc_error_t;
  *         @ref ZXC_ERROR_BAD_BLOCK_SIZE if @p dst_capacity >
  *         @ref ZXC_BLOCK_SIZE_MAX. Static context: same bound and codes as
- *         zxc_decompress_block(), a larger @p dst_capacity accepted alike.
+ *         zxc_decompress_block(), a larger @p dst_capacity accepted alike. On
+ *         error @p dst holds whatever the aborted decode wrote.
  */
 ZXC_EXPORT int64_t zxc_decompress_block_safe(zxc_dctx* dctx, const void* src, const size_t src_size,
                                              void* dst, const size_t dst_capacity,

--- a/src/lib/zxc_decompress.c
+++ b/src/lib/zxc_decompress.c
@@ -1029,7 +1029,8 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(const zxc_cctx_t* RESTRIC
     // Destination safe margin for 4x loop: max output without varint extension.
     // ll_max = 14, ml_max = 14 + 5 = 19, per-seq = 33, 4x = 132.
     // Plus the overshoot the wild copies are allowed (ZXC_PAD_SIZE) + 4 safety = 168.
-    const uint8_t* const d_end_safe = d_end - (132 + ZXC_PAD_SIZE + 4);
+    const uint8_t* const d_end_safe =
+        (dst_capacity > 132 + ZXC_PAD_SIZE + 4) ? d_end - (132 + ZXC_PAD_SIZE + 4) : dst;
 
     // Literal margin for the 4x loops: without a varint, ll <= 14 per sequence,
     // so 4 * 14 = 56. Past that margin only the cold varint path checks l_ptr.
@@ -1272,10 +1273,12 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(const zxc_cctx_t* RESTRIC
     const uint8_t* const d_end = dst + dst_capacity;
     // Lowest address a match may reach: the dictionary prefix if any, else dst.
     const uint8_t* const d_floor = dst - dict_size;
-    const uint8_t* const d_end_safe = d_end - (ZXC_PAD_SIZE * 4);  // 128
+    const uint8_t* const d_end_safe =
+        (dst_capacity > ZXC_PAD_SIZE * 4) ? d_end - (ZXC_PAD_SIZE * 4) : dst;  // 128
     // Safety margin for 4x unrolled loop: 4 * (ZXC_SEQ_LL_MASK LL +
     // ZXC_SEQ_ML_MASK+ZXC_LZ_MIN_MATCH_LEN ML) + ZXC_PAD_SIZE Pad = 4 x (255 + 255 + 5) + 32 = 2092
-    const uint8_t* const d_end_fast = d_end - ZXC_DECOMPRESS_TAIL_PAD;  // 2112
+    const uint8_t* const d_end_fast =
+        (dst_capacity > ZXC_DECOMPRESS_TAIL_PAD) ? d_end - ZXC_DECOMPRESS_TAIL_PAD : dst;  // 2112
 
     // Literal margin for the GHI loops: without a varint, ll <= 254 per sequence,
     // so 4 * 254 = 1016. Past that only the cold varint path checks l_ptr.

--- a/src/lib/zxc_dispatch.c
+++ b/src/lib/zxc_dispatch.c
@@ -1637,6 +1637,52 @@ static int64_t zxc_static_decompress_block(zxc_dctx* RESTRICT dctx, const uint8_
 }
 
 /**
+ * @brief Recarves a heap dctx when @p block_size or @p dict_size changed;
+ *        otherwise only refreshes the checksum flag.
+ */
+static int zxc_dctx_prepare(zxc_dctx* RESTRICT dctx, const size_t block_size,
+                            const size_t dict_size, const int checksum_enabled) {
+    if (LIKELY(dctx->initialized && dctx->last_block_size == block_size &&
+               dctx->last_dict_size == dict_size)) {
+        dctx->inner.checksum_enabled = checksum_enabled;
+        return ZXC_OK;
+    }
+    if (dctx->initialized) {
+        zxc_cctx_free(&dctx->inner);
+        dctx->initialized = 0;
+    }
+    // LCOV_EXCL_START
+    if (UNLIKELY(zxc_cctx_init(&dctx->inner, block_size, 0, 0, checksum_enabled, dict_size) !=
+                 ZXC_OK))
+        return ZXC_ERROR_MEMORY;
+    // LCOV_EXCL_STOP
+    dctx->last_block_size = block_size;
+    dctx->last_dict_size = dict_size;
+    dctx->initialized = 1;
+    dctx->huf_cached = 0;
+    return ZXC_OK;
+}
+
+/**
+ * @brief Block decode through work_buf for a destination without the pad:
+ *        carved for the whole @p dst_capacity, then copied out.
+ */
+static int64_t zxc_dctx_decode_bounce(zxc_dctx* RESTRICT dctx, const uint8_t* RESTRICT src,
+                                      const size_t src_size, uint8_t* RESTRICT dst,
+                                      const size_t dst_capacity, const int checksum_enabled) {
+    const int rc = zxc_dctx_prepare(dctx, zxc_block_size_ceil(dst_capacity), 0, checksum_enabled);
+    if (UNLIKELY(rc != ZXC_OK)) return rc;  // LCOV_EXCL_LINE
+    zxc_cctx_t* const ctx = &dctx->inner;
+    ctx->dict_size = 0;
+    const int res =
+        zxc_decompress_chunk_wrapper(ctx, src, src_size, ctx->work_buf, ctx->work_buf_cap);
+    if (UNLIKELY(res < 0)) return res;
+    if (UNLIKELY((size_t)res > dst_capacity)) return ZXC_ERROR_DST_TOO_SMALL;
+    ZXC_MEMCPY(dst, ctx->work_buf, (size_t)res);
+    return res;
+}
+
+/**
  * @brief Decompresses a single block (no file framing), reusing @p dctx.
  *
  * Public API; full contract in @c zxc_buffer.h. Decodes one format-conformant
@@ -1667,26 +1713,13 @@ int64_t zxc_decompress_block(zxc_dctx* dctx, const void* RESTRICT src, const siz
         return zxc_static_decompress_block(dctx, (const uint8_t*)src, src_size, (uint8_t*)dst,
                                            dst_capacity, dict_size, checksum_enabled, 0);
 
-    // Derive the block_size from dst_capacity (callers know the original size)
-    const size_t block_size = zxc_block_size_ceil(dst_capacity);
-    if (UNLIKELY(!dctx->initialized || dctx->last_block_size != block_size ||
-                 dctx->last_dict_size != dict_size)) {
-        if (dctx->initialized) {
-            zxc_cctx_free(&dctx->inner);
-            dctx->initialized = 0;
-        }
-        // LCOV_EXCL_START
-        if (UNLIKELY(zxc_cctx_init(&dctx->inner, block_size, 0, 0, checksum_enabled, dict_size) !=
-                     ZXC_OK))
-            return ZXC_ERROR_MEMORY;
-        // LCOV_EXCL_STOP
-        dctx->last_block_size = block_size;
-        dctx->last_dict_size = dict_size;
-        dctx->initialized = 1;
-        dctx->huf_cached = 0;
-    } else {
-        dctx->inner.checksum_enabled = checksum_enabled;
-    }
+    // dst_capacity = data + ZXC_DECOMPRESS_TAIL_PAD (zxc_decompress_block_bound):
+    // carve for the data and decode in place; without the pad, bounce.
+    const int padded = dst_capacity > ZXC_DECOMPRESS_TAIL_PAD;
+    const size_t block_size =
+        zxc_block_size_ceil(padded ? dst_capacity - ZXC_DECOMPRESS_TAIL_PAD : dst_capacity);
+    const int rc = zxc_dctx_prepare(dctx, block_size, dict_size, checksum_enabled);
+    if (UNLIKELY(rc != ZXC_OK)) return rc;  // LCOV_EXCL_LINE
 
     zxc_cctx_t* const ctx = &dctx->inner;
     ctx->dict_size = dict_size;
@@ -1709,17 +1742,16 @@ int64_t zxc_decompress_block(zxc_dctx* dctx, const void* RESTRICT src, const siz
             if (UNLIKELY((size_t)res > dst_capacity)) return ZXC_ERROR_DST_TOO_SMALL;
             ZXC_MEMCPY(dst, dec_buf + dict_size, (size_t)res);
         }
-    } else if (LIKELY(dst_capacity >= work_sz)) {
+    } else if (LIKELY(padded)) {
         res = zxc_decompress_chunk_wrapper(ctx, (const uint8_t*)src, src_size, (uint8_t*)dst,
                                            dst_capacity);
+        // No pad left, or a block too big for the data part: the bounce settles it.
+        if (UNLIKELY(res == ZXC_ERROR_OVERFLOW || res == ZXC_ERROR_DST_TOO_SMALL))
+            return zxc_dctx_decode_bounce(dctx, (const uint8_t*)src, src_size, (uint8_t*)dst,
+                                          dst_capacity, checksum_enabled);
     } else {
-        // Bounce through work_buf when output can't absorb wild copies.
-        res = zxc_decompress_chunk_wrapper(ctx, (const uint8_t*)src, src_size, ctx->work_buf,
-                                           ctx->work_buf_cap);
-        if (LIKELY(res > 0)) {
-            if (UNLIKELY((size_t)res > dst_capacity)) return ZXC_ERROR_DST_TOO_SMALL;
-            ZXC_MEMCPY(dst, ctx->work_buf, (size_t)res);
-        }
+        return zxc_dctx_decode_bounce(dctx, (const uint8_t*)src, src_size, (uint8_t*)dst,
+                                      dst_capacity, checksum_enabled);
     }
     if (UNLIKELY(res < 0)) return res;
     return (int64_t)res;
@@ -1760,24 +1792,8 @@ int64_t zxc_decompress_block_safe(zxc_dctx* dctx, const void* RESTRICT src, cons
 
     // GLO/GHI: use the strict-tail decoder (no bounce buffer required).
     const int checksum_enabled = opts ? opts->checksum_enabled : 0;
-    const size_t block_size = zxc_block_size_ceil(dst_capacity);
-    if (UNLIKELY(!dctx->initialized || dctx->last_block_size != block_size ||
-                 dctx->last_dict_size != 0)) {
-        if (dctx->initialized) {
-            zxc_cctx_free(&dctx->inner);
-            dctx->initialized = 0;
-        }
-        // LCOV_EXCL_START
-        if (UNLIKELY(zxc_cctx_init(&dctx->inner, block_size, 0, 0, checksum_enabled, 0) != ZXC_OK))
-            return ZXC_ERROR_MEMORY;
-        // LCOV_EXCL_STOP
-        dctx->last_block_size = block_size;
-        dctx->last_dict_size = 0;
-        dctx->initialized = 1;
-        dctx->huf_cached = 0;
-    } else {
-        dctx->inner.checksum_enabled = checksum_enabled;
-    }
+    const int rc = zxc_dctx_prepare(dctx, zxc_block_size_ceil(dst_capacity), 0, checksum_enabled);
+    if (UNLIKELY(rc != ZXC_OK)) return rc;  // LCOV_EXCL_LINE
     dctx->inner.dict_size = 0;
 
     const int res = zxc_decompress_chunk_wrapper_safe_public(&dctx->inner, (const uint8_t*)src,

--- a/src/lib/zxc_dispatch.c
+++ b/src/lib/zxc_dispatch.c
@@ -1600,6 +1600,23 @@ int64_t zxc_compress_block(zxc_cctx* cctx, const void* RESTRICT src, const size_
 }
 
 /**
+ * @brief Block decode through work_buf, for a @p dst too tight for the
+ *        speculative writes, then copied out. @p carved bounds the decoded size
+ *        on a static context; 0 leaves it unbounded.
+ */
+static int64_t zxc_decode_bounce(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRICT src,
+                                 const size_t src_size, uint8_t* RESTRICT dst,
+                                 const size_t dst_capacity, const size_t carved) {
+    const int res =
+        zxc_decompress_chunk_wrapper(ctx, src, src_size, ctx->work_buf, ctx->work_buf_cap);
+    if (UNLIKELY(res < 0)) return res;
+    if (UNLIKELY(carved != 0 && (size_t)res > carved)) return ZXC_ERROR_BAD_BLOCK_SIZE;
+    if (UNLIKELY((size_t)res > dst_capacity)) return ZXC_ERROR_DST_TOO_SMALL;
+    ZXC_MEMCPY(dst, ctx->work_buf, (size_t)res);
+    return res;
+}
+
+/**
  * @brief Block decode on a static dctx: the carved block is the effective capacity.
  *
  * Fast decoder: carved block plus wild-copy margin; strict: at most that. A
@@ -1625,12 +1642,7 @@ static int64_t zxc_static_decompress_block(zxc_dctx* RESTRICT dctx, const uint8_
         res = zxc_decompress_chunk_wrapper(ctx, src, src_size, dst, work_sz);
     } else {
         // Bounce through work_buf when dst cannot absorb wild copies.
-        res = zxc_decompress_chunk_wrapper(ctx, src, src_size, ctx->work_buf, ctx->work_buf_cap);
-        if (UNLIKELY(res > 0 && (size_t)res > carved)) return ZXC_ERROR_BAD_BLOCK_SIZE;
-        if (LIKELY(res > 0)) {
-            if (UNLIKELY((size_t)res > dst_capacity)) return ZXC_ERROR_DST_TOO_SMALL;
-            ZXC_MEMCPY(dst, ctx->work_buf, (size_t)res);
-        }
+        return zxc_decode_bounce(ctx, src, src_size, dst, dst_capacity, carved);
     }
     if (UNLIKELY(res > 0 && (size_t)res > carved)) return ZXC_ERROR_BAD_BLOCK_SIZE;
     return res;
@@ -1664,25 +1676,6 @@ static int zxc_dctx_prepare(zxc_dctx* RESTRICT dctx, const size_t block_size,
 }
 
 /**
- * @brief Block decode through work_buf when @p dst is too tight for the
- *        speculative writes; the carve already matches @p dst_capacity.
- */
-static int64_t zxc_dctx_decode_bounce(zxc_dctx* RESTRICT dctx, const uint8_t* RESTRICT src,
-                                      const size_t src_size, uint8_t* RESTRICT dst,
-                                      const size_t dst_capacity, const int checksum_enabled) {
-    const int rc = zxc_dctx_prepare(dctx, zxc_block_size_ceil(dst_capacity), 0, checksum_enabled);
-    if (UNLIKELY(rc != ZXC_OK)) return rc;  // LCOV_EXCL_LINE
-    zxc_cctx_t* const ctx = &dctx->inner;
-    ctx->dict_size = 0;
-    const int res =
-        zxc_decompress_chunk_wrapper(ctx, src, src_size, ctx->work_buf, ctx->work_buf_cap);
-    if (UNLIKELY(res < 0)) return res;
-    if (UNLIKELY((size_t)res > dst_capacity)) return ZXC_ERROR_DST_TOO_SMALL;
-    ZXC_MEMCPY(dst, ctx->work_buf, (size_t)res);
-    return res;
-}
-
-/**
  * @brief Decompresses a single block (no file framing), reusing @p dctx.
  *
  * Public API; full contract in @c zxc_buffer.h. Decodes one format-conformant
@@ -1690,7 +1683,7 @@ static int64_t zxc_dctx_decode_bounce(zxc_dctx* RESTRICT dctx, const uint8_t* RE
  * @p dst_capacity is bounded by @c ZXC_BLOCK_SIZE_MAX + @c ZXC_DECOMPRESS_TAIL_PAD.
  * With a dictionary in @p opts the decode runs through the [dict | decode]
  * bounce buffer; otherwise it goes straight into @p dst, and is redone through
- * @c work_buf if a tight tail aborted it.
+ * @c work_buf if a tight tail aborted it, leaving @p dst partly written.
  */
 int64_t zxc_decompress_block(zxc_dctx* dctx, const void* RESTRICT src, const size_t src_size,
                              void* RESTRICT dst, const size_t dst_capacity,
@@ -1742,9 +1735,10 @@ int64_t zxc_decompress_block(zxc_dctx* dctx, const void* RESTRICT src, const siz
         res = zxc_decompress_chunk_wrapper(ctx, (const uint8_t*)src, src_size, (uint8_t*)dst,
                                            dst_capacity);
         // A tight tail aborts a block that fits: work_buf has the margin.
+        // Corrupt blocks report OVERFLOW too, and pay the second decode.
         if (UNLIKELY(res == ZXC_ERROR_OVERFLOW))
-            return zxc_dctx_decode_bounce(dctx, (const uint8_t*)src, src_size, (uint8_t*)dst,
-                                          dst_capacity, checksum_enabled);
+            return zxc_decode_bounce(ctx, (const uint8_t*)src, src_size, (uint8_t*)dst,
+                                     dst_capacity, 0);
     }
     if (UNLIKELY(res < 0)) return res;
     return (int64_t)res;

--- a/src/lib/zxc_dispatch.c
+++ b/src/lib/zxc_dispatch.c
@@ -1664,8 +1664,8 @@ static int zxc_dctx_prepare(zxc_dctx* RESTRICT dctx, const size_t block_size,
 }
 
 /**
- * @brief Block decode through work_buf for a destination without the pad:
- *        carved for the whole @p dst_capacity, then copied out.
+ * @brief Block decode through work_buf when @p dst is too tight for the
+ *        speculative writes; the carve already matches @p dst_capacity.
  */
 static int64_t zxc_dctx_decode_bounce(zxc_dctx* RESTRICT dctx, const uint8_t* RESTRICT src,
                                       const size_t src_size, uint8_t* RESTRICT dst,
@@ -1713,11 +1713,8 @@ int64_t zxc_decompress_block(zxc_dctx* dctx, const void* RESTRICT src, const siz
         return zxc_static_decompress_block(dctx, (const uint8_t*)src, src_size, (uint8_t*)dst,
                                            dst_capacity, dict_size, checksum_enabled, 0);
 
-    // dst_capacity = data + ZXC_DECOMPRESS_TAIL_PAD (zxc_decompress_block_bound):
-    // carve for the data and decode in place; without the pad, bounce.
-    const int padded = dst_capacity > ZXC_DECOMPRESS_TAIL_PAD;
-    const size_t block_size =
-        zxc_block_size_ceil(padded ? dst_capacity - ZXC_DECOMPRESS_TAIL_PAD : dst_capacity);
+    // Carved for dst_capacity: the context holds any block dst can hold.
+    const size_t block_size = zxc_block_size_ceil(dst_capacity);
     const int rc = zxc_dctx_prepare(dctx, block_size, dict_size, checksum_enabled);
     if (UNLIKELY(rc != ZXC_OK)) return rc;  // LCOV_EXCL_LINE
 
@@ -1727,8 +1724,7 @@ int64_t zxc_decompress_block(zxc_dctx* dctx, const void* RESTRICT src, const siz
                                        ZXC_OPTS_DICT_HUF(opts)) != ZXC_OK))
         return ZXC_ERROR_CORRUPT_DATA;  // LCOV_EXCL_LINE
 
-    // work_buf was pre-sized to block_size + ZXC_DECOMPRESS_TAIL_PAD inside
-    // the matching zxc_cctx_init call above.
+    // The [dict | decode] buffer carries block_size + ZXC_DECOMPRESS_TAIL_PAD.
     const size_t work_sz = block_size + ZXC_DECOMPRESS_TAIL_PAD;
 
     int res;
@@ -1742,16 +1738,13 @@ int64_t zxc_decompress_block(zxc_dctx* dctx, const void* RESTRICT src, const siz
             if (UNLIKELY((size_t)res > dst_capacity)) return ZXC_ERROR_DST_TOO_SMALL;
             ZXC_MEMCPY(dst, dec_buf + dict_size, (size_t)res);
         }
-    } else if (LIKELY(padded)) {
+    } else {
         res = zxc_decompress_chunk_wrapper(ctx, (const uint8_t*)src, src_size, (uint8_t*)dst,
                                            dst_capacity);
-        // No pad left, or a block too big for the data part: the bounce settles it.
-        if (UNLIKELY(res == ZXC_ERROR_OVERFLOW || res == ZXC_ERROR_DST_TOO_SMALL))
+        // A tight tail aborts a block that fits: work_buf has the margin.
+        if (UNLIKELY(res == ZXC_ERROR_OVERFLOW))
             return zxc_dctx_decode_bounce(dctx, (const uint8_t*)src, src_size, (uint8_t*)dst,
                                           dst_capacity, checksum_enabled);
-    } else {
-        return zxc_dctx_decode_bounce(dctx, (const uint8_t*)src, src_size, (uint8_t*)dst,
-                                      dst_capacity, checksum_enabled);
     }
     if (UNLIKELY(res < 0)) return res;
     return (int64_t)res;

--- a/src/lib/zxc_dispatch.c
+++ b/src/lib/zxc_dispatch.c
@@ -1689,8 +1689,8 @@ static int64_t zxc_dctx_decode_bounce(zxc_dctx* RESTRICT dctx, const uint8_t* RE
  * block; the decoded payload cannot exceed @c ZXC_BLOCK_SIZE_MAX, so
  * @p dst_capacity is bounded by @c ZXC_BLOCK_SIZE_MAX + @c ZXC_DECOMPRESS_TAIL_PAD.
  * With a dictionary in @p opts the decode runs through the [dict | decode]
- * bounce buffer; otherwise it goes straight into @p dst when the tail padding
- * fits, or via @c work_buf when it doesn't.
+ * bounce buffer; otherwise it goes straight into @p dst, and is redone through
+ * @c work_buf if a tight tail aborted it.
  */
 int64_t zxc_decompress_block(zxc_dctx* dctx, const void* RESTRICT src, const size_t src_size,
                              void* RESTRICT dst, const size_t dst_capacity,

--- a/tests/test_block_api.c
+++ b/tests/test_block_api.c
@@ -739,3 +739,69 @@ int test_block_api_tiny_capacity(void) {
     printf("PASS\n\n");
     return 1;
 }
+
+/* dst_capacity = data + pad decodes in place; without the pad, or below it,
+ * the bounce decodes; a buffer too short is refused as before. */
+int test_block_api_direct_decode(void) {
+    printf("=== TEST: Block API - in-place decode with the tail pad ===\n");
+    static const size_t sizes[] = {100, 4096, 5000, 100000, ZXC_BLOCK_SIZE_MAX};
+    const size_t max = ZXC_BLOCK_SIZE_MAX;
+    const size_t cap = (size_t)zxc_compress_block_bound(max);
+    uint8_t* src = (uint8_t*)malloc(max);
+    uint8_t* comp = (uint8_t*)malloc(cap);
+    uint8_t* out = (uint8_t*)malloc(2 * (size_t)zxc_decompress_block_bound(max));
+    zxc_cctx* cctx = zxc_create_cctx(NULL);
+    zxc_dctx* dctx = zxc_create_dctx();
+    int ok = 0;
+    do {
+        if (!src || !comp || !out || !cctx || !dctx) {
+            printf("  [FAIL] setup\n");
+            break;
+        }
+        zxc_test_srand(0xD1EC7u);
+        gen_lz_data(src, max);
+        const zxc_compress_opts_t co = {.level = 3};
+        int failed = 0;
+        for (size_t s = 0; s < sizeof(sizes) / sizeof(sizes[0]); s++) {
+            const size_t n = sizes[s];
+            const int64_t c = zxc_compress_block(cctx, src, n, comp, cap, &co);
+            if (c <= 0) {
+                printf("  [FAIL] compress %zu: %lld\n", n, (long long)c);
+                failed++;
+                continue;
+            }
+            /* padded (in place), exact, one byte of pad, twice the bound */
+            const size_t caps[] = {(size_t)zxc_decompress_block_bound(n), n, n + 1,
+                                   2 * (size_t)zxc_decompress_block_bound(n)};
+            for (size_t k = 0; k < sizeof(caps) / sizeof(caps[0]); k++) {
+                if (caps[k] > max + ZXC_DECOMPRESS_TAIL_PAD) continue;
+                memset(out, 0xA5, caps[k]);
+                const int64_t r = zxc_decompress_block(dctx, comp, (size_t)c, out, caps[k], NULL);
+                if (r != (int64_t)n || memcmp(out, src, n) != 0) {
+                    printf("  [FAIL] block %zu, dst %zu: %lld\n", n, caps[k], (long long)r);
+                    failed++;
+                }
+            }
+            /* a buffer that cannot hold the block */
+            if (n > 1000) {
+                const int64_t r = zxc_decompress_block(dctx, comp, (size_t)c, out, n - 1000, NULL);
+                if (r != ZXC_ERROR_DST_TOO_SMALL) {
+                    printf("  [FAIL] block %zu, dst %zu: %lld (want DST_TOO_SMALL)\n", n, n - 1000,
+                           (long long)r);
+                    failed++;
+                }
+            }
+        }
+        if (failed) break;
+        printf("  [PASS] %zu sizes x {bound, exact, +1, 2x bound} decode; short buffers refused\n",
+               sizeof(sizes) / sizeof(sizes[0]));
+        ok = 1;
+    } while (0);
+    zxc_free_cctx(cctx);
+    zxc_free_dctx(dctx);
+    free(src);
+    free(comp);
+    free(out);
+    if (ok) printf("PASS\n\n");
+    return ok;
+}

--- a/tests/test_block_api.c
+++ b/tests/test_block_api.c
@@ -742,13 +742,14 @@ int test_block_api_tiny_capacity(void) {
 
 /* Direct decode and bounce must return the same bytes, literal-heavy blocks
  * sized just above a power of two included: there the carve and the decoder's
- * scratch are tightest. */
+ * scratch are tightest. Small exact destinations cover the decoder's clamped
+ * destination margins. */
 int test_block_api_direct_decode(void) {
     printf("=== TEST: Block API - direct decode and its fallback ===\n");
     /* straddling the powers of two and their tail-pad window */
     static const size_t sizes[] = {
         100, 4096, 4097, 5000, 6208, 6209, 10304, 100000, ZXC_BLOCK_SIZE_MAX};
-    static const int levels[] = {3, 7};
+    static const int levels[] = {1, 3, 7}; /* 1 emits GHI, 3 and 7 emit GLO */
     const size_t max = ZXC_BLOCK_SIZE_MAX;
     const size_t cap = (size_t)zxc_compress_block_bound(max);
     const size_t dbound_max = (size_t)zxc_decompress_block_bound(max);

--- a/tests/test_block_api.c
+++ b/tests/test_block_api.c
@@ -740,66 +740,99 @@ int test_block_api_tiny_capacity(void) {
     return 1;
 }
 
-/* dst_capacity = data + pad decodes in place; without the pad, or below it,
- * the bounce decodes; a buffer too short is refused as before. */
+/* Direct decode and bounce must return the same bytes, literal-heavy blocks
+ * sized just above a power of two included: there the carve and the decoder's
+ * scratch are tightest. */
 int test_block_api_direct_decode(void) {
-    printf("=== TEST: Block API - in-place decode with the tail pad ===\n");
-    static const size_t sizes[] = {100, 4096, 5000, 100000, ZXC_BLOCK_SIZE_MAX};
+    printf("=== TEST: Block API - direct decode and its fallback ===\n");
+    /* straddling the powers of two and their tail-pad window */
+    static const size_t sizes[] = {
+        100, 4096, 4097, 5000, 6208, 6209, 10304, 100000, ZXC_BLOCK_SIZE_MAX};
+    static const int levels[] = {3, 7};
     const size_t max = ZXC_BLOCK_SIZE_MAX;
     const size_t cap = (size_t)zxc_compress_block_bound(max);
-    uint8_t* src = (uint8_t*)malloc(max);
+    const size_t dbound_max = (size_t)zxc_decompress_block_bound(max);
+    uint8_t* lz = (uint8_t*)malloc(max);  /* matches: few literals */
+    uint8_t* lit = (uint8_t*)malloc(max); /* letters: nearly all literals */
+    uint8_t* dict = (uint8_t*)malloc(4096);
     uint8_t* comp = (uint8_t*)malloc(cap);
-    uint8_t* out = (uint8_t*)malloc(2 * (size_t)zxc_decompress_block_bound(max));
+    uint8_t* out = (uint8_t*)malloc(dbound_max);
     zxc_cctx* cctx = zxc_create_cctx(NULL);
     zxc_dctx* dctx = zxc_create_dctx();
     int ok = 0;
     do {
-        if (!src || !comp || !out || !cctx || !dctx) {
+        if (!lz || !lit || !dict || !comp || !out || !cctx || !dctx) {
             printf("  [FAIL] setup\n");
             break;
         }
         zxc_test_srand(0xD1EC7u);
-        gen_lz_data(src, max);
-        const zxc_compress_opts_t co = {.level = 3};
-        int failed = 0;
-        for (size_t s = 0; s < sizeof(sizes) / sizeof(sizes[0]); s++) {
-            const size_t n = sizes[s];
-            const int64_t c = zxc_compress_block(cctx, src, n, comp, cap, &co);
-            if (c <= 0) {
-                printf("  [FAIL] compress %zu: %lld\n", n, (long long)c);
-                failed++;
-                continue;
-            }
-            /* padded (in place), exact, one byte of pad, twice the bound */
-            const size_t caps[] = {(size_t)zxc_decompress_block_bound(n), n, n + 1,
-                                   2 * (size_t)zxc_decompress_block_bound(n)};
-            for (size_t k = 0; k < sizeof(caps) / sizeof(caps[0]); k++) {
-                if (caps[k] > max + ZXC_DECOMPRESS_TAIL_PAD) continue;
-                memset(out, 0xA5, caps[k]);
-                const int64_t r = zxc_decompress_block(dctx, comp, (size_t)c, out, caps[k], NULL);
-                if (r != (int64_t)n || memcmp(out, src, n) != 0) {
-                    printf("  [FAIL] block %zu, dst %zu: %lld\n", n, caps[k], (long long)r);
-                    failed++;
-                }
-            }
-            /* a buffer that cannot hold the block */
-            if (n > 1000) {
-                const int64_t r = zxc_decompress_block(dctx, comp, (size_t)c, out, n - 1000, NULL);
-                if (r != ZXC_ERROR_DST_TOO_SMALL) {
-                    printf("  [FAIL] block %zu, dst %zu: %lld (want DST_TOO_SMALL)\n", n, n - 1000,
-                           (long long)r);
-                    failed++;
+        gen_lz_data(lz, max);
+        for (size_t i = 0; i < max; i++) lit[i] = (uint8_t)('a' + zxc_test_rand() % 26);
+        for (size_t i = 0; i < 4096; i++) dict[i] = (uint8_t)('a' + zxc_test_rand() % 26);
+        const zxc_decompress_opts_t dopts = {.dict = dict, .dict_size = 4096};
+        int failed = 0, cells = 0;
+        for (size_t g = 0; g < 2; g++) {
+            const uint8_t* src = g ? lit : lz;
+            for (size_t s = 0; s < sizeof(sizes) / sizeof(sizes[0]); s++) {
+                const size_t n = sizes[s];
+                for (size_t l = 0; l < sizeof(levels) / sizeof(levels[0]); l++) {
+                    /* the same block without and with a dictionary */
+                    for (int with_dict = 0; with_dict < 2; with_dict++) {
+                        const zxc_compress_opts_t co = {.level = levels[l],
+                                                        .dict = with_dict ? dict : NULL,
+                                                        .dict_size = with_dict ? 4096 : 0};
+                        const int64_t c = zxc_compress_block(cctx, src, n, comp, cap, &co);
+                        if (c <= 0) {
+                            printf("  [FAIL] compress g%zu n=%zu L%d dict=%d: %lld\n", g, n,
+                                   levels[l], with_dict, (long long)c);
+                            failed++;
+                            continue;
+                        }
+                        const size_t caps[] = {(size_t)zxc_decompress_block_bound(n), n, n + 1};
+                        for (size_t k = 0; k < sizeof(caps) / sizeof(caps[0]); k++) {
+                            if (caps[k] > dbound_max) continue;
+                            memset(out, 0xA5, n);
+                            const int64_t r = zxc_decompress_block(
+                                dctx, comp, (size_t)c, out, caps[k], with_dict ? &dopts : NULL);
+                            cells++;
+                            if (r != (int64_t)n || memcmp(out, src, n) != 0) {
+                                printf("  [FAIL] g%zu n=%zu L%d dict=%d dst=%zu: %lld\n", g, n,
+                                       levels[l], with_dict, caps[k], (long long)r);
+                                failed++;
+                            }
+                        }
+                        /* strict decoder at the exact size, same contract */
+                        memset(out, 0xA5, n);
+                        const int64_t rs = zxc_decompress_block_safe(dctx, comp, (size_t)c, out, n,
+                                                                     with_dict ? &dopts : NULL);
+                        cells++;
+                        if (rs != (int64_t)n || memcmp(out, src, n) != 0) {
+                            printf("  [FAIL] strict g%zu n=%zu L%d dict=%d: %lld\n", g, n,
+                                   levels[l], with_dict, (long long)rs);
+                            failed++;
+                        }
+                    }
                 }
             }
         }
         if (failed) break;
-        printf("  [PASS] %zu sizes x {bound, exact, +1, 2x bound} decode; short buffers refused\n",
-               sizeof(sizes) / sizeof(sizes[0]));
+        /* a destination that cannot hold the block is still refused */
+        const zxc_compress_opts_t co = {.level = 3};
+        const int64_t c = zxc_compress_block(cctx, lit, 100000, comp, cap, &co);
+        const int64_t r = c > 0 ? zxc_decompress_block(dctx, comp, (size_t)c, out, 99000, NULL) : 0;
+        if (c <= 0 || r != ZXC_ERROR_DST_TOO_SMALL) {
+            printf("  [FAIL] short destination: %lld (want DST_TOO_SMALL)\n", (long long)r);
+            break;
+        }
+        printf("  [PASS] %d decodes across sizes, levels, dictionary and both decoders\n", cells);
+        printf("  [PASS] a destination too short for the block is refused\n");
         ok = 1;
     } while (0);
     zxc_free_cctx(cctx);
     zxc_free_dctx(dctx);
-    free(src);
+    free(lz);
+    free(lit);
+    free(dict);
     free(comp);
     free(out);
     if (ok) printf("PASS\n\n");

--- a/tests/test_block_api.c
+++ b/tests/test_block_api.c
@@ -743,7 +743,7 @@ int test_block_api_tiny_capacity(void) {
 /* Direct decode and bounce must return the same bytes, literal-heavy blocks
  * sized just above a power of two included: there the carve and the decoder's
  * scratch are tightest. Small exact destinations cover the decoder's clamped
- * destination margins. */
+ * destination margins, and the last step drives the tight-tail fallback. */
 int test_block_api_direct_decode(void) {
     printf("=== TEST: Block API - direct decode and its fallback ===\n");
     /* straddling the powers of two and their tail-pad window */
@@ -791,7 +791,7 @@ int test_block_api_direct_decode(void) {
                         }
                         const size_t caps[] = {(size_t)zxc_decompress_block_bound(n), n, n + 1};
                         for (size_t k = 0; k < sizeof(caps) / sizeof(caps[0]); k++) {
-                            if (caps[k] > dbound_max) continue;
+                            /* n <= max, so every cap fits dbound_max */
                             memset(out, 0xA5, n);
                             const int64_t r = zxc_decompress_block(
                                 dctx, comp, (size_t)c, out, caps[k], with_dict ? &dopts : NULL);
@@ -817,6 +817,12 @@ int test_block_api_direct_decode(void) {
             }
         }
         if (failed) break;
+        const int expected_cells = 2 * (int)(sizeof(sizes) / sizeof(sizes[0])) *
+                                   (int)(sizeof(levels) / sizeof(levels[0])) * 2 * 4;
+        if (cells != expected_cells) {
+            printf("  [FAIL] %d decodes ran, expected %d\n", cells, expected_cells);
+            break;
+        }
         /* a destination that cannot hold the block is still refused */
         const zxc_compress_opts_t co = {.level = 3};
         const int64_t c = zxc_compress_block(cctx, lit, 100000, comp, cap, &co);
@@ -827,6 +833,43 @@ int test_block_api_direct_decode(void) {
         }
         printf("  [PASS] %d decodes across sizes, levels, dictionary and both decoders\n", cells);
         printf("  [PASS] a destination too short for the block is refused\n");
+
+        /* Tight-tail fallback: skewed letters leave a long escaped length the
+         * direct decode cannot fit in an exactly-sized dst, so the bounce redoes
+         * it; both paths must yield the same bytes. */
+        static const char skewed[] = "aaaaaaaabbbbccdeffgghijklmnop";
+        static const struct {
+            uint64_t seed;
+            size_t n;
+            int level;
+        } tail_cases[] = {{2, 6209, 5}, {2, 6209, 6}, {3, 4097, 5}, {3, 8193, 7}, {4, 5000, 5}};
+        uint8_t* padded = (uint8_t*)malloc(dbound_max);
+        int tail_failed = !padded;
+        for (size_t t = 0; t < sizeof(tail_cases) / sizeof(tail_cases[0]) && !tail_failed; t++) {
+            const size_t n = tail_cases[t].n;
+            zxc_test_srand(tail_cases[t].seed);
+            for (size_t i = 0; i < n; i++)
+                lit[i] = (uint8_t)skewed[zxc_test_rand() % (sizeof(skewed) - 1)];
+            const zxc_compress_opts_t tc = {.level = tail_cases[t].level};
+            const int64_t c2 = zxc_compress_block(cctx, lit, n, comp, cap, &tc);
+            const int64_t exact =
+                c2 > 0 ? zxc_decompress_block(dctx, comp, (size_t)c2, out, n, NULL) : c2;
+            const int64_t direct =
+                c2 > 0 ? zxc_decompress_block(dctx, comp, (size_t)c2, padded,
+                                              (size_t)zxc_decompress_block_bound(n), NULL)
+                       : c2;
+            if (exact != (int64_t)n || direct != (int64_t)n || memcmp(out, lit, n) != 0 ||
+                memcmp(padded, lit, n) != 0) {
+                printf("  [FAIL] tight tail seed %llu n=%zu L%d: exact %lld, direct %lld\n",
+                       (unsigned long long)tail_cases[t].seed, n, tail_cases[t].level,
+                       (long long)exact, (long long)direct);
+                tail_failed = 1;
+            }
+        }
+        free(padded);
+        if (tail_failed) break;
+        printf("  [PASS] %zu tight-tail blocks: fallback and direct decode agree\n",
+               sizeof(tail_cases) / sizeof(tail_cases[0]));
         ok = 1;
     } while (0);
     zxc_free_cctx(cctx);

--- a/tests/test_common.h
+++ b/tests/test_common.h
@@ -76,6 +76,7 @@ int test_decompress_empty_frame_null_dst(void);
 int test_block_api(void);
 int test_block_api_boundary_sizes(void);
 int test_block_api_tiny_capacity(void);
+int test_block_api_direct_decode(void);
 int test_block_api_large_block_varint(void);
 int test_decompress_block_safe(void);
 int test_decompress_block_bound(void);

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -61,6 +61,7 @@ static const test_entry_t g_tests[] = {
     TEST_CASE(test_block_api),
     TEST_CASE(test_block_api_boundary_sizes),
     TEST_CASE(test_block_api_tiny_capacity),
+    TEST_CASE(test_block_api_direct_decode),
     TEST_CASE(test_block_api_large_block_varint),
     TEST_CASE(test_decompress_block_bound),
     TEST_CASE(test_decompress_block_safe),


### PR DESCRIPTION
Refines block decompression to prioritize direct in-place writes to the destination buffer when sufficient capacity (including `ZXC_DECOMPRESS_TAIL_PAD`) is provided. Introduces a robust fallback mechanism that utilizes an internal bounce buffer for scenarios where the destination buffer lacks the necessary tail padding for speculative writes.

This change improves decompression performance for callers able to provide the full `ZXC_DECOMPRESS_TAIL_PAD` as indicated by `zxc_decompress_block_bound()`, enabling a fast path. It also increases flexibility by allowing `dst_capacity` to be exactly the uncompressed size, avoiding potential `ZXC_ERROR_OVERFLOW` errors and improving robustness for such cases by gracefully falling back to a bounce buffer and copy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Block decompression now decodes directly into the destination buffer when sufficient space is available.
  - Smaller tail capacity is handled automatically through an internal fallback, while destinations that are genuinely too small are rejected.

- **Bug Fixes**
  - Improved handling of small destination buffers to prevent invalid memory calculations during decompression.

- **Documentation**
  - Clarified destination-capacity requirements, fallback behavior, dictionary handling, and the contents of the destination buffer after an error.

- **Tests**
  - Added coverage for direct decoding, exact and bounded capacities, dictionaries, compression levels, and insufficient destinations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->