### PR TITLE
ci: migrate release workflows to trusted publishing

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -87,7 +87,7 @@ Regenerates [`CHANGELOG.md`](../../CHANGELOG.md) with [`git-cliff`](https://git-
 ### wrapper-rust.yml - Wrapper Rust
 **Triggers:** Release published, manual dispatch
 
-Tests and publishes Rust crates to crates.io. Verifies the version matches the release tag, runs tests across platforms, and publishes `zxc-compress-sys` (FFI bindings) followed by `zxc-compress` (safe wrapper).
+Tests and publishes Rust crates to crates.io via trusted publishing. Verifies the version matches the release tag, runs tests across platforms, and publishes `zxc-compress-sys` (FFI bindings) followed by `zxc-compress` (safe wrapper).
 
 ### wrapper-python.yml - Wrapper Python
 **Triggers:** Release published, manual dispatch
@@ -97,12 +97,12 @@ Builds platform-specific wheels using `cibuildwheel` for Linux (x86_64, ARM64), 
 ### wrapper-wasm.yml - Wrapper WASM
 **Triggers:** Release published, publish on main, manual dispatch
 
-Builds the WebAssembly target using Emscripten SDK. Compiles the library with SIMD disabled (scalar codepath) and no threading, then runs a Node.js roundtrip test suite covering all compression levels, reusable contexts, and error handling. Uploads `zxc.js` + `zxc.wasm` as build artifacts.
+Builds the WebAssembly target using Emscripten SDK. Compiles the library with SIMD disabled (scalar codepath) and no threading, then runs a Node.js roundtrip test suite covering all compression levels, reusable contexts, and error handling. Uploads `zxc.js` + `zxc.wasm` as build artifacts. On tags, publishes the `zxc-wasm` package to npm via trusted publishing.
 
 ### wrapper-nodejs.yml - Wrapper Node.js
 **Triggers:** Release published, manual dispatch
 
-Builds and publishes the Node.js package to npm. Handles the compilation of native bindings and ensures the package is correctly versioned and distributed.
+Builds and publishes the Node.js package to npm via trusted publishing. Handles the compilation of native bindings and ensures the package is correctly versioned and distributed.
 
 ### wrapper-go.yml - Wrapper Go
 **Triggers:** Release published, manual dispatch

--- a/.github/workflows/wrapper-nodejs.yml
+++ b/.github/workflows/wrapper-nodejs.yml
@@ -168,7 +168,7 @@ jobs:
           registry-url: "https://registry.npmjs.org"
 
       - name: Update npm
-        run: npm install -g npm@latest
+        run: npm install -g npm@11.19.1
 
       - name: Verify Version Matches Release Tag
         env:

--- a/.github/workflows/wrapper-nodejs.yml
+++ b/.github/workflows/wrapper-nodejs.yml
@@ -151,6 +151,7 @@ jobs:
     runs-on: ubuntu-slim
     if: startsWith(github.ref, 'refs/tags/')
     permissions:
+      contents: read
       id-token: write
     defaults:
       run:
@@ -163,8 +164,11 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: "22"
+          node-version: "24"
           registry-url: "https://registry.npmjs.org"
+
+      - name: Update npm
+        run: npm install -g npm@latest
 
       - name: Verify Version Matches Release Tag
         env:
@@ -184,9 +188,7 @@ jobs:
           echo "Version matches: $RELEASE_VERSION"
 
       - name: Publish to npm
-        run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --access public
 
       - name: Summary
         if: success()

--- a/.github/workflows/wrapper-rust.yml
+++ b/.github/workflows/wrapper-rust.yml
@@ -59,6 +59,9 @@ jobs:
     needs: [test]
     runs-on: ubuntu-slim
     if: startsWith(github.ref, 'refs/tags/')
+    permissions:
+      contents: read
+      id-token: write
     defaults:
       run:
         working-directory: ./wrappers/rust
@@ -89,9 +92,13 @@ jobs:
           
           echo "Version matches: $RELEASE_VERSION"
 
+      - name: Authenticate with crates.io
+        id: auth
+        uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 # v1.0.5
+
       - name: Publish zxc-compress-sys (FFI bindings)
         env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
         run: |
           cd zxc-sys
           cargo publish
@@ -103,7 +110,7 @@ jobs:
 
       - name: Publish zxc-compress (safe wrapper)
         env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
         run: |
           cd zxc
           cargo publish

--- a/.github/workflows/wrapper-wasm.yml
+++ b/.github/workflows/wrapper-wasm.yml
@@ -106,7 +106,7 @@ jobs:
           registry-url: "https://registry.npmjs.org"
 
       - name: Update npm
-        run: npm install -g npm@latest
+        run: npm install -g npm@11.19.1
 
       - name: Verify Version Matches Release Tag
         working-directory: ./wrappers/wasm

--- a/.github/workflows/wrapper-wasm.yml
+++ b/.github/workflows/wrapper-wasm.yml
@@ -77,6 +77,7 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       id-token: write
 
     steps:
@@ -101,8 +102,11 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: '22'
+          node-version: '24'
           registry-url: "https://registry.npmjs.org"
+
+      - name: Update npm
+        run: npm install -g npm@latest
 
       - name: Verify Version Matches Release Tag
         working-directory: ./wrappers/wasm
@@ -132,9 +136,7 @@ jobs:
 
       - name: Publish to npm
         working-directory: ./wrappers/wasm
-        run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --access public
 
       - name: Summary
         if: success()


### PR DESCRIPTION
Update GitHub Actions workflows for Node.js, Rust, and WASM to utilize OIDC-based trusted publishing for package registries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that Rust, WebAssembly, and Node.js packages are published through trusted publishing.

* **Chores**
  * Updated package publishing workflows to use Node.js 24 and npm 11.19.1.
  * Improved registry authentication by using short-lived, identity-based credentials.
  * Simplified npm publishing configuration for Node.js and WebAssembly packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->