### PR TITLE
build: enforce rapidhash resolution at configure/setup time

### DIFF
--- a/.github/workflows/multicomp.yml
+++ b/.github/workflows/multicomp.yml
@@ -355,3 +355,30 @@ jobs:
 
       - name: Test (shared)
         run: meson test -C build-shared --print-errorlogs
+
+      - name: Rapidhash resolution is enforced at setup time
+        if: matrix.name == 'Linux x86_64'
+        shell: bash
+        run: |
+          # Meson mirror of the CMake guard in quality.yml (#419).
+          trap 'mv -f rapidhash.h.stash src/lib/vendors/rapidhash.h 2>/dev/null || true
+                rm -rf sysinc build-guard' EXIT
+          mkdir -p sysinc && cp src/lib/vendors/rapidhash.h sysinc/
+          mv src/lib/vendors/rapidhash.h rapidhash.h.stash
+
+          set +e; out=$(meson setup build-guard 2>&1); rc=$?; set -e
+          rm -rf build-guard
+          if [ "$rc" -eq 0 ] || ! grep -q use_system_rapidhash <<< "$out"; then
+            echo "::error::setup should have failed naming use_system_rapidhash, got rc=$rc"
+            echo "$out"
+            exit 1
+          fi
+
+          set +e
+          out=$(CFLAGS="-I$PWD/sysinc" meson setup build-guard -Duse_system_rapidhash=true 2>&1)
+          rc=$?; set -e
+          if [ "$rc" -ne 0 ]; then
+            echo "::error::setup against a system rapidhash should have succeeded"
+            echo "$out"
+            exit 1
+          fi

--- a/.github/workflows/multicomp.yml
+++ b/.github/workflows/multicomp.yml
@@ -375,7 +375,8 @@ jobs:
           fi
 
           set +e
-          out=$(CFLAGS="-I$PWD/sysinc" meson setup build-guard -Duse_system_rapidhash=true 2>&1)
+          out=$(meson setup build-guard -Duse_system_rapidhash=true \
+                  -Dc_args=-I"$PWD/sysinc" 2>&1)
           rc=$?; set -e
           if [ "$rc" -ne 0 ]; then
             echo "::error::setup against a system rapidhash should have succeeded"

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -185,6 +185,31 @@ jobs:
                    --error-exitcode=1 \
                    ./zxc_test
 
+      - name: Rapidhash resolution is enforced at configure time
+        shell: bash
+        run: |
+          # A missing or bogus rapidhash path must fail configure, naming the option (#419).
+          trap 'mv -f rapidhash.h.stash src/lib/vendors/rapidhash.h 2>/dev/null || true
+                rm -rf sysinc build_guard' EXIT
+          mkdir -p sysinc && cp src/lib/vendors/rapidhash.h sysinc/
+          mv src/lib/vendors/rapidhash.h rapidhash.h.stash
+
+          # expect <want-rc> <token> [cmake args...]
+          expect() {
+            want=$1 token=$2; shift 2
+            set +e; out=$(cmake -S . -B build_guard "$@" 2>&1); rc=$?; set -e
+            rm -rf build_guard
+            if [ "$rc" -ne "$want" ] || ! grep -q "$token" <<< "$out"; then
+              echo "::error::expected rc=$want and '$token', got rc=$rc"
+              echo "$out"
+              exit 1
+            fi
+          }
+
+          expect 1 ZXC_USE_SYSTEM_RAPIDHASH
+          expect 1 ZXC_USE_SYSTEM_RAPIDHASH -DZXC_USE_SYSTEM_RAPIDHASH=ON -DRAPIDHASH_INCLUDE_DIR=/nonexistent
+          expect 0 "Using system rapidhash" -DZXC_USE_SYSTEM_RAPIDHASH=ON -DRAPIDHASH_INCLUDE_DIR="$PWD/sysinc"
+
       - name: Unicode Linting
         shell: bash
         run: |

--- a/cmake/zxcDependencies.cmake
+++ b/cmake/zxcDependencies.cmake
@@ -4,14 +4,26 @@
 # SPDX-License-Identifier: BSD-3-Clause
 #
 # Rapidhash: system-installed (e.g. vcpkg) or vendored fallback.
+# Resolved at configure time so a missing header names the option to set.
 
 if(ZXC_USE_SYSTEM_RAPIDHASH)
     find_path(RAPIDHASH_INCLUDE_DIR rapidhash.h)
