### PR TITLE
ci(nodejs): drop unpinned global npm install from publish job

### DIFF
--- a/.github/workflows/wrapper-nodejs.yml
+++ b/.github/workflows/wrapper-nodejs.yml
@@ -164,11 +164,11 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: "24"
+          # Exact patch pin: this release bundles npm 11.19.0, new enough for
+          # OIDC trusted publishing (npm >= 11.5.1). Installing npm globally
+          # instead would be an unpinned download (Scorecard pinned-dependencies).
+          node-version: "24.21.0"
           registry-url: "https://registry.npmjs.org"
-
-      - name: Update npm
-        run: npm install -g npm@11.19.1
 
       - name: Verify Version Matches Release Tag
         env:


### PR DESCRIPTION
fix scorecard (pinned-dependencies, alert #266)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release publishing environment to use a fixed Node.js version.
  * Removed the separate npm update step from the publishing workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->