### PR TITLE
ci(wasm): drop unpinned global npm install from publish job

### DIFF
--- a/.github/workflows/wrapper-wasm.yml
+++ b/.github/workflows/wrapper-wasm.yml
@@ -102,11 +102,11 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: '24'
+          # Exact patch pin: this release bundles npm 11.19.0, new enough for
+          # OIDC trusted publishing (npm >= 11.5.1). Installing npm globally
+          # instead would be an unpinned download (Scorecard pinned-dependencies).
+          node-version: '24.21.0'
           registry-url: "https://registry.npmjs.org"
-
-      - name: Update npm
-        run: npm install -g npm@11.19.1
 
       - name: Verify Version Matches Release Tag
         working-directory: ./wrappers/wasm


### PR DESCRIPTION
fix scorecard (pinned-dependencies, alert #267)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized the release publishing environment on Node.js 24.21.0.
  * Removed the separate npm update step from the publishing workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->