-    if(NOT RAPIDHASH_INCLUDE_DIR)
-        message(FATAL_ERROR "ZXC_USE_SYSTEM_RAPIDHASH is ON but rapidhash.h was not found.")
+    if(NOT RAPIDHASH_INCLUDE_DIR OR NOT EXISTS "${RAPIDHASH_INCLUDE_DIR}/rapidhash.h")
+        message(FATAL_ERROR
+            "ZXC_USE_SYSTEM_RAPIDHASH is ON but no rapidhash.h was found "
+            "(RAPIDHASH_INCLUDE_DIR=${RAPIDHASH_INCLUDE_DIR}). Install rapidhash, "
+            "add its prefix to CMAKE_PREFIX_PATH, or point "
+            "-DRAPIDHASH_INCLUDE_DIR=<dir> at the directory holding the header.")
     endif()
     message(STATUS "Using system rapidhash from ${RAPIDHASH_INCLUDE_DIR}")
 else()
     set(RAPIDHASH_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/src/lib/vendors")
+    if(NOT EXISTS "${RAPIDHASH_INCLUDE_DIR}/rapidhash.h")
+        message(FATAL_ERROR
+            "Vendored rapidhash.h not found in ${RAPIDHASH_INCLUDE_DIR}. "
+            "If the vendored copy was removed on purpose (packaging against a "
+            "system or vcpkg rapidhash), configure with "
+            "-DZXC_USE_SYSTEM_RAPIDHASH=ON.")
+    endif()
     message(STATUS "Using vendored rapidhash from ${RAPIDHASH_INCLUDE_DIR}")
 endif()

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -67,6 +67,7 @@ Installing into a system prefix needs `sudo` on Unix or an elevated shell on Win
 | `ZXC_ENABLE_COVERAGE` | OFF | OFF | Enable code coverage generation (disables LTO/PGO) |
 | `ZXC_DISABLE_SIMD` | OFF | OFF | Disable hand-written SIMD paths (AVX2/AVX512/NEON) |
 | `ZXC_USE_SYSTEM_RAPIDHASH` | OFF | OFF | Use a system-installed `rapidhash.h` instead of the vendored copy |
+| `RAPIDHASH_INCLUDE_DIR` | *(found)* | *(found)* | Directory holding a system `rapidhash.h`, when `find_path` cannot locate it |
 
 "Vendored" is a build where zxc is not the top-level project (`add_subdirectory()`,
 `FetchContent`): the embedding project then keeps control of its own compiler flags,
@@ -172,7 +173,9 @@ then be built unoptimised.
 
 Third-party code is vendored, never probed: `rapidhash.h` comes from the copy in
 the tree unless `-DZXC_USE_SYSTEM_RAPIDHASH=ON` asks for a system one, so a
-build cannot silently pick up a header from the host.
+build cannot silently pick up a header from the host. Packagers who strip the
+vendored copy must pass that option: either header is resolved at configure
+time, so a missing one fails there rather than once per translation unit.
 
 ## Meson subproject (or WrapDB)
 
@@ -207,3 +210,15 @@ meson compile -C build
 
 When consumed as a subproject, only the library is built (CLI and tests are
 skipped automatically).
+
+### Meson options
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `build_cli` | `false` | Build the command-line interface |
+| `use_system_rapidhash` | `false` | Use a system-installed `rapidhash.h` instead of the vendored copy |
+
+`use_system_rapidhash` mirrors `ZXC_USE_SYSTEM_RAPIDHASH` in the CMake build,
+with the same setup-time check. It has no equivalent of `RAPIDHASH_INCLUDE_DIR`:
+Meson probes the compiler's default search path, so a header installed elsewhere
+is reached with `-Dc_args=-I<dir>`.

--- a/meson.build
+++ b/meson.build
@@ -65,7 +65,7 @@ inc_private   = include_directories('src/lib')
 # Rapidhash: system or vendored, mirroring ZXC_USE_SYSTEM_RAPIDHASH in CMake.
 # Resolved at setup time so a missing header names the option to set.
 if get_option('use_system_rapidhash')
-  if not cc.has_header('rapidhash.h')
+  if not cc.has_header('rapidhash.h', args : get_option('c_args'))
     error('use_system_rapidhash is enabled but rapidhash.h was not found. ' +
           'Install rapidhash or add its include directory to c_args.')
   endif

--- a/meson.build
+++ b/meson.build
@@ -12,6 +12,7 @@ project('zxc', 'c',
 )
 
 cc = meson.get_compiler('c')
+fs = import('fs')
 host_cpu = host_machine.cpu_family()
 
 msvc_syntax = cc.get_argument_syntax() == 'msvc'
@@ -60,8 +61,25 @@ endif
 
 inc_public    = include_directories('include')
 inc_private   = include_directories('src/lib')
-rapidhash_inc = include_directories('src/lib/vendors')
-libzxc_includes = [inc_public, inc_private, rapidhash_inc]
+
+# Rapidhash: system or vendored, mirroring ZXC_USE_SYSTEM_RAPIDHASH in CMake.
+# Resolved at setup time so a missing header names the option to set.
+if get_option('use_system_rapidhash')
+  if not cc.has_header('rapidhash.h')
+    error('use_system_rapidhash is enabled but rapidhash.h was not found. ' +
+          'Install rapidhash or add its include directory to c_args.')
+  endif
+  rapidhash_inc = []
+else
+  if not fs.exists('src/lib/vendors/rapidhash.h')
+    error('Vendored rapidhash.h not found in src/lib/vendors. If the vendored ' +
+          'copy was removed on purpose (packaging against a system rapidhash), ' +
+          'configure with -Duse_system_rapidhash=true.')
+  endif
+  rapidhash_inc = [include_directories('src/lib/vendors')]
+endif
+
+libzxc_includes = [inc_public, inc_private] + rapidhash_inc
 
 # =============================================================================
 # SIMD runtime dispatch

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,2 +1,4 @@
 option('build_cli', type : 'boolean', value : false,
        description : 'Build the command-line interface')
+option('use_system_rapidhash', type : 'boolean', value : false,
+       description : 'Use a system-installed rapidhash.h instead of the vendored copy')


### PR DESCRIPTION
Update CMake and Meson configurations to explicitly validate the presence of `rapidhash.h` during the initial build configuration. This ensures that missing headers or misconfigured paths are identified immediately with clear diagnostic messages, preventing silent build failures during the compilation phase.

Fix issue #419

Signed-off-by: Bertrand Lebonnois <5901952+hellobertrand@users.noreply.github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Meson option to use a system-installed Rapidhash header instead of the bundled copy.
  * Added configure-time validation for Rapidhash headers in both CMake and Meson builds, with actionable error messages.
  * Added CMake support for specifying the system Rapidhash header location.

* **Documentation**
  * Documented Rapidhash configuration options and system-header setup for CMake and Meson.

* **Tests**
  * Added build checks covering missing, invalid, and valid Rapidhash header configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->