### PR TITLE
fix(lib): enforces strict block size and EOF validation

### DIFF
--- a/docs/FORMAT.md
+++ b/docs/FORMAT.md
@@ -95,7 +95,12 @@ Offset  Size  Field
   - `255` = EOF
 - **Block Flags**: currently not used by implementation (written as `0`).
 - **Reserved**: must be 0.
-- **comp_size**: payload size in bytes (does **not** include the optional trailing 4-byte block checksum).
+- **comp_size**: payload size in bytes (does **not** include the optional trailing 4-byte block
+  checksum). For a data block (RAW, GLO, GHI) it never exceeds the `block_size` declared in the
+  file header: a block that would grow falls back to RAW, whose payload equals its content, so
+  `block_size` is reached exactly and never passed. A decoder **MUST** reject a larger value.
+  This does not apply to SEK, which is not a data block: its payload is one 4-byte entry per
+  block and routinely exceeds `block_size`.
 - **Header Checksum**: the 8-bit header checksum of [7.1](#71-header-checksums), computed over the 8-byte header with byte `0x07` zeroed.
 
 ### 4.2 Block physical layout
@@ -454,6 +459,9 @@ The **Seek Table** block is an optional block appended between the EOF block and
 4. Calculate `seek_block_size = 8 + (N × 4)`.
 5. Seek backward by `seek_block_size` bytes from the start of the footer to read the Block Header.
 6. Validate `block_type == 254 (SEK)` and `comp_size == N × 4`.
+7. Validate every entry: one entry spans one whole block, so it lies in
+   `[8, 8 + block_size + checksum_size]`, and the running sum must land exactly on the EOF
+   block.
 
 ---
 
@@ -678,6 +686,9 @@ The recommended behavior for each class is specified below.
 | **Block payload truncated** | During `fread` of `comp_size` bytes | Reject. Unexpected end of stream. |
 | **Block checksum mismatch** | Trailing 4-byte checksum | Reject block. Payload is corrupt. |
 | **EOF block with non-zero comp_size** | EOF block header | Reject. Malformed EOF marker. |
+| **Data block comp_size above block size** | Block header, offset 0x03 | Reject. A data block never compresses past its own content (§4.1). |
+| **Block walk ends without an EOF block** | End of the block walk | Reject. A forged `comp_size` can span the EOF marker; the resulting short decode must not be reported as success. |
+| **Seek table entry above one block** | SEK payload | Reject. One entry spans one block (§5). |
 | **Footer source size mismatch** | File footer, offset 0x00 | Reject. Output size does not match declared original size. |
 | **Footer global hash mismatch** | File footer, offset 0x08 | Reject (if checksum mode active). Integrity failure. |
 | **Decompressed output exceeds chunk size** | During LZ decode | Reject. Corrupt or malicious payload. |

--- a/src/lib/zxc_decompress.c
+++ b/src/lib/zxc_decompress.c
@@ -1655,6 +1655,9 @@ static ZXC_ALWAYS_INLINE int zxc_decompress_chunk_wrapper_body(
     const uint32_t comp_sz = zxc_le32(src + 3);
     const int has_checksum = ctx->checksum_enabled;
 
+    // A block never compresses past its own content size
+    if (UNLIKELY((uint64_t)comp_sz > (uint64_t)ctx->chunk_size)) return ZXC_ERROR_BAD_BLOCK_SIZE;
+
     // Check bounds: Header + Body + Checksum(if any)
     const size_t expected_sz =
         (size_t)ZXC_BLOCK_HEADER_SIZE + comp_sz + (has_checksum ? ZXC_BLOCK_CHECKSUM_SIZE : 0);

--- a/src/lib/zxc_dispatch.c
+++ b/src/lib/zxc_dispatch.c
@@ -759,21 +759,6 @@ static int zxc_footer_dsize_plausible(const uint64_t dsize, const size_t chunk_s
 }
 
 /**
- * @brief Caps a data block's payload at one block size.
- *
- * A block that would grow falls back to RAW, so @p comp_size reaches
- * @p chunk_size exactly and never passes it. Data blocks only: SEK holds one
- * entry per block and is routinely larger.
- *
- * @param[in] comp_size  Payload size from the block header.
- * @param[in] chunk_size Block size declared by the file header.
- * @return 1 when the payload fits one block, 0 for a forged size.
- */
-static int zxc_block_comp_size_plausible(const uint32_t comp_size, const size_t chunk_size) {
-    return (uint64_t)comp_size <= (uint64_t)chunk_size;
-}
-
-/**
  * @brief Validates a frame envelope without decoding it: file header, then the
  *        decompressed size stored in the footer.
  *
@@ -901,13 +886,16 @@ static int64_t zxc_decompress_frame(const uint8_t* src, const size_t src_size, u
     // Dict decode buffer: [dict_content | decode_space + PAD], carved into the
     // cctx workspace (NULL when no dictionary is active).
     int ctx_ready = 0;
-    int saw_eof = 0;
     uint8_t* dict_dec = NULL;
 
     // Block decompression loop
     uint32_t global_hash = 0;
 
-    while (ip < ip_end) {
+    for (;;) {
+        if (UNLIKELY(ip >= ip_end)) {
+            if (ctx_ready) zxc_cctx_free(&ctx);
+            return ZXC_ERROR_CORRUPT_DATA;
+        }
         const size_t rem_src = (size_t)(ip_end - ip);
         zxc_block_header_t bh;
         // Read the block header to determine the compressed size
@@ -918,7 +906,6 @@ static int64_t zxc_decompress_frame(const uint8_t* src, const size_t src_size, u
 
         // Handle EOF block separately (not a real chunk to decompress)
         if (UNLIKELY(bh.block_type == ZXC_BLOCK_EOF)) {
-            saw_eof = 1;
             // EOF carries no payload; a non-zero comp_size is a malformed header.
             if (UNLIKELY(bh.comp_size != 0)) {
                 if (ctx_ready) zxc_cctx_free(&ctx);
@@ -949,12 +936,16 @@ static int64_t zxc_decompress_frame(const uint8_t* src, const size_t src_size, u
                     return ZXC_ERROR_BAD_CHECKSUM;
                 }
             }
-            break;  // EOF reached, exit loop
+            break;  // EOF reached, exit the block loop
         }
 
-        if (UNLIKELY(!zxc_block_comp_size_plausible(bh.comp_size, runtime_chunk_size))) {
+        // The decoder only requires the payload, the step also covers the
+        // checksum.
+        const size_t advance = ZXC_BLOCK_HEADER_SIZE + bh.comp_size +
+                               (file_has_checksums ? ZXC_BLOCK_CHECKSUM_SIZE : 0);
+        if (UNLIKELY(advance > rem_src)) {
             if (ctx_ready) zxc_cctx_free(&ctx);
-            return ZXC_ERROR_BAD_BLOCK_SIZE;
+            return ZXC_ERROR_SRC_TOO_SMALL;
         }
 
         if (!ctx_ready) {
@@ -1013,14 +1004,11 @@ static int64_t zxc_decompress_frame(const uint8_t* src, const size_t src_size, u
             global_hash = zxc_hash_combine_rotate(global_hash, block_hash);
         }
 
-        ip += ZXC_BLOCK_HEADER_SIZE + bh.comp_size +
-              (file_has_checksums ? ZXC_BLOCK_CHECKSUM_SIZE : 0);
+        ip += advance;
         op += res;
     }
 
     if (ctx_ready) zxc_cctx_free(&ctx);
-    if (UNLIKELY(!saw_eof)) return ZXC_ERROR_CORRUPT_DATA;
-
     return (int64_t)(op - op_start);
 }
 
@@ -1583,18 +1571,17 @@ int64_t zxc_decompress_dctx(zxc_dctx* dctx, const void* RESTRICT src, const size
     uint8_t* const dict_dec = ctx->dict_buffer;
     if (dict_dec) ZXC_MEMCPY(dict_dec, dict, dict_size);
 
-    int saw_eof = 0;
-    while (ip < ip_end) {
+    for (;;) {
+        // See zxc_decompress_frame: only the EOF block may end the walk.
+        if (UNLIKELY(ip >= ip_end)) return ZXC_ERROR_CORRUPT_DATA;
         const size_t rem_src = (size_t)(ip_end - ip);
         zxc_block_header_t bh;
         if (UNLIKELY(zxc_read_block_header(ip, rem_src, &bh) != ZXC_OK))
             return ZXC_ERROR_BAD_HEADER;
 
         if (UNLIKELY(bh.block_type == ZXC_BLOCK_EOF)) {
-            saw_eof = 1;
             if (UNLIKELY(bh.comp_size != 0)) return ZXC_ERROR_BAD_HEADER;
-            // Same rule as zxc_decompress(): the footer is the archive's last
-            // bytes, even when a seek table sits between the EOF block and it.
+
             const uint8_t* const footer = (const uint8_t*)src + src_size - ZXC_FILE_FOOTER_SIZE;
             const uint64_t stored_size = zxc_le64(footer);
             if (UNLIKELY(stored_size != (uint64_t)(op - op_start))) return ZXC_ERROR_CORRUPT_DATA;
@@ -1603,11 +1590,12 @@ int64_t zxc_decompress_dctx(zxc_dctx* dctx, const void* RESTRICT src, const size
                 const uint32_t stored_hash = zxc_le32(footer + sizeof(uint64_t));
                 if (UNLIKELY(stored_hash != global_hash)) return ZXC_ERROR_BAD_CHECKSUM;
             }
-            break;
+            break;  // EOF reached, stop decoding
         }
 
-        if (UNLIKELY(!zxc_block_comp_size_plausible(bh.comp_size, runtime_chunk_size)))
-            return ZXC_ERROR_BAD_BLOCK_SIZE;
+        const size_t advance = ZXC_BLOCK_HEADER_SIZE + bh.comp_size +
+                               (file_has_checksums ? ZXC_BLOCK_CHECKSUM_SIZE : 0);
+        if (UNLIKELY(advance > rem_src)) return ZXC_ERROR_SRC_TOO_SMALL;
 
         const size_t rem_cap = (size_t)(op_end - op);
         int res;
@@ -1620,8 +1608,7 @@ int64_t zxc_decompress_dctx(zxc_dctx* dctx, const void* RESTRICT src, const size
                 ZXC_MEMCPY(op, dict_dec + dict_size, (size_t)res);
             }
         } else if (LIKELY(rem_cap >= work_sz)) {
-            // Fast path: decode directly into dst (enough padding for wild copies).
-            res = zxc_decompress_chunk_wrapper(ctx, ip, rem_src, op, rem_cap);
+            res = zxc_decompress_chunk_wrapper(ctx, ip, rem_src, op, work_sz);
         } else {
             // Safe path: decode into bounce buffer, then copy exact result.
             res = zxc_decompress_chunk_wrapper(ctx, ip, rem_src, ctx->work_buf, ctx->work_buf_cap);
@@ -1638,12 +1625,9 @@ int64_t zxc_decompress_dctx(zxc_dctx* dctx, const void* RESTRICT src, const size
             global_hash = zxc_hash_combine_rotate(global_hash, block_hash);
         }
 
-        ip += ZXC_BLOCK_HEADER_SIZE + bh.comp_size +
-              (file_has_checksums ? ZXC_BLOCK_CHECKSUM_SIZE : 0);
+        ip += advance;
         op += res;
     }
-
-    if (UNLIKELY(!saw_eof)) return ZXC_ERROR_CORRUPT_DATA;
 
     return (int64_t)(op - op_start);
 }

--- a/src/lib/zxc_dispatch.c
+++ b/src/lib/zxc_dispatch.c
@@ -759,6 +759,21 @@ static int zxc_footer_dsize_plausible(const uint64_t dsize, const size_t chunk_s
 }
 
 /**
+ * @brief Caps a data block's payload at one block size.
+ *
+ * A block that would grow falls back to RAW, so @p comp_size reaches
+ * @p chunk_size exactly and never passes it. Data blocks only: SEK holds one
+ * entry per block and is routinely larger.
+ *
+ * @param[in] comp_size  Payload size from the block header.
+ * @param[in] chunk_size Block size declared by the file header.
+ * @return 1 when the payload fits one block, 0 for a forged size.
+ */
+static int zxc_block_comp_size_plausible(const uint32_t comp_size, const size_t chunk_size) {
+    return (uint64_t)comp_size <= (uint64_t)chunk_size;
+}
+
+/**
  * @brief Validates a frame envelope without decoding it: file header, then the
  *        decompressed size stored in the footer.
  *
@@ -886,6 +901,7 @@ static int64_t zxc_decompress_frame(const uint8_t* src, const size_t src_size, u
     // Dict decode buffer: [dict_content | decode_space + PAD], carved into the
     // cctx workspace (NULL when no dictionary is active).
     int ctx_ready = 0;
+    int saw_eof = 0;
     uint8_t* dict_dec = NULL;
 
     // Block decompression loop
@@ -902,6 +918,7 @@ static int64_t zxc_decompress_frame(const uint8_t* src, const size_t src_size, u
 
         // Handle EOF block separately (not a real chunk to decompress)
         if (UNLIKELY(bh.block_type == ZXC_BLOCK_EOF)) {
+            saw_eof = 1;
             // EOF carries no payload; a non-zero comp_size is a malformed header.
             if (UNLIKELY(bh.comp_size != 0)) {
                 if (ctx_ready) zxc_cctx_free(&ctx);
@@ -933,6 +950,11 @@ static int64_t zxc_decompress_frame(const uint8_t* src, const size_t src_size, u
                 }
             }
             break;  // EOF reached, exit loop
+        }
+
+        if (UNLIKELY(!zxc_block_comp_size_plausible(bh.comp_size, runtime_chunk_size))) {
+            if (ctx_ready) zxc_cctx_free(&ctx);
+            return ZXC_ERROR_BAD_BLOCK_SIZE;
         }
 
         if (!ctx_ready) {
@@ -997,6 +1019,8 @@ static int64_t zxc_decompress_frame(const uint8_t* src, const size_t src_size, u
     }
 
     if (ctx_ready) zxc_cctx_free(&ctx);
+    if (UNLIKELY(!saw_eof)) return ZXC_ERROR_CORRUPT_DATA;
+
     return (int64_t)(op - op_start);
 }
 
@@ -1559,6 +1583,7 @@ int64_t zxc_decompress_dctx(zxc_dctx* dctx, const void* RESTRICT src, const size
     uint8_t* const dict_dec = ctx->dict_buffer;
     if (dict_dec) ZXC_MEMCPY(dict_dec, dict, dict_size);
 
+    int saw_eof = 0;
     while (ip < ip_end) {
         const size_t rem_src = (size_t)(ip_end - ip);
         zxc_block_header_t bh;
@@ -1566,6 +1591,7 @@ int64_t zxc_decompress_dctx(zxc_dctx* dctx, const void* RESTRICT src, const size
             return ZXC_ERROR_BAD_HEADER;
 
         if (UNLIKELY(bh.block_type == ZXC_BLOCK_EOF)) {
+            saw_eof = 1;
             if (UNLIKELY(bh.comp_size != 0)) return ZXC_ERROR_BAD_HEADER;
             // Same rule as zxc_decompress(): the footer is the archive's last
             // bytes, even when a seek table sits between the EOF block and it.
@@ -1579,6 +1605,9 @@ int64_t zxc_decompress_dctx(zxc_dctx* dctx, const void* RESTRICT src, const size
             }
             break;
         }
+
+        if (UNLIKELY(!zxc_block_comp_size_plausible(bh.comp_size, runtime_chunk_size)))
+            return ZXC_ERROR_BAD_BLOCK_SIZE;
 
         const size_t rem_cap = (size_t)(op_end - op);
         int res;
@@ -1613,6 +1642,8 @@ int64_t zxc_decompress_dctx(zxc_dctx* dctx, const void* RESTRICT src, const size
               (file_has_checksums ? ZXC_BLOCK_CHECKSUM_SIZE : 0);
         op += res;
     }
+
+    if (UNLIKELY(!saw_eof)) return ZXC_ERROR_CORRUPT_DATA;
 
     return (int64_t)(op - op_start);
 }

--- a/src/lib/zxc_driver.c
+++ b/src/lib/zxc_driver.c
@@ -544,10 +544,12 @@ static int zxc_stream_read_loop(zxc_stream_ctx_t* ctx, FILE* f_in, const int mod
             } else {
                 zxc_block_header_t bh;
                 if (UNLIKELY(zxc_read_block_header(bh_buf, ZXC_BLOCK_HEADER_SIZE, &bh) != ZXC_OK)) {
+                    // LCOV_EXCL_START
                     ctx->io_error = 1;
                     if (!ctx->fail_code) ctx->fail_code = ZXC_ERROR_CORRUPT_DATA;
                     read_eof = 1;
                     goto _job_prepared;
+                    // LCOV_EXCL_STOP
                 }
 
                 if (bh.block_type == ZXC_BLOCK_EOF) {
@@ -561,6 +563,15 @@ static int zxc_stream_read_loop(zxc_stream_ctx_t* ctx, FILE* f_in, const int mod
                     read_eof = 1;
                     read_sz = 0;
                     goto _job_prepared;
+                }
+
+                if (UNLIKELY((uint64_t)bh.comp_size > (uint64_t)ctx->chunk_size)) {
+                    // LCOV_EXCL_START
+                    ctx->io_error = 1;
+                    if (!ctx->fail_code) ctx->fail_code = ZXC_ERROR_BAD_BLOCK_SIZE;
+                    read_eof = 1;
+                    goto _job_prepared;
+                    // LCOV_EXCL_STOP
                 }
 
                 const int has_checksum = ctx->file_has_checksum;

--- a/src/lib/zxc_pstream.c
+++ b/src/lib/zxc_pstream.c
@@ -918,7 +918,11 @@ static int ds_handle_need_block_header(zxc_dstream* ds, zxc_inbuf_t* in) {
         return 0;
     }
 
-    // Normal data block: read comp_size [+ ZXC_BLOCK_CHECKSUM_SIZE if file-level checksums].
+    // Data block: validate comp_size against the block_size negotiated in the file header.
+    if (UNLIKELY((uint64_t)ds->cur_bh.comp_size > (uint64_t)ds->block_size))
+        return ds_set_error(ds, ZXC_ERROR_BAD_BLOCK_SIZE);
+
+    // Read comp_size [+ ZXC_BLOCK_CHECKSUM_SIZE if file-level checksums].
     const uint64_t need = (uint64_t)ds->cur_bh.comp_size +
                           (ds->file_has_checksum ? (uint64_t)ZXC_BLOCK_CHECKSUM_SIZE : 0U);
     if (UNLIKELY(need > ds->payload_cap)) return ds_set_error(ds, ZXC_ERROR_BAD_BLOCK_SIZE);

--- a/src/lib/zxc_seekable.c
+++ b/src/lib/zxc_seekable.c
@@ -272,12 +272,14 @@ static zxc_seekable* zxc_seekable_parse(const zxc_seek_source_t* src) {
     {
         const uint8_t* ep = seek_blk + ZXC_BLOCK_HEADER_SIZE;
         uint64_t comp_acc = ZXC_FILE_HEADER_SIZE; /* blocks start after file header */
+        const uint64_t entry_max = (uint64_t)ZXC_BLOCK_HEADER_SIZE + block_size +
+                                   (file_has_chk ? ZXC_BLOCK_CHECKSUM_SIZE : 0U);
+
         for (uint32_t i = 0; i < num_blocks; i++) {
             s->comp_sizes[i] = zxc_le32(ep);
             ep += sizeof(uint32_t);
 
-            // Reject entries below minimum (block header) or larger than the file
-            if (UNLIKELY(s->comp_sizes[i] < ZXC_BLOCK_HEADER_SIZE || s->comp_sizes[i] > src->size))
+            if (UNLIKELY(s->comp_sizes[i] < ZXC_BLOCK_HEADER_SIZE || s->comp_sizes[i] > entry_max))
                 goto fail;
             if (s->comp_sizes[i] > s->max_comp_size) s->max_comp_size = s->comp_sizes[i];
             s->comp_offsets[i] = comp_acc;

--- a/src/lib/zxc_seekable.c
+++ b/src/lib/zxc_seekable.c
@@ -266,9 +266,9 @@ static zxc_seekable* zxc_seekable_parse(const zxc_seek_source_t* src) {
     s->comp_offsets = (uint64_t*)ZXC_CALLOC((size_t)num_blocks + 1, sizeof(uint64_t));
     if (UNLIKELY(!s->comp_sizes || !s->comp_offsets)) goto fail;  // LCOV_EXCL_LINE
 
-    // Parse comp_sizes and build compressed prefix sums. Every entry is checked
-    // against the archive size, so the prefix sum can neither overflow nor
-    // point a later read out of bounds.
+    // Parse comp_sizes and build compressed prefix sums. Entries are capped at
+    // one block and the running sum at the archive size, so no later read can
+    // land out of bounds.
     {
         const uint8_t* ep = seek_blk + ZXC_BLOCK_HEADER_SIZE;
         uint64_t comp_acc = ZXC_FILE_HEADER_SIZE; /* blocks start after file header */
@@ -284,8 +284,7 @@ static zxc_seekable* zxc_seekable_parse(const zxc_seek_source_t* src) {
             if (s->comp_sizes[i] > s->max_comp_size) s->max_comp_size = s->comp_sizes[i];
             s->comp_offsets[i] = comp_acc;
             comp_acc += s->comp_sizes[i];
-            // Reject if cumulative offset exceeds file size (inconsistent table)
-            if (UNLIKELY(comp_acc > src->size)) goto fail;  // LCOV_EXCL_LINE
+            if (UNLIKELY(comp_acc > src->size)) goto fail;
         }
         s->comp_offsets[num_blocks] = comp_acc;
 

--- a/tests/test_common.h
+++ b/tests/test_common.h
@@ -176,6 +176,7 @@ int test_seekable_open_reader_mt(void);
 int test_seekable_cross_boundary(void);
 int test_seekable_truncated_input(void);
 int test_seekable_corrupted_sek(void);
+int test_seekable_forged_table_entry(void);
 int test_seekable_range_out_of_bounds(void);
 int test_seekable_dst_too_small(void);
 int test_seekable_empty_file(void);
@@ -199,6 +200,7 @@ int test_huffman_single_symbol_validation(void);
 int test_eof_block_structure(void);
 int test_header_checksum(void);
 int test_global_checksum_order(void);
+int test_forged_block_comp_size(void);
 int test_chunk_size_code(void);
 
 /* Misc */

--- a/tests/test_format.c
+++ b/tests/test_format.c
@@ -967,10 +967,6 @@ static int64_t forge_decode_via(const uint8_t* arc, size_t arc_sz, size_t plain_
     return r;
 }
 
-static int64_t forge_decode(const uint8_t* arc, size_t arc_sz, size_t plain_sz, int checksum) {
-    return forge_decode_via(arc, arc_sz, plain_sz, checksum, 0);
-}
-
 /*
  * A block header carries comp_size as a plain u32, and the header checksum
  * covers it, so a forged size is structurally valid. Two things must stop it:
@@ -1013,18 +1009,24 @@ int test_forged_block_comp_size() {
                    b0.block_type, b0.comp_size);
             ok = 0;
         }
-        if (ok && forge_decode(arc, arc_sz, plain_sz, checksum) != (int64_t)plain_sz) {
-            printf("  [FAIL] intact archive rejected\n");
-            ok = 0;
+        for (int via = 0; ok && via <= 1; via++) {
+            if (forge_decode_via(arc, arc_sz, plain_sz, checksum, via) != (int64_t)plain_sz) {
+                printf("  [FAIL] intact archive rejected via %s\n",
+                       via ? "dctx" : "zxc_decompress");
+                ok = 0;
+            }
         }
 
         if (ok) { /* One byte over the bound. */
             memcpy(forged, arc, arc_sz);
             ok = forge_comp_size(forged, arc_sz, (uint32_t)block_sz + 1u);
-            const int64_t r = ok ? forge_decode(forged, arc_sz, plain_sz, checksum) : 0;
-            if (ok && r != ZXC_ERROR_BAD_BLOCK_SIZE) {
-                printf("  [FAIL] comp_size = block_size + 1 gave %lld\n", (long long)r);
-                ok = 0;
+            for (int via = 0; ok && via <= 1; via++) {
+                const int64_t r = forge_decode_via(forged, arc_sz, plain_sz, checksum, via);
+                if (r != ZXC_ERROR_BAD_BLOCK_SIZE) {
+                    printf("  [FAIL] comp_size = block_size + 1 via %s gave %lld\n",
+                           via ? "dctx" : "zxc_decompress", (long long)r);
+                    ok = 0;
+                }
             }
         }
 
@@ -1033,10 +1035,13 @@ int test_forged_block_comp_size() {
             ok = forge_comp_size(
                 forged, arc_sz,
                 (uint32_t)(arc_sz - ZXC_FILE_HEADER_SIZE - ZXC_BLOCK_HEADER_SIZE - trailer));
-            const int64_t r = ok ? forge_decode(forged, arc_sz, plain_sz, checksum) : 0;
-            if (ok && r != ZXC_ERROR_BAD_BLOCK_SIZE) {
-                printf("  [FAIL] swallowing comp_size gave %lld\n", (long long)r);
-                ok = 0;
+            for (int via = 0; ok && via <= 1; via++) {
+                const int64_t r = forge_decode_via(forged, arc_sz, plain_sz, checksum, via);
+                if (r != ZXC_ERROR_BAD_BLOCK_SIZE) {
+                    printf("  [FAIL] swallowing comp_size via %s gave %lld\n",
+                           via ? "dctx" : "zxc_decompress", (long long)r);
+                    ok = 0;
+                }
             }
         }
         free(forged);

--- a/tests/test_format.c
+++ b/tests/test_format.c
@@ -932,21 +932,43 @@ static uint8_t* forge_build(size_t plain_sz, int compressible, size_t block_sz, 
 }
 
 /* Rewrites block 0's comp_size, keeping the 8-bit header checksum valid. */
-static void forge_comp_size(uint8_t* arc, size_t arc_sz, uint32_t comp_size) {
+static int forge_comp_size(uint8_t* arc, size_t arc_sz, uint32_t comp_size) {
+    const size_t rem = arc_sz - ZXC_FILE_HEADER_SIZE;
     zxc_block_header_t bh;
-    zxc_read_block_header(arc + ZXC_FILE_HEADER_SIZE, arc_sz - ZXC_FILE_HEADER_SIZE, &bh);
+    if (zxc_read_block_header(arc + ZXC_FILE_HEADER_SIZE, rem, &bh) != ZXC_OK) {
+        printf("  [FAIL] block 0 header unreadable\n");
+        return 0;
+    }
     bh.comp_size = comp_size;
-    zxc_write_block_header(arc + ZXC_FILE_HEADER_SIZE, arc_sz - ZXC_FILE_HEADER_SIZE, &bh);
+    if (zxc_write_block_header(arc + ZXC_FILE_HEADER_SIZE, rem, &bh) != ZXC_BLOCK_HEADER_SIZE) {
+        printf("  [FAIL] block 0 header not rewritten\n");
+        return 0;
+    }
+    return 1;
 }
 
-static int64_t forge_decode(const uint8_t* arc, size_t arc_sz, size_t plain_sz, int checksum) {
+/* Decodes through zxc_decompress (use_dctx == 0) or a reusable zxc_dctx: the
+   two frame walks are separate code and must reject the same forgeries. */
+static int64_t forge_decode_via(const uint8_t* arc, size_t arc_sz, size_t plain_sz, int checksum,
+                                int use_dctx) {
     uint8_t* out = (uint8_t*)malloc(plain_sz);
     if (!out) return ZXC_ERROR_MEMORY;
     zxc_decompress_opts_t o = {0};
     o.checksum_enabled = checksum;
-    const int64_t r = zxc_decompress(arc, arc_sz, out, plain_sz, &o);
+    int64_t r;
+    if (use_dctx) {
+        zxc_dctx* d = zxc_create_dctx();
+        r = d ? zxc_decompress_dctx(d, arc, arc_sz, out, plain_sz, &o) : ZXC_ERROR_MEMORY;
+        zxc_free_dctx(d);
+    } else {
+        r = zxc_decompress(arc, arc_sz, out, plain_sz, &o);
+    }
     free(out);
     return r;
+}
+
+static int64_t forge_decode(const uint8_t* arc, size_t arc_sz, size_t plain_sz, int checksum) {
+    return forge_decode_via(arc, arc_sz, plain_sz, checksum, 0);
 }
 
 /*
@@ -981,8 +1003,12 @@ int test_forged_block_comp_size() {
         }
 
         zxc_block_header_t b0;
-        zxc_read_block_header(arc + ZXC_FILE_HEADER_SIZE, arc_sz - ZXC_FILE_HEADER_SIZE, &b0);
-        if (b0.block_type != ZXC_BLOCK_RAW || b0.comp_size != block_sz) {
+        if (zxc_read_block_header(arc + ZXC_FILE_HEADER_SIZE, arc_sz - ZXC_FILE_HEADER_SIZE, &b0) !=
+            ZXC_OK) {
+            printf("  [FAIL] block 0 header unreadable\n");
+            ok = 0;
+        }
+        if (ok && (b0.block_type != ZXC_BLOCK_RAW || b0.comp_size != block_sz)) {
             printf("  [FAIL] expected a RAW block at the bound, got type=%u comp_size=%u\n",
                    b0.block_type, b0.comp_size);
             ok = 0;
@@ -994,9 +1020,9 @@ int test_forged_block_comp_size() {
 
         if (ok) { /* One byte over the bound. */
             memcpy(forged, arc, arc_sz);
-            forge_comp_size(forged, arc_sz, (uint32_t)block_sz + 1u);
-            const int64_t r = forge_decode(forged, arc_sz, plain_sz, checksum);
-            if (r != ZXC_ERROR_BAD_BLOCK_SIZE) {
+            ok = forge_comp_size(forged, arc_sz, (uint32_t)block_sz + 1u);
+            const int64_t r = ok ? forge_decode(forged, arc_sz, plain_sz, checksum) : 0;
+            if (ok && r != ZXC_ERROR_BAD_BLOCK_SIZE) {
                 printf("  [FAIL] comp_size = block_size + 1 gave %lld\n", (long long)r);
                 ok = 0;
             }
@@ -1004,11 +1030,11 @@ int test_forged_block_comp_size() {
 
         if (ok) { /* Spans every remaining byte, EOF and footer included. */
             memcpy(forged, arc, arc_sz);
-            forge_comp_size(
+            ok = forge_comp_size(
                 forged, arc_sz,
                 (uint32_t)(arc_sz - ZXC_FILE_HEADER_SIZE - ZXC_BLOCK_HEADER_SIZE - trailer));
-            const int64_t r = forge_decode(forged, arc_sz, plain_sz, checksum);
-            if (r != ZXC_ERROR_BAD_BLOCK_SIZE) {
+            const int64_t r = ok ? forge_decode(forged, arc_sz, plain_sz, checksum) : 0;
+            if (ok && r != ZXC_ERROR_BAD_BLOCK_SIZE) {
                 printf("  [FAIL] swallowing comp_size gave %lld\n", (long long)r);
                 ok = 0;
             }
@@ -1034,13 +1060,15 @@ int test_forged_block_comp_size() {
             ok = 0;
         }
         if (ok) {
-            forge_comp_size(arc, arc_sz, swallow);
-            const int64_t r = forge_decode(arc, arc_sz, small_sz, checksum);
+            ok = forge_comp_size(arc, arc_sz, swallow);
             const int64_t want = checksum ? ZXC_ERROR_BAD_CHECKSUM : ZXC_ERROR_CORRUPT_DATA;
-            if (r != want) {
-                printf("  [FAIL] skipped EOF gave %lld, expected %lld\n", (long long)r,
-                       (long long)want);
-                ok = 0;
+            for (int via = 0; ok && via <= 1; via++) {
+                const int64_t r = forge_decode_via(arc, arc_sz, small_sz, checksum, via);
+                if (r != want) {
+                    printf("  [FAIL] skipped EOF via %s gave %lld, expected %lld\n",
+                           via ? "dctx" : "zxc_decompress", (long long)r, (long long)want);
+                    ok = 0;
+                }
             }
         }
         free(arc);

--- a/tests/test_format.c
+++ b/tests/test_format.c
@@ -899,3 +899,155 @@ int test_chunk_size_code() {
     printf("PASS\n\n");
     return 1;
 }
+
+/* Compresses a deterministic payload into a fresh buffer; caller frees both. */
+static uint8_t* forge_build(size_t plain_sz, int compressible, size_t block_sz, int checksum,
+                            uint8_t** out_plain, size_t* out_sz) {
+    uint8_t* plain = (uint8_t*)malloc(plain_sz);
+    if (!plain) return NULL;
+    unsigned s = 99u;
+    for (size_t i = 0; i < plain_sz; i++) {
+        s = s * 1103515245u + 12345u;
+        plain[i] = compressible ? (uint8_t)('a' + (i % 26)) : (uint8_t)(s >> 24);
+    }
+    const uint64_t bound = zxc_compress_bound(plain_sz);
+    uint8_t* arc = (uint8_t*)malloc((size_t)bound);
+    if (!arc) {
+        free(plain);
+        return NULL;
+    }
+    zxc_compress_opts_t o = {0};
+    o.level = 3;
+    o.block_size = block_sz;
+    o.checksum_enabled = checksum;
+    const int64_t n = zxc_compress(plain, plain_sz, arc, (size_t)bound, &o);
+    if (n < 0) {
+        free(plain);
+        free(arc);
+        return NULL;
+    }
+    *out_plain = plain;
+    *out_sz = (size_t)n;
+    return arc;
+}
+
+/* Rewrites block 0's comp_size, keeping the 8-bit header checksum valid. */
+static void forge_comp_size(uint8_t* arc, size_t arc_sz, uint32_t comp_size) {
+    zxc_block_header_t bh;
+    zxc_read_block_header(arc + ZXC_FILE_HEADER_SIZE, arc_sz - ZXC_FILE_HEADER_SIZE, &bh);
+    bh.comp_size = comp_size;
+    zxc_write_block_header(arc + ZXC_FILE_HEADER_SIZE, arc_sz - ZXC_FILE_HEADER_SIZE, &bh);
+}
+
+static int64_t forge_decode(const uint8_t* arc, size_t arc_sz, size_t plain_sz, int checksum) {
+    uint8_t* out = (uint8_t*)malloc(plain_sz);
+    if (!out) return ZXC_ERROR_MEMORY;
+    zxc_decompress_opts_t o = {0};
+    o.checksum_enabled = checksum;
+    const int64_t r = zxc_decompress(arc, arc_sz, out, plain_sz, &o);
+    free(out);
+    return r;
+}
+
+/*
+ * A block header carries comp_size as a plain u32, and the header checksum
+ * covers it, so a forged size is structurally valid. Two things must stop it:
+ * comp_size may not exceed the file's block size, and the walk may not report
+ * success without having reached the EOF block - a forged size can span it.
+ */
+int test_forged_block_comp_size() {
+    printf("TEST: Forged block comp_size... ");
+    const size_t block_sz = 4096;
+    int ok = 1;
+
+    for (int checksum = 0; checksum <= 1 && ok; checksum++) {
+        const size_t trailer = checksum ? ZXC_BLOCK_CHECKSUM_SIZE : 0;
+        uint8_t* plain = NULL;
+        size_t arc_sz = 0;
+        /* Incompressible: block 0 falls back to RAW with comp_size == block_sz,
+           so the legal case sits exactly on the bound. */
+        uint8_t* arc = forge_build(64 * 1024, 0, block_sz, checksum, &plain, &arc_sz);
+        if (!arc) {
+            printf("  [FAIL] setup\n");
+            return 0;
+        }
+        const size_t plain_sz = 64 * 1024;
+        uint8_t* forged = (uint8_t*)malloc(arc_sz);
+        if (!forged) {
+            free(arc);
+            free(plain);
+            printf("  [FAIL] setup\n");
+            return 0;
+        }
+
+        zxc_block_header_t b0;
+        zxc_read_block_header(arc + ZXC_FILE_HEADER_SIZE, arc_sz - ZXC_FILE_HEADER_SIZE, &b0);
+        if (b0.block_type != ZXC_BLOCK_RAW || b0.comp_size != block_sz) {
+            printf("  [FAIL] expected a RAW block at the bound, got type=%u comp_size=%u\n",
+                   b0.block_type, b0.comp_size);
+            ok = 0;
+        }
+        if (ok && forge_decode(arc, arc_sz, plain_sz, checksum) != (int64_t)plain_sz) {
+            printf("  [FAIL] intact archive rejected\n");
+            ok = 0;
+        }
+
+        if (ok) { /* One byte over the bound. */
+            memcpy(forged, arc, arc_sz);
+            forge_comp_size(forged, arc_sz, (uint32_t)block_sz + 1u);
+            const int64_t r = forge_decode(forged, arc_sz, plain_sz, checksum);
+            if (r != ZXC_ERROR_BAD_BLOCK_SIZE) {
+                printf("  [FAIL] comp_size = block_size + 1 gave %lld\n", (long long)r);
+                ok = 0;
+            }
+        }
+
+        if (ok) { /* Spans every remaining byte, EOF and footer included. */
+            memcpy(forged, arc, arc_sz);
+            forge_comp_size(
+                forged, arc_sz,
+                (uint32_t)(arc_sz - ZXC_FILE_HEADER_SIZE - ZXC_BLOCK_HEADER_SIZE - trailer));
+            const int64_t r = forge_decode(forged, arc_sz, plain_sz, checksum);
+            if (r != ZXC_ERROR_BAD_BLOCK_SIZE) {
+                printf("  [FAIL] swallowing comp_size gave %lld\n", (long long)r);
+                ok = 0;
+            }
+        }
+        free(forged);
+        free(arc);
+        free(plain);
+
+        if (!ok) break;
+
+        /* Compressible: the swallowing size stays under block_size, so only the
+           EOF requirement can catch it. */
+        const size_t small_sz = 40 * 1024;
+        arc = forge_build(small_sz, 1, block_sz, checksum, &plain, &arc_sz);
+        if (!arc) {
+            printf("  [FAIL] setup\n");
+            return 0;
+        }
+        const uint32_t swallow =
+            (uint32_t)(arc_sz - ZXC_FILE_HEADER_SIZE - ZXC_BLOCK_HEADER_SIZE - trailer);
+        if (swallow > block_sz) {
+            printf("  [FAIL] archive too large to test the EOF path (%u)\n", swallow);
+            ok = 0;
+        }
+        if (ok) {
+            forge_comp_size(arc, arc_sz, swallow);
+            const int64_t r = forge_decode(arc, arc_sz, small_sz, checksum);
+            const int64_t want = checksum ? ZXC_ERROR_BAD_CHECKSUM : ZXC_ERROR_CORRUPT_DATA;
+            if (r != want) {
+                printf("  [FAIL] skipped EOF gave %lld, expected %lld\n", (long long)r,
+                       (long long)want);
+                ok = 0;
+            }
+        }
+        free(arc);
+        free(plain);
+    }
+
+    if (!ok) return 0;
+    printf("PASS\n\n");
+    return 1;
+}

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -122,6 +122,7 @@ static const test_entry_t g_tests[] = {
     TEST_CASE(test_eof_block_structure),
     TEST_CASE(test_header_checksum),
     TEST_CASE(test_global_checksum_order),
+    TEST_CASE(test_forged_block_comp_size),
     TEST_CASE(test_chunk_size_code),
 
     /* --- Misc --- */
@@ -184,6 +185,7 @@ static const test_entry_t g_tests[] = {
     TEST_CASE(test_seekable_cross_boundary),
     TEST_CASE(test_seekable_truncated_input),
     TEST_CASE(test_seekable_corrupted_sek),
+    TEST_CASE(test_seekable_forged_table_entry),
     TEST_CASE(test_seekable_range_out_of_bounds),
     TEST_CASE(test_seekable_dst_too_small),
     TEST_CASE(test_seekable_empty_file),

--- a/tests/test_seekable.c
+++ b/tests/test_seekable.c
@@ -1960,3 +1960,74 @@ int test_seekable_work_buf_tail_pad(void) {
     printf("PASS\n\n");
     return 1;
 }
+
+/*
+ * A seek-table entry spans exactly one block, so it cannot exceed a block
+ * header plus a full block plus its checksum. Inflating one entry and
+ * deflating the next by the same amount keeps the prefix sum landing on the
+ * EOF block, so only the per-entry bound can reject the table.
+ */
+int test_seekable_forged_table_entry() {
+    printf("=== TEST: Seekable - Forged Table Entry ===\n");
+
+    const size_t SRC_SIZE = 64 * 1024;
+    const size_t BLOCK_SIZE = 4096;
+    uint8_t* src = malloc(SRC_SIZE);
+    if (!src) return 0;
+    /* Incompressible: every block falls back to RAW and sits on the bound. */
+    unsigned rng = 4242u;
+    for (size_t i = 0; i < SRC_SIZE; i++) {
+        rng = rng * 1103515245u + 12345u;
+        src[i] = (uint8_t)(rng >> 24);
+    }
+
+    const size_t dst_cap = (size_t)zxc_compress_bound(SRC_SIZE) + 256;
+    uint8_t* dst = malloc(dst_cap);
+    if (!dst) {
+        free(src);
+        return 0;
+    }
+    zxc_compress_opts_t opts = {.level = 1, .seekable = 1, .block_size = BLOCK_SIZE};
+    const int64_t csize = zxc_compress(src, SRC_SIZE, dst, dst_cap, &opts);
+    free(src);
+    if (csize <= 0) {
+        printf("Failed: compress\n");
+        free(dst);
+        return 0;
+    }
+
+    const uint32_t num_blocks = (uint32_t)(SRC_SIZE / BLOCK_SIZE);
+    /* [file header][blocks][EOF][SEK header + N*4][footer] */
+    uint8_t* const entries =
+        dst + csize - ZXC_FILE_FOOTER_SIZE - (size_t)num_blocks * sizeof(uint32_t);
+    const uint32_t e0 = zxc_le32(entries);
+    const uint32_t e1 = zxc_le32(entries + sizeof(uint32_t));
+    const uint32_t entry_max = (uint32_t)(ZXC_BLOCK_HEADER_SIZE + BLOCK_SIZE);
+
+    int ok = 1;
+    if (e0 != entry_max) {
+        printf("Failed: expected a RAW entry on the bound, got %u (bound %u)\n", e0, entry_max);
+        ok = 0;
+    }
+    if (ok && !zxc_seekable_open(dst, (size_t)csize)) {
+        printf("Failed: intact archive rejected\n");
+        ok = 0;
+    }
+
+    if (ok) {
+        const uint32_t shift = 4000u;
+        zxc_store_le32(entries, e0 + shift);
+        zxc_store_le32(entries + sizeof(uint32_t), e1 - shift);
+        zxc_seekable* s = zxc_seekable_open(dst, (size_t)csize);
+        if (s) {
+            printf("Failed: entry of %u accepted, bound is %u\n", e0 + shift, entry_max);
+            zxc_seekable_free(s);
+            ok = 0;
+        }
+    }
+
+    free(dst);
+    if (!ok) return 0;
+    printf("PASS\n\n");
+    return 1;
+}

--- a/tests/test_seekable.c
+++ b/tests/test_seekable.c
@@ -2005,17 +2005,24 @@ int test_seekable_forged_table_entry() {
     const uint32_t entry_max = (uint32_t)(ZXC_BLOCK_HEADER_SIZE + BLOCK_SIZE);
 
     int ok = 1;
-    if (e0 != entry_max) {
-        printf("Failed: expected a RAW entry on the bound, got %u (bound %u)\n", e0, entry_max);
+    const uint32_t shift = 4000u;
+    if (e0 != entry_max || e1 != entry_max) {
+        /* Both on the bound: an e1 under `shift` would wrap, and the prefix
+           sum would reject instead of the per-entry bound this test covers. */
+        printf("Failed: expected RAW entries on the bound, got %u and %u (bound %u)\n", e0, e1,
+               entry_max);
         ok = 0;
     }
-    if (ok && !zxc_seekable_open(dst, (size_t)csize)) {
-        printf("Failed: intact archive rejected\n");
-        ok = 0;
+    if (ok) {
+        zxc_seekable* intact = zxc_seekable_open(dst, (size_t)csize);
+        if (!intact) {
+            printf("Failed: intact archive rejected\n");
+            ok = 0;
+        }
+        zxc_seekable_free(intact);
     }
 
     if (ok) {
-        const uint32_t shift = 4000u;
         zxc_store_le32(entries, e0 + shift);
         zxc_store_le32(entries + sizeof(uint32_t), e1 - shift);
         zxc_seekable* s = zxc_seekable_open(dst, (size_t)csize);

--- a/tests/test_static_ctx.c
+++ b/tests/test_static_ctx.c
@@ -499,9 +499,9 @@ static int64_t bound_decode(zxc_dctx* d, const bound_block_t* b, int strict, uin
 }
 
 /* Static dctx block API: the carved block is the effective capacity. Fitting
- * blocks decode whatever the buffer; larger ones are BAD_BLOCK_SIZE within
- * the margin, the decoder's too-small codes beyond; corruption keeps the
- * dynamic codes. */
+ * blocks decode whatever the buffer. A payload larger than the carved block is
+ * BAD_BLOCK_SIZE, checked before decoding; one that fits but decodes past the
+ * block keeps the decoder's own codes. Corruption keeps the dynamic codes. */
 int test_static_dctx_block_bounds(void) {
     printf("=== TEST: Static dctx - blocks bounded by the carved block ===\n");
     enum {
@@ -621,20 +621,21 @@ int test_static_dctx_block_bounds(void) {
             {B_LZ_MID, 1, PIN, ZXC_ERROR_OVERFLOW},
             {B_RAW_MID, 0, MID + PAD, ZXC_ERROR_BAD_BLOCK_SIZE},
             {B_RAW_MID, 1, MID, ZXC_ERROR_BAD_BLOCK_SIZE},
-            {B_RAW_MID, 1, PIN, ZXC_ERROR_DST_TOO_SMALL},
-            /* beyond the margin: the decoder's own codes, buffer-independent */
+            {B_RAW_MID, 1, PIN, ZXC_ERROR_BAD_BLOCK_SIZE},
+            /* beyond the margin: BAD_BLOCK_SIZE when the payload is too big,
+               the decoder's own codes when only its output is */
             {B_LZ_XL, 0, XL + 200, ZXC_ERROR_OVERFLOW},
             {B_LZ_XL, 0, PIN, ZXC_ERROR_OVERFLOW},
             {B_LZ_XL, 1, XL, ZXC_ERROR_OVERFLOW},
-            {B_RAW_XL, 0, XL + 200, ZXC_ERROR_DST_TOO_SMALL},
-            {B_RAW_XL, 1, XL, ZXC_ERROR_DST_TOO_SMALL},
+            {B_RAW_XL, 0, XL + 200, ZXC_ERROR_BAD_BLOCK_SIZE},
+            {B_RAW_XL, 1, XL, ZXC_ERROR_BAD_BLOCK_SIZE},
             /* more literals or sequences than the carved block's scratch */
             {B_LIT6, 0, LIT + PAD, ZXC_ERROR_DST_TOO_SMALL},
             {B_LIT6, 1, LIT, ZXC_ERROR_DST_TOO_SMALL},
             {B_LIT1, 0, LIT + PAD, ZXC_ERROR_BAD_BLOCK_SIZE},
             {B_LIT1, 1, LIT, ZXC_ERROR_BAD_BLOCK_SIZE},
-            {B_SEQ7, 0, SEQ + PAD, ZXC_ERROR_DST_TOO_SMALL},
-            {B_SEQ7, 1, SEQ, ZXC_ERROR_DST_TOO_SMALL},
+            {B_SEQ7, 0, SEQ + PAD, ZXC_ERROR_BAD_BLOCK_SIZE},
+            {B_SEQ7, 1, SEQ, ZXC_ERROR_BAD_BLOCK_SIZE},
             {B_HDR_LIT, 0, LIT + PAD, ZXC_ERROR_DST_TOO_SMALL},
             {B_HDR_LIT, 1, LIT, ZXC_ERROR_DST_TOO_SMALL},
         };


### PR DESCRIPTION
Introduces robust validation checks to enhance archive integrity and security:

*   Enforces that `comp_size` for data blocks does not exceed the `block_size` declared in the file header, preventing potential out-of-bounds reads and ensuring data integrity.
*   Ensures the decompression process always terminates by explicitly encountering an EOF block, guarding against forged `comp_size` values that could bypass the EOF marker and report false success.
*   Validates seek table entries to confirm each entry accurately represents the size of a single block.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Decompression now rejects data blocks whose compressed size exceeds the configured block limit.
  - Archives that end without a valid EOF block are rejected.
  - Seekable archives reject seek-table entries that span more than one block.
  - Improved validation prevents invalid block metadata from causing incorrect decoding.
  - Error reporting distinguishes invalid block sizes, missing EOF markers, and corrupt seek tables.

- **Documentation**
  - Updated the format specification with block-size, EOF, seek-table, and error-handling rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->