### PR TITLE
fix(lib): fix empty frame compression in contexts

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -385,7 +385,8 @@ ZXC_EXPORT int64_t zxc_compress(
 Compresses `src` into `dst`. Only `level`, `block_size`, `checksum_enabled`, and
 `seekable` fields of `opts` are used. `n_threads` is ignored (always single-threaded).
 
-**Returns**: compressed size (> 0) on success, or negative `zxc_error_t`.
+**Returns**: compressed size (> 0) on success, or negative `zxc_error_t`. A
+zero `src_size` (with `src` NULL or not) writes the 36-byte empty archive.
 
 ### `zxc_decompress`
 
@@ -678,10 +679,12 @@ ZXC_EXPORT int64_t zxc_compress_cctx(
 ```
 
 Same as `zxc_compress()` but reuses internal buffers from `cctx`.
-Automatically re-initializes when `block_size` or `level` changes. Dictionary
-options are honoured as in `zxc_compress()` but are not sticky; the shared
-literal table is rebuilt only when it changes. A static context returns
-`ZXC_ERROR_DICT_UNSUPPORTED` for any dictionary.
+Automatically re-initializes when `block_size` or `level` changes. A zero
+`src_size` writes the empty archive, as `zxc_compress()` does, without carving
+the workspace. Dictionary options are honoured as in `zxc_compress()` but are
+not sticky; the shared literal table is rebuilt only when it changes. A static
+context returns `ZXC_ERROR_DICT_UNSUPPORTED` for any dictionary. `seekable` is
+ignored here: use `zxc_compress()` when the archive needs a seek table.
 
 ### `zxc_create_dctx`
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -405,7 +405,17 @@ Decompresses `src` into `dst`. `checksum_enabled` and the dictionary fields
 `src` and `dst` must not overlap (same contract as `memcpy`); for overlapping
 single-buffer decode, use `zxc_decompress_inplace` below.
 
-**Returns**: decompressed size (> 0) on success, or negative `zxc_error_t`.
+**Asking without a destination**: a NULL `dst`, or a `dst_capacity` of 0,
+decodes nothing and reports whether the archive holds anything: `0` for a
+well-formed empty archive, `ZXC_ERROR_DST_TOO_SMALL` when it stores a payload,
+and the archive's own error otherwise. The verdict is the one a call with a
+destination would have returned, checksum and dictionary binding included, so
+a probe never waves through an archive the decode would refuse. A NULL `dst`
+with a non-zero `dst_capacity` is a caller error (`ZXC_ERROR_NULL_INPUT`), not
+a probe.
+
+**Returns**: decompressed size, `0` for an empty archive, or negative
+`zxc_error_t`.
 
 ### `zxc_decompress_inplace_bound`
 
@@ -718,6 +728,16 @@ ZXC_EXPORT int64_t zxc_decompress_dctx(
 Same as `zxc_decompress()`, dictionary options included, but reuses buffers
 from `dctx`; the shared literal table is rebuilt only when it changes between
 calls. A static context returns `ZXC_ERROR_DICT_UNSUPPORTED` for any dictionary.
+
+The no-destination probe works here too, answered under this context's rules:
+a static context still rejects a foreign block size and a dictionary-bound
+archive.
+
+**Error codes changed after v0.14.0**: they now match `zxc_decompress()`
+exactly. A truncated input reports `ZXC_ERROR_SRC_TOO_SMALL` and a malformed
+header reports what the header parse found (`ZXC_ERROR_BAD_MAGIC`,
+`ZXC_ERROR_BAD_VERSION`, `ZXC_ERROR_BAD_BLOCK_SIZE`), where both used to
+flatten to `ZXC_ERROR_NULL_INPUT` or `ZXC_ERROR_BAD_HEADER`.
 
 ---
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -417,8 +417,9 @@ archive that stores a payload reports `ZXC_ERROR_DST_TOO_SMALL` even where a
 decode would name the actual fault (a footer contradicting the blocks, say).
 Callers that need that fault must decode into a buffer.
 
-A NULL `dst` with a non-zero `dst_capacity` is a caller error
-(`ZXC_ERROR_NULL_INPUT`), not a probe.
+Caller errors outrank all of it, before the archive is read at all: a NULL
+`dst` with a non-zero `dst_capacity` is `ZXC_ERROR_NULL_INPUT`, and a
+`dict_size` the library cannot honour is `ZXC_ERROR_DICT_TOO_LARGE`.
 
 **Returns**: decompressed size, `0` for an empty archive, or negative
 `zxc_error_t`.

--- a/docs/API.md
+++ b/docs/API.md
@@ -408,11 +408,17 @@ single-buffer decode, use `zxc_decompress_inplace` below.
 **Asking without a destination**: a NULL `dst`, or a `dst_capacity` of 0,
 decodes nothing and reports whether the archive holds anything: `0` for a
 well-formed empty archive, `ZXC_ERROR_DST_TOO_SMALL` when it stores a payload,
-and the archive's own error otherwise. The verdict is the one a call with a
-destination would have returned, checksum and dictionary binding included, so
-a probe never waves through an archive the decode would refuse. A NULL `dst`
-with a non-zero `dst_capacity` is a caller error (`ZXC_ERROR_NULL_INPUT`), not
-a probe.
+and the archive's own error otherwise.
+
+A probe never waves through an archive the decode would refuse: a `0` here
+means a call with a destination would have returned `0` too, checksum and
+dictionary binding included. Not the reverse, since nothing is decoded: an
+archive that stores a payload reports `ZXC_ERROR_DST_TOO_SMALL` even where a
+decode would name the actual fault (a footer contradicting the blocks, say).
+Callers that need that fault must decode into a buffer.
+
+A NULL `dst` with a non-zero `dst_capacity` is a caller error
+(`ZXC_ERROR_NULL_INPUT`), not a probe.
 
 **Returns**: decompressed size, `0` for an empty archive, or negative
 `zxc_error_t`.

--- a/docs/API.md
+++ b/docs/API.md
@@ -417,9 +417,10 @@ archive that stores a payload reports `ZXC_ERROR_DST_TOO_SMALL` even where a
 decode would name the actual fault (a footer contradicting the blocks, say).
 Callers that need that fault must decode into a buffer.
 
-Caller errors outrank all of it, before the archive is read at all: a NULL
-`dst` with a non-zero `dst_capacity` is `ZXC_ERROR_NULL_INPUT`, and a
-`dict_size` the library cannot honour is `ZXC_ERROR_DICT_TOO_LARGE`.
+Caller errors outrank all of it, before anything is read from `src`, a source
+too short to hold a frame included: a NULL `dst` with a non-zero
+`dst_capacity` is `ZXC_ERROR_NULL_INPUT`, and a `dict_size` the library cannot
+honour is `ZXC_ERROR_DICT_TOO_LARGE`.
 
 **Returns**: decompressed size, `0` for an empty archive, or negative
 `zxc_error_t`.

--- a/include/zxc_buffer.h
+++ b/include/zxc_buffer.h
@@ -103,8 +103,9 @@ ZXC_EXPORT uint64_t zxc_compress_bound(const size_t input_size);
  * Writes the file header followed by compressed blocks. Single-threaded and
  * blocking, so @c n_threads and the progress callback in @p opts are ignored.
  *
- * @param[in]  src          Source buffer.
- * @param[in]  src_size     Source size in bytes.
+ * @param[in]  src          Source buffer; may be NULL when @p src_size is 0.
+ * @param[in]  src_size     Source size in bytes; 0 writes the empty archive
+ *                          (file header + EOF block + footer).
  * @param[out] dst          Destination buffer.
  * @param[in]  dst_capacity Capacity of @p dst.
  * @param[in]  opts         Compression options, or NULL for defaults.
@@ -450,13 +451,14 @@ ZXC_EXPORT void zxc_free_cctx(zxc_cctx* cctx);
  * Dictionary options are the exception: honoured as in zxc_compress() but
  * never remembered, so pass them on every call; the shared table is rebuilt
  * only when it changes. A static context returns
- * @ref ZXC_ERROR_DICT_UNSUPPORTED for any dictionary.
+ * @ref ZXC_ERROR_DICT_UNSUPPORTED for any dictionary. @c seekable is ignored
+ * here: use zxc_compress() when the archive needs a seek table.
  *
  * @param[in,out] cctx         Reusable compression context.
  * @param[in]     src          Source data; may be NULL when @p src_size is 0.
- * @param[in]     src_size     Source size in bytes; 0 writes the empty archive
- *                             (header + EOF block + footer), as zxc_compress()
- *                             does.
+ * @param[in]     src_size     Source size in bytes; 0 writes the empty archive,
+ *                             as zxc_compress() does, without carving the
+ *                             encoder workspace.
  * @param[out]    dst          Destination buffer.
  * @param[in]     dst_capacity Capacity of @p dst.
  * @param[in]     opts         Options, or NULL to reuse the sticky settings.
@@ -504,7 +506,8 @@ ZXC_EXPORT void zxc_free_dctx(zxc_dctx* dctx);
  *
  * @note @p src and @p dst must not overlap (same contract as memcpy).
  *
- * @return Decompressed size (> 0), or a negative @ref zxc_error_t.
+ * @return Decompressed size, 0 for an empty archive, or a negative
+ *         @ref zxc_error_t.
  */
 ZXC_EXPORT int64_t zxc_decompress_dctx(zxc_dctx* dctx, const void* src, size_t src_size, void* dst,
                                        size_t dst_capacity, const zxc_decompress_opts_t* opts);

--- a/include/zxc_buffer.h
+++ b/include/zxc_buffer.h
@@ -453,8 +453,10 @@ ZXC_EXPORT void zxc_free_cctx(zxc_cctx* cctx);
  * @ref ZXC_ERROR_DICT_UNSUPPORTED for any dictionary.
  *
  * @param[in,out] cctx         Reusable compression context.
- * @param[in]     src          Source data.
- * @param[in]     src_size     Source size in bytes.
+ * @param[in]     src          Source data; may be NULL when @p src_size is 0.
+ * @param[in]     src_size     Source size in bytes; 0 writes the empty archive
+ *                             (header + EOF block + footer), as zxc_compress()
+ *                             does.
  * @param[out]    dst          Destination buffer.
  * @param[in]     dst_capacity Capacity of @p dst.
  * @param[in]     opts         Options, or NULL to reuse the sticky settings.

--- a/include/zxc_buffer.h
+++ b/include/zxc_buffer.h
@@ -127,16 +127,24 @@ ZXC_EXPORT int64_t zxc_compress(const void* src, const size_t src_size, void* ds
  * and blocking, so @c n_threads and the progress callback in @p opts are
  * ignored.
  *
+ * @par Asking without a destination
+ * A NULL @p dst, or a @p dst_capacity of 0, decodes nothing and reports what
+ * the archive holds: 0 for a well-formed empty one, @ref ZXC_ERROR_DST_TOO_SMALL
+ * when it stores a payload, its own error otherwise. That verdict is the one a
+ * call with a destination would have got, checksum and dictionary binding
+ * included. A NULL @p dst with a non-zero @p dst_capacity is a caller error
+ * (@ref ZXC_ERROR_NULL_INPUT), not a probe.
+ *
  * @param[in]  src          Compressed buffer.
  * @param[in]  src_size     Compressed size in bytes.
- * @param[out] dst          Destination buffer.
+ * @param[out] dst          Destination buffer, or NULL to probe (see above).
  * @param[in]  dst_capacity Capacity of @p dst.
  * @param[in]  opts         Decompression options, or NULL for defaults.
  *
  * @note @p src and @p dst must not overlap (same contract as memcpy).
  *
- * @return Bytes written to @p dst (> 0), or a negative @ref zxc_error_t
- *         (e.g. @ref ZXC_ERROR_CORRUPT_DATA).
+ * @return Bytes written to @p dst, 0 for an empty archive, or a negative
+ *         @ref zxc_error_t (e.g. @ref ZXC_ERROR_CORRUPT_DATA).
  */
 ZXC_EXPORT int64_t zxc_decompress(const void* src, const size_t src_size, void* dst,
                                   const size_t dst_capacity, const zxc_decompress_opts_t* opts);
@@ -497,10 +505,21 @@ ZXC_EXPORT void zxc_free_dctx(zxc_dctx* dctx);
  * calls. A static context returns @ref ZXC_ERROR_DICT_UNSUPPORTED for any
  * dictionary.
  *
+ * @par Asking without a destination
+ * Same probe as zxc_decompress(), answered under this context's rules: a static
+ * context still rejects a foreign block size and a dictionary-bound archive.
+ *
+ * @par Error codes changed after v0.14.0
+ * They now match zxc_decompress() exactly. A truncated input reports
+ * @ref ZXC_ERROR_SRC_TOO_SMALL and a malformed header reports what the header
+ * parse found (@ref ZXC_ERROR_BAD_MAGIC, @ref ZXC_ERROR_BAD_VERSION,
+ * @ref ZXC_ERROR_BAD_BLOCK_SIZE), where both used to flatten to
+ * @ref ZXC_ERROR_NULL_INPUT or @ref ZXC_ERROR_BAD_HEADER.
+ *
  * @param[in,out] dctx         Reusable decompression context.
  * @param[in]     src          Compressed data.
  * @param[in]     src_size     Compressed size in bytes.
- * @param[out]    dst          Destination buffer.
+ * @param[out]    dst          Destination buffer, or NULL to probe (see above).
  * @param[in]     dst_capacity Capacity of @p dst.
  * @param[in]     opts         Decompression options, or NULL for defaults.
  *

--- a/include/zxc_buffer.h
+++ b/include/zxc_buffer.h
@@ -135,8 +135,9 @@ ZXC_EXPORT int64_t zxc_compress(const void* src, const size_t src_size, void* ds
  * too, checksum and dictionary binding included. Not the reverse, since nothing
  * is decoded: an archive that stores a payload reports
  * @ref ZXC_ERROR_DST_TOO_SMALL even where a decode would name the actual fault.
- * A NULL @p dst with a non-zero @p dst_capacity is a caller error
- * (@ref ZXC_ERROR_NULL_INPUT), not a probe.
+ * Caller errors outrank all of it, before the archive is read at all: a NULL
+ * @p dst with a non-zero @p dst_capacity is @ref ZXC_ERROR_NULL_INPUT, and a
+ * @c dict_size the library cannot honour is @ref ZXC_ERROR_DICT_TOO_LARGE.
  *
  * @param[in]  src          Compressed buffer.
  * @param[in]  src_size     Compressed size in bytes.

--- a/include/zxc_buffer.h
+++ b/include/zxc_buffer.h
@@ -135,9 +135,10 @@ ZXC_EXPORT int64_t zxc_compress(const void* src, const size_t src_size, void* ds
  * too, checksum and dictionary binding included. Not the reverse, since nothing
  * is decoded: an archive that stores a payload reports
  * @ref ZXC_ERROR_DST_TOO_SMALL even where a decode would name the actual fault.
- * Caller errors outrank all of it, before the archive is read at all: a NULL
- * @p dst with a non-zero @p dst_capacity is @ref ZXC_ERROR_NULL_INPUT, and a
- * @c dict_size the library cannot honour is @ref ZXC_ERROR_DICT_TOO_LARGE.
+ * Caller errors outrank all of it, before anything is read from @p src, a
+ * source too short to hold a frame included: a NULL @p dst with a non-zero
+ * @p dst_capacity is @ref ZXC_ERROR_NULL_INPUT, and a @c dict_size the library
+ * cannot honour is @ref ZXC_ERROR_DICT_TOO_LARGE.
  *
  * @param[in]  src          Compressed buffer.
  * @param[in]  src_size     Compressed size in bytes.

--- a/include/zxc_buffer.h
+++ b/include/zxc_buffer.h
@@ -130,9 +130,12 @@ ZXC_EXPORT int64_t zxc_compress(const void* src, const size_t src_size, void* ds
  * @par Asking without a destination
  * A NULL @p dst, or a @p dst_capacity of 0, decodes nothing and reports what
  * the archive holds: 0 for a well-formed empty one, @ref ZXC_ERROR_DST_TOO_SMALL
- * when it stores a payload, its own error otherwise. That verdict is the one a
- * call with a destination would have got, checksum and dictionary binding
- * included. A NULL @p dst with a non-zero @p dst_capacity is a caller error
+ * when it stores a payload, its own error otherwise. Success is never handed
+ * out early: a 0 here means a call with a destination would have returned 0
+ * too, checksum and dictionary binding included. Not the reverse, since nothing
+ * is decoded: an archive that stores a payload reports
+ * @ref ZXC_ERROR_DST_TOO_SMALL even where a decode would name the actual fault.
+ * A NULL @p dst with a non-zero @p dst_capacity is a caller error
  * (@ref ZXC_ERROR_NULL_INPUT), not a probe.
  *
  * @param[in]  src          Compressed buffer.

--- a/src/lib/zxc_dispatch.c
+++ b/src/lib/zxc_dispatch.c
@@ -527,6 +527,34 @@ int zxc_huf_unpack_lengths(const uint8_t* RESTRICT in, uint8_t* RESTRICT code_le
 // allocation and looping over blocks. They call the dispatched wrappers above.
 
 /**
+ * @brief Writes the whole archive an empty source produces: file header, EOF
+ *        block, footer, and nothing between them.
+ *
+ * Both entry points return through here, so their empty archives are the same
+ * bytes by construction rather than by a test that compares them. Neither
+ * carves a workspace to get here: there is no block to encode.
+ *
+ * @return Bytes written, or a negative @ref zxc_error_t.
+ */
+static int64_t zxc_write_empty_frame(uint8_t* RESTRICT dst, const size_t dst_capacity,
+                                     const size_t block_size, const int checksum_enabled,
+                                     const uint32_t did) {
+    const int h = zxc_write_file_header(dst, dst_capacity, block_size, checksum_enabled, did);
+    if (UNLIKELY(h < 0)) return h;
+    size_t off = (size_t)h;
+
+    const zxc_block_header_t eof = {
+        .block_type = ZXC_BLOCK_EOF, .block_flags = 0, .reserved = 0, .comp_size = 0};
+    const int e = zxc_write_block_header(dst + off, dst_capacity - off, &eof);
+    if (UNLIKELY(e < 0)) return e;
+    off += (size_t)e;
+
+    const int f = zxc_write_file_footer(dst + off, dst_capacity - off, 0, 0, checksum_enabled);
+    if (UNLIKELY(f < 0)) return f;
+    return (int64_t)(off + (size_t)f);
+}
+
+/**
  * @brief Compresses an entire buffer in one call.
  *
  * Manages context allocation internally, loops over blocks, writes the
@@ -549,6 +577,10 @@ int64_t zxc_compress(const void* RESTRICT src, const size_t src_size, void* REST
     if (UNLIKELY(!zxc_validate_block_size(block_size))) return ZXC_ERROR_BAD_BLOCK_SIZE;
 
     const uint32_t did = (dict && dict_size > 0) ? zxc_dict_id(dict, dict_size, dict_huf) : 0;
+
+    if (UNLIKELY(src_size == 0))
+        return zxc_write_empty_frame((uint8_t*)dst, dst_capacity, block_size, checksum_enabled,
+                                     did);
 
     const uint8_t* ip = (const uint8_t*)src;
     uint8_t* op = (uint8_t*)dst;
@@ -834,36 +866,26 @@ static int64_t zxc_decompress_frame(const uint8_t* src, const size_t src_size, u
     const int hrc = zxc_read_file_header(ip, src_size, &runtime_chunk_size, &file_has_checksums,
                                          &header_dict_id);
     if (UNLIKELY(hrc != ZXC_OK)) return hrc;
-    if (UNLIKELY(zxc_cctx_init(&ctx, runtime_chunk_size, 0, 0,
-                               file_has_checksums && checksum_enabled, dict_size) != ZXC_OK))
-        return ZXC_ERROR_MEMORY;
 
-    // Dictionary validation
+    // Dictionary validation, before any allocation: a binding the caller cannot
+    // satisfy is settled from the header alone.
     if (header_dict_id != 0) {
-        if (UNLIKELY(!dict || dict_size == 0)) {
-            zxc_cctx_free(&ctx);
-            return ZXC_ERROR_DICT_REQUIRED;
-        }
-        if (UNLIKELY(zxc_dict_id(dict, dict_size, dict_huf) != header_dict_id)) {
-            zxc_cctx_free(&ctx);
+        if (UNLIKELY(!dict || dict_size == 0)) return ZXC_ERROR_DICT_REQUIRED;
+        if (UNLIKELY(zxc_dict_id(dict, dict_size, dict_huf) != header_dict_id))
             return ZXC_ERROR_DICT_MISMATCH;
-        }
-    }
-    if (UNLIKELY(zxc_cctx_attach_dict_huf(&ctx, dict_huf) != ZXC_OK)) {
-        // LCOV_EXCL_START
-        zxc_cctx_free(&ctx);
-        return ZXC_ERROR_CORRUPT_DATA;
-        // LCOV_EXCL_STOP
     }
 
     ip += ZXC_FILE_HEADER_SIZE;
 
     const size_t work_sz = runtime_chunk_size + ZXC_DECOMPRESS_TAIL_PAD;
 
+    // Carved on the first block that needs it: an archive storing nothing, and
+    // a no-destination probe of one, never reach that point, and half a
+    // megabyte is a lot to allocate for a 36-byte frame.
     // Dict decode buffer: [dict_content | decode_space + PAD], carved into the
     // cctx workspace (NULL when no dictionary is active).
-    uint8_t* const dict_dec = ctx.dict_buffer;
-    if (dict_dec) ZXC_MEMCPY(dict_dec, dict, dict_size);
+    int ctx_ready = 0;
+    uint8_t* dict_dec = NULL;
 
     // Block decompression loop
     uint32_t global_hash = 0;
@@ -873,7 +895,7 @@ static int64_t zxc_decompress_frame(const uint8_t* src, const size_t src_size, u
         zxc_block_header_t bh;
         // Read the block header to determine the compressed size
         if (UNLIKELY(zxc_read_block_header(ip, rem_src, &bh) != ZXC_OK)) {
-            zxc_cctx_free(&ctx);
+            if (ctx_ready) zxc_cctx_free(&ctx);
             return ZXC_ERROR_BAD_HEADER;
         }
 
@@ -881,14 +903,14 @@ static int64_t zxc_decompress_frame(const uint8_t* src, const size_t src_size, u
         if (UNLIKELY(bh.block_type == ZXC_BLOCK_EOF)) {
             // EOF carries no payload; a non-zero comp_size is a malformed header.
             if (UNLIKELY(bh.comp_size != 0)) {
-                zxc_cctx_free(&ctx);
+                if (ctx_ready) zxc_cctx_free(&ctx);
                 return ZXC_ERROR_BAD_HEADER;
             }
             // Footer is always the last ZXC_FILE_FOOTER_SIZE bytes of the source,
             // even when a seek table is inserted between EOF block and footer.
             // LCOV_EXCL_START
             if (UNLIKELY(src_size < ZXC_FILE_FOOTER_SIZE)) {
-                zxc_cctx_free(&ctx);
+                if (ctx_ready) zxc_cctx_free(&ctx);
                 return ZXC_ERROR_SRC_TOO_SMALL;
             }
             // LCOV_EXCL_STOP
@@ -897,7 +919,7 @@ static int64_t zxc_decompress_frame(const uint8_t* src, const size_t src_size, u
             // Validate source size matches what we decompressed
             const uint64_t stored_size = zxc_le64(footer);
             if (UNLIKELY(stored_size != (uint64_t)(op - op_start))) {
-                zxc_cctx_free(&ctx);
+                if (ctx_ready) zxc_cctx_free(&ctx);
                 return ZXC_ERROR_CORRUPT_DATA;
             }
 
@@ -905,11 +927,27 @@ static int64_t zxc_decompress_frame(const uint8_t* src, const size_t src_size, u
             if (checksum_enabled && file_has_checksums) {
                 const uint32_t stored_hash = zxc_le32(footer + sizeof(uint64_t));
                 if (UNLIKELY(stored_hash != global_hash)) {
-                    zxc_cctx_free(&ctx);
+                    if (ctx_ready) zxc_cctx_free(&ctx);
                     return ZXC_ERROR_BAD_CHECKSUM;
                 }
             }
             break;  // EOF reached, exit loop
+        }
+
+        if (!ctx_ready) {
+            if (UNLIKELY(zxc_cctx_init(&ctx, runtime_chunk_size, 0, 0,
+                                       file_has_checksums && checksum_enabled,
+                                       dict_size) != ZXC_OK))
+                return ZXC_ERROR_MEMORY;
+            ctx_ready = 1;
+            if (UNLIKELY(zxc_cctx_attach_dict_huf(&ctx, dict_huf) != ZXC_OK)) {
+                // LCOV_EXCL_START
+                zxc_cctx_free(&ctx);
+                return ZXC_ERROR_CORRUPT_DATA;
+                // LCOV_EXCL_STOP
+            }
+            dict_dec = ctx.dict_buffer;
+            if (dict_dec) ZXC_MEMCPY(dict_dec, dict, dict_size);
         }
 
         int res;
@@ -919,11 +957,10 @@ static int64_t zxc_decompress_frame(const uint8_t* src, const size_t src_size, u
             // copies that reference dict content resolve naturally.
             res = zxc_decompress_chunk_wrapper(&ctx, ip, rem_src, dict_dec + dict_size, work_sz);
             if (LIKELY(res > 0)) {
+                // A no-destination probe lands here too.
                 if (UNLIKELY((size_t)res > rem_cap)) {
-                    // LCOV_EXCL_START
-                    zxc_cctx_free(&ctx);
+                    if (ctx_ready) zxc_cctx_free(&ctx);
                     return ZXC_ERROR_DST_TOO_SMALL;
-                    // LCOV_EXCL_STOP
                 }
                 ZXC_MEMCPY(op, dict_dec + dict_size, (size_t)res);
             }
@@ -934,17 +971,16 @@ static int64_t zxc_decompress_frame(const uint8_t* src, const size_t src_size, u
             // Safe path: decode into bounce buffer, then copy exact result.
             res = zxc_decompress_chunk_wrapper(&ctx, ip, rem_src, ctx.work_buf, ctx.work_buf_cap);
             if (LIKELY(res > 0)) {
-                // LCOV_EXCL_START
+                // A no-destination probe lands here too.
                 if (UNLIKELY((size_t)res > rem_cap)) {
-                    zxc_cctx_free(&ctx);
+                    if (ctx_ready) zxc_cctx_free(&ctx);
                     return ZXC_ERROR_DST_TOO_SMALL;
                 }
-                // LCOV_EXCL_STOP
                 ZXC_MEMCPY(op, ctx.work_buf, (size_t)res);
             }
         }
         if (UNLIKELY(res < 0)) {
-            zxc_cctx_free(&ctx);
+            if (ctx_ready) zxc_cctx_free(&ctx);
             return res;
         }
 
@@ -959,7 +995,7 @@ static int64_t zxc_decompress_frame(const uint8_t* src, const size_t src_size, u
         op += res;
     }
 
-    zxc_cctx_free(&ctx);
+    if (ctx_ready) zxc_cctx_free(&ctx);
     return (int64_t)(op - op_start);
 }
 
@@ -1279,15 +1315,17 @@ int64_t zxc_compress_cctx(zxc_cctx* cctx, const void* RESTRICT src, const size_t
         dict_size > 0 ? zxc_block_size_ceil(dict_size + block_size) : block_size;
     const uint32_t did = (dict && dict_size > 0) ? zxc_dict_id(dict, dict_size, dict_huf) : 0;
 
-    // An empty source encodes no block: leave the workspace alone rather than
-    // carve megabytes for a 36-byte frame. The sticky settings above still hold.
-    const int empty_frame = (src_size == 0);
+    // The sticky settings above are already stored, so an empty source is done:
+    // same writer as the one-shot, and the workspace is left alone.
+    if (UNLIKELY(src_size == 0))
+        return zxc_write_empty_frame((uint8_t*)dst, dst_capacity, block_size, checksum_enabled,
+                                     did);
 
     // Re-init when the chunk changed, a level raise needs the optimal-parser
     // scratch, or a dictionary arrives on a context carved without its prefix.
-    if (!empty_frame && UNLIKELY(!cctx->initialized || cctx->last_block_size != eff_chunk ||
-                                 (level >= ZXC_LEVEL_DENSITY && !cctx->inner.opt_scratch) ||
-                                 (dict_size > 0 && !cctx->inner.dict_buffer))) {
+    if (UNLIKELY(!cctx->initialized || cctx->last_block_size != eff_chunk ||
+                 (level >= ZXC_LEVEL_DENSITY && !cctx->inner.opt_scratch) ||
+                 (dict_size > 0 && !cctx->inner.dict_buffer))) {
         if (cctx->initialized) {
             zxc_cctx_free(&cctx->inner);
             cctx->initialized = 0;
@@ -1307,17 +1345,14 @@ int64_t zxc_compress_cctx(zxc_cctx* cctx, const void* RESTRICT src, const size_t
     }
 
     zxc_cctx_t* const ctx = &cctx->inner;
-    uint8_t* dict_input = NULL;
-    if (!empty_frame) {
-        ctx->dict_size = dict_size;
-        if (UNLIKELY(zxc_ctx_sync_dict_huf(ctx, cctx->huf_cache, &cctx->huf_cached, dict_huf) !=
-                     ZXC_OK))
-            return ZXC_ERROR_CORRUPT_DATA;
+    ctx->dict_size = dict_size;
+    if (UNLIKELY(zxc_ctx_sync_dict_huf(ctx, cctx->huf_cache, &cctx->huf_cached, dict_huf) !=
+                 ZXC_OK))
+        return ZXC_ERROR_CORRUPT_DATA;
 
-        // [dict | block] input for the encoder, NULL without a dictionary.
-        dict_input = dict_size > 0 ? ctx->dict_buffer : NULL;
-        if (dict_input) ZXC_MEMCPY(dict_input, dict, dict_size);
-    }
+    // [dict | block] input for the encoder, NULL without a dictionary.
+    uint8_t* const dict_input = dict_size > 0 ? ctx->dict_buffer : NULL;
+    if (dict_input) ZXC_MEMCPY(dict_input, dict, dict_size);
 
     uint8_t* op = (uint8_t*)dst;
     const uint8_t* const op_start = op;
@@ -1414,6 +1449,27 @@ void zxc_free_dctx(zxc_dctx* dctx) {
 }
 
 /**
+ * @brief Answers a no-destination decode on a reusable context.
+ *
+ * This context's own rules come first: one that could never decode the archive
+ * has to say why, not "give me a buffer". The answer then comes from the shared
+ * probe, which walks a private workspace, so a read-only query leaves the
+ * buffers this context has carved untouched.
+ */
+static int64_t zxc_dctx_probe(const zxc_dctx* dctx, const uint8_t* RESTRICT src,
+                              const size_t src_size, const zxc_decompress_opts_t* opts) {
+    size_t chunk_size = 0;
+    uint32_t header_dict_id = 0;
+    const int hrc = zxc_read_file_header(src, src_size, &chunk_size, NULL, &header_dict_id);
+    if (UNLIKELY(hrc != ZXC_OK)) return hrc;
+    if (UNLIKELY(dctx->owns_workspace && chunk_size != dctx->last_block_size))
+        return ZXC_ERROR_BAD_BLOCK_SIZE;
+    if (UNLIKELY(dctx->owns_workspace && (header_dict_id != 0 || ZXC_OPTS_DICT_SIZE(opts) != 0)))
+        return ZXC_ERROR_DICT_UNSUPPORTED;
+    return zxc_probe_without_dst(src, src_size, opts);
+}
+
+/**
  * @brief Decompresses a framed archive into @p dst, reusing @p dctx.
  *
  * Public API; full contract in @c zxc_buffer.h. Same frame walk and dictionary
@@ -1426,19 +1482,7 @@ int64_t zxc_decompress_dctx(zxc_dctx* dctx, const void* RESTRICT src, const size
     if (UNLIKELY(!dctx || !src || (!dst && dst_capacity != 0))) return ZXC_ERROR_NULL_INPUT;
     if (UNLIKELY(src_size < ZXC_FILE_HEADER_SIZE + ZXC_FILE_FOOTER_SIZE))
         return ZXC_ERROR_SRC_TOO_SMALL;
-
-    // No destination: turn away anything with a payload, then walk the rest on
-    // a stand-in buffer rather than short-circuit, so a probe answers under
-    // this context's own rules (pinned block size, no dictionary).
-    uint8_t probe_dst[1];
-    uint8_t* out_buf = (uint8_t*)dst;
-    size_t out_cap = dst_capacity;
-    if (UNLIKELY(!dst || dst_capacity == 0)) {
-        const int prc = zxc_probe_reject_payload(src, src_size);
-        if (UNLIKELY(prc != ZXC_OK)) return prc;
-        out_buf = probe_dst;
-        out_cap = 0;
-    }
+    if (UNLIKELY(!dst || dst_capacity == 0)) return zxc_dctx_probe(dctx, src, src_size, opts);
 
     const int checksum_enabled = opts ? opts->checksum_enabled : 0;
     const uint8_t* dict = opts ? (const uint8_t*)opts->dict : NULL;
@@ -1449,9 +1493,9 @@ int64_t zxc_decompress_dctx(zxc_dctx* dctx, const void* RESTRICT src, const size
 
     const uint8_t* ip = (const uint8_t*)src;
     const uint8_t* const ip_end = ip + src_size;
-    uint8_t* op = out_buf;
+    uint8_t* op = (uint8_t*)dst;
     const uint8_t* const op_start = op;
-    const uint8_t* const op_end = op + out_cap;
+    const uint8_t* const op_end = op + dst_capacity;
     size_t runtime_chunk_size = 0;
     int file_has_checksums = 0;
     uint32_t header_dict_id = 0;
@@ -1522,10 +1566,9 @@ int64_t zxc_decompress_dctx(zxc_dctx* dctx, const void* RESTRICT src, const size
 
         if (UNLIKELY(bh.block_type == ZXC_BLOCK_EOF)) {
             if (UNLIKELY(bh.comp_size != 0)) return ZXC_ERROR_BAD_HEADER;
-            if (UNLIKELY(rem_src < ZXC_BLOCK_HEADER_SIZE + ZXC_FILE_FOOTER_SIZE))
-                return ZXC_ERROR_SRC_TOO_SMALL;
-
-            const uint8_t* const footer = ip + ZXC_BLOCK_HEADER_SIZE;
+            // Same rule as zxc_decompress(): the footer is the archive's last
+            // bytes, even when a seek table sits between the EOF block and it.
+            const uint8_t* const footer = (const uint8_t*)src + src_size - ZXC_FILE_FOOTER_SIZE;
             const uint64_t stored_size = zxc_le64(footer);
             if (UNLIKELY(stored_size != (uint64_t)(op - op_start))) return ZXC_ERROR_CORRUPT_DATA;
 

--- a/src/lib/zxc_dispatch.c
+++ b/src/lib/zxc_dispatch.c
@@ -820,6 +820,8 @@ static int zxc_probe_reject_payload(const uint8_t* RESTRICT src, const size_t sr
  */
 static int64_t zxc_probe_without_dst(const uint8_t* RESTRICT src, const size_t src_size,
                                      const zxc_decompress_opts_t* opts) {
+    if (UNLIKELY(ZXC_OPTS_DICT_SIZE(opts) > ZXC_DICT_SIZE_MAX)) return ZXC_ERROR_DICT_TOO_LARGE;
+
     const int rc = zxc_probe_reject_payload(src, src_size);
     if (UNLIKELY(rc != ZXC_OK)) return rc;
     uint8_t probe_dst[1];
@@ -1458,13 +1460,16 @@ void zxc_free_dctx(zxc_dctx* dctx) {
  */
 static int64_t zxc_dctx_probe(const zxc_dctx* dctx, const uint8_t* RESTRICT src,
                               const size_t src_size, const zxc_decompress_opts_t* opts) {
+    const size_t dict_size = ZXC_OPTS_DICT_SIZE(opts);
+    if (UNLIKELY(dict_size > ZXC_DICT_SIZE_MAX)) return ZXC_ERROR_DICT_TOO_LARGE;
+
     size_t chunk_size = 0;
     uint32_t header_dict_id = 0;
     const int hrc = zxc_read_file_header(src, src_size, &chunk_size, NULL, &header_dict_id);
     if (UNLIKELY(hrc != ZXC_OK)) return hrc;
     if (UNLIKELY(dctx->owns_workspace && chunk_size != dctx->last_block_size))
         return ZXC_ERROR_BAD_BLOCK_SIZE;
-    if (UNLIKELY(dctx->owns_workspace && (header_dict_id != 0 || ZXC_OPTS_DICT_SIZE(opts) != 0)))
+    if (UNLIKELY(dctx->owns_workspace && (header_dict_id != 0 || dict_size != 0)))
         return ZXC_ERROR_DICT_UNSUPPORTED;
     return zxc_probe_without_dst(src, src_size, opts);
 }

--- a/src/lib/zxc_dispatch.c
+++ b/src/lib/zxc_dispatch.c
@@ -743,6 +743,7 @@ static int zxc_footer_dsize_plausible(const uint64_t dsize, const size_t chunk_s
 static int zxc_read_frame_envelope(const uint8_t* RESTRICT src, const size_t src_size,
                                    uint64_t* RESTRICT dsize, size_t* RESTRICT chunk_size,
                                    int* RESTRICT has_cs) {
+    if (UNLIKELY(!src)) return ZXC_ERROR_NULL_INPUT;
     if (UNLIKELY(src_size < ZXC_FILE_HEADER_SIZE + ZXC_FILE_FOOTER_SIZE))
         return ZXC_ERROR_SRC_TOO_SMALL;
 
@@ -762,26 +763,35 @@ static int zxc_read_frame_envelope(const uint8_t* RESTRICT src, const size_t src
 }
 
 /**
- * @brief Answers a decode request that carries no destination.
+ * @brief Turns away a no-destination decode that cannot possibly succeed.
  *
- * Only an archive that stores nothing can succeed without a buffer, so the frame
- * is checked as far as reading allows: file header, stored size, and the EOF
- * block that has to sit right behind the header.
+ * Only an archive that stores nothing can succeed without a buffer. Refusing
+ * the rest here spares the frame walk a workspace carved only to refuse; what
+ * survives goes on to that walk, the sole place the EOF payload size, the
+ * dictionary binding and the global checksum are checked.
+ *
+ * @return @ref ZXC_OK to keep walking, or the code to hand back.
  */
-static int64_t zxc_probe_without_dst(const uint8_t* RESTRICT src, const size_t src_size) {
+static int zxc_probe_reject_payload(const uint8_t* RESTRICT src, const size_t src_size) {
     uint64_t dsize = 0;
     const int rc = zxc_read_frame_envelope(src, src_size, &dsize, NULL, NULL);
     if (UNLIKELY(rc != ZXC_OK)) return rc;
-    if (UNLIKELY(dsize != 0)) return ZXC_ERROR_DST_TOO_SMALL;
+    return (dsize != 0) ? ZXC_ERROR_DST_TOO_SMALL : ZXC_OK;
+}
 
-    if (UNLIKELY(src_size < ZXC_FILE_HEADER_SIZE + ZXC_BLOCK_HEADER_SIZE + ZXC_FILE_FOOTER_SIZE))
-        return ZXC_ERROR_SRC_TOO_SMALL;
-    zxc_block_header_t bh;
-    if (UNLIKELY(zxc_read_block_header(src + ZXC_FILE_HEADER_SIZE, src_size - ZXC_FILE_HEADER_SIZE,
-                                       &bh) != ZXC_OK ||
-                 bh.block_type != ZXC_BLOCK_EOF))
-        return ZXC_ERROR_CORRUPT_DATA;
-    return 0;
+/**
+ * @brief Answers a decode request that carries no destination.
+ *
+ * Walks the surviving frame for real on a stand-in buffer, so the verdict is
+ * the one a caller with a destination would have got, by construction rather
+ * than by keeping a second copy of the checks in step.
+ */
+static int64_t zxc_probe_without_dst(const uint8_t* RESTRICT src, const size_t src_size,
+                                     const zxc_decompress_opts_t* opts) {
+    const int rc = zxc_probe_reject_payload(src, src_size);
+    if (UNLIKELY(rc != ZXC_OK)) return rc;
+    uint8_t probe_dst[1];
+    return zxc_decompress_frame(src, src_size, probe_dst, 0, opts);
 }
 
 /**
@@ -797,7 +807,7 @@ int64_t zxc_decompress(const void* RESTRICT src, const size_t src_size, void* RE
     if (UNLIKELY(src_size < ZXC_FILE_HEADER_SIZE + ZXC_FILE_FOOTER_SIZE))
         return ZXC_ERROR_SRC_TOO_SMALL;
 
-    if (UNLIKELY(!dst || dst_capacity == 0)) return zxc_probe_without_dst(src, src_size);
+    if (UNLIKELY(!dst || dst_capacity == 0)) return zxc_probe_without_dst(src, src_size, opts);
 
     return zxc_decompress_frame((const uint8_t*)src, src_size, (uint8_t*)dst, dst_capacity, opts);
 }
@@ -1413,10 +1423,22 @@ void zxc_free_dctx(zxc_dctx* dctx) {
 int64_t zxc_decompress_dctx(zxc_dctx* dctx, const void* RESTRICT src, const size_t src_size,
                             void* RESTRICT dst, const size_t dst_capacity,
                             const zxc_decompress_opts_t* opts) {
-    if (UNLIKELY(!dctx || !src)) return ZXC_ERROR_NULL_INPUT;
+    if (UNLIKELY(!dctx || !src || (!dst && dst_capacity != 0))) return ZXC_ERROR_NULL_INPUT;
     if (UNLIKELY(src_size < ZXC_FILE_HEADER_SIZE + ZXC_FILE_FOOTER_SIZE))
         return ZXC_ERROR_SRC_TOO_SMALL;
-    if (UNLIKELY(!dst || dst_capacity == 0)) return zxc_probe_without_dst(src, src_size);
+
+    // No destination: turn away anything with a payload, then walk the rest on
+    // a stand-in buffer rather than short-circuit, so a probe answers under
+    // this context's own rules (pinned block size, no dictionary).
+    uint8_t probe_dst[1];
+    uint8_t* out_buf = (uint8_t*)dst;
+    size_t out_cap = dst_capacity;
+    if (UNLIKELY(!dst || dst_capacity == 0)) {
+        const int prc = zxc_probe_reject_payload(src, src_size);
+        if (UNLIKELY(prc != ZXC_OK)) return prc;
+        out_buf = probe_dst;
+        out_cap = 0;
+    }
 
     const int checksum_enabled = opts ? opts->checksum_enabled : 0;
     const uint8_t* dict = opts ? (const uint8_t*)opts->dict : NULL;
@@ -1427,9 +1449,9 @@ int64_t zxc_decompress_dctx(zxc_dctx* dctx, const void* RESTRICT src, const size
 
     const uint8_t* ip = (const uint8_t*)src;
     const uint8_t* const ip_end = ip + src_size;
-    uint8_t* op = (uint8_t*)dst;
+    uint8_t* op = out_buf;
     const uint8_t* const op_start = op;
-    const uint8_t* const op_end = op + dst_capacity;
+    const uint8_t* const op_end = op + out_cap;
     size_t runtime_chunk_size = 0;
     int file_has_checksums = 0;
     uint32_t header_dict_id = 0;

--- a/src/lib/zxc_dispatch.c
+++ b/src/lib/zxc_dispatch.c
@@ -820,8 +820,6 @@ static int zxc_probe_reject_payload(const uint8_t* RESTRICT src, const size_t sr
  */
 static int64_t zxc_probe_without_dst(const uint8_t* RESTRICT src, const size_t src_size,
                                      const zxc_decompress_opts_t* opts) {
-    if (UNLIKELY(ZXC_OPTS_DICT_SIZE(opts) > ZXC_DICT_SIZE_MAX)) return ZXC_ERROR_DICT_TOO_LARGE;
-
     const int rc = zxc_probe_reject_payload(src, src_size);
     if (UNLIKELY(rc != ZXC_OK)) return rc;
     uint8_t probe_dst[1];
@@ -838,6 +836,7 @@ static int64_t zxc_probe_without_dst(const uint8_t* RESTRICT src, const size_t s
 int64_t zxc_decompress(const void* RESTRICT src, const size_t src_size, void* RESTRICT dst,
                        const size_t dst_capacity, const zxc_decompress_opts_t* opts) {
     if (UNLIKELY(!src || (!dst && dst_capacity != 0))) return ZXC_ERROR_NULL_INPUT;
+    if (UNLIKELY(ZXC_OPTS_DICT_SIZE(opts) > ZXC_DICT_SIZE_MAX)) return ZXC_ERROR_DICT_TOO_LARGE;
     if (UNLIKELY(src_size < ZXC_FILE_HEADER_SIZE + ZXC_FILE_FOOTER_SIZE))
         return ZXC_ERROR_SRC_TOO_SMALL;
 
@@ -1461,8 +1460,6 @@ void zxc_free_dctx(zxc_dctx* dctx) {
 static int64_t zxc_dctx_probe(const zxc_dctx* dctx, const uint8_t* RESTRICT src,
                               const size_t src_size, const zxc_decompress_opts_t* opts) {
     const size_t dict_size = ZXC_OPTS_DICT_SIZE(opts);
-    if (UNLIKELY(dict_size > ZXC_DICT_SIZE_MAX)) return ZXC_ERROR_DICT_TOO_LARGE;
-
     size_t chunk_size = 0;
     uint32_t header_dict_id = 0;
     const int hrc = zxc_read_file_header(src, src_size, &chunk_size, NULL, &header_dict_id);
@@ -1485,6 +1482,7 @@ int64_t zxc_decompress_dctx(zxc_dctx* dctx, const void* RESTRICT src, const size
                             void* RESTRICT dst, const size_t dst_capacity,
                             const zxc_decompress_opts_t* opts) {
     if (UNLIKELY(!dctx || !src || (!dst && dst_capacity != 0))) return ZXC_ERROR_NULL_INPUT;
+    if (UNLIKELY(ZXC_OPTS_DICT_SIZE(opts) > ZXC_DICT_SIZE_MAX)) return ZXC_ERROR_DICT_TOO_LARGE;
     if (UNLIKELY(src_size < ZXC_FILE_HEADER_SIZE + ZXC_FILE_FOOTER_SIZE))
         return ZXC_ERROR_SRC_TOO_SMALL;
     if (UNLIKELY(!dst || dst_capacity == 0)) return zxc_dctx_probe(dctx, src, src_size, opts);
@@ -1493,8 +1491,6 @@ int64_t zxc_decompress_dctx(zxc_dctx* dctx, const void* RESTRICT src, const size
     const uint8_t* dict = opts ? (const uint8_t*)opts->dict : NULL;
     const size_t dict_size = ZXC_OPTS_DICT_SIZE(opts);
     const uint8_t* dict_huf = ZXC_OPTS_DICT_HUF(opts);
-
-    if (UNLIKELY(dict_size > ZXC_DICT_SIZE_MAX)) return ZXC_ERROR_DICT_TOO_LARGE;
 
     const uint8_t* ip = (const uint8_t*)src;
     const uint8_t* const ip_end = ip + src_size;

--- a/src/lib/zxc_dispatch.c
+++ b/src/lib/zxc_dispatch.c
@@ -1371,9 +1371,11 @@ int64_t zxc_decompress_dctx(zxc_dctx* dctx, const void* RESTRICT src, const size
     if (UNLIKELY(!dctx || !src)) return ZXC_ERROR_NULL_INPUT;
     if (UNLIKELY(src_size < ZXC_FILE_HEADER_SIZE + ZXC_FILE_FOOTER_SIZE))
         return ZXC_ERROR_SRC_TOO_SMALL;
+    if (UNLIKELY(zxc_le32(src) != ZXC_MAGIC_WORD)) return ZXC_ERROR_BAD_MAGIC;
 
+    // No destination: only an archive that stores nothing can be reported as
+    // decoded, as zxc_decompress() does.
     if (UNLIKELY(!dst || dst_capacity == 0)) {
-        if (UNLIKELY(zxc_le32(src) != ZXC_MAGIC_WORD)) return ZXC_ERROR_BAD_MAGIC;
         const uint8_t* footer = (const uint8_t*)src + src_size - ZXC_FILE_FOOTER_SIZE;
         return (zxc_le64(footer) == 0) ? 0 : (int64_t)ZXC_ERROR_DST_TOO_SMALL;
     }
@@ -1395,9 +1397,9 @@ int64_t zxc_decompress_dctx(zxc_dctx* dctx, const void* RESTRICT src, const size
     uint32_t header_dict_id = 0;
     uint32_t global_hash = 0;
 
-    if (UNLIKELY(zxc_read_file_header(ip, src_size, &runtime_chunk_size, &file_has_checksums,
-                                      &header_dict_id) != ZXC_OK))
-        return ZXC_ERROR_BAD_HEADER;
+    const int hrc = zxc_read_file_header(ip, src_size, &runtime_chunk_size, &file_has_checksums,
+                                         &header_dict_id);
+    if (UNLIKELY(hrc != ZXC_OK)) return hrc;
 
     // Static dctx: block_size is locked at workspace init; reject any
     // archive whose declared block_size would require a re-partition.

--- a/src/lib/zxc_dispatch.c
+++ b/src/lib/zxc_dispatch.c
@@ -1185,14 +1185,15 @@ void zxc_free_cctx(zxc_cctx* cctx) {
  * @brief Compresses data using a reusable context.
  *
  * Public API; full contract in @c zxc_buffer.h. Same frame walk and dictionary
- * binding as zxc_compress(); buffers re-carved only when [dict | block] or the
- * parser tier changes, shared table rebuilt only when it changes.
+ * binding as zxc_compress(), empty source included; buffers re-carved only when
+ * [dict | block] or the parser tier changes, shared table rebuilt only when it
+ * changes.
  */
 int64_t zxc_compress_cctx(zxc_cctx* cctx, const void* RESTRICT src, const size_t src_size,
                           void* RESTRICT dst, const size_t dst_capacity,
                           const zxc_compress_opts_t* opts) {
     if (UNLIKELY(!cctx)) return ZXC_ERROR_NULL_INPUT;
-    if (UNLIKELY(!src || !dst || src_size == 0 || dst_capacity == 0)) return ZXC_ERROR_NULL_INPUT;
+    if (UNLIKELY(!dst || dst_capacity == 0 || (src_size > 0 && !src))) return ZXC_ERROR_NULL_INPUT;
 
     const int checksum_enabled = opts ? opts->checksum_enabled : cctx->stored_checksum;
     const int level = ZXC_OPTS_LEVEL(opts, cctx->stored_level);

--- a/src/lib/zxc_dispatch.c
+++ b/src/lib/zxc_dispatch.c
@@ -1224,11 +1224,15 @@ int64_t zxc_compress_cctx(zxc_cctx* cctx, const void* RESTRICT src, const size_t
         dict_size > 0 ? zxc_block_size_ceil(dict_size + block_size) : block_size;
     const uint32_t did = (dict && dict_size > 0) ? zxc_dict_id(dict, dict_size, dict_huf) : 0;
 
+    // An empty source encodes no block: leave the workspace alone rather than
+    // carve megabytes for a 36-byte frame. The sticky settings above still hold.
+    const int empty_frame = (src_size == 0);
+
     // Re-init when the chunk changed, a level raise needs the optimal-parser
     // scratch, or a dictionary arrives on a context carved without its prefix.
-    if (UNLIKELY(!cctx->initialized || cctx->last_block_size != eff_chunk ||
-                 (level >= ZXC_LEVEL_DENSITY && !cctx->inner.opt_scratch) ||
-                 (dict_size > 0 && !cctx->inner.dict_buffer))) {
+    if (!empty_frame && UNLIKELY(!cctx->initialized || cctx->last_block_size != eff_chunk ||
+                                 (level >= ZXC_LEVEL_DENSITY && !cctx->inner.opt_scratch) ||
+                                 (dict_size > 0 && !cctx->inner.dict_buffer))) {
         if (cctx->initialized) {
             zxc_cctx_free(&cctx->inner);
             cctx->initialized = 0;
@@ -1240,7 +1244,7 @@ int64_t zxc_compress_cctx(zxc_cctx* cctx, const void* RESTRICT src, const size_t
         // LCOV_EXCL_STOP
         cctx->last_block_size = eff_chunk;
         cctx->initialized = 1;
-        cctx->huf_cached = 0; /* attach state died with inner */
+        cctx->huf_cached = 0;
     } else {
         // Same chunk: update level + checksum without realloc.
         cctx->inner.compression_level = level;
@@ -1248,14 +1252,17 @@ int64_t zxc_compress_cctx(zxc_cctx* cctx, const void* RESTRICT src, const size_t
     }
 
     zxc_cctx_t* const ctx = &cctx->inner;
-    ctx->dict_size = dict_size;
-    if (UNLIKELY(zxc_ctx_sync_dict_huf(ctx, cctx->huf_cache, &cctx->huf_cached, dict_huf) !=
-                 ZXC_OK))
-        return ZXC_ERROR_CORRUPT_DATA;
+    uint8_t* dict_input = NULL;
+    if (!empty_frame) {
+        ctx->dict_size = dict_size;
+        if (UNLIKELY(zxc_ctx_sync_dict_huf(ctx, cctx->huf_cache, &cctx->huf_cached, dict_huf) !=
+                     ZXC_OK))
+            return ZXC_ERROR_CORRUPT_DATA;
 
-    // [dict | block] input for the encoder, NULL without a dictionary.
-    uint8_t* const dict_input = dict_size > 0 ? ctx->dict_buffer : NULL;
-    if (dict_input) ZXC_MEMCPY(dict_input, dict, dict_size);
+        // [dict | block] input for the encoder, NULL without a dictionary.
+        dict_input = dict_size > 0 ? ctx->dict_buffer : NULL;
+        if (dict_input) ZXC_MEMCPY(dict_input, dict, dict_size);
+    }
 
     uint8_t* op = (uint8_t*)dst;
     const uint8_t* const op_start = op;
@@ -1361,8 +1368,15 @@ void zxc_free_dctx(zxc_dctx* dctx) {
 int64_t zxc_decompress_dctx(zxc_dctx* dctx, const void* RESTRICT src, const size_t src_size,
                             void* RESTRICT dst, const size_t dst_capacity,
                             const zxc_decompress_opts_t* opts) {
-    if (UNLIKELY(!dctx || !src || !dst || src_size < ZXC_FILE_HEADER_SIZE))
-        return ZXC_ERROR_NULL_INPUT;
+    if (UNLIKELY(!dctx || !src)) return ZXC_ERROR_NULL_INPUT;
+    if (UNLIKELY(src_size < ZXC_FILE_HEADER_SIZE + ZXC_FILE_FOOTER_SIZE))
+        return ZXC_ERROR_SRC_TOO_SMALL;
+
+    if (UNLIKELY(!dst || dst_capacity == 0)) {
+        if (UNLIKELY(zxc_le32(src) != ZXC_MAGIC_WORD)) return ZXC_ERROR_BAD_MAGIC;
+        const uint8_t* footer = (const uint8_t*)src + src_size - ZXC_FILE_FOOTER_SIZE;
+        return (zxc_le64(footer) == 0) ? 0 : (int64_t)ZXC_ERROR_DST_TOO_SMALL;
+    }
 
     const int checksum_enabled = opts ? opts->checksum_enabled : 0;
     const uint8_t* dict = opts ? (const uint8_t*)opts->dict : NULL;
@@ -1416,7 +1430,7 @@ int64_t zxc_decompress_dctx(zxc_dctx* dctx, const void* RESTRICT src, const size
         dctx->last_block_size = runtime_chunk_size;
         dctx->last_dict_size = dict_size;
         dctx->initialized = 1;
-        dctx->huf_cached = 0; /* attach state died with inner */
+        dctx->huf_cached = 0;
     } else {
         dctx->inner.checksum_enabled = file_has_checksums && checksum_enabled;
     }
@@ -1573,7 +1587,7 @@ int64_t zxc_compress_block(zxc_cctx* cctx, const void* RESTRICT src, const size_
         // LCOV_EXCL_STOP
         cctx->last_block_size = effective_block_size;
         cctx->initialized = 1;
-        cctx->huf_cached = 0; /* attach state died with inner */
+        cctx->huf_cached = 0;
     } else {
         cctx->inner.compression_level = level;
         cctx->inner.checksum_enabled = checksum_enabled;

--- a/src/lib/zxc_dispatch.c
+++ b/src/lib/zxc_dispatch.c
@@ -702,6 +702,89 @@ static int64_t zxc_decompress_frame(const uint8_t* src, size_t src_size, uint8_t
                                     size_t dst_capacity, const zxc_decompress_opts_t* opts);
 
 /**
+ * @brief Whether a footer's decompressed size is reachable for this archive.
+ *
+ * The footer is untrusted and its size becomes the caller's allocation, so it is
+ * capped by what the archive could physically hold: every block costs at least
+ * @ref ZXC_BLOCK_HEADER_SIZE compressed bytes and decodes to at most one block
+ * size. The cap also keeps @ref zxc_inplace_margin's block count from
+ * overflowing. Reached only through @ref zxc_read_frame_envelope, so no reader
+ * can skip it.
+ *
+ * Division rather than the usual ceil, which would wrap near @c UINT64_MAX.
+ *
+ * @param[in] dsize      Decompressed size read from the footer.
+ * @param[in] chunk_size Block size from the file header; never 0 after a
+ *                       @ref ZXC_OK from @ref zxc_read_file_header.
+ * @param[in] comp_size  Size of the whole archive in bytes.
+ * @return 1 when @p dsize is reachable, 0 for a forged footer.
+ */
+static int zxc_footer_dsize_plausible(const uint64_t dsize, const size_t chunk_size,
+                                      const size_t comp_size) {
+    const uint64_t blocks_needed =
+        dsize / (uint64_t)chunk_size + (dsize % (uint64_t)chunk_size != 0);
+    return blocks_needed <= (uint64_t)(comp_size / ZXC_BLOCK_HEADER_SIZE);
+}
+
+/**
+ * @brief Validates a frame envelope without decoding it: file header, then the
+ *        decompressed size stored in the footer.
+ *
+ * What every reader must clear before trusting an archive; each caller adds its
+ * own policy: what to do with the size, which codes to surface.
+ *
+ * @param[in]  src        Archive bytes.
+ * @param[in]  src_size   Archive size in bytes.
+ * @param[out] dsize      Stored decompressed size.
+ * @param[out] chunk_size Block size declared by the header, or NULL.
+ * @param[out] has_cs     Set when the archive carries checksums, or NULL.
+ * @return @ref ZXC_OK, or a negative @ref zxc_error_t.
+ */
+static int zxc_read_frame_envelope(const uint8_t* RESTRICT src, const size_t src_size,
+                                   uint64_t* RESTRICT dsize, size_t* RESTRICT chunk_size,
+                                   int* RESTRICT has_cs) {
+    if (UNLIKELY(src_size < ZXC_FILE_HEADER_SIZE + ZXC_FILE_FOOTER_SIZE))
+        return ZXC_ERROR_SRC_TOO_SMALL;
+
+    size_t chunk = 0;
+    int cs = 0;
+    const int hrc = zxc_read_file_header(src, src_size, &chunk, &cs, NULL);
+    if (UNLIKELY(hrc != ZXC_OK)) return hrc;
+
+    const uint64_t stored = zxc_le64(src + src_size - ZXC_FILE_FOOTER_SIZE);
+    if (UNLIKELY(!zxc_footer_dsize_plausible(stored, chunk, src_size)))
+        return ZXC_ERROR_CORRUPT_DATA;
+
+    *dsize = stored;
+    if (chunk_size) *chunk_size = chunk;
+    if (has_cs) *has_cs = cs;
+    return ZXC_OK;
+}
+
+/**
+ * @brief Answers a decode request that carries no destination.
+ *
+ * Only an archive that stores nothing can succeed without a buffer, so the frame
+ * is checked as far as reading allows: file header, stored size, and the EOF
+ * block that has to sit right behind the header.
+ */
+static int64_t zxc_probe_without_dst(const uint8_t* RESTRICT src, const size_t src_size) {
+    uint64_t dsize = 0;
+    const int rc = zxc_read_frame_envelope(src, src_size, &dsize, NULL, NULL);
+    if (UNLIKELY(rc != ZXC_OK)) return rc;
+    if (UNLIKELY(dsize != 0)) return ZXC_ERROR_DST_TOO_SMALL;
+
+    if (UNLIKELY(src_size < ZXC_FILE_HEADER_SIZE + ZXC_BLOCK_HEADER_SIZE + ZXC_FILE_FOOTER_SIZE))
+        return ZXC_ERROR_SRC_TOO_SMALL;
+    zxc_block_header_t bh;
+    if (UNLIKELY(zxc_read_block_header(src + ZXC_FILE_HEADER_SIZE, src_size - ZXC_FILE_HEADER_SIZE,
+                                       &bh) != ZXC_OK ||
+                 bh.block_type != ZXC_BLOCK_EOF))
+        return ZXC_ERROR_CORRUPT_DATA;
+    return 0;
+}
+
+/**
  * @brief Decompresses an entire buffer in one call.
  *
  * Validates the file header and footer, loops over compressed blocks,
@@ -714,12 +797,7 @@ int64_t zxc_decompress(const void* RESTRICT src, const size_t src_size, void* RE
     if (UNLIKELY(src_size < ZXC_FILE_HEADER_SIZE + ZXC_FILE_FOOTER_SIZE))
         return ZXC_ERROR_SRC_TOO_SMALL;
 
-    if (UNLIKELY(!dst || dst_capacity == 0)) {
-        // Empty-frame case (stored size == 0).
-        if (UNLIKELY(zxc_le32(src) != ZXC_MAGIC_WORD)) return ZXC_ERROR_BAD_MAGIC;
-        const uint8_t* footer = (const uint8_t*)src + src_size - ZXC_FILE_FOOTER_SIZE;
-        return (zxc_le64(footer) == 0) ? 0 : (int64_t)ZXC_ERROR_DST_TOO_SMALL;
-    }
+    if (UNLIKELY(!dst || dst_capacity == 0)) return zxc_probe_without_dst(src, src_size);
 
     return zxc_decompress_frame((const uint8_t*)src, src_size, (uint8_t*)dst, dst_capacity, opts);
 }
@@ -876,31 +954,6 @@ static int64_t zxc_decompress_frame(const uint8_t* src, const size_t src_size, u
 }
 
 /**
- * @brief Whether a footer's decompressed size is reachable for this archive.
- *
- * The footer is untrusted and its size becomes the caller's allocation, so it is
- * capped by what the archive could physically hold: every block costs at least
- * @ref ZXC_BLOCK_HEADER_SIZE compressed bytes and decodes to at most one block
- * size. The cap also keeps @ref zxc_inplace_margin's block count from
- * overflowing. Shared with @ref zxc_get_decompressed_size so the two readers
- * cannot drift apart.
- *
- * Division rather than the usual ceil, which would wrap near @c UINT64_MAX.
- *
- * @param[in] dsize      Decompressed size read from the footer.
- * @param[in] chunk_size Block size from the file header; never 0 after a
- *                       @ref ZXC_OK from @ref zxc_read_file_header.
- * @param[in] comp_size  Size of the whole archive in bytes.
- * @return 1 when @p dsize is reachable, 0 for a forged footer.
- */
-static int zxc_footer_dsize_plausible(const uint64_t dsize, const size_t chunk_size,
-                                      const size_t comp_size) {
-    const uint64_t blocks_needed =
-        dsize / (uint64_t)chunk_size + (dsize % (uint64_t)chunk_size != 0);
-    return blocks_needed <= (uint64_t)(comp_size / ZXC_BLOCK_HEADER_SIZE);
-}
-
-/**
  * @brief Bytes an in-place decode needs on top of the decompressed size.
  *
  * Flush-right placement puts block 0 at `capacity - comp_size`, so the read
@@ -948,8 +1001,8 @@ static uint64_t zxc_inplace_margin(const uint64_t dsize, const size_t chunk_size
  * and @ref zxc_decompress_inplace always agree on what a buffer of at least
  * the bound must satisfy.
  *
- * The footer is untrusted, so its size goes through
- * @ref zxc_footer_dsize_plausible like @ref zxc_get_decompressed_size does.
+ * The envelope is untrusted, so it goes through @ref zxc_read_frame_envelope
+ * like @ref zxc_get_decompressed_size does; only the error mapping differs.
  *
  * @param[in]  comp      Compressed archive; only the header and footer are read.
  * @param[in]  comp_size Size of the archive in bytes. The caller guarantees it
@@ -964,13 +1017,14 @@ static int zxc_inplace_probe(const uint8_t* comp, const size_t comp_size, uint64
                              uint64_t* margin, uint64_t* floor) {
     size_t chunk_size = 0;
     int has_cs = 0;
+    uint64_t d = 0;
 
-    const int hr = zxc_read_file_header(comp, comp_size, &chunk_size, &has_cs, NULL);
-    if (UNLIKELY(hr != ZXC_OK)) return (hr == ZXC_ERROR_BAD_MAGIC) ? hr : ZXC_ERROR_BAD_HEADER;
-
-    const uint64_t d = zxc_le64(comp + comp_size - ZXC_FILE_FOOTER_SIZE);
-    if (UNLIKELY(!zxc_footer_dsize_plausible(d, chunk_size, comp_size)))
-        return ZXC_ERROR_CORRUPT_DATA;
+    // Own mapping: only a wrong magic word and a forged footer keep their code,
+    // everything else reads as a bad header.
+    const int rc = zxc_read_frame_envelope(comp, comp_size, &d, &chunk_size, &has_cs);
+    if (UNLIKELY(rc != ZXC_OK))
+        return (rc == ZXC_ERROR_BAD_MAGIC || rc == ZXC_ERROR_CORRUPT_DATA) ? rc
+                                                                           : ZXC_ERROR_BAD_HEADER;
 
     *dsize = d;
     *margin = zxc_inplace_margin(d, chunk_size, has_cs);
@@ -1048,23 +1102,14 @@ int64_t zxc_decompress_inplace(void* buffer, const size_t buffer_capacity, const
  * @brief Reads the decompressed size from a ZXC-compressed buffer.
  *
  * The size sits in the file footer (last @ref ZXC_FILE_FOOTER_SIZE bytes) and is
- * untrusted, so it goes through zxc_footer_dsize_plausible(): a forged size
- * returns 0, and callers sizing an allocation from it inherit the check.
+ * untrusted, so it goes through @ref zxc_read_frame_envelope: an envelope that
+ * does not hold up returns 0, and callers sizing an allocation inherit the check.
  */
 uint64_t zxc_get_decompressed_size(const void* src, const size_t src_size) {
-    if (UNLIKELY(src_size < ZXC_FILE_HEADER_SIZE + ZXC_FILE_FOOTER_SIZE)) return 0;
-
-    const uint8_t* const p = (const uint8_t*)src;
-    size_t chunk_size = 0;
-    int has_cs = 0;
-
-    if (UNLIKELY(zxc_read_file_header(p, src_size, &chunk_size, &has_cs, NULL) != ZXC_OK)) return 0;
-
-    const uint8_t* const footer = p + src_size - ZXC_FILE_FOOTER_SIZE;
-    const uint64_t dsize = zxc_le64(footer);
-
-    if (UNLIKELY(!zxc_footer_dsize_plausible(dsize, chunk_size, src_size))) return 0;
-
+    uint64_t dsize = 0;
+    if (UNLIKELY(zxc_read_frame_envelope((const uint8_t*)src, src_size, &dsize, NULL, NULL) !=
+                 ZXC_OK))
+        return 0;
     return dsize;
 }
 
@@ -1371,14 +1416,7 @@ int64_t zxc_decompress_dctx(zxc_dctx* dctx, const void* RESTRICT src, const size
     if (UNLIKELY(!dctx || !src)) return ZXC_ERROR_NULL_INPUT;
     if (UNLIKELY(src_size < ZXC_FILE_HEADER_SIZE + ZXC_FILE_FOOTER_SIZE))
         return ZXC_ERROR_SRC_TOO_SMALL;
-    if (UNLIKELY(zxc_le32(src) != ZXC_MAGIC_WORD)) return ZXC_ERROR_BAD_MAGIC;
-
-    // No destination: only an archive that stores nothing can be reported as
-    // decoded, as zxc_decompress() does.
-    if (UNLIKELY(!dst || dst_capacity == 0)) {
-        const uint8_t* footer = (const uint8_t*)src + src_size - ZXC_FILE_FOOTER_SIZE;
-        return (zxc_le64(footer) == 0) ? 0 : (int64_t)ZXC_ERROR_DST_TOO_SMALL;
-    }
+    if (UNLIKELY(!dst || dst_capacity == 0)) return zxc_probe_without_dst(src, src_size);
 
     const int checksum_enabled = opts ? opts->checksum_enabled : 0;
     const uint8_t* dict = opts ? (const uint8_t*)opts->dict : NULL;

--- a/tests/test_common.h
+++ b/tests/test_common.h
@@ -92,6 +92,7 @@ int test_static_ctx_roundtrip_all_levels(void);
 int test_static_ctx_size_query(void);
 int test_static_ctx_workspace_too_small(void);
 int test_static_ctx_block_size_locked(void);
+int test_static_dctx_probe_honours_guards(void);
 int test_static_ctx_level_raise_rejected(void);
 int test_static_ctx_null_inputs(void);
 int test_static_dctx_block_bounds(void);

--- a/tests/test_common.h
+++ b/tests/test_common.h
@@ -84,6 +84,7 @@ int test_decompress_block_bound(void);
 /* Context API */
 int test_opaque_context_api(void);
 int test_context_api_empty_input(void);
+int test_context_api_seekable_frame(void);
 int test_cctx_level_raise_reinit(void);
 int test_estimate_cctx_size(void);
 

--- a/tests/test_common.h
+++ b/tests/test_common.h
@@ -83,6 +83,7 @@ int test_decompress_block_bound(void);
 
 /* Context API */
 int test_opaque_context_api(void);
+int test_context_api_empty_input(void);
 int test_cctx_level_raise_reinit(void);
 int test_estimate_cctx_size(void);
 

--- a/tests/test_context_api.c
+++ b/tests/test_context_api.c
@@ -298,6 +298,23 @@ int test_context_api_empty_input(void) {
         const int64_t d3 = zxc_decompress(from_ctx, (size_t)n2, NULL, 0, NULL);
         const int64_t d4 =
             dctx ? zxc_decompress_dctx(dctx, from_ctx, (size_t)n2, NULL, 0, NULL) : -1;
+        /* Junk whose tail happens to be zero is not an empty archive, and the
+         * verdict must not depend on whether a destination was supplied. */
+        uint8_t junk[36] = {0};
+        zxc_dctx* junk_dctx = zxc_create_dctx();
+        const int64_t j1 = zxc_decompress(junk, sizeof(junk), NULL, 0, NULL);
+        const int64_t j2 =
+            junk_dctx ? zxc_decompress_dctx(junk_dctx, junk, sizeof(junk), NULL, 0, NULL) : 0;
+        const int64_t j3 =
+            junk_dctx ? zxc_decompress_dctx(junk_dctx, junk, sizeof(junk), out, sizeof(out), NULL)
+                      : 0;
+        zxc_free_dctx(junk_dctx);
+        if (j1 != ZXC_ERROR_BAD_MAGIC || j2 != ZXC_ERROR_BAD_MAGIC || j3 != ZXC_ERROR_BAD_MAGIC) {
+            printf("  [FAIL] zeroed junk: one-shot %lld, dctx probe %lld, dctx decode %lld\n",
+                   (long long)j1, (long long)j2, (long long)j3);
+            break;
+        }
+
         /* A header without its footer is truncated, not an empty archive. */
         const int64_t t1 = zxc_decompress(from_ctx, ZXC_FILE_HEADER_SIZE, out, sizeof(out), NULL);
         const int64_t t2 =

--- a/tests/test_context_api.c
+++ b/tests/test_context_api.c
@@ -261,11 +261,53 @@ int test_estimate_cctx_size() {
     return 1;
 }
 
-/* The invariant a size probe has to hold: asking without a destination must
- * answer exactly what asking with one would, through both entry points. */
-static int probe_agrees(const char* what, const uint8_t* arc, const size_t n,
-                        const zxc_decompress_opts_t* opts, const int64_t want) {
-    uint8_t out[256];
+/* A seek table sits between the EOF block and the footer. The one-shot reads
+ * the footer from the end of the archive; the context path used to read it
+ * straight after the EOF block and parse the seek table as the footer, so it
+ * refused archives zxc_decompress() accepts. */
+int test_context_api_seekable_frame(void) {
+    printf("=== TEST: Context API - seekable archives decode through a context ===\n");
+    static uint8_t body[16384], arc[24576], out[16384];
+    for (size_t i = 0; i < sizeof(body); i++) body[i] = (uint8_t)('a' + (i % 23));
+
+    zxc_compress_opts_t co = {.level = 3, .block_size = 4096, .seekable = 1};
+    const int64_t n = zxc_compress(body, sizeof(body), arc, sizeof(arc), &co);
+    if (n <= 0) {
+        printf("  [FAIL] seekable compress returned %lld\n", (long long)n);
+        return 0;
+    }
+    zxc_dctx* dctx = zxc_create_dctx();
+    if (!dctx) {
+        printf("  [FAIL] zxc_create_dctx\n");
+        return 0;
+    }
+    const int64_t d1 = zxc_decompress(arc, (size_t)n, out, sizeof(out), NULL);
+    memset(out, 0, sizeof(out));
+    const int64_t d2 = zxc_decompress_dctx(dctx, arc, (size_t)n, out, sizeof(out), NULL);
+    const int same = (d2 == (int64_t)sizeof(body)) && memcmp(out, body, sizeof(body)) == 0;
+    const int64_t p1 = zxc_decompress(arc, (size_t)n, NULL, 0, NULL);
+    const int64_t p2 = zxc_decompress_dctx(dctx, arc, (size_t)n, NULL, 0, NULL);
+    zxc_free_dctx(dctx);
+
+    if (d1 != (int64_t)sizeof(body) || !same || p1 != ZXC_ERROR_DST_TOO_SMALL || p1 != p2) {
+        printf("  [FAIL] one-shot %lld, context %lld (bytes %s), probes %lld %lld\n", (long long)d1,
+               (long long)d2, same ? "ok" : "differ", (long long)p1, (long long)p2);
+        return 0;
+    }
+    printf("  [PASS] seek table between EOF and footer: both entry points agree\n");
+    printf("PASS\n\n");
+    return 1;
+}
+
+/* Pins both halves of the no-destination contract, through both entry points:
+ * what the probe answers, and what a real decode of the same bytes answers.
+ * They agree on every archive that reports an empty payload. On one that stores
+ * data the probe decodes nothing and can only say "give me a buffer", so the
+ * two verdicts are pinned separately rather than assumed equal. */
+static int probe_and_decode(const char* what, const uint8_t* arc, const size_t n,
+                            const zxc_decompress_opts_t* opts, const int64_t want_probe,
+                            const int64_t want_decode) {
+    static uint8_t out[8192];
     zxc_dctx* dctx = zxc_create_dctx();
     if (!dctx) {
         printf("  [FAIL] %s: zxc_create_dctx\n", what);
@@ -276,9 +318,10 @@ static int probe_agrees(const char* what, const uint8_t* arc, const size_t n,
     const int64_t d1 = zxc_decompress(arc, n, out, sizeof(out), opts);
     const int64_t d2 = zxc_decompress_dctx(dctx, arc, n, out, sizeof(out), opts);
     zxc_free_dctx(dctx);
-    if (p1 == want && p2 == want && d1 == want && d2 == want) return 1;
-    printf("  [FAIL] %s: probe %lld %lld, decode %lld %lld, want %lld\n", what, (long long)p1,
-           (long long)p2, (long long)d1, (long long)d2, (long long)want);
+    if (p1 == want_probe && p2 == want_probe && d1 == want_decode && d2 == want_decode) return 1;
+    printf("  [FAIL] %s: probe %lld %lld (want %lld), decode %lld %lld (want %lld)\n", what,
+           (long long)p1, (long long)p2, (long long)want_probe, (long long)d1, (long long)d2,
+           (long long)want_decode);
     return 0;
 }
 
@@ -315,10 +358,11 @@ int test_context_api_empty_input(void) {
          * than tested one by one, so a regression shows every shape it broke. */
         const uint8_t junk[36] = {0};
         int disagreed = 0;
-        disagreed += !probe_agrees("empty archive", from_ctx, (size_t)n2, NULL, 0);
-        disagreed += !probe_agrees("zeroed junk", junk, sizeof(junk), NULL, ZXC_ERROR_BAD_MAGIC);
-        disagreed += !probe_agrees("header without footer", from_ctx, ZXC_FILE_HEADER_SIZE, NULL,
-                                   ZXC_ERROR_SRC_TOO_SMALL);
+        disagreed += !probe_and_decode("empty archive", from_ctx, (size_t)n2, NULL, 0, 0);
+        disagreed += !probe_and_decode("zeroed junk", junk, sizeof(junk), NULL, ZXC_ERROR_BAD_MAGIC,
+                                       ZXC_ERROR_BAD_MAGIC);
+        disagreed += !probe_and_decode("header without footer", from_ctx, ZXC_FILE_HEADER_SIZE,
+                                       NULL, ZXC_ERROR_SRC_TOO_SMALL, ZXC_ERROR_SRC_TOO_SMALL);
 
         /* Crafted block headers, each rewritten through zxc_write_block_header
          * so its hash8 stays valid: a broken hash masks the shape check behind
@@ -335,14 +379,14 @@ int test_context_api_empty_input(void) {
 
         bh.comp_size = 7; /* EOF carries no payload */
         zxc_write_block_header(bad + ZXC_FILE_HEADER_SIZE, ZXC_BLOCK_HEADER_SIZE, &bh);
-        disagreed +=
-            !probe_agrees("EOF with a payload size", bad, (size_t)n2, NULL, ZXC_ERROR_BAD_HEADER);
+        disagreed += !probe_and_decode("EOF with a payload size", bad, (size_t)n2, NULL,
+                                       ZXC_ERROR_BAD_HEADER, ZXC_ERROR_BAD_HEADER);
 
         bh = eof;
         bh.block_type = ZXC_BLOCK_RAW; /* an empty archive stores no data block */
         zxc_write_block_header(bad + ZXC_FILE_HEADER_SIZE, ZXC_BLOCK_HEADER_SIZE, &bh);
-        disagreed += !probe_agrees("data block where EOF belongs", bad, (size_t)n2, NULL,
-                                   ZXC_ERROR_BAD_HEADER);
+        disagreed += !probe_and_decode("data block where EOF belongs", bad, (size_t)n2, NULL,
+                                       ZXC_ERROR_BAD_HEADER, ZXC_ERROR_BAD_HEADER);
 
         /* A corrupted global checksum and an unsupplied dictionary are only
          * caught by the frame walk, so the probe has to reach it. */
@@ -354,21 +398,24 @@ int test_context_api_empty_input(void) {
             break;
         }
         bad[cn - 1] ^= 0xFF;
-        disagreed += !probe_agrees("corrupted global checksum", bad, (size_t)cn, &cs_do,
-                                   ZXC_ERROR_BAD_CHECKSUM);
+        disagreed += !probe_and_decode("corrupted global checksum", bad, (size_t)cn, &cs_do,
+                                       ZXC_ERROR_BAD_CHECKSUM, ZXC_ERROR_BAD_CHECKSUM);
 
         static uint8_t dict[8192];
         memset(dict, 'x', sizeof(dict));
         zxc_compress_opts_t dict_co = {.level = 3};
         dict_co.dict = dict;
         dict_co.dict_size = sizeof(dict);
+        zxc_decompress_opts_t dict_do = {0};
+        dict_do.dict = dict;
+        dict_do.dict_size = sizeof(dict);
         const int64_t dn = zxc_compress(NULL, 0, bad, sizeof(bad), &dict_co);
         if (dn <= (int64_t)ZXC_FILE_FOOTER_SIZE) {
             printf("  [FAIL] empty+dict setup: %lld\n", (long long)dn);
             break;
         }
-        disagreed += !probe_agrees("dictionary not supplied", bad, (size_t)dn, NULL,
-                                   ZXC_ERROR_DICT_REQUIRED);
+        disagreed += !probe_and_decode("dictionary not supplied", bad, (size_t)dn, NULL,
+                                       ZXC_ERROR_DICT_REQUIRED, ZXC_ERROR_DICT_REQUIRED);
 
         /* A forged stored size is corrupt data, not "destination too small". */
         static const char payload[] = "a forged footer must read as corrupt data, not as size";
@@ -379,14 +426,46 @@ int test_context_api_empty_input(void) {
             break;
         }
         memset(bad + fn - ZXC_FILE_FOOTER_SIZE, 0xFF, 4);
-        disagreed +=
-            !probe_agrees("forged stored size", bad, (size_t)fn, NULL, ZXC_ERROR_CORRUPT_DATA);
+        disagreed += !probe_and_decode("forged stored size", bad, (size_t)fn, NULL,
+                                       ZXC_ERROR_CORRUPT_DATA, ZXC_ERROR_CORRUPT_DATA);
+
+        /* Archives that store data: the probe has no buffer to decode into, so
+         * it reports DST_TOO_SMALL where the decode names the real fault. Both
+         * sides are pinned: neither half follows from the other. */
+        const int64_t pn =
+            zxc_compress_cctx(cctx, payload, sizeof(payload) - 1, bad, sizeof(bad), &co);
+        if (pn <= (int64_t)ZXC_FILE_FOOTER_SIZE) {
+            printf("  [FAIL] payload archive setup: %lld\n", (long long)pn);
+            break;
+        }
+        disagreed += !probe_and_decode("intact payload", bad, (size_t)pn, NULL,
+                                       ZXC_ERROR_DST_TOO_SMALL, (int64_t)(sizeof(payload) - 1));
+        /* A footer claiming an empty payload the blocks contradict. */
+        uint8_t zeroed[256];
+        memcpy(zeroed, bad, (size_t)pn);
+        memset(zeroed + pn - ZXC_FILE_FOOTER_SIZE, 0, 8);
+        disagreed += !probe_and_decode("payload behind a zeroed size", zeroed, (size_t)pn, NULL,
+                                       ZXC_ERROR_DST_TOO_SMALL, ZXC_ERROR_CORRUPT_DATA);
+        /* Same, with the dictionary the archive needs: the probe still refuses
+         * on capacity, through the dictionary bounce path this time. */
+        const int64_t pdn =
+            zxc_compress_cctx(cctx, payload, sizeof(payload) - 1, bad, sizeof(bad), &dict_co);
+        if (pdn <= (int64_t)ZXC_FILE_FOOTER_SIZE) {
+            printf("  [FAIL] dict payload archive setup: %lld\n", (long long)pdn);
+            break;
+        }
+        disagreed += !probe_and_decode("payload behind a dictionary", bad, (size_t)pdn, &dict_do,
+                                       ZXC_ERROR_DST_TOO_SMALL, (int64_t)(sizeof(payload) - 1));
 
         /* A NULL destination with a non-zero capacity is a caller mistake, not
          * a probe, and both entry points have to say so. */
         zxc_dctx* nd = zxc_create_dctx();
+        if (!nd) {
+            printf("  [FAIL] zxc_create_dctx\n");
+            break;
+        }
         const int64_t z1 = zxc_decompress(from_ctx, (size_t)n2, NULL, 64, NULL);
-        const int64_t z2 = nd ? zxc_decompress_dctx(nd, from_ctx, (size_t)n2, NULL, 64, NULL) : 0;
+        const int64_t z2 = zxc_decompress_dctx(nd, from_ctx, (size_t)n2, NULL, 64, NULL);
         zxc_free_dctx(nd);
         if (z1 != ZXC_ERROR_NULL_INPUT || z2 != ZXC_ERROR_NULL_INPUT) {
             printf("  [FAIL] NULL destination with capacity 64: %lld %lld\n", (long long)z1,
@@ -435,9 +514,6 @@ int test_context_api_empty_input(void) {
                    (long long)e4);
             break;
         }
-        zxc_decompress_opts_t dict_do = {0};
-        dict_do.dict = dict;
-        dict_do.dict_size = sizeof(dict);
         const int64_t dc = zxc_compress_cctx(cctx, text, len, comp, sizeof(comp), &dict_co);
         const int64_t dr =
             dc > 0 ? zxc_decompress(comp, (size_t)dc, back, sizeof(back), &dict_do) : dc;

--- a/tests/test_context_api.c
+++ b/tests/test_context_api.c
@@ -469,6 +469,11 @@ int test_context_api_empty_input(void) {
         disagreed +=
             !probe_and_decode("oversized dictionary, payload archive", bad, (size_t)pdn, &huge_do,
                               ZXC_ERROR_DICT_TOO_LARGE, ZXC_ERROR_DICT_TOO_LARGE);
+        /* Including over a source too short to hold a frame: the caller's fault
+         * is settled before anything is read from it. */
+        disagreed += !probe_and_decode("oversized dictionary, truncated source", from_ctx,
+                                       ZXC_FILE_HEADER_SIZE, &huge_do, ZXC_ERROR_DICT_TOO_LARGE,
+                                       ZXC_ERROR_DICT_TOO_LARGE);
 
         /* A NULL destination with a non-zero capacity is a caller mistake, not
          * a probe, and both entry points have to say so. */

--- a/tests/test_context_api.c
+++ b/tests/test_context_api.c
@@ -260,3 +260,54 @@ int test_estimate_cctx_size() {
     printf("PASS\n\n");
     return 1;
 }
+
+/* An empty source is a valid frame: the reusable context must write the same
+ * archive as the one-shot entry point, and stay usable afterwards. */
+int test_context_api_empty_input(void) {
+    printf("=== TEST: Context API - empty input matches the one-shot ===\n");
+    uint8_t one_shot[64], from_ctx[64], out[64];
+    const zxc_compress_opts_t co = {.level = 3};
+    zxc_cctx* cctx = zxc_create_cctx(NULL);
+    int ok = 0;
+    do {
+        if (!cctx) {
+            printf("  [FAIL] zxc_create_cctx\n");
+            break;
+        }
+        const int64_t n1 = zxc_compress(NULL, 0, one_shot, sizeof(one_shot), &co);
+        const int64_t n2 = zxc_compress_cctx(cctx, NULL, 0, from_ctx, sizeof(from_ctx), &co);
+        if (n1 <= 0 || n2 != n1 || memcmp(one_shot, from_ctx, (size_t)n1) != 0) {
+            printf("  [FAIL] one-shot %lld, context %lld\n", (long long)n1, (long long)n2);
+            break;
+        }
+        const int64_t d = zxc_decompress(from_ctx, (size_t)n2, out, sizeof(out), NULL);
+        if (d != 0) {
+            printf("  [FAIL] decoding the empty archive: %lld\n", (long long)d);
+            break;
+        }
+        printf("  [PASS] %lld-byte empty archive, identical to the one-shot\n", (long long)n2);
+
+        /* The context keeps working for a normal payload. */
+        static const char text[] = "the quick brown fox jumps over the lazy dog, twice over";
+        const size_t len = sizeof(text) - 1;
+        uint8_t comp[256], back[256];
+        const int64_t n3 = zxc_compress_cctx(cctx, text, len, comp, sizeof(comp), &co);
+        const int64_t d3 = n3 > 0 ? zxc_decompress(comp, (size_t)n3, back, sizeof(back), NULL) : n3;
+        if (d3 != (int64_t)len || memcmp(back, text, len) != 0) {
+            printf("  [FAIL] next call: %lld -> %lld\n", (long long)n3, (long long)d3);
+            break;
+        }
+        printf("  [PASS] the context still compresses after an empty call\n");
+
+        /* The block API keeps its documented [1, MAX] contract. */
+        if (zxc_compress_block(cctx, NULL, 0, comp, sizeof(comp), &co) != ZXC_ERROR_NULL_INPUT) {
+            printf("  [FAIL] the block API should refuse an empty block\n");
+            break;
+        }
+        printf("  [PASS] the block API still refuses an empty block\n");
+        ok = 1;
+    } while (0);
+    zxc_free_cctx(cctx);
+    if (ok) printf("PASS\n\n");
+    return ok;
+}

--- a/tests/test_context_api.c
+++ b/tests/test_context_api.c
@@ -457,6 +457,19 @@ int test_context_api_empty_input(void) {
         disagreed += !probe_and_decode("payload behind a dictionary", bad, (size_t)pdn, &dict_do,
                                        ZXC_ERROR_DST_TOO_SMALL, (int64_t)(sizeof(payload) - 1));
 
+        /* A dictionary size the library cannot honour is a caller error, not an
+         * archive fault, so it outranks both the payload refusal and anything
+         * the header could be rejected for. */
+        zxc_decompress_opts_t huge_do = {0};
+        huge_do.dict = dict;
+        huge_do.dict_size = (size_t)ZXC_DICT_SIZE_MAX + 1;
+        disagreed +=
+            !probe_and_decode("oversized dictionary, empty archive", from_ctx, (size_t)n2, &huge_do,
+                              ZXC_ERROR_DICT_TOO_LARGE, ZXC_ERROR_DICT_TOO_LARGE);
+        disagreed +=
+            !probe_and_decode("oversized dictionary, payload archive", bad, (size_t)pdn, &huge_do,
+                              ZXC_ERROR_DICT_TOO_LARGE, ZXC_ERROR_DICT_TOO_LARGE);
+
         /* A NULL destination with a non-zero capacity is a caller mistake, not
          * a probe, and both entry points have to say so. */
         zxc_dctx* nd = zxc_create_dctx();

--- a/tests/test_context_api.c
+++ b/tests/test_context_api.c
@@ -261,11 +261,32 @@ int test_estimate_cctx_size() {
     return 1;
 }
 
+/* The invariant a size probe has to hold: asking without a destination must
+ * answer exactly what asking with one would, through both entry points. */
+static int probe_agrees(const char* what, const uint8_t* arc, const size_t n,
+                        const zxc_decompress_opts_t* opts, const int64_t want) {
+    uint8_t out[256];
+    zxc_dctx* dctx = zxc_create_dctx();
+    if (!dctx) {
+        printf("  [FAIL] %s: zxc_create_dctx\n", what);
+        return 0;
+    }
+    const int64_t p1 = zxc_decompress(arc, n, NULL, 0, opts);
+    const int64_t p2 = zxc_decompress_dctx(dctx, arc, n, NULL, 0, opts);
+    const int64_t d1 = zxc_decompress(arc, n, out, sizeof(out), opts);
+    const int64_t d2 = zxc_decompress_dctx(dctx, arc, n, out, sizeof(out), opts);
+    zxc_free_dctx(dctx);
+    if (p1 == want && p2 == want && d1 == want && d2 == want) return 1;
+    printf("  [FAIL] %s: probe %lld %lld, decode %lld %lld, want %lld\n", what, (long long)p1,
+           (long long)p2, (long long)d1, (long long)d2, (long long)want);
+    return 0;
+}
+
 /* An empty source is a valid frame: the reusable context must write the same
  * archive as the one-shot entry point, and stay usable afterwards. */
 int test_context_api_empty_input(void) {
     printf("=== TEST: Context API - empty input matches the one-shot ===\n");
-    uint8_t one_shot[64], from_ctx[64], out[64];
+    uint8_t one_shot[64], from_ctx[64];
     const zxc_compress_opts_t co = {.level = 3};
     zxc_cctx* cctx = zxc_create_cctx(NULL);
     int ok = 0;
@@ -290,87 +311,89 @@ int test_context_api_empty_input(void) {
             printf("  [FAIL] non-NULL source with a zero size: %lld\n", (long long)n2b);
             break;
         }
-        /* Both decoders, and the size probe both of them support. */
-        zxc_dctx* dctx = zxc_create_dctx();
-        const int64_t d1 = zxc_decompress(from_ctx, (size_t)n2, out, sizeof(out), NULL);
-        const int64_t d2 =
-            dctx ? zxc_decompress_dctx(dctx, from_ctx, (size_t)n2, out, sizeof(out), NULL) : -1;
-        const int64_t d3 = zxc_decompress(from_ctx, (size_t)n2, NULL, 0, NULL);
-        const int64_t d4 =
-            dctx ? zxc_decompress_dctx(dctx, from_ctx, (size_t)n2, NULL, 0, NULL) : -1;
-        /* Junk whose tail happens to be zero is not an empty archive, and the
-         * verdict must not depend on whether a destination was supplied. */
-        uint8_t junk[36] = {0};
-        zxc_dctx* junk_dctx = zxc_create_dctx();
-        const int64_t j1 = zxc_decompress(junk, sizeof(junk), NULL, 0, NULL);
-        const int64_t j2 =
-            junk_dctx ? zxc_decompress_dctx(junk_dctx, junk, sizeof(junk), NULL, 0, NULL) : 0;
-        const int64_t j3 =
-            junk_dctx ? zxc_decompress_dctx(junk_dctx, junk, sizeof(junk), out, sizeof(out), NULL)
-                      : 0;
-        zxc_free_dctx(junk_dctx);
-        if (j1 != ZXC_ERROR_BAD_MAGIC || j2 != ZXC_ERROR_BAD_MAGIC || j3 != ZXC_ERROR_BAD_MAGIC) {
-            printf("  [FAIL] zeroed junk: one-shot %lld, dctx probe %lld, dctx decode %lld\n",
-                   (long long)j1, (long long)j2, (long long)j3);
+        /* Every shape below is checked both ways. Verdicts are tallied rather
+         * than tested one by one, so a regression shows every shape it broke. */
+        const uint8_t junk[36] = {0};
+        int disagreed = 0;
+        disagreed += !probe_agrees("empty archive", from_ctx, (size_t)n2, NULL, 0);
+        disagreed += !probe_agrees("zeroed junk", junk, sizeof(junk), NULL, ZXC_ERROR_BAD_MAGIC);
+        disagreed += !probe_agrees("header without footer", from_ctx, ZXC_FILE_HEADER_SIZE, NULL,
+                                   ZXC_ERROR_SRC_TOO_SMALL);
+
+        /* Crafted block headers, each rewritten through zxc_write_block_header
+         * so its hash8 stays valid: a broken hash masks the shape check behind
+         * it. */
+        uint8_t bad[256];
+        zxc_block_header_t bh;
+        memcpy(bad, from_ctx, (size_t)n2);
+        if (zxc_read_block_header(bad + ZXC_FILE_HEADER_SIZE, (size_t)n2 - ZXC_FILE_HEADER_SIZE,
+                                  &bh) != ZXC_OK) {
+            printf("  [FAIL] could not read the empty archive's EOF block\n");
             break;
         }
+        const zxc_block_header_t eof = bh;
 
-        /* A well-formed header and a zero stored size are not enough: an
-         * archive that stores nothing still carries its EOF block. */
-        uint8_t stub[ZXC_FILE_HEADER_SIZE + ZXC_FILE_FOOTER_SIZE] = {0};
-        memcpy(stub, from_ctx, ZXC_FILE_HEADER_SIZE);
-        uint8_t no_eof[64] = {0};
-        memcpy(no_eof, from_ctx, (size_t)n2);
-        no_eof[ZXC_FILE_HEADER_SIZE] = ZXC_BLOCK_RAW; /* no longer the EOF block */
-        zxc_dctx* shape = zxc_create_dctx();
-        const int64_t s1 = zxc_decompress(stub, sizeof(stub), NULL, 0, NULL);
-        const int64_t s2 =
-            shape ? zxc_decompress_dctx(shape, stub, sizeof(stub), NULL, 0, NULL) : 0;
-        const int64_t s3 = zxc_decompress(no_eof, (size_t)n2, NULL, 0, NULL);
-        const int64_t s4 =
-            shape ? zxc_decompress_dctx(shape, no_eof, (size_t)n2, NULL, 0, NULL) : 0;
-        zxc_free_dctx(shape);
-        if (s1 >= 0 || s2 >= 0 || s3 >= 0 || s4 >= 0) {
-            printf("  [FAIL] header+footer only: %lld %lld, EOF corrupted: %lld %lld\n",
-                   (long long)s1, (long long)s2, (long long)s3, (long long)s4);
+        bh.comp_size = 7; /* EOF carries no payload */
+        zxc_write_block_header(bad + ZXC_FILE_HEADER_SIZE, ZXC_BLOCK_HEADER_SIZE, &bh);
+        disagreed +=
+            !probe_agrees("EOF with a payload size", bad, (size_t)n2, NULL, ZXC_ERROR_BAD_HEADER);
+
+        bh = eof;
+        bh.block_type = ZXC_BLOCK_RAW; /* an empty archive stores no data block */
+        zxc_write_block_header(bad + ZXC_FILE_HEADER_SIZE, ZXC_BLOCK_HEADER_SIZE, &bh);
+        disagreed += !probe_agrees("data block where EOF belongs", bad, (size_t)n2, NULL,
+                                   ZXC_ERROR_BAD_HEADER);
+
+        /* A corrupted global checksum and an unsupplied dictionary are only
+         * caught by the frame walk, so the probe has to reach it. */
+        const zxc_compress_opts_t cs_co = {.level = 3, .checksum_enabled = 1};
+        const zxc_decompress_opts_t cs_do = {.checksum_enabled = 1};
+        const int64_t cn = zxc_compress(NULL, 0, bad, sizeof(bad), &cs_co);
+        if (cn <= (int64_t)ZXC_FILE_FOOTER_SIZE) {
+            printf("  [FAIL] empty+checksum setup: %lld\n", (long long)cn);
             break;
         }
+        bad[cn - 1] ^= 0xFF;
+        disagreed += !probe_agrees("corrupted global checksum", bad, (size_t)cn, &cs_do,
+                                   ZXC_ERROR_BAD_CHECKSUM);
 
-        /* A forged stored size is corrupt data: the probe must say so with the
-         * code the real decode gives, not "destination too small". */
+        static uint8_t dict[8192];
+        memset(dict, 'x', sizeof(dict));
+        zxc_compress_opts_t dict_co = {.level = 3};
+        dict_co.dict = dict;
+        dict_co.dict_size = sizeof(dict);
+        const int64_t dn = zxc_compress(NULL, 0, bad, sizeof(bad), &dict_co);
+        if (dn <= (int64_t)ZXC_FILE_FOOTER_SIZE) {
+            printf("  [FAIL] empty+dict setup: %lld\n", (long long)dn);
+            break;
+        }
+        disagreed += !probe_agrees("dictionary not supplied", bad, (size_t)dn, NULL,
+                                   ZXC_ERROR_DICT_REQUIRED);
+
+        /* A forged stored size is corrupt data, not "destination too small". */
         static const char payload[] = "a forged footer must read as corrupt data, not as size";
-        uint8_t forged[256] = {0};
         const int64_t fn =
-            zxc_compress_cctx(cctx, payload, sizeof(payload) - 1, forged, sizeof(forged), &co);
+            zxc_compress_cctx(cctx, payload, sizeof(payload) - 1, bad, sizeof(bad), &co);
         if (fn <= (int64_t)ZXC_FILE_FOOTER_SIZE) {
             printf("  [FAIL] forged footer setup: compress returned %lld\n", (long long)fn);
             break;
         }
-        memset(forged + fn - ZXC_FILE_FOOTER_SIZE, 0xFF, 4);
-        zxc_dctx* fd = zxc_create_dctx();
-        const int64_t f1 = zxc_decompress(forged, (size_t)fn, NULL, 0, NULL);
-        const int64_t f2 = fd ? zxc_decompress_dctx(fd, forged, (size_t)fn, NULL, 0, NULL) : 0;
-        const int64_t f3 = zxc_decompress(forged, (size_t)fn, out, sizeof(out), NULL);
-        zxc_free_dctx(fd);
-        if (f1 != ZXC_ERROR_CORRUPT_DATA || f2 != ZXC_ERROR_CORRUPT_DATA || f1 != f3) {
-            printf("  [FAIL] forged footer: probe %lld %lld, decode %lld\n", (long long)f1,
-                   (long long)f2, (long long)f3);
-            break;
-        }
+        memset(bad + fn - ZXC_FILE_FOOTER_SIZE, 0xFF, 4);
+        disagreed +=
+            !probe_agrees("forged stored size", bad, (size_t)fn, NULL, ZXC_ERROR_CORRUPT_DATA);
 
-        /* A header without its footer is truncated, not an empty archive. */
-        const int64_t t1 = zxc_decompress(from_ctx, ZXC_FILE_HEADER_SIZE, out, sizeof(out), NULL);
-        const int64_t t2 =
-            dctx ? zxc_decompress_dctx(dctx, from_ctx, ZXC_FILE_HEADER_SIZE, out, sizeof(out), NULL)
-                 : 0;
-        zxc_free_dctx(dctx);
-        if (d1 != 0 || d2 != 0 || d3 != 0 || d4 != 0 || t1 != ZXC_ERROR_SRC_TOO_SMALL ||
-            t2 != ZXC_ERROR_SRC_TOO_SMALL) {
-            printf("  [FAIL] decode %lld %lld, probe %lld %lld, truncated %lld %lld\n",
-                   (long long)d1, (long long)d2, (long long)d3, (long long)d4, (long long)t1,
-                   (long long)t2);
+        /* A NULL destination with a non-zero capacity is a caller mistake, not
+         * a probe, and both entry points have to say so. */
+        zxc_dctx* nd = zxc_create_dctx();
+        const int64_t z1 = zxc_decompress(from_ctx, (size_t)n2, NULL, 64, NULL);
+        const int64_t z2 = nd ? zxc_decompress_dctx(nd, from_ctx, (size_t)n2, NULL, 64, NULL) : 0;
+        zxc_free_dctx(nd);
+        if (z1 != ZXC_ERROR_NULL_INPUT || z2 != ZXC_ERROR_NULL_INPUT) {
+            printf("  [FAIL] NULL destination with capacity 64: %lld %lld\n", (long long)z1,
+                   (long long)z2);
             break;
         }
+        if (disagreed) break;
         printf("  [PASS] %lld-byte empty archive: same bytes and same codes as the one-shot\n",
                (long long)n2);
 
@@ -386,6 +409,44 @@ int test_context_api_empty_input(void) {
             break;
         }
         printf("  [PASS] the context still compresses after an empty call\n");
+
+        /* An archive with a payload is the one case where the two answers must
+         * differ: nothing is wrong with it, there is just nowhere to put it. */
+        if (zxc_decompress(comp, (size_t)n3, NULL, 0, NULL) != ZXC_ERROR_DST_TOO_SMALL) {
+            printf("  [FAIL] probing a non-empty archive should be DST_TOO_SMALL\n");
+            break;
+        }
+
+        /* The empty-source fast path skips the option plumbing a normal call
+         * runs. Pin what it must still produce: the one-shot's bytes for the
+         * same options, and a dictionary left intact for the next call. */
+        const zxc_compress_opts_t cs_only = {.level = 3, .checksum_enabled = 1};
+        const int64_t e1 = zxc_compress(NULL, 0, one_shot, sizeof(one_shot), &cs_only);
+        const int64_t e2 = zxc_compress_cctx(cctx, NULL, 0, bad, sizeof(bad), &cs_only);
+        if (e1 <= 0 || e2 != e1 || memcmp(one_shot, bad, (size_t)e1) != 0) {
+            printf("  [FAIL] empty + checksum: one-shot %lld, context %lld\n", (long long)e1,
+                   (long long)e2);
+            break;
+        }
+        const int64_t e3 = zxc_compress(NULL, 0, one_shot, sizeof(one_shot), &dict_co);
+        const int64_t e4 = zxc_compress_cctx(cctx, NULL, 0, bad, sizeof(bad), &dict_co);
+        if (e3 <= 0 || e4 != e3 || memcmp(one_shot, bad, (size_t)e3) != 0) {
+            printf("  [FAIL] empty + dictionary: one-shot %lld, context %lld\n", (long long)e3,
+                   (long long)e4);
+            break;
+        }
+        zxc_decompress_opts_t dict_do = {0};
+        dict_do.dict = dict;
+        dict_do.dict_size = sizeof(dict);
+        const int64_t dc = zxc_compress_cctx(cctx, text, len, comp, sizeof(comp), &dict_co);
+        const int64_t dr =
+            dc > 0 ? zxc_decompress(comp, (size_t)dc, back, sizeof(back), &dict_do) : dc;
+        if (dr != (int64_t)len || memcmp(back, text, len) != 0) {
+            printf("  [FAIL] dictionary lost across the empty call: %lld -> %lld\n", (long long)dc,
+                   (long long)dr);
+            break;
+        }
+        printf("  [PASS] the empty fast path keeps checksum and dictionary options\n");
 
         /* The block API keeps its documented [1, MAX] contract: a real pointer
          * with a zero size must be refused on the size alone. */

--- a/tests/test_context_api.c
+++ b/tests/test_context_api.c
@@ -315,6 +315,49 @@ int test_context_api_empty_input(void) {
             break;
         }
 
+        /* A well-formed header and a zero stored size are not enough: an
+         * archive that stores nothing still carries its EOF block. */
+        uint8_t stub[ZXC_FILE_HEADER_SIZE + ZXC_FILE_FOOTER_SIZE] = {0};
+        memcpy(stub, from_ctx, ZXC_FILE_HEADER_SIZE);
+        uint8_t no_eof[64] = {0};
+        memcpy(no_eof, from_ctx, (size_t)n2);
+        no_eof[ZXC_FILE_HEADER_SIZE] = ZXC_BLOCK_RAW; /* no longer the EOF block */
+        zxc_dctx* shape = zxc_create_dctx();
+        const int64_t s1 = zxc_decompress(stub, sizeof(stub), NULL, 0, NULL);
+        const int64_t s2 =
+            shape ? zxc_decompress_dctx(shape, stub, sizeof(stub), NULL, 0, NULL) : 0;
+        const int64_t s3 = zxc_decompress(no_eof, (size_t)n2, NULL, 0, NULL);
+        const int64_t s4 =
+            shape ? zxc_decompress_dctx(shape, no_eof, (size_t)n2, NULL, 0, NULL) : 0;
+        zxc_free_dctx(shape);
+        if (s1 >= 0 || s2 >= 0 || s3 >= 0 || s4 >= 0) {
+            printf("  [FAIL] header+footer only: %lld %lld, EOF corrupted: %lld %lld\n",
+                   (long long)s1, (long long)s2, (long long)s3, (long long)s4);
+            break;
+        }
+
+        /* A forged stored size is corrupt data: the probe must say so with the
+         * code the real decode gives, not "destination too small". */
+        static const char payload[] = "a forged footer must read as corrupt data, not as size";
+        uint8_t forged[256] = {0};
+        const int64_t fn =
+            zxc_compress_cctx(cctx, payload, sizeof(payload) - 1, forged, sizeof(forged), &co);
+        if (fn <= (int64_t)ZXC_FILE_FOOTER_SIZE) {
+            printf("  [FAIL] forged footer setup: compress returned %lld\n", (long long)fn);
+            break;
+        }
+        memset(forged + fn - ZXC_FILE_FOOTER_SIZE, 0xFF, 4);
+        zxc_dctx* fd = zxc_create_dctx();
+        const int64_t f1 = zxc_decompress(forged, (size_t)fn, NULL, 0, NULL);
+        const int64_t f2 = fd ? zxc_decompress_dctx(fd, forged, (size_t)fn, NULL, 0, NULL) : 0;
+        const int64_t f3 = zxc_decompress(forged, (size_t)fn, out, sizeof(out), NULL);
+        zxc_free_dctx(fd);
+        if (f1 != ZXC_ERROR_CORRUPT_DATA || f2 != ZXC_ERROR_CORRUPT_DATA || f1 != f3) {
+            printf("  [FAIL] forged footer: probe %lld %lld, decode %lld\n", (long long)f1,
+                   (long long)f2, (long long)f3);
+            break;
+        }
+
         /* A header without its footer is truncated, not an empty archive. */
         const int64_t t1 = zxc_decompress(from_ctx, ZXC_FILE_HEADER_SIZE, out, sizeof(out), NULL);
         const int64_t t2 =

--- a/tests/test_context_api.c
+++ b/tests/test_context_api.c
@@ -274,33 +274,62 @@ int test_context_api_empty_input(void) {
             printf("  [FAIL] zxc_create_cctx\n");
             break;
         }
+        const int64_t expected =
+            ZXC_FILE_HEADER_SIZE + ZXC_BLOCK_HEADER_SIZE + ZXC_FILE_FOOTER_SIZE;
         const int64_t n1 = zxc_compress(NULL, 0, one_shot, sizeof(one_shot), &co);
         const int64_t n2 = zxc_compress_cctx(cctx, NULL, 0, from_ctx, sizeof(from_ctx), &co);
-        if (n1 <= 0 || n2 != n1 || memcmp(one_shot, from_ctx, (size_t)n1) != 0) {
-            printf("  [FAIL] one-shot %lld, context %lld\n", (long long)n1, (long long)n2);
+        if (n1 != expected || n2 != n1 || memcmp(one_shot, from_ctx, (size_t)n1) != 0) {
+            printf("  [FAIL] one-shot %lld, context %lld (expected %lld)\n", (long long)n1,
+                   (long long)n2, (long long)expected);
             break;
         }
-        const int64_t d = zxc_decompress(from_ctx, (size_t)n2, out, sizeof(out), NULL);
-        if (d != 0) {
-            printf("  [FAIL] decoding the empty archive: %lld\n", (long long)d);
+        /* The other accepted shape: a real pointer with a zero size. */
+        uint8_t probe = 0;
+        const int64_t n2b = zxc_compress_cctx(cctx, &probe, 0, from_ctx, sizeof(from_ctx), &co);
+        if (n2b != n1 || memcmp(one_shot, from_ctx, (size_t)n1) != 0) {
+            printf("  [FAIL] non-NULL source with a zero size: %lld\n", (long long)n2b);
             break;
         }
-        printf("  [PASS] %lld-byte empty archive, identical to the one-shot\n", (long long)n2);
+        /* Both decoders, and the size probe both of them support. */
+        zxc_dctx* dctx = zxc_create_dctx();
+        const int64_t d1 = zxc_decompress(from_ctx, (size_t)n2, out, sizeof(out), NULL);
+        const int64_t d2 =
+            dctx ? zxc_decompress_dctx(dctx, from_ctx, (size_t)n2, out, sizeof(out), NULL) : -1;
+        const int64_t d3 = zxc_decompress(from_ctx, (size_t)n2, NULL, 0, NULL);
+        const int64_t d4 =
+            dctx ? zxc_decompress_dctx(dctx, from_ctx, (size_t)n2, NULL, 0, NULL) : -1;
+        /* A header without its footer is truncated, not an empty archive. */
+        const int64_t t1 = zxc_decompress(from_ctx, ZXC_FILE_HEADER_SIZE, out, sizeof(out), NULL);
+        const int64_t t2 =
+            dctx ? zxc_decompress_dctx(dctx, from_ctx, ZXC_FILE_HEADER_SIZE, out, sizeof(out), NULL)
+                 : 0;
+        zxc_free_dctx(dctx);
+        if (d1 != 0 || d2 != 0 || d3 != 0 || d4 != 0 || t1 != ZXC_ERROR_SRC_TOO_SMALL ||
+            t2 != ZXC_ERROR_SRC_TOO_SMALL) {
+            printf("  [FAIL] decode %lld %lld, probe %lld %lld, truncated %lld %lld\n",
+                   (long long)d1, (long long)d2, (long long)d3, (long long)d4, (long long)t1,
+                   (long long)t2);
+            break;
+        }
+        printf("  [PASS] %lld-byte empty archive: same bytes and same codes as the one-shot\n",
+               (long long)n2);
 
         /* The context keeps working for a normal payload. */
         static const char text[] = "the quick brown fox jumps over the lazy dog, twice over";
         const size_t len = sizeof(text) - 1;
         uint8_t comp[256], back[256];
         const int64_t n3 = zxc_compress_cctx(cctx, text, len, comp, sizeof(comp), &co);
-        const int64_t d3 = n3 > 0 ? zxc_decompress(comp, (size_t)n3, back, sizeof(back), NULL) : n3;
-        if (d3 != (int64_t)len || memcmp(back, text, len) != 0) {
-            printf("  [FAIL] next call: %lld -> %lld\n", (long long)n3, (long long)d3);
+        const int64_t back_len =
+            n3 > 0 ? zxc_decompress(comp, (size_t)n3, back, sizeof(back), NULL) : n3;
+        if (back_len != (int64_t)len || memcmp(back, text, len) != 0) {
+            printf("  [FAIL] next call: %lld -> %lld\n", (long long)n3, (long long)back_len);
             break;
         }
         printf("  [PASS] the context still compresses after an empty call\n");
 
-        /* The block API keeps its documented [1, MAX] contract. */
-        if (zxc_compress_block(cctx, NULL, 0, comp, sizeof(comp), &co) != ZXC_ERROR_NULL_INPUT) {
+        /* The block API keeps its documented [1, MAX] contract: a real pointer
+         * with a zero size must be refused on the size alone. */
+        if (zxc_compress_block(cctx, text, 0, comp, sizeof(comp), &co) != ZXC_ERROR_NULL_INPUT) {
             printf("  [FAIL] the block API should refuse an empty block\n");
             break;
         }

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -68,6 +68,7 @@ static const test_entry_t g_tests[] = {
 
     /* --- Context API --- */
     TEST_CASE(test_opaque_context_api),
+    TEST_CASE(test_context_api_empty_input),
     TEST_CASE(test_cctx_level_raise_reinit),
     TEST_CASE(test_estimate_cctx_size),
 

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -76,6 +76,7 @@ static const test_entry_t g_tests[] = {
     TEST_CASE(test_static_ctx_size_query),
     TEST_CASE(test_static_ctx_workspace_too_small),
     TEST_CASE(test_static_ctx_block_size_locked),
+    TEST_CASE(test_static_dctx_probe_honours_guards),
     TEST_CASE(test_static_ctx_level_raise_rejected),
     TEST_CASE(test_static_ctx_null_inputs),
     TEST_CASE(test_static_ctx_roundtrip_all_levels),

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -69,6 +69,7 @@ static const test_entry_t g_tests[] = {
     /* --- Context API --- */
     TEST_CASE(test_opaque_context_api),
     TEST_CASE(test_context_api_empty_input),
+    TEST_CASE(test_context_api_seekable_frame),
     TEST_CASE(test_cctx_level_raise_reinit),
     TEST_CASE(test_estimate_cctx_size),
 

--- a/tests/test_static_ctx.c
+++ b/tests/test_static_ctx.c
@@ -275,7 +275,7 @@ int test_static_dctx_probe_honours_guards(void) {
     }
 
     int ok = 0;
-    uint8_t arc[256], out[256];
+    uint8_t arc[8192], out[256];
     static uint8_t dict[8192];
     memset(dict, 'x', sizeof(dict));
     do {
@@ -308,6 +308,34 @@ int test_static_dctx_probe_honours_guards(void) {
         if (dp != ZXC_ERROR_DICT_UNSUPPORTED || dd != ZXC_ERROR_DICT_UNSUPPORTED) {
             printf("  [FAIL] dict-bound archive: probe %lld, decode %lld\n", (long long)dp,
                    (long long)dd);
+            break;
+        }
+
+        /* Same guards on an archive that stores data: the payload rejection
+         * must not answer first, or the caller is told "give me a buffer" for
+         * an archive this context could never decode. */
+        uint8_t body[4096];
+        memset(body, 'z', sizeof(body));
+        const int64_t pn = zxc_compress(body, sizeof(body), arc, sizeof(arc), &wrong_bs);
+        if (pn <= 0) {
+            printf("  [FAIL] setup: payload archive at %zu -> %lld\n", pinned_bs * 2,
+                   (long long)pn);
+            break;
+        }
+        if (zxc_decompress_dctx(dctx, arc, (size_t)pn, NULL, 0, NULL) != ZXC_ERROR_BAD_BLOCK_SIZE) {
+            printf("  [FAIL] payload archive, foreign block size: probe %lld\n",
+                   (long long)zxc_decompress_dctx(dctx, arc, (size_t)pn, NULL, 0, NULL));
+            break;
+        }
+        const int64_t pdn = zxc_compress(body, sizeof(body), arc, sizeof(arc), &with_dict);
+        if (pdn <= 0) {
+            printf("  [FAIL] setup: dict payload archive -> %lld\n", (long long)pdn);
+            break;
+        }
+        if (zxc_decompress_dctx(dctx, arc, (size_t)pdn, NULL, 0, NULL) !=
+            ZXC_ERROR_DICT_UNSUPPORTED) {
+            printf("  [FAIL] payload archive, dictionary: probe %lld\n",
+                   (long long)zxc_decompress_dctx(dctx, arc, (size_t)pdn, NULL, 0, NULL));
             break;
         }
 

--- a/tests/test_static_ctx.c
+++ b/tests/test_static_ctx.c
@@ -339,6 +339,19 @@ int test_static_dctx_probe_honours_guards(void) {
             break;
         }
 
+        /* A dictionary size the library cannot honour is a caller error: it
+         * outranks this context's own no-dictionary rule, on both paths. */
+        zxc_decompress_opts_t huge = {0};
+        huge.dict = dict;
+        huge.dict_size = (size_t)ZXC_DICT_SIZE_MAX + 1;
+        const int64_t hp = zxc_decompress_dctx(dctx, arc, (size_t)pn, NULL, 0, &huge);
+        const int64_t hd = zxc_decompress_dctx(dctx, arc, (size_t)pn, out, sizeof(out), &huge);
+        if (hp != ZXC_ERROR_DICT_TOO_LARGE || hd != ZXC_ERROR_DICT_TOO_LARGE) {
+            printf("  [FAIL] oversized dictionary: probe %lld, decode %lld\n", (long long)hp,
+                   (long long)hd);
+            break;
+        }
+
         /* An archive the context can decode still probes as empty. */
         zxc_compress_opts_t good = {.level = 3, .block_size = pinned_bs};
         const int64_t gn = zxc_compress(NULL, 0, arc, sizeof(arc), &good);

--- a/tests/test_static_ctx.c
+++ b/tests/test_static_ctx.c
@@ -253,6 +253,81 @@ int test_static_ctx_block_size_locked(void) {
     return 1;
 }
 
+/* A size probe on a static dctx must answer under that context's own rules.
+ * Short-circuiting the no-destination case ahead of the block-size lock and the
+ * no-dictionary rule handed callers a green light for archives the context
+ * cannot decode. */
+int test_static_dctx_probe_honours_guards(void) {
+    printf("=== TEST: Static Context API - size probe honours the dctx guards ===\n");
+
+    const size_t pinned_bs = 64 * 1024;
+    const size_t ws_sz = zxc_static_dctx_workspace_size(pinned_bs);
+    void* const ws = test_aligned_alloc(64, ws_sz);
+    if (!ws) {
+        printf("  [FAIL] aligned_alloc\n");
+        return 0;
+    }
+    zxc_dctx* const dctx = zxc_init_static_dctx(ws, ws_sz, pinned_bs);
+    if (!dctx) {
+        printf("  [FAIL] init_static_dctx\n");
+        test_aligned_free(ws);
+        return 0;
+    }
+
+    int ok = 0;
+    uint8_t arc[256], out[256];
+    static uint8_t dict[8192];
+    memset(dict, 'x', sizeof(dict));
+    do {
+        /* An archive whose header declares another block size. */
+        zxc_compress_opts_t wrong_bs = {.level = 3, .block_size = pinned_bs * 2};
+        const int64_t bn = zxc_compress(NULL, 0, arc, sizeof(arc), &wrong_bs);
+        if (bn <= 0) {
+            printf("  [FAIL] setup: empty archive at %zu -> %lld\n", pinned_bs * 2, (long long)bn);
+            break;
+        }
+        const int64_t bp = zxc_decompress_dctx(dctx, arc, (size_t)bn, NULL, 0, NULL);
+        const int64_t bd = zxc_decompress_dctx(dctx, arc, (size_t)bn, out, sizeof(out), NULL);
+        if (bp != ZXC_ERROR_BAD_BLOCK_SIZE || bd != ZXC_ERROR_BAD_BLOCK_SIZE) {
+            printf("  [FAIL] foreign block size: probe %lld, decode %lld\n", (long long)bp,
+                   (long long)bd);
+            break;
+        }
+
+        /* A dictionary-bound archive, which a static dctx has no room for. */
+        zxc_compress_opts_t with_dict = {.level = 3, .block_size = pinned_bs};
+        with_dict.dict = dict;
+        with_dict.dict_size = sizeof(dict);
+        const int64_t dn = zxc_compress(NULL, 0, arc, sizeof(arc), &with_dict);
+        if (dn <= 0) {
+            printf("  [FAIL] setup: dict-bound empty archive -> %lld\n", (long long)dn);
+            break;
+        }
+        const int64_t dp = zxc_decompress_dctx(dctx, arc, (size_t)dn, NULL, 0, NULL);
+        const int64_t dd = zxc_decompress_dctx(dctx, arc, (size_t)dn, out, sizeof(out), NULL);
+        if (dp != ZXC_ERROR_DICT_UNSUPPORTED || dd != ZXC_ERROR_DICT_UNSUPPORTED) {
+            printf("  [FAIL] dict-bound archive: probe %lld, decode %lld\n", (long long)dp,
+                   (long long)dd);
+            break;
+        }
+
+        /* An archive the context can decode still probes as empty. */
+        zxc_compress_opts_t good = {.level = 3, .block_size = pinned_bs};
+        const int64_t gn = zxc_compress(NULL, 0, arc, sizeof(arc), &good);
+        if (gn <= 0 || zxc_decompress_dctx(dctx, arc, (size_t)gn, NULL, 0, NULL) != 0) {
+            printf("  [FAIL] matching empty archive did not probe as empty (%lld)\n",
+                   (long long)gn);
+            break;
+        }
+        ok = 1;
+    } while (0);
+
+    zxc_free_dctx(dctx);
+    test_aligned_free(ws);
+    if (ok) printf("  [PASS] the probe is refused exactly where the decode is\n");
+    return ok;
+}
+
 /* Regression: a static cctx carved below ZXC_LEVEL_DENSITY has no opt_scratch
  * and its workspace cannot grow. A per-call raise into the optimal-parser tier
  * must be rejected with ZXC_ERROR_BAD_LEVEL - before the fix it silently

--- a/wrappers/go/zxc_buffer.go
+++ b/wrappers/go/zxc_buffer.go
@@ -168,12 +168,8 @@ func Decompress(data []byte, opts ...Option) ([]byte, error) {
 	}
 
 	if size == 0 {
-		// Either a valid empty-payload archive, or invalid input (bad header,
-		// or a footer whose size failed the C-side plausibility check). Let
-		// the C decoder decide: it returns 0 for a valid empty archive, or a
-		// negative error code otherwise. Decode into a zero-length buffer;
-		// DST_TOO_SMALL here can only mean the footer contradicts the payload
-		// (the caller supplied no buffer), so report it as invalid data.
+		// Ambiguous: a valid empty-payload archive, or input the C envelope
+		// rejected. Decoding into a zero-length buffer settles it.
 		var dummy [1]byte
 		written := C.zxc_decompress(
 			unsafe.Pointer(&data[0]),
@@ -183,9 +179,6 @@ func Decompress(data []byte, opts ...Option) ([]byte, error) {
 			&dopts,
 		)
 		if written < 0 {
-			if int(written) == int(C.ZXC_ERROR_DST_TOO_SMALL) {
-				return nil, ErrInvalidData
-			}
 			return nil, errorFromCode(written)
 		}
 		if written != 0 {

--- a/wrappers/go/zxc_buffer.go
+++ b/wrappers/go/zxc_buffer.go
@@ -169,7 +169,10 @@ func Decompress(data []byte, opts ...Option) ([]byte, error) {
 
 	if size == 0 {
 		// Ambiguous: a valid empty-payload archive, or input the C envelope
-		// rejected. Decoding into a zero-length buffer settles it.
+		// rejected. Decoding into a zero-length buffer settles it. No
+		// destination was supplied, so DST_TOO_SMALL cannot be about the
+		// caller's buffer: blocks contradict the empty size the footer claims,
+		// which reads as invalid data.
 		var dummy [1]byte
 		written := C.zxc_decompress(
 			unsafe.Pointer(&data[0]),
@@ -179,6 +182,9 @@ func Decompress(data []byte, opts ...Option) ([]byte, error) {
 			&dopts,
 		)
 		if written < 0 {
+			if int(written) == int(C.ZXC_ERROR_DST_TOO_SMALL) {
+				return nil, ErrInvalidData
+			}
 			return nil, errorFromCode(written)
 		}
 		if written != 0 {

--- a/wrappers/go/zxc_regression_test.go
+++ b/wrappers/go/zxc_regression_test.go
@@ -64,8 +64,8 @@ func TestFixDecompressCraftedFooter(t *testing.T) {
 			t.Fatalf("Decompress panicked on crafted footer: %v", r)
 		}
 	}()
-	if _, err := Decompress(comp); !errors.Is(err, ErrInvalidData) {
-		t.Fatalf("want ErrInvalidData, got %v", err)
+	if _, err := Decompress(comp); !errors.Is(err, ErrCorruptData) {
+		t.Fatalf("want ErrCorruptData, got %v", err)
 	}
 }
 

--- a/wrappers/go/zxc_regression_test.go
+++ b/wrappers/go/zxc_regression_test.go
@@ -69,6 +69,20 @@ func TestFixDecompressCraftedFooter(t *testing.T) {
 	}
 }
 
+func TestDecompressZeroedFooterSize(t *testing.T) {
+	comp, err := Compress([]byte("hello world hello world hello world"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	// A stored size of 0 is plausible, so the C size probe reports the archive
+	// as empty; only the block walk contradicts it. Decompress must not hand
+	// that back as a buffer-sizing error.
+	binary.LittleEndian.PutUint64(comp[len(comp)-12:], 0)
+	if _, err := Decompress(comp); !errors.Is(err, ErrInvalidData) {
+		t.Fatalf("want ErrInvalidData, got %v", err)
+	}
+}
+
 func TestFixPstreamDictRejected(t *testing.T) {
 	if _, err := NewCStream(WithDict([]byte("abc"))); !errors.Is(err, ErrDictUnsupported) {
 		t.Fatalf("NewCStream(WithDict): want ErrDictUnsupported, got %v", err)


### PR DESCRIPTION
Previously, reusable compression contexts did not consistently or efficiently handle zero-size inputs, leading to unnecessary resource allocation and inconsistent behavior compared to one-shot compression functions.

This change optimizes the handling of empty frames within compression contexts:
*   Enables `zxc_compress_cctx` to accept zero-size inputs (including `NULL` source pointers), producing a valid empty archive consistent with `zxc_compress`.
*   Aligns `zxc_decompress_dctx` behavior to return `0` for empty archives, even when probing for the output size with a `NULL` destination buffer.
*   Prevents redundant workspace re-initialization and carving when compressing an empty frame, improving performance and reducing resource overhead for such calls.
*   Ensures compression contexts remain fully functional for subsequent non-empty payloads after processing an empty frame, and `zxc_compress_block` maintains its contract by refusing empty blocks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Compression APIs support zero-length input, including `NULL` sources, and produce valid empty archives.
  * Decompression APIs can validate and size-probe empty archives, returning a zero-length result when appropriate.
  * Reusable compression contexts continue to support normal data after empty input.
  * Seekable archives now have consistent probing and decoding behavior across API variants.

* **Bug Fixes**
  * Improved error reporting for truncated or malformed archives.
  * Prevented crafted or invalid footer data from causing incorrect results or crashes.
  * Static-context probes now enforce decoding constraints consistently.

* **Documentation**
  * Clarified empty-input behavior, probing, dictionary handling, static-context errors, and ignored options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->